### PR TITLE
feat: add OrcaRouter as a named OpenCode model source

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Yes. Agents send direct messages, create shared tasks, and leave comments - all 
 <details>
 <summary><strong>Is it free?</strong></summary>
 <br />
-Yes. The app is free and open source, and you can start with a free model with no auth - no registration, API keys, or credit card. If you want more models, connect the provider access you already have, including Claude Code, Codex, OpenCode/OpenRouter, Cursor, SuperGrok, GitHub Copilot, Z.AI, MiniMax, and Kiro.
+Yes. The app is free and open source, and you can start with a free model with no auth - no registration, API keys, or credit card. If you want more models, connect the provider access you already have, including Claude Code, Codex, OpenCode/OpenRouter, OpenAI-compatible gateways such as OrcaRouter, Cursor, SuperGrok, GitHub Copilot, Z.AI, MiniMax, and Kiro.
 </details>
 
 <details>

--- a/src/renderer/analytics/productAnalytics.ts
+++ b/src/renderer/analytics/productAnalytics.ts
@@ -27,6 +27,7 @@ export type AnalyticsProviderId =
   | 'openai'
   | 'opencode'
   | 'openrouter'
+  | 'orcarouter'
   | 'other'
   | 'perplexity'
   | 'togetherai'
@@ -139,6 +140,7 @@ const SAFE_PROVIDER_IDS: ReadonlySet<string> = new Set([
   'openai',
   'opencode',
   'openrouter',
+  'orcarouter',
   'perplexity',
   'togetherai',
   'xai',

--- a/src/shared/utils/__tests__/opencodeModelRef.test.ts
+++ b/src/shared/utils/__tests__/opencodeModelRef.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { getOpenCodeSourceDisplayName } from '../opencodeModelRef';
+
+describe('opencodeModelRef', () => {
+  it('uses the registry label for known OpenCode source ids', () => {
+    expect(getOpenCodeSourceDisplayName('openrouter')).toBe('OpenRouter');
+    expect(getOpenCodeSourceDisplayName('orcarouter')).toBe('OrcaRouter');
+    expect(getOpenCodeSourceDisplayName('openai')).toBe('OpenAI');
+  });
+
+  it('falls back to the runtime-supplied display name', () => {
+    expect(getOpenCodeSourceDisplayName('custom-provider', 'Custom Provider')).toBe(
+      'Custom Provider'
+    );
+  });
+
+  it('title-cases unknown source ids without a runtime label', () => {
+    expect(getOpenCodeSourceDisplayName('my-local-gateway')).toBe('My Local Gateway');
+  });
+});

--- a/src/shared/utils/__tests__/providerBillingMode.test.ts
+++ b/src/shared/utils/__tests__/providerBillingMode.test.ts
@@ -24,6 +24,7 @@ describe('providerBillingMode', () => {
     expect(inferProviderBillingMode({ providerBackendId: 'api' })).toBe('api');
     expect(inferProviderBillingMode({ authMethod: 'api_key' })).toBe('api');
     expect(inferProviderBillingMode({ authMethodDetail: 'openrouter_gateway' })).toBe('api');
+    expect(inferProviderBillingMode({ authMethodDetail: 'orcarouter_gateway' })).toBe('api');
   });
 
   it('classifies subscription billing from account auth hints', () => {

--- a/src/shared/utils/opencodeModelRef.ts
+++ b/src/shared/utils/opencodeModelRef.ts
@@ -28,6 +28,7 @@ const OPEN_CODE_SOURCE_LABELS: Record<string, string> = {
   openai: 'OpenAI',
   'openai-compatible': 'OpenAI Compatible',
   openrouter: 'OpenRouter',
+  orcarouter: 'OrcaRouter',
   together: 'Together',
   vercel: 'Vercel AI Gateway',
   'vercel-ai-gateway': 'Vercel AI Gateway',

--- a/src/shared/utils/providerBillingMode.ts
+++ b/src/shared/utils/providerBillingMode.ts
@@ -69,7 +69,7 @@ export function inferProviderBillingMode(
     .join(' ')
     .toLowerCase();
 
-  if (/(api[_ -]?key|bearer|gateway|provider|openrouter|anthropic_auth_token)/i.test(authHints)) {
+  if (/(api[_ -]?key|bearer|gateway|provider|openrouter|orcarouter|anthropic_auth_token)/i.test(authHints)) {
     return 'api';
   }
 


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a named OpenCode model source, mirroring how the repo already treats OpenRouter in the same spots. When a user adds an OrcaRouter OpenAI-compatible provider to an OpenCode runtime, model references such as `orcarouter/openai/gpt-5.5` now display as "OrcaRouter" in the UI instead of a title-cased fallback, are classified as API billing, and are tracked under their own analytics provider id.

OrcaRouter is an OpenAI-compatible gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind one API key (keys start with `sk-orca-`) and a single `https://api.orcarouter.ai/v1` endpoint. It also provides gateway-level security controls for AI agents.

## What this changes

- `src/shared/utils/opencodeModelRef.ts` — add `orcarouter: 'OrcaRouter'` to the OpenCode model source display-label registry, right next to `openrouter`.
- `src/shared/utils/providerBillingMode.ts` — include `orcarouter` in the API-billing auth-hint classifier, mirroring `openrouter`.
- `src/renderer/analytics/productAnalytics.ts` — add `orcarouter` to the analytics provider-id union and safe set.
- Tests for the display label and billing classification.
- `README.md` — list OrcaRouter among optional OpenAI-compatible gateways.

## Verification

- `pnpm vitest run src/shared/utils/__tests__/opencodeModelRef.test.ts src/shared/utils/__tests__/providerBillingMode.test.ts` — 10 tests passed.
- ESLint on changed files — clean.

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter support across provider recognition and display labels.
  * OrcaRouter is now included in the FAQ’s list of compatible free-model providers.

* **Bug Fixes**
  * OrcaRouter authentication is now correctly identified as API-based billing.
  * Provider normalization now preserves OrcaRouter as a supported analytics provider.

* **Tests**
  * Added coverage for provider labels, custom and unknown sources, and OrcaRouter billing classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->