### PR TITLE
chore(review): activate ReviewRouter v1.0.135 E17

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_7c1309558b6f6a034fa9374b3b5cd847;epoch=16;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E16_7c1309558b6f6a034fa9374b3b5cd847]
+name: ReviewRouter Codex OAuth [namespace=sns_a592159def0bb510b4ab38e067dacd93;epoch=17;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E17_a592159def0bb510b4ab38e067dacd93]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@66e622677c3eb18ef427cec91207cc896c94ef75
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@4d32aed89a9d74f1dbceaaef0c76b70f166ca6a4
     with:
-      runtime_ref: "66e622677c3eb18ef427cec91207cc896c94ef75"
+      runtime_ref: "4d32aed89a9d74f1dbceaaef0c76b70f166ca6a4"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E16_7c1309558b6f6a034fa9374b3b5cd847 }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E17_a592159def0bb510b4ab38e067dacd93 }}
 
   codex-refresh:
     name: codex-refresh
@@ -48,10 +48,10 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@66e622677c3eb18ef427cec91207cc896c94ef75
+        uses: 777genius/review-router@4d32aed89a9d74f1dbceaaef0c76b70f166ca6a4
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E16_7c1309558b6f6a034fa9374b3b5cd847 }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E17_a592159def0bb510b4ab38e067dacd93 }}


### PR DESCRIPTION
## Summary
- activate the officially reseeded ReviewRouter rotating auth namespace E17
- pin Action v1.0.135 by immutable commit SHA
- update only the ReviewRouter workflow identity and secret references

## Safety
- reseed used `scripts/reseed-codex-rotating-auth.sh --reuse-current-auth`
- no direct secret mutation was used
- auth payload was not printed or read
- E16 remains available until E17 workflow attestation succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code review workflow to use the latest authentication configuration and pinned workflow revisions.
  * Refreshed the workflow’s OAuth token namespace for continued operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->