### PR TITLE
chore(review): pin ReviewRouter v1.0.134

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@dfb4fe4d4185086e0c9375b2b2fd7aeed2d5a16b
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@66e622677c3eb18ef427cec91207cc896c94ef75
     with:
-      runtime_ref: "dfb4fe4d4185086e0c9375b2b2fd7aeed2d5a16b"
+      runtime_ref: "66e622677c3eb18ef427cec91207cc896c94ef75"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@dfb4fe4d4185086e0c9375b2b2fd7aeed2d5a16b
+        uses: 777genius/review-router@66e622677c3eb18ef427cec91207cc896c94ef75
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
## Summary
- pin the ReviewRouter reusable workflow and runtime to immutable Action v1.0.134
- keep rotating auth namespace E15 unchanged
- include the app-server summary-view compatibility fix for live reviews

## Evidence
- ReviewRouter Action release v1.0.134 published from `66e622677c3eb18ef427cec91207cc896c94ef75`
- Action release workflow 32735738257 passed
- SaaS pairing PR 777genius/review-router-saas#226 merged
- local `git diff --check` passed

## Scope
Only `.github/workflows/reviewrouter-codex.yml` changes. No application runtime code or auth secret changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code review and authentication workflows to use a newer pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->