### PR TITLE
chore(reviewrouter): activate v1.0.132 E14

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_40adf2793e379a80300270ce72b66a56;epoch=13;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E13_40adf2793e379a80300270ce72b66a56]
+name: ReviewRouter Codex OAuth [namespace=sns_044150b9e8106184b81814ae6d8839a1;epoch=14;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E14_044150b9e8106184b81814ae6d8839a1]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@ce837abb4d14c09553c0f5a39031902e24d3c10c
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@3be22472c1560842db0a7ff4e5ef4111134aefce
     with:
-      runtime_ref: "ce837abb4d14c09553c0f5a39031902e24d3c10c"
+      runtime_ref: "3be22472c1560842db0a7ff4e5ef4111134aefce"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E13_40adf2793e379a80300270ce72b66a56 }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E14_044150b9e8106184b81814ae6d8839a1 }}
 
   codex-refresh:
     name: codex-refresh
@@ -48,10 +48,10 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@ce837abb4d14c09553c0f5a39031902e24d3c10c
+        uses: 777genius/review-router@3be22472c1560842db0a7ff4e5ef4111134aefce
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E13_40adf2793e379a80300270ce72b66a56 }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E14_044150b9e8106184b81814ae6d8839a1 }}


### PR DESCRIPTION
Updates the canonical ReviewRouter workflow to immutable Action v1.0.132 and activates generation-aware Codex auth epoch E14.

- keeps provider identity unchanged
- updates reusable workflow, runtime_ref, and refresh Action to one exact SHA
- uses the officially reseeded versioned secret namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review workflow components.
  * Rotated authentication secret references to a newer credential version.
  * Refreshed workflow metadata for compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->