### PR TITLE
fix(opencode): allow stop with stale runtime watermark

### DIFF
--- a/src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService.ts
@@ -400,7 +400,10 @@ function requiresOpenCodeVideoFilePartsContract(
 function commandRequiresRuntimeStoreManifestPrecondition(
   command: OpenCodeBridgeCommandName
 ): boolean {
-  return command !== 'opencode.sendMessage';
+  // Message delivery has its own durable acceptance evidence. Stop is a
+  // monotonic teardown fenced by exact team/lane/run ownership, so app-owned
+  // manifest evidence must not prevent the runtime from being terminated.
+  return command !== 'opencode.sendMessage' && command !== 'opencode.stopTeam';
 }
 
 export function resolveOpenCodeBridgeLeaseAcquireTimeoutMs(input: {

--- a/test/main/services/team/OpenCodeStateChangingBridgeCommandService.test.ts
+++ b/test/main/services/team/OpenCodeStateChangingBridgeCommandService.test.ts
@@ -220,6 +220,68 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
     await expect(leaseStore.getActive('team-a')).resolves.toBeNull();
   });
 
+  it('does not let app-owned runtime manifest progress block an exact-run stop', async () => {
+    handshakePort.nextHandshake = buildHandshake({
+      client: clientIdentity,
+      server: peerIdentity('agent_teams_orchestrator', {
+        runtimeStoreManifestHighWatermark: 0,
+      }),
+    });
+    bridge.resultFactory = ({ body, command, options }) =>
+      bridgeSuccess({
+        requestId: options.requestId,
+        command,
+        data: {
+          runId: 'run-1',
+          stopped: true,
+          members: {},
+          warnings: [],
+          diagnostics: [],
+          idempotencyKey: body.preconditions.idempotencyKey,
+          runtimeStoreManifestHighWatermark: 0,
+        },
+      });
+    const service = createService();
+
+    await expect(service.execute(buildStopInput())).resolves.toMatchObject({
+      ok: true,
+      data: { runId: 'run-1', stopped: true },
+    });
+    expect(bridge.calls).toHaveLength(1);
+    expect(bridge.calls[0].body.preconditions).toMatchObject({
+      laneId: 'primary',
+      expectedRunId: 'run-1',
+      expectedManifestHighWatermark: null,
+      idempotencyKey: expect.stringMatching(/^opencode:opencode\.stopTeam:team-a:primary:run-1:/),
+    });
+    await expect(
+      ledger.getByIdempotencyKey(bridge.calls[0].body.preconditions.idempotencyKey)
+    ).resolves.toMatchObject({
+      requestId: 'cmd-1',
+      status: 'completed',
+      retryable: false,
+    });
+    await expect(leaseStore.getActive('team-a')).resolves.toBeNull();
+  });
+
+  it('still rejects a stop when the bridge reports a different active run', async () => {
+    handshakePort.nextHandshake = buildHandshake({
+      client: clientIdentity,
+      server: peerIdentity('agent_teams_orchestrator', {
+        runtimeStoreManifestHighWatermark: 0,
+        activeRunId: 'run-2',
+      }),
+    });
+    const service = createService();
+
+    await expect(service.execute(buildStopInput())).rejects.toThrow(
+      'Bridge server active run mismatch'
+    );
+    expect(bridge.calls).toHaveLength(0);
+    await expect(ledger.list()).resolves.toEqual([]);
+    await expect(leaseStore.getActive('team-a')).resolves.toBeNull();
+  });
+
   it('adds preconditions, commits ledger, and releases lease on success', async () => {
     bridge.resultFactory = ({ body, options }) =>
       bridgeSuccess({
@@ -674,6 +736,28 @@ function buildSendInput(
       messageId: 'msg-1',
       settlementMode,
       ...(fileParts ? { fileParts } : {}),
+    },
+    cwd: '/tmp/project',
+    timeoutMs: 10_000,
+  };
+}
+
+function buildStopInput(): Parameters<OpenCodeStateChangingBridgeCommandService['execute']>[0] {
+  return {
+    command: 'opencode.stopTeam',
+    teamName: 'team-a',
+    laneId: 'primary',
+    runId: 'run-1',
+    capabilitySnapshotId: 'cap-1',
+    behaviorFingerprint: null,
+    body: {
+      runId: 'run-1',
+      laneId: 'primary',
+      teamId: 'team-a',
+      teamName: 'team-a',
+      projectPath: '/tmp/project',
+      reason: 'user_requested',
+      force: true,
     },
     cwd: '/tmp/project',
     timeoutMs: 10_000,

--- a/test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts
+++ b/test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts
@@ -7,6 +7,7 @@
 /* eslint-disable sonarjs/file-permissions -- The executable permission applies only to an isolated test fixture. */
 
 import { EventEmitter } from 'events';
+import Fastify from 'fastify';
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -37,11 +38,28 @@ vi.mock('@main/utils/childProcess', async (importOriginal) => {
   };
 });
 
+import { registerTeamRoutes } from '../../../../src/main/http/teams';
 import { agentTeamsMcpHttpServer } from '../../../../src/main/services/team/AgentTeamsMcpHttpServer';
 import { ClaudeBinaryResolver } from '../../../../src/main/services/team/ClaudeBinaryResolver';
+import { bindTeamHttpHandlerApis } from '../../../../src/main/services/team/contracts/TeamProvisioningApis';
+import { createOpenCodeBridgeHandshakeIdentityHash } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeCommandContract';
+import {
+  createOpenCodeBridgeCommandLeaseStore,
+  createOpenCodeBridgeCommandLedgerStore,
+} from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeCommandLedgerStore';
+import {
+  createOpenCodeBridgeClientIdentity,
+  OpenCodeBridgeCommandHandshakePort,
+} from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
+import { OpenCodeReadinessBridge } from '../../../../src/main/services/team/opencode/bridge/OpenCodeReadinessBridge';
+import {
+  type OpenCodeBridgeCommandExecutor,
+  OpenCodeStateChangingBridgeCommandService,
+} from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import {
   getOpenCodeRuntimeLaneIndexPath,
   getOpenCodeRuntimeManifestPath,
+  OpenCodeRuntimeManifestEvidenceReader,
   readCommittedOpenCodeBootstrapSessionEvidence,
   readOpenCodeRuntimeLaneIndex,
   setOpenCodeRuntimeActiveRunManifest,
@@ -53,6 +71,12 @@ import {
   OPENCODE_RUNTIME_STORE_DESCRIPTORS,
   RuntimeStoreBatchWriter,
 } from '../../../../src/main/services/team/opencode/store/RuntimeStoreManifest';
+import {
+  cancelRuntimeAdapterProvisioning,
+  type RuntimeAdapterCancellationPorts,
+  stopAndClearOpenCodeRuntimeAdapterPrimaryLaneIfOwned,
+} from '../../../../src/main/services/team/provisioning/TeamProvisioningRuntimeAdapterCancellation';
+import { OpenCodeTeamRuntimeAdapter } from '../../../../src/main/services/team/runtime/OpenCodeTeamRuntimeAdapter';
 import {
   type TeamLaunchRuntimeAdapter,
   TeamRuntimeAdapterRegistry,
@@ -77,11 +101,6 @@ import {
   TeamProvisioningService,
 } from '../../../../src/main/services/team/TeamProvisioningService';
 import {
-  cancelRuntimeAdapterProvisioning,
-  stopAndClearOpenCodeRuntimeAdapterPrimaryLaneIfOwned,
-  type RuntimeAdapterCancellationPorts,
-} from '../../../../src/main/services/team/provisioning/TeamProvisioningRuntimeAdapterCancellation';
-import {
   encodePath,
   extractBaseDir,
   getProjectsBasePath,
@@ -93,6 +112,13 @@ import type {
   WorkspaceTrustCoordinator,
   WorkspaceTrustExecutionPlan,
 } from '../../../../src/features/workspace-trust/core/application/WorkspaceTrustCoordinator';
+import type { HttpServices } from '../../../../src/main/http';
+import type {
+  OpenCodeBridgeCommandName,
+  OpenCodeBridgeHandshake,
+  OpenCodeBridgePeerIdentity,
+  OpenCodeBridgeResult,
+} from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeCommandContract';
 import type {
   OpenCodeTeamRuntimeMessageInput,
   OpenCodeTeamRuntimeMessageResult,
@@ -2617,6 +2643,67 @@ describe(
         reason: 'user_requested',
         force: true,
       });
+    });
+
+    it('stops a pure OpenCode team when the bridge runtime watermark trails app evidence', async () => {
+      const teamName = 'opencode-stale-stop-watermark-safe-e2e';
+      const launchAdapter = new FakeOpenCodeRuntimeAdapter();
+      const svc = new TeamProvisioningService();
+      svc.setRuntimeAdapterRegistry(new TeamRuntimeAdapterRegistry([launchAdapter]));
+
+      const { runId } = await svc.createTeam(
+        {
+          teamName,
+          cwd: projectPath,
+          providerId: 'opencode',
+          model: 'opencode/big-pickle',
+          skipPermissions: true,
+          members: [{ name: 'alice', role: 'Developer', providerId: 'opencode' }],
+        },
+        () => undefined
+      );
+
+      const manifestReader = new OpenCodeRuntimeManifestEvidenceReader({
+        teamsBasePath: getTeamsBasePath(),
+      });
+      const manifestBeforeStop = await manifestReader.read(teamName, 'primary');
+      expect(manifestBeforeStop).toMatchObject({ activeRunId: runId });
+      expect(manifestBeforeStop.highWatermark).toBeGreaterThan(0);
+      expect(svc.isTeamAlive(teamName)).toBe(true);
+
+      const stopFixture = createStaleWatermarkStopAdapterFixture({
+        controlDir: path.join(tempDir, 'opencode-stale-stop-control'),
+        manifestReader,
+      });
+      svc.setRuntimeAdapterRegistry(new TeamRuntimeAdapterRegistry([stopFixture.adapter]));
+      const app = Fastify();
+      registerTeamRoutes(app, {
+        teamApis: bindTeamHttpHandlerApis(svc),
+      } as HttpServices);
+
+      try {
+        const response = await app.inject({
+          method: 'POST',
+          url: `/api/teams/${teamName}/stop`,
+        });
+
+        expect(response.statusCode).toBe(200);
+        expect(response.json()).toMatchObject({
+          teamName,
+          runId: null,
+          isAlive: false,
+        });
+        expect(stopFixture.handshakeExpectedWatermarks).toEqual([null]);
+        expect(stopFixture.stopExpectedWatermarks).toEqual([null]);
+        expect(stopFixture.stoppedRunIds).toEqual([runId]);
+        await expect(
+          readOpenCodeRuntimeLaneIndex(getTeamsBasePath(), teamName)
+        ).resolves.toMatchObject({
+          lanes: {},
+        });
+      } finally {
+        await app.close();
+      }
     });
 
     it('stops one pure OpenCode runtime adapter team without disconnecting another team', async () => {
@@ -21578,6 +21665,152 @@ describe(
 
 type FakeMemberOutcome = 'confirmed' | 'permission' | 'launching' | 'failed';
 type MixedPrimaryProviderId = 'anthropic' | 'codex';
+
+function createStaleWatermarkStopAdapterFixture(input: {
+  controlDir: string;
+  manifestReader: OpenCodeRuntimeManifestEvidenceReader;
+}): {
+  adapter: OpenCodeTeamRuntimeAdapter;
+  handshakeExpectedWatermarks: Array<number | null>;
+  stopExpectedWatermarks: Array<number | null>;
+  stoppedRunIds: string[];
+} {
+  const handshakeExpectedWatermarks: Array<number | null> = [];
+  const stopExpectedWatermarks: Array<number | null> = [];
+  const stoppedRunIds: string[] = [];
+  const clientIdentity = createOpenCodeBridgeClientIdentity({
+    appVersion: 'issue-504-fixture-e2e',
+    buildId: 'issue-504-fixture-e2e',
+  });
+
+  const executor: OpenCodeBridgeCommandExecutor = {
+    async execute<TBody, TData>(
+      command: OpenCodeBridgeCommandName,
+      body: TBody,
+      options: {
+        cwd: string;
+        timeoutMs: number;
+        requestId?: string;
+        stdoutLimitBytes?: number;
+        stderrLimitBytes?: number;
+      }
+    ): Promise<OpenCodeBridgeResult<TData>> {
+      const requestId = options.requestId ?? `fixture-${command}`;
+      const completedAt = '2026-08-26T12:00:00.000Z';
+      if (command === 'opencode.handshake') {
+        const request = body as TBody & {
+          client: OpenCodeBridgePeerIdentity;
+          expectedRunId: string | null;
+          expectedManifestHighWatermark: number | null;
+        };
+        handshakeExpectedWatermarks.push(request.expectedManifestHighWatermark);
+        const server: OpenCodeBridgePeerIdentity = {
+          ...clientIdentity,
+          peer: 'agent_teams_orchestrator',
+          appVersion: 'fixture-orchestrator',
+          runtime: {
+            providerId: 'opencode',
+            binaryPath: 'fixture-opencode',
+            binaryFingerprint: 'fixture-opencode-1.18.22',
+            version: '1.18.22',
+            capabilitySnapshotId: null,
+            runtimeStoreManifestHighWatermark: 0,
+            activeRunId: null,
+          },
+        };
+        const handshakeWithoutHash: Omit<OpenCodeBridgeHandshake, 'identityHash'> = {
+          schemaVersion: 1,
+          requestId,
+          client: request.client,
+          server,
+          agreedProtocolVersion: 1,
+          acceptedCommands: server.bridgeProtocol.supportedCommands,
+          serverTime: completedAt,
+        };
+        const handshake: OpenCodeBridgeHandshake = {
+          ...handshakeWithoutHash,
+          identityHash: createOpenCodeBridgeHandshakeIdentityHash(handshakeWithoutHash),
+        };
+        return {
+          ok: true,
+          schemaVersion: 1,
+          requestId,
+          command,
+          completedAt,
+          durationMs: 1,
+          runtime: server.runtime,
+          diagnostics: [],
+          data: handshake,
+        } as unknown as OpenCodeBridgeResult<TData>;
+      }
+
+      if (command === 'opencode.stopTeam') {
+        const request = body as TBody & {
+          runId: string;
+          preconditions: {
+            expectedManifestHighWatermark: number | null;
+            idempotencyKey: string;
+          };
+        };
+        stopExpectedWatermarks.push(request.preconditions.expectedManifestHighWatermark);
+        stoppedRunIds.push(request.runId);
+        return {
+          ok: true,
+          schemaVersion: 1,
+          requestId,
+          command,
+          completedAt,
+          durationMs: 1,
+          runtime: {
+            providerId: 'opencode',
+            binaryPath: 'fixture-opencode',
+            binaryFingerprint: 'fixture-opencode-1.18.22',
+            version: '1.18.22',
+            capabilitySnapshotId: null,
+          },
+          diagnostics: [],
+          data: {
+            runId: request.runId,
+            stopped: true,
+            members: {},
+            warnings: [],
+            diagnostics: [],
+            idempotencyKey: request.preconditions.idempotencyKey,
+            manifestHighWatermark: 0,
+            runtimeStoreManifestHighWatermark: 0,
+          },
+        } as unknown as OpenCodeBridgeResult<TData>;
+      }
+
+      throw new Error(`Unexpected fixture bridge command: ${command}`);
+    },
+  };
+  const stateChangingCommands = new OpenCodeStateChangingBridgeCommandService({
+    expectedClientIdentity: clientIdentity,
+    handshakePort: new OpenCodeBridgeCommandHandshakePort({
+      bridge: executor,
+      clientIdentity,
+    }),
+    leaseStore: createOpenCodeBridgeCommandLeaseStore({
+      filePath: path.join(input.controlDir, 'leases.json'),
+    }),
+    ledger: createOpenCodeBridgeCommandLedgerStore({
+      filePath: path.join(input.controlDir, 'ledger.json'),
+    }),
+    bridge: executor,
+    manifestReader: input.manifestReader,
+  });
+  const bridge = new OpenCodeReadinessBridge(executor, {
+    stateChangingCommands,
+  });
+
+  return {
+    adapter: new OpenCodeTeamRuntimeAdapter(bridge),
+    handshakeExpectedWatermarks,
+    stopExpectedWatermarks,
+    stoppedRunIds,
+  };
+}
 
 class FakeOpenCodeRuntimeAdapter implements TeamLaunchRuntimeAdapter {
   readonly providerId = 'opencode' as const;


### PR DESCRIPTION
## Summary

- allow OpenCode stopTeam to proceed when bridge runtime watermark trails app manifest evidence
- preserve exact team, lane, and run ownership fencing plus command lease and idempotency checks
- add unit regressions and a safe fixture HTTP E2E for the Windows failure mode

## Testing

- pnpm typecheck
- 132 focused OpenCode bridge and runtime unit tests
- safe fixture HTTP E2E for stale watermark stop
- Team Provisioning architecture and source-size guards

Fixes #504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenCode team stopping so it can proceed when runtime status evidence is outdated.
  * Prevented stop requests for mismatched active runs from proceeding.
  * Ensured stopping a pure OpenCode team correctly clears its runtime lane.

* **Tests**
  * Added coverage for stop behavior with stale runtime status and mismatched runs.
  * Added end-to-end validation for OpenCode team cancellation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->