### PR TITLE
fix(team): give the create-mode lead the authoritative roster

### DIFF
--- a/src/main/services/team/provisioning/TeamProvisioningCreateDeterministicSpawnFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningCreateDeterministicSpawnFlow.ts
@@ -32,6 +32,7 @@ import { applyAppManagedRuntimeSettingsPathEnv } from './TeamProvisioningEnvGuar
 import { mergeProvisioningWarnings } from './TeamProvisioningLaunchCompatibility';
 import { emitProvisioningCheckpoint } from './TeamProvisioningProgressBuffers';
 import { extractCliLogsFromRun } from './TeamProvisioningRetainedLogs';
+import { buildCreateBootstrapUserPrompt } from './TeamProvisioningRosterPrompt';
 import {
   buildRuntimeLaunchWarning,
   getPromptSizeSummary,
@@ -353,7 +354,13 @@ export async function runDeterministicCreateSpawnFlow<
   logger,
   ports,
 }: RunDeterministicCreateSpawnFlowInput<TRun>): Promise<{ runId: string }> {
-  const initialUserPrompt = request.prompt?.trim() ?? '';
+  // Create-mode delivers this deferred prompt before any teammate confirms
+  // bootstrap; the roster wrap keeps the lead from inventing teammate names
+  // or executing teammates' work while they are still joining.
+  const initialUserPrompt = buildCreateBootstrapUserPrompt(
+    request.prompt ?? '',
+    allEffectiveMemberSpecs
+  );
   const promptSize = getPromptSizeSummary(initialUserPrompt);
   let child: SpawnedChild;
   shellEnv.CLAUDE_ENABLE_DETERMINISTIC_TEAM_BOOTSTRAP = '1';

--- a/src/main/services/team/provisioning/TeamProvisioningPromptBuilders.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningPromptBuilders.ts
@@ -38,6 +38,9 @@ import type {
   TeamTask,
 } from '@shared/types';
 
+// Re-exported for backwards compatibility: these roster helpers used to live here.
+export { buildCompactMembersRoster, buildMembersPrompt } from './TeamProvisioningRosterPrompt';
+
 const { protocols } = agentTeamsControllerModule;
 
 export interface TeamProvisioningHydrationRun {

--- a/src/main/services/team/provisioning/TeamProvisioningPromptBuilders.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningPromptBuilders.ts
@@ -20,6 +20,14 @@ import { buildActionModeProtocol } from '../actionModeInstructions';
 import { normalizeLaunchFailureReasonText } from '../TeamLaunchStateEvaluator';
 
 import { getAgentLanguageInstruction } from './TeamProvisioningAgentLanguage';
+import {
+  buildCompactMembersRoster,
+  buildLeadRosterIntegrityRules,
+  buildMembersPrompt,
+  formatWorkflowBlock,
+  getTeammateRosterMembers,
+  indentMultiline,
+} from './TeamProvisioningRosterPrompt';
 
 import type { RuntimeBootstrapMemberMcpLaunchConfig } from './TeamProvisioningBootstrapSpec';
 import type {
@@ -123,49 +131,6 @@ export function getVisibleTaskReferenceFormattingRule(): string {
 
 /** @deprecated Use wrapAgentBlock from @shared/constants/agentBlocks instead. */
 const wrapInAgentBlock = wrapAgentBlock;
-
-function indentMultiline(text: string, indent: string): string {
-  return text
-    .split(/\r?\n/g)
-    .map((line) => `${indent}${line}`)
-    .join('\n');
-}
-
-function formatWorkflowBlock(workflow: string, indent: string): string {
-  const trimmed = workflow.trim();
-  if (trimmed.length === 0) return '';
-  const body = indentMultiline(trimmed, indent);
-  return `\n${indent}---BEGIN WORKFLOW---\n${body}\n${indent}---END WORKFLOW---`;
-}
-
-export function buildMembersPrompt(members: TeamCreateRequest['members']): string {
-  return members
-    .map((member) => {
-      const rolePart = member.role?.trim() ? ` (role: ${member.role.trim()})` : '';
-      const providerPart =
-        member.providerId && member.providerId !== 'anthropic'
-          ? ` [provider: ${member.providerId}]`
-          : '';
-      const modelPart = member.model?.trim() ? ` [model: ${member.model.trim()}]` : '';
-      const effortPart = member.effort ? ` [effort: ${member.effort}]` : '';
-      const isolationPart = member.isolation === 'worktree' ? ' [isolation: worktree]' : '';
-      const workflowPart = member.workflow?.trim()
-        ? `\n     Workflow/instructions:${formatWorkflowBlock(member.workflow, '       ')}`
-        : '';
-      return `- ${member.name}${rolePart}${providerPart}${modelPart}${effortPart}${isolationPart}${workflowPart}`;
-    })
-    .join('\n');
-}
-
-/** Compact roster: name + role only, no workflow details. Used for post-compact reminders. */
-export function buildCompactMembersRoster(members: TeamCreateRequest['members']): string {
-  return members
-    .map((member) => {
-      const rolePart = member.role?.trim() ? ` (${member.role.trim()})` : '';
-      return `- ${member.name}${rolePart}`;
-    })
-    .join('\n');
-}
 
 export function buildTeammateAgentBlockReminder(): string {
   return [
@@ -906,6 +871,11 @@ export function buildPersistentLeadContext(opts: {
   const membersFooter = membersBlock
     ? `Members:\n${membersBlock}`
     : 'Members: (none — solo team lead)';
+  const teammateRoster = getTeammateRosterMembers(members);
+  const rosterRulesBlock =
+    teammateRoster.length > 0
+      ? `\n\n${buildLeadRosterIntegrityRules(teammateRoster.map((member) => member.name))}`
+      : '';
 
   return `${languageInstruction}
 
@@ -973,7 +943,7 @@ Message formatting:
 ${getVisibleTaskReferenceFormattingRule()}
 ${agentBlockPolicy}
 
-${membersFooter}`;
+${membersFooter}${rosterRulesBlock}`;
 }
 
 export function buildAgentBlockUsagePolicy(): string {

--- a/src/main/services/team/provisioning/TeamProvisioningRosterPrompt.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningRosterPrompt.ts
@@ -1,0 +1,91 @@
+import type { TeamCreateRequest } from '@shared/types';
+
+export function indentMultiline(text: string, indent: string): string {
+  return text
+    .split(/\r?\n/g)
+    .map((line) => `${indent}${line}`)
+    .join('\n');
+}
+
+export function formatWorkflowBlock(workflow: string, indent: string): string {
+  const trimmed = workflow.trim();
+  if (trimmed.length === 0) return '';
+  const body = indentMultiline(trimmed, indent);
+  return `\n${indent}---BEGIN WORKFLOW---\n${body}\n${indent}---END WORKFLOW---`;
+}
+
+export function buildMembersPrompt(members: TeamCreateRequest['members']): string {
+  return members
+    .map((member) => {
+      const rolePart = member.role?.trim() ? ` (role: ${member.role.trim()})` : '';
+      const providerPart =
+        member.providerId && member.providerId !== 'anthropic'
+          ? ` [provider: ${member.providerId}]`
+          : '';
+      const modelPart = member.model?.trim() ? ` [model: ${member.model.trim()}]` : '';
+      const effortPart = member.effort ? ` [effort: ${member.effort}]` : '';
+      const isolationPart = member.isolation === 'worktree' ? ' [isolation: worktree]' : '';
+      const workflowPart = member.workflow?.trim()
+        ? `\n     Workflow/instructions:${formatWorkflowBlock(member.workflow, '       ')}`
+        : '';
+      return `- ${member.name}${rolePart}${providerPart}${modelPart}${effortPart}${isolationPart}${workflowPart}`;
+    })
+    .join('\n');
+}
+
+/** Compact roster: name + role only, no workflow details. Used for post-compact reminders. */
+export function buildCompactMembersRoster(members: TeamCreateRequest['members']): string {
+  return members
+    .map((member) => {
+      const rolePart = member.role?.trim() ? ` (${member.role.trim()})` : '';
+      return `- ${member.name}${rolePart}`;
+    })
+    .join('\n');
+}
+
+function isLeadRosterMember(member: TeamCreateRequest['members'][number]): boolean {
+  return Boolean(member.role?.toLowerCase().includes('lead'));
+}
+
+/** Roster entries the lead may delegate to — every configured member except the lead itself. */
+export function getTeammateRosterMembers(
+  members: TeamCreateRequest['members']
+): TeamCreateRequest['members'] {
+  return members.filter((member) => !isLeadRosterMember(member));
+}
+
+export function buildLeadRosterIntegrityRules(teammateNames: readonly string[]): string {
+  const names = teammateNames.join(', ');
+  return [
+    `Teammate roster rules (CRITICAL — exact names only):`,
+    `- Your teammates are EXACTLY: ${names}. No other teammate exists.`,
+    `- NEVER invent, guess, rename, or paraphrase teammate names (no placeholders like "alice"/"bob"). Use these exact names in task owners, SendMessage \`to\`, and Agent spawns.`,
+    `- "One per teammate" / "each teammate" in instructions means exactly this roster — one item per listed name, nothing more.`,
+    `- Do NOT do work meant for a teammate before that teammate is available. If a teammate has not joined or confirmed bootstrap yet, create the task, assign it to the exact roster name, and WAIT for the owner to do it — never produce their deliverable yourself.`,
+  ].join('\n');
+}
+
+// Create-mode launches deliver the deferred first user prompt before any
+// teammate confirms bootstrap, so the authoritative roster must ride along
+// with it — otherwise the lead has no teammate names in-context and may
+// invent teammates or execute their work itself.
+export function buildCreateBootstrapUserPrompt(
+  initialUserPrompt: string,
+  members: TeamCreateRequest['members']
+): string {
+  const trimmedPrompt = initialUserPrompt.trim();
+  const teammates = getTeammateRosterMembers(members);
+  if (!trimmedPrompt || teammates.length === 0) {
+    return trimmedPrompt;
+  }
+  const roster = buildMembersPrompt(teammates.map(({ workflow: _workflow, ...member }) => member));
+  return [
+    'Team roster (authoritative — from the team configuration):',
+    roster,
+    '',
+    buildLeadRosterIntegrityRules(teammates.map((member) => member.name)),
+    '',
+    'User instructions:',
+    trimmedPrompt,
+  ].join('\n');
+}

--- a/src/main/services/team/provisioning/TeamProvisioningRosterPrompt.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningRosterPrompt.ts
@@ -1,3 +1,5 @@
+import { isLeadMember, isReservedLeadRole } from '@shared/utils/leadDetection';
+
 import type { TeamCreateRequest } from '@shared/types';
 
 export function indentMultiline(text: string, indent: string): string {
@@ -43,8 +45,14 @@ export function buildCompactMembersRoster(members: TeamCreateRequest['members'])
     .join('\n');
 }
 
+// Canonical lead detection only — a free-form teammate role such as
+// "Frontend lead" or "Tech lead" is a normal delegable teammate and must stay
+// in the roster. Only the runtime-owned lead identity (lead agentType, the
+// "team-lead" name, or a role reserved for the lead) is filtered out.
 function isLeadRosterMember(member: TeamCreateRequest['members'][number]): boolean {
-  return Boolean(member.role?.toLowerCase().includes('lead'));
+  if (isLeadMember(member)) return true;
+  const role = member.role?.trim() ?? '';
+  return role.length > 0 && isReservedLeadRole(role);
 }
 
 /** Roster entries the lead may delegate to — every configured member except the lead itself. */

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningRosterPrompt.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningRosterPrompt.test.ts
@@ -34,6 +34,34 @@ describe('getTeammateRosterMembers', () => {
       'cursor-worker',
     ]);
   });
+
+  it('keeps teammates whose free-form role merely contains "lead"', () => {
+    const roster: TeamCreateRequest['members'] = [
+      { name: 'team-lead', role: 'lead' },
+      { name: 'ana', role: 'Frontend lead' },
+      { name: 'ben', role: 'Tech Lead' },
+      { name: 'cleo', role: 'team leader' },
+      { name: 'dan', role: 'leadership coach' },
+    ];
+
+    expect(getTeammateRosterMembers(roster).map((member) => member.name)).toEqual([
+      'ana',
+      'ben',
+      'cleo',
+      'dan',
+    ]);
+  });
+
+  it('still excludes the lead by reserved role or canonical name', () => {
+    const roster: TeamCreateRequest['members'] = [
+      { name: 'ana', role: 'Frontend lead' },
+      { name: 'team-lead', role: 'Frontend lead' },
+      { name: 'orchestra', role: 'orchestrator' },
+      { name: 'boss', role: 'Team Lead' },
+    ];
+
+    expect(getTeammateRosterMembers(roster).map((member) => member.name)).toEqual(['ana']);
+  });
 });
 
 describe('buildLeadRosterIntegrityRules', () => {
@@ -75,6 +103,20 @@ describe('buildCreateBootstrapUserPrompt', () => {
 
     expect(wrapped).toContain('Your teammates are EXACTLY: local-worker, cursor-worker.');
     expect(wrapped).not.toContain('EXACTLY: team-lead');
+    expect(wrapped).not.toContain('- team-lead (role: lead)');
+  });
+
+  it('keeps a teammate whose role contains "lead" in the authoritative roster', () => {
+    const wrapped = buildCreateBootstrapUserPrompt('do the thing', [
+      { name: 'team-lead', role: 'lead' },
+      { name: 'ana', role: 'Frontend lead' },
+      ...teammates,
+    ]);
+
+    expect(wrapped).toContain('- ana (role: Frontend lead)');
+    expect(wrapped).toContain(
+      'Your teammates are EXACTLY: ana, local-worker, cursor-worker. No other teammate exists.'
+    );
     expect(wrapped).not.toContain('- team-lead (role: lead)');
   });
 

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningRosterPrompt.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningRosterPrompt.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildDeterministicLaunchHydrationPrompt,
+  buildPersistentLeadContext,
+} from '../TeamProvisioningPromptBuilders';
+import {
+  buildCreateBootstrapUserPrompt,
+  buildLeadRosterIntegrityRules,
+  getTeammateRosterMembers,
+} from '../TeamProvisioningRosterPrompt';
+
+import type { TeamCreateRequest, TeamLaunchRequest } from '@shared/types';
+
+vi.mock('../TeamProvisioningAgentLanguage', () => ({
+  getAgentLanguageInstruction: () => 'IMPORTANT: Communicate in English.',
+  getConfiguredAgentLanguageName: () => 'English',
+}));
+
+const teammates: TeamCreateRequest['members'] = [
+  { name: 'local-worker', role: 'implementer' },
+  { name: 'cursor-worker', role: 'reviewer', providerId: 'opencode' },
+];
+
+const rosterWithLead: TeamCreateRequest['members'] = [
+  { name: 'team-lead', role: 'lead' },
+  ...teammates,
+];
+
+describe('getTeammateRosterMembers', () => {
+  it('filters lead-role entries out of the delegable roster', () => {
+    expect(getTeammateRosterMembers(rosterWithLead).map((member) => member.name)).toEqual([
+      'local-worker',
+      'cursor-worker',
+    ]);
+  });
+});
+
+describe('buildLeadRosterIntegrityRules', () => {
+  it('names the exact roster and forbids invented names and premature lead execution', () => {
+    const rules = buildLeadRosterIntegrityRules(['local-worker', 'cursor-worker']);
+
+    expect(rules).toContain('Teammate roster rules (CRITICAL — exact names only):');
+    expect(rules).toContain(
+      'Your teammates are EXACTLY: local-worker, cursor-worker. No other teammate exists.'
+    );
+    expect(rules).toContain('NEVER invent, guess, rename, or paraphrase teammate names');
+    expect(rules).toContain('WAIT for the owner');
+  });
+});
+
+describe('buildCreateBootstrapUserPrompt', () => {
+  it('wraps the deferred create prompt with the roster and integrity rules', () => {
+    const wrapped = buildCreateBootstrapUserPrompt(
+      'create one task per teammate: each writes hello-<their-name>.md',
+      teammates
+    );
+
+    expect(wrapped).toContain('Team roster (authoritative — from the team configuration):');
+    expect(wrapped).toContain('- local-worker (role: implementer)');
+    expect(wrapped).toContain('- cursor-worker (role: reviewer) [provider: opencode]');
+    expect(wrapped).toContain(
+      'Your teammates are EXACTLY: local-worker, cursor-worker. No other teammate exists.'
+    );
+    expect(wrapped).toContain('NEVER invent, guess, rename, or paraphrase teammate names');
+    expect(
+      wrapped.endsWith(
+        'User instructions:\ncreate one task per teammate: each writes hello-<their-name>.md'
+      )
+    ).toBe(true);
+  });
+
+  it('excludes the lead entry from the roster and the EXACTLY list', () => {
+    const wrapped = buildCreateBootstrapUserPrompt('do the thing', rosterWithLead);
+
+    expect(wrapped).toContain('Your teammates are EXACTLY: local-worker, cursor-worker.');
+    expect(wrapped).not.toContain('EXACTLY: team-lead');
+    expect(wrapped).not.toContain('- team-lead (role: lead)');
+  });
+
+  it('passes the prompt through untouched when there are no teammates', () => {
+    expect(buildCreateBootstrapUserPrompt('  solo work  ', [])).toBe('solo work');
+    expect(buildCreateBootstrapUserPrompt('lead only', [{ name: 'team-lead', role: 'lead' }])).toBe(
+      'lead only'
+    );
+  });
+
+  it('stays empty for an empty prompt so create mode skips the deferred prompt file', () => {
+    expect(buildCreateBootstrapUserPrompt('', teammates)).toBe('');
+    expect(buildCreateBootstrapUserPrompt('   ', teammates)).toBe('');
+  });
+});
+
+describe('lead launch prompts include the teammate roster rules', () => {
+  it('puts exact teammate names and the integrity rules into the launch hydration prompt', () => {
+    const request = {
+      teamName: 'matrix-team',
+      cwd: '/repo',
+      prompt: 'resume the campaign',
+    } as TeamLaunchRequest;
+
+    const prompt = buildDeterministicLaunchHydrationPrompt(request, rosterWithLead, [], false);
+
+    expect(prompt).toContain('- local-worker (role: implementer)');
+    expect(prompt).toContain('- cursor-worker (role: reviewer) [provider: opencode]');
+    expect(prompt).toContain(
+      'Your teammates are EXACTLY: local-worker, cursor-worker. No other teammate exists.'
+    );
+    expect(prompt).toContain('NEVER invent, guess, rename, or paraphrase teammate names');
+    expect(prompt).not.toContain('EXACTLY: team-lead');
+  });
+
+  it('keeps the integrity rules in the compact post-compact persistent context', () => {
+    const context = buildPersistentLeadContext({
+      teamName: 'matrix-team',
+      leadName: 'team-lead',
+      isSolo: false,
+      members: teammates,
+      compact: true,
+    });
+
+    expect(context).toContain('- local-worker (implementer)');
+    expect(context).toContain(
+      'Your teammates are EXACTLY: local-worker, cursor-worker. No other teammate exists.'
+    );
+  });
+
+  it('omits the roster rules for a solo lead with no teammates', () => {
+    const context = buildPersistentLeadContext({
+      teamName: 'matrix-team',
+      leadName: 'team-lead',
+      isSolo: true,
+      members: [],
+    });
+
+    expect(context).not.toContain('Teammate roster rules');
+  });
+});


### PR DESCRIPTION
## Problem

Create a team with, say, `local-worker` and `cursor-worker`, and give it a first prompt like *"create one task per teammate: each writes hello-&lt;their-name&gt;.md"*. The lead frequently creates tasks for teammates that do not exist — `alice`, `bob`, `engineer-1` — and then writes the files itself instead of waiting for the real teammates.

The root cause is an asymmetry between how the lead is briefed on the two entry paths:

* **Launch / resume hydration** goes through `buildPersistentLeadContext`, which ends with a `Members:` block built from `buildMembersPrompt(members)`. The lead sees the real roster.
* **Create mode** defers the user's first prompt and delivers it separately, at the very start of `runDeterministicCreateSpawnFlow`:

  ```ts
  const initialUserPrompt = request.prompt?.trim() ?? '';
  ```

  That bare string is everything the lead has at that moment. This line is unchanged since 785c16d21 (`refactor(team): reapply team provisioning round2`).

The timing makes it worse: the deferred create prompt is delivered **before any teammate has confirmed bootstrap**. So the lead is asked to delegate at the exact moment when (a) it has no teammate names in context and (b) nobody is available to delegate to. Both failure modes follow directly — the model fills the gap with plausible names, and, seeing no available owners, does the work itself.

Because the invented names are then written into task owners and `SendMessage` targets, the damage outlives the first turn: tasks are owned by nobody, DMs go nowhere, and the real teammates sit idle once they do join.

## Fix

* **The deferred create prompt now carries the roster.** `buildCreateBootstrapUserPrompt(prompt, members)` wraps the user's text with an authoritative roster block (from the team configuration, lead excluded, workflow bodies stripped to keep it compact) followed by short integrity rules:
  * teammates are **exactly** these names, no other teammate exists;
  * never invent, guess, rename or paraphrase teammate names — use the exact names in task owners, `SendMessage` `to`, and agent spawns;
  * "one per teammate" means exactly this roster;
  * do **not** do a teammate's work before that teammate is available — create the task, assign it to the exact roster name, and wait for the owner.
* **The same rules are appended to `buildPersistentLeadContext`**, so launch hydration and post-compact recovery reinforce them rather than only the create path having them. A solo lead (no teammates) gets no roster-rules block.
* **Degenerate cases pass through untouched:** an empty prompt stays empty so create mode still skips writing a deferred prompt file, and a team with no teammates gets the raw prompt.
* The roster formatting helpers (`indentMultiline`, `formatWorkflowBlock`, `buildMembersPrompt`, `buildCompactMembersRoster`) move out of `TeamProvisioningPromptBuilders.ts` into a focused `TeamProvisioningRosterPrompt.ts`, joined by `getTeammateRosterMembers` and `buildLeadRosterIntegrityRules`. Both callers now build the roster through one module instead of two copies drifting apart, and `TeamProvisioningPromptBuilders.ts` drops below its frozen size cap in the process.

This is prompt-level guidance, not an enforcement mechanism — it does not stop a model from misbehaving, it removes the information gap that was causing it.

## Tests

New `src/main/services/team/provisioning/__tests__/TeamProvisioningRosterPrompt.test.ts` (9 tests):

* `getTeammateRosterMembers` filters lead-role entries out of the delegable roster.
* `buildLeadRosterIntegrityRules` names the exact roster and contains the "never invent" and "wait for the owner" rules.
* `buildCreateBootstrapUserPrompt` wraps the deferred prompt with the roster and rules; excludes the lead from both the roster and the EXACTLY list; passes the prompt through untouched when there are no teammates; stays empty for an empty prompt so create mode still skips the deferred prompt file.
* `buildDeterministicLaunchHydrationPrompt` / `buildPersistentLeadContext` carry the exact teammate names and the integrity rules, keep them in the compact post-compact context, and omit the roster-rules block for a solo lead.

Existing suites re-run green: `TeamProvisioningCreateDeterministicSpawnFlow.test.ts` (16), `TeamProvisioningCreateDeterministicRunFlow.test.ts` (4), `TeamProvisioningIdlePromptInjection.test.ts` (5), `TeamProvisioningPromptBuilders.test.ts` (5), `TeamProvisioningLaunchFailurePolicy.test.ts` (6) — 45 tests total.

## Tested on

Windows 11 (Electron dev build).

* Reproduced and verified with **mixed teams**: a **Cursor/opencode** lead with **local models via opencode** teammates (the configuration where the fabricated-name behavior was most reliable), and with an **Anthropic (API key)** lead. Ran the exact "one task per teammate" prompt before and after: before, invented owners and lead-authored files; after, one task per real roster name with the lead waiting for bootstrap.
* Also smoke-checked create mode with **Codex (ChatGPT)** and **Anthropic (OAuth)** leads to confirm the wrapped prompt does not disturb normal single-instruction runs.
* Not exercised: **Gemini**, macOS and Linux. The change is prompt text plus roster filtering, with no provider-specific branching.

## References

* #113 — lead invents teammate names and does teammates' work on the first create-mode prompt
* #439 — partially: the lead acting before teammates are available

## Validation checklist

- [x] `pnpm typecheck` — exit 0
- [x] Targeted vitest files — 45 tests passing
- [x] `pnpm guard:source-file-size` — passes (`TeamProvisioningPromptBuilders.ts` drops 1160 -> 1130, under its frozen cap; the new module is 91 lines; the baseline file is deliberately left untouched so this PR does not conflict with the others in this batch)
- [x] `pnpm guard:team-provisioning-architecture` — passes
- [x] `pnpm exec eslint` on touched files — 0 errors
- [x] `pnpm exec prettier --check` on touched files — clean

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely. Full context: Discord thread, Aug 30. Review questions are welcome; answers will come from the same Claude-assisted workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved team setup prompts with clearer teammate rosters, roles, models, and workflows.
  * Added safeguards to prevent invented teammate names and duplicated work during team startup.
  * Preserved the original request while providing richer context during setup and ongoing interactions.
  * Improved handling of lead and teammate roles for more accurate roster assignments.

* **Bug Fixes**
  * Improved roster consistency across initial setup and persistent team context.

* **Tests**
  * Added coverage for roster filtering, prompt generation, edge cases, and solo-team behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->