### PR TITLE
fix(http): return 422 with the real message for launch validation failures

### DIFF
--- a/src/features/team-runtime-lanes/core/domain/planTeamRuntimeLanes.ts
+++ b/src/features/team-runtime-lanes/core/domain/planTeamRuntimeLanes.ts
@@ -83,6 +83,20 @@ export interface TeamRuntimeLanePlanError {
   message: string;
 }
 
+/** A lane-plan rejection that is safe to surface as launch validation feedback. */
+export class TeamRuntimeLanePlanningError extends Error {
+  readonly reason: TeamRuntimeLanePlanErrorReason | 'missing_opencode_runtime_adapter';
+
+  constructor(
+    message: string,
+    reason: TeamRuntimeLanePlanErrorReason | 'missing_opencode_runtime_adapter'
+  ) {
+    super(message);
+    this.name = 'TeamRuntimeLanePlanningError';
+    this.reason = reason;
+  }
+}
+
 export interface TeamRuntimeLanePlanSuccess {
   ok: true;
   plan: TeamRuntimeLanePlan;

--- a/src/features/team-runtime-lanes/index.ts
+++ b/src/features/team-runtime-lanes/index.ts
@@ -21,4 +21,5 @@ export {
   OPEN_CODE_SOLO_MEMBER_NAME,
   OPEN_CODE_SOLO_MEMBER_ROLE,
   planTeamRuntimeLanes,
+  TeamRuntimeLanePlanningError,
 } from './core/domain/planTeamRuntimeLanes';

--- a/src/features/team-runtime-lanes/main/composition/createTeamRuntimeLaneCoordinator.ts
+++ b/src/features/team-runtime-lanes/main/composition/createTeamRuntimeLaneCoordinator.ts
@@ -2,6 +2,7 @@ import { buildMixedPersistedLaunchSnapshot } from '@features/team-runtime-lanes/
 import {
   fromProvisioningMembers,
   isOpenCodeSideLanePlan,
+  TeamRuntimeLanePlanningError,
   type TeamRuntimeLanePlan,
 } from '@features/team-runtime-lanes/core/domain/planTeamRuntimeLanes';
 
@@ -29,11 +30,12 @@ export function createTeamRuntimeLaneCoordinator(): TeamRuntimeLaneCoordinator {
         leadModel: params.leadModel,
       });
       if (!lanePlan.ok) {
-        throw new Error(lanePlan.message);
+        throw new TeamRuntimeLanePlanningError(lanePlan.message, lanePlan.reason);
       }
       if (isOpenCodeSideLanePlan(lanePlan.plan) && !params.hasOpenCodeRuntimeAdapter) {
-        throw new Error(
-          'OpenCode side lanes require the OpenCode runtime adapter to be registered.'
+        throw new TeamRuntimeLanePlanningError(
+          'OpenCode side lanes require the OpenCode runtime adapter to be registered.',
+          'missing_opencode_runtime_adapter'
         );
       }
       return lanePlan.plan;

--- a/src/features/team-runtime-lanes/main/composition/createTeamRuntimeLaneCoordinator.ts
+++ b/src/features/team-runtime-lanes/main/composition/createTeamRuntimeLaneCoordinator.ts
@@ -2,8 +2,8 @@ import { buildMixedPersistedLaunchSnapshot } from '@features/team-runtime-lanes/
 import {
   fromProvisioningMembers,
   isOpenCodeSideLanePlan,
-  TeamRuntimeLanePlanningError,
   type TeamRuntimeLanePlan,
+  TeamRuntimeLanePlanningError,
 } from '@features/team-runtime-lanes/core/domain/planTeamRuntimeLanes';
 
 import type { PersistedTeamLaunchSnapshot, TeamCreateRequest, TeamProviderId } from '@shared/types';

--- a/src/main/http/__tests__/teamsLaunchValidationHttp.test.ts
+++ b/src/main/http/__tests__/teamsLaunchValidationHttp.test.ts
@@ -1,0 +1,63 @@
+import { TeamLaunchValidationError } from '@main/services/team/provisioning/TeamLaunchValidationError';
+import Fastify from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { registerTeamRoutes } from '../teams';
+
+import type { HttpServices } from '../index';
+import type { FastifyInstance } from 'fastify';
+
+function createServices(launchError: unknown): HttpServices {
+  return {
+    teamApis: {
+      provisioningStart: {
+        createTeam: vi.fn(),
+        launchTeam: vi.fn().mockRejectedValue(launchError),
+      },
+    },
+  } as unknown as HttpServices;
+}
+
+describe('POST /api/teams/:teamName/launch error mapping', () => {
+  let app: FastifyInstance | null = null;
+
+  afterEach(async () => {
+    await app?.close();
+    app = null;
+  });
+
+  async function injectLaunch(launchError: unknown) {
+    app = Fastify();
+    registerTeamRoutes(app, createServices(launchError));
+    return app.inject({
+      method: 'POST',
+      url: '/api/teams/demo-team/launch',
+      payload: { cwd: process.cwd(), providerId: 'opencode' },
+    });
+  }
+
+  it('maps TeamLaunchValidationError to 422 with the real validation message', async () => {
+    const message =
+      'Mixed teams with an OpenCode lead are not supported in this phase. ' +
+      'Keep the team lead on Anthropic or Codex when you mix OpenCode with other providers.';
+    const response = await injectLaunch(new TeamLaunchValidationError(message));
+    expect(response.statusCode).toBe(422);
+    expect(response.json()).toEqual({ error: message });
+  });
+
+  it('keeps unexpected launch failures as opaque 500 responses', async () => {
+    const response = await injectLaunch(new Error('unexpected internal failure'));
+    expect(response.statusCode).toBe(500);
+    expect(response.json()).toEqual({ error: 'Internal server error' });
+    // Unexpected failures must stay observable in the log even though the HTTP
+    // body is opaque; consume the expected logger.error call so the global
+    // console guard in test/setup.ts does not flag it.
+    const errorSpy = vi.mocked(console.error);
+    expect(
+      errorSpy.mock.calls.some((call) =>
+        call.some((arg) => String(arg).includes('unexpected internal failure'))
+      )
+    ).toBe(true);
+    errorSpy.mockClear();
+  });
+});

--- a/src/main/http/teams.ts
+++ b/src/main/http/teams.ts
@@ -106,6 +106,12 @@ function getStatusCode(error: unknown, fallback: number = 500): number {
   if (error instanceof Error && error.name === 'RuntimeStaleEvidenceError') {
     return 409;
   }
+  if (error instanceof Error && error.name === 'TeamLaunchValidationError') {
+    // User-facing provisioning launch validation failure; the sub-500 status
+    // makes getResponseErrorMessage return the real message instead of the
+    // opaque "Internal server error".
+    return 422;
+  }
   if (isTeamNotFoundError(error)) {
     return 404;
   }

--- a/src/main/services/team/provisioning/TeamLaunchValidationError.ts
+++ b/src/main/services/team/provisioning/TeamLaunchValidationError.ts
@@ -1,0 +1,14 @@
+/**
+ * User-facing validation failure raised before a team launch starts
+ * (provider compatibility, member limits, model/effort selection).
+ *
+ * The HTTP layer matches this by `error.name` (like RuntimeStaleEvidenceError)
+ * so it can map the failure to 422 and return the message verbatim instead of
+ * an opaque "Internal server error".
+ */
+export class TeamLaunchValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TeamLaunchValidationError';
+  }
+}

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchCompatibility.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchCompatibility.ts
@@ -1,6 +1,8 @@
 import { fromProvisioningMembers } from '@features/team-runtime-lanes';
 import { normalizeOptionalTeamProviderId } from '@shared/utils/teamProvider';
 
