### PR TITLE
chore(deps): bump Electron to 41.10.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,7 +260,7 @@
     "@vitest/coverage-v8": "^3.2.5",
     "autoprefixer": "^10.4.17",
     "better-sqlite3-node": "npm:better-sqlite3@12.10.1",
-    "electron": "^41.10.5",
+    "electron": "^41.10.6",
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
     "eslint": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,8 +515,8 @@ importers:
         specifier: npm:better-sqlite3@12.10.1
         version: better-sqlite3@12.10.1
       electron:
-        specifier: ^41.10.5
-        version: 41.10.5(supports-color@10.2.2)
+        specifier: ^41.10.6
+        version: 41.10.6(supports-color@10.2.2)
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@10.2.2)
@@ -6519,8 +6519,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.10.5:
-    resolution: {integrity: sha512-grSJOhLddanWX1UfE8B4xA2kOOduUCfpYoOQ2D4zEYte8lSQtrd1HYbV4xErsZmm+V+1Q3yzCQLBsCxEIiw/QQ==}
+  electron@41.10.6:
+    resolution: {integrity: sha512-NEB7QnVpT2p8S9U5jOCPAtCyhl1WjRT/ODvJP6ec1/dZRUmf/EjYVOBb/dthCmJh4bISqpAroGJ/xRRxX7VwJw==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -18173,7 +18173,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.10.5(supports-color@10.2.2):
+  electron@41.10.6(supports-color@10.2.2):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0(supports-color@10.2.2)


### PR DESCRIPTION
## Summary

- update the Electron dev dependency from 41.10.5 to 41.10.6
- refresh only the corresponding pnpm lockfile entries

## Verification

- pnpm install --frozen-lockfile
- native Electron rebuild completed successfully
- pnpm exec electron --version (v41.10.6)
- pnpm typecheck
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Electron runtime to the latest patch release for improved stability and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->