### PR TITLE
chore(review): activate Codex auth generation E19 on main

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -1,4 +1,4 @@
-name: ReviewRouter Codex OAuth [namespace=sns_e64e449dd792733ddd3409e8bca0c1d3;epoch=18;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E18_e64e449dd792733ddd3409e8bca0c1d3]
+name: ReviewRouter Codex OAuth [namespace=sns_c543a2f6835e527bbdf262538ae05c26;epoch=19;secret=REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E19_c543a2f6835e527bbdf262538ae05c26]
 
 run-name: ${{ format('ReviewRouter review PR {0} at {1}', github.event.pull_request.number, github.event.pull_request.head.sha) }}
 
@@ -33,7 +33,7 @@ jobs:
       max_changed_lines: ${{ vars.REVIEW_ROUTER_MAX_CHANGED_LINES }}
       review_timeout_minutes: ${{ fromJSON(vars.REVIEW_ROUTER_TIMEOUT_MINUTES || '60') }}
     secrets:
-      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E18_e64e449dd792733ddd3409e8bca0c1d3 }}
+      CODEX_AUTH_JSON: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E19_c543a2f6835e527bbdf262538ae05c26 }}
 
   codex-refresh:
     name: codex-refresh
@@ -54,4 +54,4 @@ jobs:
           api-url: "https://api.reviewrouter.site"
           provider-instance-id: "codex-rotating:1163183284"
           workflow-schema-version: "4"
-          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E18_e64e449dd792733ddd3409e8bca0c1d3 }}
+          auth-json: ${{ secrets.REVIEWROUTER_CODEX_AUTH_JSON_R1163183284_Pc11a7080815e939d_E19_c543a2f6835e527bbdf262538ae05c26 }}


### PR DESCRIPTION
Updates the canonical ReviewRouter workflow namespace to the newly confirmed E19 account. This is the required default-branch attestation step before activation. It does not change PR #252 or merge the temporary review campaign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ReviewRouter Codex authentication secret namespace to the latest version.
  * No user-facing behavior or workflow functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->