### PR TITLE
fix(ci): retry Windows runtime smoke cleanup

### DIFF
--- a/scripts/smoke/codex-runtime-install.ts
+++ b/scripts/smoke/codex-runtime-install.ts
@@ -155,7 +155,12 @@ async function runSmoke(): Promise<CodexRuntimeSmokeReport> {
     if (keepTemp) {
       console.log(`CODEX_RUNTIME_SMOKE_KEEP_TEMP=1, keeping temp root: ${tempRoot}`);
     } else {
-      await rm(tempRoot, { recursive: true, force: true });
+      await rm(tempRoot, {
+        recursive: true,
+        force: true,
+        maxRetries: 10,
+        retryDelay: 250,
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary

- retry recursive temp cleanup for transient Windows EBUSY locks
- keep install and executable verification failures strict

## Verification

- pnpm typecheck
- pnpm lint:fast:files -- scripts/smoke/codex-runtime-install.ts
- pnpm smoke:codex-runtime-install on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup reliability for temporary smoke-test files by retrying failed removals before giving up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->