### PR TITLE
chore(review): activate ReviewRouter v1.0.136 on main

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@4d32aed89a9d74f1dbceaaef0c76b70f166ca6a4
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@b931bc6c070058657cc1a5db4fdc13da336fbf26
     with:
-      runtime_ref: "4d32aed89a9d74f1dbceaaef0c76b70f166ca6a4"
+      runtime_ref: "b931bc6c070058657cc1a5db4fdc13da336fbf26"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@4d32aed89a9d74f1dbceaaef0c76b70f166ca6a4
+        uses: 777genius/review-router@b931bc6c070058657cc1a5db4fdc13da336fbf26
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
## Summary
- pin ReviewRouter reusable workflow and runtime to released v1.0.136 SHA
- preserve rotating auth namespace and E17 generation

## Verification
- exact immutable SHA used in all three references
- workflow diff check passed
- no auth reseed required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated code review workflow to use a newer verified revision.
  * No user-facing functionality or configuration behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->