### PR TITLE
chore(review): trust ReviewRouter v1.0.139 for E19 on main

### DIFF
--- a/.github/workflows/reviewrouter-codex.yml
+++ b/.github/workflows/reviewrouter-codex.yml
@@ -21,9 +21,9 @@ jobs:
       contents: read
       pull-requests: read
       id-token: write
-    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@7af79cbcbdf4f522b2410fadc7361f75149a63fd
+    uses: 777genius/review-router/.github/workflows/reviewrouter-t0-reusable.yml@2cecf3249a4e4d02eb6bc629d0752773ba58690d
     with:
-      runtime_ref: "7af79cbcbdf4f522b2410fadc7361f75149a63fd"
+      runtime_ref: "2cecf3249a4e4d02eb6bc629d0752773ba58690d"
       api_url: "https://api.reviewrouter.site"
       runtime_config_mode: oidc
       pr_number: ${{ format('{0}', github.event.pull_request.number) }}
@@ -48,7 +48,7 @@ jobs:
     steps:
       - name: ReviewRouter Codex OAuth refresh
         id: refresh_codex
-        uses: 777genius/review-router@7af79cbcbdf4f522b2410fadc7361f75149a63fd
+        uses: 777genius/review-router@2cecf3249a4e4d02eb6bc629d0752773ba58690d
         with:
           mode: codex-oauth-refresh
           api-url: "https://api.reviewrouter.site"


### PR DESCRIPTION
Pins the canonical E19 workflow to the exact ReviewRouter v1.0.139 SHA issued by the recovery setup command. This is required for server-side workflow attestation and does not modify PR #252 or the temporary campaign.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review workflow to use the latest pinned action versions.
  * Improved reliability and consistency of automated review runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->