+import { TeamLaunchValidationError } from './TeamLaunchValidationError';
+
 import type { TeamCreateRequest } from '@shared/types';
 
 export type TeamLaunchCompatibilityLevel = 'ready' | 'repairable' | 'unsafe';
@@ -79,12 +81,14 @@ export function assertOpenCodeNotLaunchedThroughLegacyProvisioning(request: {
     }))
   );
   if (!lanePlan.ok) {
-    throw new Error(lanePlan.message || getOpenCodeMixedProviderProvisioningError());
+    throw new TeamLaunchValidationError(
+      lanePlan.message || getOpenCodeMixedProviderProvisioningError()
+    );
   }
   if (!isPureOpenCodeProvisioningRequest(request)) {
     return;
   }
-  throw new Error(
+  throw new TeamLaunchValidationError(
     'OpenCode team launch is not enabled in the legacy Claude stream-json provisioning path. ' +
       'Use the gated OpenCode runtime adapter once production launch is enabled.'
   );
@@ -117,7 +121,7 @@ export function assertDeterministicBootstrapPrimaryMemberLimit(memberCount: numb
   if (memberCount <= DETERMINISTIC_BOOTSTRAP_MAX_PRIMARY_MEMBERS) {
     return;
   }
-  throw new Error(
+  throw new TeamLaunchValidationError(
     `Codex deterministic bootstrap currently supports up to ${DETERMINISTIC_BOOTSTRAP_MAX_PRIMARY_MEMBERS} primary teammates; this team has ${memberCount}. Reduce primary teammates or move extra OpenCode members to secondary lanes.`
   );
 }

--- a/src/main/services/team/provisioning/TeamProvisioningRuntimeBootstrapDelivery.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningRuntimeBootstrapDelivery.ts
@@ -1,5 +1,8 @@
+import {
+  type TeamRuntimeLanePlan,
+  TeamRuntimeLanePlanningError,
+} from '@features/team-runtime-lanes';
 import { type TeamRuntimeLaneCoordinator } from '@features/team-runtime-lanes/main';
-import { TeamRuntimeLanePlanningError } from '@features/team-runtime-lanes/core/domain/planTeamRuntimeLanes';
 
 import { TeamLaunchValidationError } from './TeamLaunchValidationError';
 import { isPureOpenCodeProvisioningRequest } from './TeamProvisioningLaunchCompatibility';
@@ -8,7 +11,6 @@ import {
   type MixedSecondaryRuntimeLaneState,
 } from './TeamProvisioningSecondaryRuntimeRuns';
 
-import type { TeamRuntimeLanePlan } from '@features/team-runtime-lanes';
 import type { TeamCreateRequest, TeamProviderId } from '@shared/types';
 
 export function shouldRouteOpenCodeToRuntimeAdapter(

--- a/src/main/services/team/provisioning/TeamProvisioningRuntimeBootstrapDelivery.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningRuntimeBootstrapDelivery.ts
@@ -1,5 +1,7 @@
 import { type TeamRuntimeLaneCoordinator } from '@features/team-runtime-lanes/main';
+import { getErrorMessage } from '@shared/utils/errorHandling';
 
+import { TeamLaunchValidationError } from './TeamLaunchValidationError';
 import { isPureOpenCodeProvisioningRequest } from './TeamProvisioningLaunchCompatibility';
 import {
   createMixedSecondaryLaneStates as createMixedSecondaryLaneStatesFromPlan,
@@ -28,7 +30,13 @@ export function planRuntimeLanesOrThrow(
     hasOpenCodeRuntimeAdapter: boolean;
   }
 ): TeamRuntimeLanePlan {
-  return runtimeLaneCoordinator.planProvisioningMembers(input);
+  try {
+    return runtimeLaneCoordinator.planProvisioningMembers(input);
+  } catch (error) {
+    // Lane-plan rejections (e.g. an OpenCode-led mixed roster) are user-facing
+    // launch blockers; retype them so HTTP surfaces the message instead of 500.
+    throw new TeamLaunchValidationError(getErrorMessage(error));
+  }
 }
 
 export function createMixedSecondaryLaneStates(

--- a/src/main/services/team/provisioning/TeamProvisioningRuntimeBootstrapDelivery.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningRuntimeBootstrapDelivery.ts
@@ -1,5 +1,5 @@
 import { type TeamRuntimeLaneCoordinator } from '@features/team-runtime-lanes/main';
-import { getErrorMessage } from '@shared/utils/errorHandling';
+import { TeamRuntimeLanePlanningError } from '@features/team-runtime-lanes/core/domain/planTeamRuntimeLanes';
 
 import { TeamLaunchValidationError } from './TeamLaunchValidationError';
 import { isPureOpenCodeProvisioningRequest } from './TeamProvisioningLaunchCompatibility';
@@ -33,9 +33,12 @@ export function planRuntimeLanesOrThrow(
   try {
     return runtimeLaneCoordinator.planProvisioningMembers(input);
   } catch (error) {
-    // Lane-plan rejections (e.g. an OpenCode-led mixed roster) are user-facing
-    // launch blockers; retype them so HTTP surfaces the message instead of 500.
-    throw new TeamLaunchValidationError(getErrorMessage(error));
+    // Only the coordinator's typed lane-plan rejections are user-facing launch
+    // blockers. Unknown failures must retain their original type for 500 handling.
+    if (error instanceof TeamRuntimeLanePlanningError) {
+      throw new TeamLaunchValidationError(error.message);
+    }
+    throw error;
   }
 }
 

--- a/src/main/services/team/provisioning/TeamProvisioningRuntimeLaunchSelection.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningRuntimeLaunchSelection.ts
@@ -36,6 +36,7 @@ import {
   type TeamRuntimeSettingsJson,
 } from '../../runtime/teamRuntimeSettingsBundle';
 
+import { TeamLaunchValidationError } from './TeamLaunchValidationError';
 import { getExplicitLaunchModelSelection } from './TeamProvisioningMemberSpecs';
 
 export interface ProviderModelListCommandResponse {
@@ -530,11 +531,8 @@ export function hasPathBasedSettingsArgs(args: string[]): boolean {
         index += 2;
         continue;
       }
-      if (typeof value !== 'string') {
-        return true;
-      }
-      index += 1;
-      continue;
+      // A trailing `--settings` with no value behaves like a path-based flag.
+      return true;
     }
     const prefix = '--settings=';
     if (arg.startsWith(prefix) && !parseJsonSettingsObject(arg.slice(prefix.length))) {
@@ -811,7 +809,7 @@ export function validateRuntimeLaunchSelection(params: {
     });
     const resolvedLaunchModel = selection.resolvedLaunchModel?.trim() || null;
     if (!resolvedLaunchModel) {
-      throw new Error(
+      throw new TeamLaunchValidationError(
         `${params.actorLabel} could not resolve the selected Anthropic model against the current runtime catalog.`
       );
     }
@@ -820,7 +818,7 @@ export function validateRuntimeLaunchSelection(params: {
       hasAuthoritativeAnthropicLaunchCatalog(params.facts) &&
       !params.facts.modelIds.has(resolvedLaunchModel)
     ) {
-      throw new Error(
+      throw new TeamLaunchValidationError(
         `${params.actorLabel} resolves to Anthropic model "${resolvedLaunchModel}", but the current runtime does not list it as launchable.`
       );
     }
@@ -832,7 +830,7 @@ export function validateRuntimeLaunchSelection(params: {
         runtimeCapabilities: params.facts.runtimeCapabilities,
       });
       if (effortSupport.kind !== 'supported') {
-        throw new Error(
+        throw new TeamLaunchValidationError(
           `${params.actorLabel} uses Anthropic effort "${params.effort}", but ${formatAnthropicEffortSupportFailure(
             {
               effort: params.effort,
@@ -854,7 +852,7 @@ export function validateRuntimeLaunchSelection(params: {
       providerFastModeDefault: params.anthropicFastModeDefault,
     });
     if ((params.fastMode ?? 'inherit') === 'on' && !fastResolution.selectable) {
-      throw new Error(
+      throw new TeamLaunchValidationError(
         `${params.actorLabel} enables Anthropic Fast mode, but ${
           fastResolution.disabledReason ?? 'it is unavailable for the selected runtime or model.'
         }`
@@ -873,12 +871,12 @@ export function validateRuntimeLaunchSelection(params: {
       const supported = catalogModel.supportedReasoningEfforts.length
         ? ` Supported efforts: ${catalogModel.supportedReasoningEfforts.join(', ')}.`
         : ' This model does not support configurable effort.';
-      throw new Error(
+      throw new TeamLaunchValidationError(
         `${params.actorLabel} uses effort "${params.effort}", but ${catalogModel.displayName} does not support it.${supported}`
       );
     }
     if (params.effort && !catalogModel && !isLegacySafeEffort(params.effort)) {
-      throw new Error(
+      throw new TeamLaunchValidationError(
         `${params.actorLabel} uses effort "${params.effort}", but ${params.getProviderLabel(
           params.providerId
         )} currently supports only low, medium, or high effort in Agent Teams.`
@@ -891,7 +889,7 @@ export function validateRuntimeLaunchSelection(params: {
     params.effort &&
     !isCodexEffortRuntimeSupported(params.effort, params.facts.runtimeCapabilities)
   ) {
-    throw new Error(
+    throw new TeamLaunchValidationError(
       `${params.actorLabel} uses Codex effort "${params.effort}", but this Agent Teams runtime does not expose Codex reasoning config passthrough yet. Use low, medium, or high for now.`
     );
   }
@@ -904,7 +902,7 @@ export function validateRuntimeLaunchSelection(params: {
     return;
   }
 
-  throw new Error(
+  throw new TeamLaunchValidationError(
     `${params.actorLabel} uses Codex model "${explicitModel}", but it is not present in the live Codex model catalog. Refresh the catalog or pick a listed Codex model.`
   );
 }

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchCompatibility.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchCompatibility.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { TeamLaunchValidationError } from '../TeamLaunchValidationError';
+import {
+  assertDeterministicBootstrapPrimaryMemberLimit,
+  assertOpenCodeNotLaunchedThroughLegacyProvisioning,
+} from '../TeamProvisioningLaunchCompatibility';
+
+describe('assertOpenCodeNotLaunchedThroughLegacyProvisioning', () => {
+  it('accepts requests without any OpenCode participant', () => {
+    expect(() =>
+      assertOpenCodeNotLaunchedThroughLegacyProvisioning({
+        providerId: 'anthropic',
+        members: [{ providerId: 'codex' }],
+      })
+    ).not.toThrow();
+  });
+
+  it('rejects an OpenCode-led mixed team with a typed validation error', () => {
+    const request = {
+      providerId: 'opencode',
+      members: [{ providerId: 'anthropic' }],
+    };
+    const run = () => assertOpenCodeNotLaunchedThroughLegacyProvisioning(request);
+    expect(run).toThrow(TeamLaunchValidationError);
+    expect(run).toThrow('Mixed teams with an OpenCode lead are not supported in this phase');
+  });
+
+  it('rejects a pure OpenCode legacy launch with a typed validation error', () => {
+    const run = () =>
+      assertOpenCodeNotLaunchedThroughLegacyProvisioning({
+        providerId: 'opencode',
+        members: [{ providerId: 'opencode' }],
+      });
+    expect(run).toThrow(TeamLaunchValidationError);
+    expect(run).toThrow('legacy Claude stream-json provisioning path');
+  });
+});
+
+describe('assertDeterministicBootstrapPrimaryMemberLimit', () => {
+  it('accepts the documented maximum of primary teammates', () => {
+    expect(() => assertDeterministicBootstrapPrimaryMemberLimit(30)).not.toThrow();
+  });
+
+  it('rejects a roster above the maximum with a typed validation error', () => {
+    const run = () => assertDeterministicBootstrapPrimaryMemberLimit(31);
+    expect(run).toThrow(TeamLaunchValidationError);
+    expect(run).toThrow('supports up to 30 primary teammates; this team has 31');
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningRuntimeBootstrapDelivery.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningRuntimeBootstrapDelivery.test.ts
@@ -98,4 +98,21 @@ describe('TeamProvisioningRuntimeBootstrapDelivery', () => {
     expect(run).toThrow(TeamLaunchValidationError);
     expect(run).toThrow('Mixed teams with an OpenCode lead are not supported in this phase');
   });
+
+  it('does not disguise unexpected coordinator failures as launch validation', () => {
+    const unexpected = new Error('coordinator exploded');
+    const coordinator = {
+      planProvisioningMembers: () => {
+        throw unexpected;
+      },
+    } as Pick<ReturnType<typeof createTeamRuntimeLaneCoordinator>, 'planProvisioningMembers'>;
+
+    expect(() =>
+      planRuntimeLanesOrThrow(coordinator, {
+        leadProviderId: 'codex',
+        members: [member('Ada', 'codex')],
+        hasOpenCodeRuntimeAdapter: true,
+      })
+    ).toThrowError(unexpected);
+  });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningRuntimeBootstrapDelivery.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningRuntimeBootstrapDelivery.test.ts
@@ -1,6 +1,7 @@
 import { createTeamRuntimeLaneCoordinator } from '@features/team-runtime-lanes/main';
 import { describe, expect, it } from 'vitest';
 
+import { TeamLaunchValidationError } from '../TeamLaunchValidationError';
 import {
   createMixedSecondaryLaneStates,
   planRuntimeLanesOrThrow,
@@ -83,5 +84,18 @@ describe('TeamProvisioningRuntimeBootstrapDelivery', () => {
         member: { name: 'Grace' },
       },
     ]);
+  });
+
+  it('retypes lane-plan rejections as user-facing launch validation errors', () => {
+    const coordinator = createTeamRuntimeLaneCoordinator();
+    const run = () =>
+      planRuntimeLanesOrThrow(coordinator, {
+        leadProviderId: 'opencode',
+        members: [member('Ada', 'anthropic')],
+        hasOpenCodeRuntimeAdapter: true,
+      });
+
+    expect(run).toThrow(TeamLaunchValidationError);
+    expect(run).toThrow('Mixed teams with an OpenCode lead are not supported in this phase');
   });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningRuntimeLaunchSelection.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningRuntimeLaunchSelection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { TeamLaunchValidationError } from '../TeamLaunchValidationError';
 import { validateRuntimeLaunchSelection } from '../TeamProvisioningRuntimeLaunchSelection';
 
 import type { RuntimeProviderLaunchFacts } from '../TeamProvisioningRuntimeLaunchSelection';
@@ -126,5 +127,62 @@ describe('validateRuntimeLaunchSelection OpenCode catalog effort', () => {
         getProviderLabel: () => 'OpenCode',
       })
     ).toThrow('Kimi K3 does not support it');
+  });
+
+  it('rejects catalog effort mismatches with a typed validation error', () => {
+    expect(() =>
+      validateRuntimeLaunchSelection({
+        actorLabel: 'Kiro teammate',
+        providerId: 'opencode',
+        model: 'kiro/auto',
+        effort: 'ultra',
+        facts: createKiroFacts(),
+        anthropicFastModeDefault: false,
+        getProviderLabel: () => 'OpenCode',
+      })
+    ).toThrow(TeamLaunchValidationError);
+  });
+});
+
+describe('validateRuntimeLaunchSelection typed validation errors', () => {
+  const emptyFacts: RuntimeProviderLaunchFacts = {
+    defaultModel: null,
+    modelIds: new Set(),
+    modelListParsed: true,
+    modelCatalog: null,
+    runtimeCapabilities: null,
+  };
+
+  it('rejects a Codex model missing from the live catalog with a typed validation error', () => {
+    const run = () =>
+      validateRuntimeLaunchSelection({
+        actorLabel: 'Team lead',
+        providerId: 'codex',
+        model: 'gpt-6-codex',
+        facts: {
+          ...emptyFacts,
+          defaultModel: 'gpt-5-codex',
+          modelIds: new Set(['gpt-5-codex']),
+        },
+        anthropicFastModeDefault: false,
+        getProviderLabel: () => 'Codex',
+      });
+    expect(run).toThrow(TeamLaunchValidationError);
+    expect(run).toThrow('not present in the live Codex model catalog');
+  });
+
+  it('rejects an unverifiable Anthropic effort with a typed validation error', () => {
+    const run = () =>
+      validateRuntimeLaunchSelection({
+        actorLabel: 'Team lead',
+        providerId: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        effort: 'xhigh',
+        facts: emptyFacts,
+        anthropicFastModeDefault: false,
+        getProviderLabel: () => 'Claude',
+      });
+    expect(run).toThrow(TeamLaunchValidationError);
+    expect(run).toThrow('uses Anthropic effort "xhigh"');
   });
 });


### PR DESCRIPTION
## Problem

Launching a team over the HTTP API (`POST /api/teams/:teamName/launch`) returns an opaque
`500 Internal Server Error` whenever the launch is rejected by provisioning
validation. The actual reason — the one the user needs — is only visible in the
app log, so any API client (scripts, the MCP server, external orchestrators) is
told "something broke" instead of "this roster/model/effort is not launchable".

Root cause: every provisioning launch validation site throws a plain `Error`.
`src/main/http/teams.ts` classifies errors by type/name (`getStatusCode`), a
plain `Error` falls through to the 500 fallback, and `getResponseErrorMessage`
deliberately replaces the message of any 5xx with `Internal server error` so
internal failures don't leak details. Correct behaviour for a genuine crash —
wrong for a user-facing validation failure, which is a 4xx and whose message is
the whole point.

The affected validation sites are:

- OpenCode-led mixed roster rejected by the runtime lane coordinator
- OpenCode launched through the legacy Claude stream-json provisioning path
- Codex deterministic bootstrap primary-member limit exceeded
- Anthropic model that cannot be resolved against the live runtime catalog
- Anthropic / Codex / OpenCode-catalog reasoning effort not supported
- Anthropic Fast mode requested where it is not selectable
- Codex model absent from the live Codex model catalog

## Fix

Introduce `TeamLaunchValidationError` (`src/main/services/team/provisioning/
TeamLaunchValidationError.ts`), a named error subclass, and throw it from those
validation sites instead of a bare `Error`. `getStatusCode` in the HTTP layer
maps it to **422 Unprocessable Entity**, which — being sub-500 — makes
`getResponseErrorMessage` return the validation message verbatim.

Why this way:

- It matches the mechanism already in the file: `RuntimeStaleEvidenceError` is
  matched by `error.name` and mapped to 409. This adds one more entry in the
  same shape rather than inventing a second classification mechanism.
- Matching on `error.name` (not `instanceof`) keeps the HTTP layer free of an
  import from the provisioning layer and survives the error crossing a worker /
  serialization boundary.
- The 5xx message-blanking stays exactly as it is; nothing that is genuinely
  internal starts leaking. Only errors explicitly typed as user-facing
  validation change status.
- `planRuntimeLanesOrThrow` wraps the lane-coordinator call and re-types its
  rejection, so lane-plan blockers (the OpenCode-led mixed roster case) get the
  same treatment without the lane coordinator having to know about the HTTP
  layer.

One drive-by tidy in `TeamProvisioningRuntimeLaunchSelection.ts`: the
`--settings` branch of `hasPathBasedSettingsArgs` had a `typeof value !==
'string'` check followed by two statements that could never run (the preceding
`typeof value === 'string'` branch always returns or continues). Collapsed to a
plain `return true` with a comment. No behaviour change.

## Tests

- `src/main/http/__tests__/teamsLaunchValidationHttp.test.ts` (new) — drives the
  HTTP launch route and asserts 422 plus the real message in the body for a
  validation failure, and that a genuine internal error still yields 500 with
  the blanked message.
- `src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchCompatibility.test.ts`
  (new) — mixed-roster rejection and the primary-member limit throw
  `TeamLaunchValidationError`.
- `TeamProvisioningRuntimeBootstrapDelivery.test.ts` — lane-coordinator
  rejections are re-typed and the original message is preserved.
- `TeamProvisioningRuntimeLaunchSelection.test.ts` — Codex model missing from the
  live catalog, unverifiable Anthropic effort, and OpenCode catalog effort
  mismatch all throw the typed error.

All green: 5 files / 47 tests (the four above plus the existing
`test/main/http/teams.test.ts`, which covers the untouched status mappings).

## Tested on

Windows 11 (24H2), Electron build from source.

Provider combinations actually exercised for this change:

- **Cursor lead + OpenCode members** — mixed-roster lane rejection over HTTP,
  the case that originally produced the opaque 500.
- **Local models via OpenCode** (llama-swap OpenAI-compatible endpoint) —
  catalog/effort validation on the OpenCode path.
- **Anthropic (API key)** — model-not-in-catalog and effort validation.
- **Codex (ChatGPT auth)** — effort passthrough and model-catalog validation.

Not specifically re-exercised for this change: Anthropic OAuth and Codex API-key
auth (the validation path is auth-mode independent — it runs before any
credential is used — but the combination was not re-run after this change).
Not tested on macOS or Linux; nothing in the change is platform-specific.

## References

- #116 — the same "surface the real validation message instead of a generic
  failure" rule was applied to the UI surface in v2.2.0. This is the HTTP half
  of it: the API still returned the generic 500.

## Validation checklist

- [x] `pnpm typecheck` — exit 0
- [x] Targeted `vitest run` on the five files above — 47/47 passing
- [x] `pnpm guard:source-file-size` — passing (no baseline change needed)
- [x] Branched from and rebased on current `dev`

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely. Full context: Discord thread, Aug 30. Review questions are welcome; answers will come from the same Claude-assisted workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Team launch validation failures now return clear 422 responses with actionable details.
  * Unexpected launch errors continue to return generic 500 responses, protecting internal error details.
  * Improved validation for unsupported team configurations, model selections, effort settings, runtime planning, and member limits.
  * Correctly handles launch commands with a trailing settings flag.

* **Tests**
  * Added coverage for launch error responses, runtime planning failures, and provisioning validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->