### PR TITLE
chore(review): activate ReviewRouter v1.0.137 on main

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@b931bc6c070058657cc1a5db4fdc13da336fbf26
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@7af79cbcbdf4f522b2410fadc7361f75149a63fd
     with:
-      runtime_ref: "b931bc6c070058657cc1a5db4fdc13da336fbf26"
+      runtime_ref: "7af79cbcbdf4f522b2410fadc7361f75149a63fd"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@b931bc6c070058657cc1a5db4fdc13da336fbf26
+        uses: 777genius/review-router@7af79cbcbdf4f522b2410fadc7361f75149a63fd
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Pins the reusable review workflow, runtime_ref, and OAuth refresh action to the immutable v1.0.137 Action SHA.

Release evidence: SaaS v1.0.137 is live on Render at d7714b4 and Action v1.0.137 is published at 7af79cb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation workflows to use the latest ReviewRouter and Codex refresh actions.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->