### PR TITLE
chore(review): pin ReviewRouter v1.0.134

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@dfb4fe4d4185086e0c9375b2b2fd7aeed2d5a16b
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@66e622677c3eb18ef427cec91207cc896c94ef75
     with:
-      runtime_ref: "dfb4fe4d4185086e0c9375b2b2fd7aeed2d5a16b"
+      runtime_ref: "66e622677c3eb18ef427cec91207cc896c94ef75"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@dfb4fe4d4185086e0c9375b2b2fd7aeed2d5a16b
+        uses: 777genius/review-router@66e622677c3eb18ef427cec91207cc896c94ef75
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
## Summary
- keep the default branch aligned with the ReviewRouter v1.0.134 pin already merged to `dev`
- preserve the existing rotating auth E15 namespace and secret generation

## Evidence
- equivalent `dev` update merged in #490
- ReviewRouter Action release workflow 32735738257 passed
- SaaS pairing #226 merged with full green CI
- only three immutable Action SHA references change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review workflow and refresh action to use the latest pinned revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->