### PR TITLE
chore(review): activate rotating auth E16

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_a3dfd6feb5aa952162a4febf33c2a67e;epoch=15;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E15_a3dfd6feb5aa952162a4febf33c2a67e]
+name: ReviewRouter Codex OAuth [namespace=sns_7c1309558b6f6a034fa9374b3b5cd847;epoch=16;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E16_7c1309558b6f6a034fa9374b3b5cd847]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E15_a3dfd6feb5aa952162a4febf33c2a67e }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E16_7c1309558b6f6a034fa9374b3b5cd847 }}
 
   codex-refresh:
     name: codex-refresh
@@ -54,4 +54,4 @@ jobs:
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E15_a3dfd6feb5aa952162a4febf33c2a67e }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E16_7c1309558b6f6a034fa9374b3b5cd847 }}


### PR DESCRIPTION
## Summary
- activate the officially reseeded ReviewRouter rotating auth namespace E16
- keep Action v1.0.134 pinned by immutable SHA
- replace only the workflow namespace marker and two secret references

## Safety
- reseed used `scripts/reseed-codex-rotating-auth.sh --reuse-current-auth`
- no direct secret mutation was used
- auth payload was not printed or read
- E15 remains available until E16 workflow attestation succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Codex authentication configuration for review and scheduled refresh workflows.
  * Improved compatibility with the latest authentication secret version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->