### PR TITLE
chore(review): activate ReviewRouter E15

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_044150b9e8106184b81814ae6d8839a1;epoch=14;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E14_044150b9e8106184b81814ae6d8839a1]
+name: ReviewRouter Codex OAuth [namespace=sns_a3dfd6feb5aa952162a4febf33c2a67e;epoch=15;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E15_a3dfd6feb5aa952162a4febf33c2a67e]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@3be22472c1560842db0a7ff4e5ef4111134aefce
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@dfb4fe4d4185086e0c9375b2b2fd7aeed2d5a16b
     with:
-      runtime_ref: "3be22472c1560842db0a7ff4e5ef4111134aefce"
+      runtime_ref: "dfb4fe4d4185086e0c9375b2b2fd7aeed2d5a16b"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E14_044150b9e8106184b81814ae6d8839a1 }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E15_a3dfd6feb5aa952162a4febf33c2a67e }}
 
   codex-refresh:
     name: codex-refresh
@@ -48,10 +48,10 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@3be22472c1560842db0a7ff4e5ef4111134aefce
+        uses: 777genius/review-router@dfb4fe4d4185086e0c9375b2b2fd7aeed2d5a16b
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E14_044150b9e8106184b81814ae6d8839a1 }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E15_a3dfd6feb5aa952162a4febf33c2a67e }}


### PR DESCRIPTION
## Summary
- move the rotating Codex workflow to namespace epoch E15
- pin both reusable review and refresh jobs to immutable ReviewRouter v1.0.133 SHA
- preserve provider identity, concurrency, permissions, draft policy and runtime config

## Safety
- secret payload was written only through the official reseed generation contract
- no auth material is stored in this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review workflow configuration to the latest runtime, action revisions, and authentication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->