### PR TITLE
fix(codex): stop the ChatGPT refresh-token revocation loop

### DIFF
--- a/src/features/codex-account/main/composition/codexSnapshotRefreshOptions.ts
+++ b/src/features/codex-account/main/composition/codexSnapshotRefreshOptions.ts
@@ -1,0 +1,75 @@
+// Pure refresh-option policy for the codex account snapshot pipeline: normalization, batch
+// merging, and the forced token refresh reuse window. Kept free of runtime dependencies.
+
+export interface CodexSnapshotRefreshOptions {
+  includeRateLimits: boolean;
+  forceRefreshToken: boolean;
+}
+
+// Every forceRefreshToken read rotates the ChatGPT refresh token inside its own
+// `codex app-server` process, and one launch preparation issues several such reads
+// sequentially. Rotating the token multiple times within seconds risks OpenAI's
+// refresh_token_reused revocation, so a forced call inside this window of the last completed
+// forced rotation is downgraded to a regular read that reuses that rotation's result. A forced
+// call after the window rotates again; explicit login/logout resets the window.
+const FORCED_TOKEN_REFRESH_REUSE_WINDOW_MS = 30_000;
+
+export function normalizeRefreshOptions(options?: {
+  includeRateLimits?: boolean;
+  forceRefreshToken?: boolean;
+}): CodexSnapshotRefreshOptions {
+  return {
+    includeRateLimits: options?.includeRateLimits === true,
+    forceRefreshToken: options?.forceRefreshToken === true,
+  };
+}
+
+export function mergeRefreshOptions(
+  current: CodexSnapshotRefreshOptions | null,
+  next: CodexSnapshotRefreshOptions
+): CodexSnapshotRefreshOptions {
+  if (!current) {
+    return next;
+  }
+
+  return {
+    includeRateLimits: current.includeRateLimits || next.includeRateLimits,
+    forceRefreshToken: current.forceRefreshToken || next.forceRefreshToken,
+  };
+}
+
+export function doRefreshOptionsCover(
+  current: CodexSnapshotRefreshOptions | null,
+  requested: CodexSnapshotRefreshOptions
+): boolean {
+  return Boolean(
+    current &&
+    (!requested.includeRateLimits || current.includeRateLimits) &&
+    (!requested.forceRefreshToken || current.forceRefreshToken)
+  );
+}
+
+function isInsideForcedTokenRefreshReuseWindow(
+  lastForcedTokenRefreshAtMs: number,
+  now: number
+): boolean {
+  return (
+    lastForcedTokenRefreshAtMs > 0 &&
+    now - lastForcedTokenRefreshAtMs <= FORCED_TOKEN_REFRESH_REUSE_WINDOW_MS
+  );
+}
+
+export function applyForcedTokenRefreshReuseWindow(
+  options: CodexSnapshotRefreshOptions,
+  lastForcedTokenRefreshAtMs: number,
+  now: number
+): CodexSnapshotRefreshOptions {
+  if (
+    !options.forceRefreshToken ||
+    !isInsideForcedTokenRefreshReuseWindow(lastForcedTokenRefreshAtMs, now)
+  ) {
+    return options;
+  }
+
+  return { ...options, forceRefreshToken: false };
+}

--- a/src/features/codex-account/main/composition/createCodexAccountFeature.ts
+++ b/src/features/codex-account/main/composition/createCodexAccountFeature.ts
@@ -387,8 +387,18 @@ class CodexAccountFeatureFacadeImpl implements CodexAccountFeatureFacade {
       }
 
       const env = this.envBuilder.buildControlPlaneEnv({ binaryPath });
-      this.lastForcedTokenRefreshAtMs = 0;
-      await this.loginSessionManager.start({ binaryPath, env, mode: options?.mode });
+      // Only a login that this call actually owns invalidates the forced-rotation reuse
+      // window. A duplicate request (a second click while a login is starting or pending)
+      // is a no-op inside the manager and leaves the credentials untouched, so clearing
+      // the window for it would spend an extra refresh-token rotation on nothing.
+      const started = await this.loginSessionManager.start({
+        binaryPath,
+        env,
+        mode: options?.mode,
+      });
+      if (started) {
+        this.lastForcedTokenRefreshAtMs = 0;
+      }
     });
 
     if (binaryMissing) {

--- a/src/features/codex-account/main/composition/createCodexAccountFeature.ts
+++ b/src/features/codex-account/main/composition/createCodexAccountFeature.ts
@@ -33,6 +33,14 @@ import {
   ensureCodexLegacyAuthFromActiveAccount,
 } from '../infrastructure/detectCodexLocalAccountArtifacts';
 
+import {
+  applyForcedTokenRefreshReuseWindow,
+  type CodexSnapshotRefreshOptions,
+  doRefreshOptionsCover,
+  mergeRefreshOptions,
+  normalizeRefreshOptions,
+} from './codexSnapshotRefreshOptions';
+
 import type { Logger } from '@shared/utils/logger';
 import type { BrowserWindow } from 'electron';
 
@@ -65,11 +73,6 @@ interface CodexRuntimeContext {
 interface CodexLastKnownRuntimeContext {
   payload: CodexRuntimeContext;
   observedAt: number;
-}
-
-interface CodexSnapshotRefreshOptions {
-  includeRateLimits: boolean;
-  forceRefreshToken: boolean;
 }
 
 interface CodexSnapshotRefreshBatch {
@@ -223,41 +226,6 @@ function classifyAppServerFailure(error: unknown): {
   };
 }
 
-function normalizeRefreshOptions(options?: {
-  includeRateLimits?: boolean;
-  forceRefreshToken?: boolean;
-}): CodexSnapshotRefreshOptions {
-  return {
-    includeRateLimits: options?.includeRateLimits === true,
-    forceRefreshToken: options?.forceRefreshToken === true,
-  };
-}
-
-function mergeRefreshOptions(
-  current: CodexSnapshotRefreshOptions | null,
-  next: CodexSnapshotRefreshOptions
-): CodexSnapshotRefreshOptions {
-  if (!current) {
-    return next;
-  }
-
-  return {
-    includeRateLimits: current.includeRateLimits || next.includeRateLimits,
-    forceRefreshToken: current.forceRefreshToken || next.forceRefreshToken,
-  };
-}
-
-function doRefreshOptionsCover(
-  current: CodexSnapshotRefreshOptions | null,
-  requested: CodexSnapshotRefreshOptions
-): boolean {
-  return Boolean(
-    current &&
-    (!requested.includeRateLimits || current.includeRateLimits) &&
-    (!requested.forceRefreshToken || current.forceRefreshToken)
-  );
-}
-
 async function resolveCodexBinaryForAccountSnapshot(): Promise<string | null> {
   const binaryPath = await CodexBinaryResolver.resolve();
   if (binaryPath) {
@@ -306,6 +274,7 @@ class CodexAccountFeatureFacadeImpl implements CodexAccountFeatureFacade {
   private lastKnownAccount: CodexLastKnownAccount | null = null;
   private lastKnownRateLimits: CodexLastKnownRateLimits | null = null;
   private lastKnownRuntimeContext: CodexLastKnownRuntimeContext | null = null;
+  private lastForcedTokenRefreshAtMs = 0;
   private queuedMutationCount = 0;
   private activeMutationCount = 0;
   private disposed = false;
@@ -350,7 +319,11 @@ class CodexAccountFeatureFacadeImpl implements CodexAccountFeatureFacade {
     forceRefreshToken?: boolean;
   }): Promise<CodexAccountSnapshotDto> {
     this.ensureActive();
-    const normalizedOptions = normalizeRefreshOptions(options);
+    const normalizedOptions = applyForcedTokenRefreshReuseWindow(
+      normalizeRefreshOptions(options),
+      this.lastForcedTokenRefreshAtMs,
+      Date.now()
+    );
     if (this.refreshBatch?.acceptingRequests) {
       if (
         doRefreshOptionsCover(this.refreshBatch.initialOptions, normalizedOptions) ||
@@ -414,6 +387,7 @@ class CodexAccountFeatureFacadeImpl implements CodexAccountFeatureFacade {
       }
 
       const env = this.envBuilder.buildControlPlaneEnv({ binaryPath });
+      this.lastForcedTokenRefreshAtMs = 0;
       await this.loginSessionManager.start({ binaryPath, env, mode: options?.mode });
     });
 
@@ -445,6 +419,7 @@ class CodexAccountFeatureFacadeImpl implements CodexAccountFeatureFacade {
       await this.appServerClient.logout({ binaryPath, env });
       this.lastKnownAccount = null;
       this.lastKnownRateLimits = null;
+      this.lastForcedTokenRefreshAtMs = 0;
       await this.publishLoggedOutSnapshot();
     });
 
@@ -491,6 +466,7 @@ class CodexAccountFeatureFacadeImpl implements CodexAccountFeatureFacade {
     this.lastKnownAccount = null;
     this.lastKnownRateLimits = null;
     this.lastKnownRuntimeContext = null;
+    this.lastForcedTokenRefreshAtMs = 0;
     this.lastPublishedSnapshotUpdatedAtMs = 0;
     this.queuedMutationCount = 0;
     this.activeMutationCount = 0;
@@ -505,9 +481,17 @@ class CodexAccountFeatureFacadeImpl implements CodexAccountFeatureFacade {
 
     while (nextOptions) {
       this.ensureActive();
-      batch.activeOptions = nextOptions;
+      // Queued forced options may have waited behind a rotation that just completed, so the
+      // reuse-window downgrade is re-evaluated per drained iteration.
+      const effectiveOptions = applyForcedTokenRefreshReuseWindow(
+        nextOptions,
+        this.lastForcedTokenRefreshAtMs,
+        Date.now()
+      );
+      batch.activeOptions = effectiveOptions;
       lastSnapshot =
-        this.getCachedSnapshotForOptions(nextOptions) ?? (await this.loadSnapshot(nextOptions));
+        this.getCachedSnapshotForOptions(effectiveOptions) ??
+        (await this.loadSnapshot(effectiveOptions));
       batch.activeOptions = null;
       nextOptions = batch.pendingOptions;
       batch.pendingOptions = null;
@@ -630,6 +614,9 @@ class CodexAccountFeatureFacadeImpl implements CodexAccountFeatureFacade {
         refreshToken: options?.forceRefreshToken ?? false,
         includeRateLimits: shouldRequestRateLimits,
       });
+      if (options?.forceRefreshToken === true) {
+        this.lastForcedTokenRefreshAtMs = Date.now();
+      }
       runtimeContext = createRuntimeContext(binaryPath, accountResult.initialize.codexHome);
       if (runtimeContext.codexHome) {
         this.lastKnownRuntimeContext = {

--- a/src/features/codex-account/main/infrastructure/CodexLoginSessionManager.ts
+++ b/src/features/codex-account/main/infrastructure/CodexLoginSessionManager.ts
@@ -59,13 +59,20 @@ export class CodexLoginSessionManager {
     return structuredClone(this.state);
   }
 
+  /**
+   * Begins a ChatGPT login. Resolves to `false` when the call is a no-op because a login
+   * is already starting or pending, and `true` when this call took ownership of the
+   * attempt. Callers that reset login-scoped state must key off the return value: a
+   * duplicate request changes no credentials, so treating it as a real login would clear
+   * state that nothing has invalidated.
+   */
   async start(options: {
     binaryPath: string;
     env: NodeJS.ProcessEnv;
     mode?: CodexChatgptLoginMode;
-  }): Promise<void> {
+  }): Promise<boolean> {
     if (this.activeSession || this.pendingStartToken) {
-      return;
+      return false;
     }
 
     const startToken = Symbol('codex-login-start');
@@ -90,7 +97,7 @@ export class CodexLoginSessionManager {
 
       if (this.pendingStartToken !== startToken) {
         await session.close().catch(() => undefined);
-        return;
+        return true;
       }
 
       const requestedResponseType =
@@ -103,7 +110,7 @@ export class CodexLoginSessionManager {
 
       if (this.pendingStartToken !== startToken) {
         await session.close().catch(() => undefined);
-        return;
+        return true;
       }
 
       if (response.type !== requestedResponseType) {
@@ -154,6 +161,7 @@ export class CodexLoginSessionManager {
         authUrl: authUrl.toString(),
         userCode,
       });
+      return true;
     } catch (error) {
       const wasAbandonedDuringStart =
         this.pendingStartToken !== startToken &&
@@ -168,7 +176,7 @@ export class CodexLoginSessionManager {
         this.activeSession = null;
       }
       if (wasAbandonedDuringStart) {
-        return;
+        return true;
       }
       this.setState({
         status: 'failed',

--- a/src/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.ts
+++ b/src/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.ts
@@ -6,6 +6,13 @@ import path from 'path';
 const CODEX_ACCOUNTS_DIR = path.join(os.homedir(), '.codex', 'accounts');
 const LEGACY_AUTH_SYNC_MARKER_FILE = '.agent-teams-legacy-auth-sync.json';
 
+// Newer Codex CLIs keep auth in their own store (accounts/ registry, sqlite) and
+// never rewrite a leftover legacy ~/.codex/auth.json. Replaying the long-rotated
+// refresh_token from such a stale file trips OpenAI's reuse detection, which
+// revokes the entire token family — so a legacy auth.json only counts as an
+// active account while it is fresh. The stale file is ignored, never deleted.
+const LEGACY_AUTH_STALE_AFTER_MS = 14 * 24 * 60 * 60 * 1000;
+
 interface CodexAccountsRegistry {
   active_account_id?: string | null;
   active_account_key?: string | null;
@@ -16,6 +23,8 @@ interface CodexAccountsRegistry {
 interface CodexAuthFile {
   auth_mode?: string | null;
   authMode?: string | null;
+  last_refresh?: string | null;
+  lastRefresh?: string | null;
   tokens?: {
     refresh_token?: string | null;
     refreshToken?: string | null;
@@ -86,6 +95,26 @@ function hasChatgptRefreshToken(authFile: CodexAuthFile | null): boolean {
 
 async function readCodexAuthFile(filePath: string): Promise<CodexAuthFile | null> {
   return readJsonFile<CodexAuthFile>(filePath);
+}
+
+function getLastRefreshMs(authFile: CodexAuthFile | null): number | null {
+  const raw = authFile?.last_refresh ?? authFile?.lastRefresh ?? null;
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function isLegacyAuthFileFresh(
+  filePath: string,
+  authFile: CodexAuthFile | null
+): Promise<boolean> {
+  // The in-file last_refresh timestamp is authoritative when present; file mtime
+  // is the fallback. Unknown freshness counts as stale to avoid token-family
+  // revocation from a reused refresh_token.
+  const lastRefreshMs = getLastRefreshMs(authFile) ?? (await getMtimeMs(filePath));
+  return lastRefreshMs !== null && Date.now() - lastRefreshMs <= LEGACY_AUTH_STALE_AFTER_MS;
 }
 
 function getLegacyAuthFilePath(accountsDir: string): string {
@@ -162,14 +191,18 @@ export async function resolveCodexActiveChatgptAuthFile(
 
   if (!hasRegistry) {
     const legacyAuthFile = await readCodexAuthFile(legacyAuthFilePath);
-    return hasChatgptRefreshToken(legacyAuthFile)
-      ? {
-          codexHome,
-          authFilePath: legacyAuthFilePath,
-          source: 'legacy',
-          activeAccountKey: null,
-        }
-      : null;
+    if (!hasChatgptRefreshToken(legacyAuthFile)) {
+      return null;
+    }
+    if (!(await isLegacyAuthFileFresh(legacyAuthFilePath, legacyAuthFile))) {
+      return null;
+    }
+    return {
+      codexHome,
+      authFilePath: legacyAuthFilePath,
+      source: 'legacy',
+      activeAccountKey: null,
+    };
   }
 
   const registry = await readJsonFile<CodexAccountsRegistry>(registryPath);

--- a/src/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.ts
+++ b/src/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.ts
@@ -114,7 +114,12 @@ async function isLegacyAuthFileFresh(
   // is the fallback. Unknown freshness counts as stale to avoid token-family
   // revocation from a reused refresh_token.
   const lastRefreshMs = getLastRefreshMs(authFile) ?? (await getMtimeMs(filePath));
-  return lastRefreshMs !== null && Date.now() - lastRefreshMs <= LEGACY_AUTH_STALE_AFTER_MS;
+  const now = Date.now();
+  return (
+    lastRefreshMs !== null &&
+    lastRefreshMs <= now &&
+    now - lastRefreshMs <= LEGACY_AUTH_STALE_AFTER_MS
+  );
 }
 
 function getLegacyAuthFilePath(accountsDir: string): string {

--- a/src/features/team-runtime-recovery/core/domain/RuntimeFailureClassifier.ts
+++ b/src/features/team-runtime-recovery/core/domain/RuntimeFailureClassifier.ts
@@ -39,6 +39,17 @@ const SENSITIVE_ASSIGNMENT_KEYS = new Set([
 const TRANSIENT_SERVER_STATUSES = new Set([500, 502, 503, 504, 529]);
 const TERMINAL_CLIENT_STATUSES = new Set([400, 404, 413, 422]);
 
+// Codex CLI stale-auth signatures: a reused/rotated refresh token or a missing
+// `codex login` is never fixed by re-running the same exec, so the delivery loop
+// must not retry it. Matched against the raw detail because the secret redactor
+// rewrites "token: <word>" sequences, which erases these markers from
+// normalizedDetail (e.g. "Failed to refresh token: ..." loses "token:").
+const CODEX_AUTH_FAILURE_MARKERS = [
+  'refresh_token_reused',
+  'failed to refresh token',
+  'codex_login',
+] as const;
+
 function containsAny(value: string, tokens: readonly string[]): boolean {
   return tokens.some((token) => value.includes(token));
 }
@@ -122,6 +133,7 @@ function result(
 export function classifyRuntimeFailure(signal: RuntimeFailureSignal): RuntimeFailureClassification {
   const normalizedDetail = normalizeRuntimeFailureDetail(signal.detail);
   const lower = normalizedDetail.toLowerCase();
+  const rawLower = signal.detail.toLowerCase();
   const statusCode = extractRuntimeFailureStatusCode(normalizedDetail, signal.statusCode);
   const providerCode = signal.providerCode?.trim().toLowerCase() ?? '';
   const retryAt = resolveRetryAt(signal);
@@ -159,7 +171,8 @@ export function classifyRuntimeFailure(signal: RuntimeFailureSignal): RuntimeFai
       'missing credential',
       'permission denied',
       'does not have access',
-    ])
+    ]) ||
+    containsAny(rawLower, CODEX_AUTH_FAILURE_MARKERS)
   ) {
     return result('auth_error', 'manual', normalizedDetail, {
       statusCode,

--- a/src/features/team-runtime-recovery/core/domain/RuntimeFailureClassifier.ts
+++ b/src/features/team-runtime-recovery/core/domain/RuntimeFailureClassifier.ts
@@ -38,17 +38,51 @@ const SENSITIVE_ASSIGNMENT_KEYS = new Set([
 
 const TRANSIENT_SERVER_STATUSES = new Set([500, 502, 503, 504, 529]);
 const TERMINAL_CLIENT_STATUSES = new Set([400, 404, 413, 422]);
+// Statuses that a later branch already turns into a retryable disposition. A refresh
+// failure carrying one of these is an outage of the refresh endpoint, not a dead grant.
+const TRANSIENT_RETRY_STATUSES = new Set([408, 409, 429, 500, 502, 503, 504, 529]);
+
+const NETWORK_FAILURE_MARKERS = [
+  'econnreset',
+  'epipe',
+  'etimedout',
+  'connection reset',
+  'connection refused',
+  'network error',
+  'fetch failed',
+  'unable to connect',
+  'connect failed',
+] as const;
+
+const PROVIDER_OVERLOAD_MARKERS = [
+  'overloaded_error',
+  'temporarily unavailable',
+  'service unavailable',
+] as const;
+
+const TRANSIENT_TRANSPORT_MARKERS = [
+  ...NETWORK_FAILURE_MARKERS,
+  ...PROVIDER_OVERLOAD_MARKERS,
+] as const;
 
 // Codex CLI stale-auth signatures: a reused/rotated refresh token or a missing
 // `codex login` is never fixed by re-running the same exec, so the delivery loop
 // must not retry it. Matched against the raw detail because the secret redactor
 // rewrites "token: <word>" sequences, which erases these markers from
 // normalizedDetail (e.g. "Failed to refresh token: ..." loses "token:").
-const CODEX_AUTH_FAILURE_MARKERS = [
+const CODEX_TERMINAL_AUTH_MARKERS = [
   'refresh_token_reused',
-  'failed to refresh token',
+  'invalid_grant',
   'codex_login',
 ] as const;
+
+// A bare "failed to refresh token" only reports that the refresh call did not
+// succeed; it does not say the grant is dead. Classifying it as terminal auth
+// regardless of cause strands the teammate with no recovery job whenever the
+// refresh endpoint has a transient outage (e.g. "Failed to refresh token: API
+// Error: 503"), so it counts as auth failure only when nothing else in the signal
+// points at a retryable transport problem.
+const CODEX_REFRESH_FAILURE_MARKERS = ['failed to refresh token'] as const;
 
 function containsAny(value: string, tokens: readonly string[]): boolean {
   return tokens.some((token) => value.includes(token));
@@ -134,9 +168,21 @@ export function classifyRuntimeFailure(signal: RuntimeFailureSignal): RuntimeFai
   const normalizedDetail = normalizeRuntimeFailureDetail(signal.detail);
   const lower = normalizedDetail.toLowerCase();
   const rawLower = signal.detail.toLowerCase();
-  const statusCode = extractRuntimeFailureStatusCode(normalizedDetail, signal.statusCode);
+  // The redactor rewrites "token: <word>" sequences, so "Failed to refresh token: API
+  // Error: 503" loses its "API Error:" prefix in normalizedDetail. Fall back to the raw
+  // detail so a transient status is not lost; only the number is read from it.
+  const statusCode =
+    extractRuntimeFailureStatusCode(normalizedDetail, signal.statusCode) ??
+    extractRuntimeFailureStatusCode(signal.detail);
   const providerCode = signal.providerCode?.trim().toLowerCase() ?? '';
   const retryAt = resolveRetryAt(signal);
+  const hasTransientTransportEvidence =
+    (statusCode != null && TRANSIENT_RETRY_STATUSES.has(statusCode)) ||
+    providerCode === 'overloaded_error' ||
+    containsAny(rawLower, TRANSIENT_TRANSPORT_MARKERS);
+  const hasCodexAuthFailureMarker =
+    containsAny(rawLower, CODEX_TERMINAL_AUTH_MARKERS) ||
+    (!hasTransientTransportEvidence && containsAny(rawLower, CODEX_REFRESH_FAILURE_MARKERS));
 
   if (signal.phase === 'sdk_retrying') {
     return result('backend_error', 'observe_only', normalizedDetail, {
@@ -172,7 +218,7 @@ export function classifyRuntimeFailure(signal: RuntimeFailureSignal): RuntimeFai
       'permission denied',
       'does not have access',
     ]) ||
-    containsAny(rawLower, CODEX_AUTH_FAILURE_MARKERS)
+    hasCodexAuthFailureMarker
   ) {
     return result('auth_error', 'manual', normalizedDetail, {
       statusCode,
@@ -234,9 +280,8 @@ export function classifyRuntimeFailure(signal: RuntimeFailureSignal): RuntimeFai
 
   if (
     providerCode === 'overloaded_error' ||
-    lower.includes('overloaded_error') ||
-    lower.includes('temporarily unavailable') ||
-    lower.includes('service unavailable')
+    containsAny(lower, PROVIDER_OVERLOAD_MARKERS) ||
+    containsAny(rawLower, PROVIDER_OVERLOAD_MARKERS)
   ) {
     return result('provider_overloaded', 'retry_transient', normalizedDetail, {
       statusCode,
@@ -288,18 +333,11 @@ export function classifyRuntimeFailure(signal: RuntimeFailureSignal): RuntimeFai
     return result('codex_native_timeout', 'retry_transient', normalizedDetail, { statusCode });
   }
 
+  // Raw detail is consulted too: redaction of "token: ETIMEDOUT" style sequences would
+  // otherwise hide a transport failure behind an `unknown`/manual verdict.
   if (
-    containsAny(lower, [
-      'econnreset',
-      'epipe',
-      'etimedout',
-      'connection reset',
-      'connection refused',
-      'network error',
-      'fetch failed',
-      'unable to connect',
-      'connect failed',
-    ])
+    containsAny(lower, NETWORK_FAILURE_MARKERS) ||
+    containsAny(rawLower, NETWORK_FAILURE_MARKERS)
   ) {
     return result('network_error', 'retry_transient', normalizedDetail, { statusCode });
   }

--- a/src/features/team-runtime-recovery/core/domain/RuntimeFailureClassifier.ts
+++ b/src/features/team-runtime-recovery/core/domain/RuntimeFailureClassifier.ts
@@ -65,24 +65,14 @@ const TRANSIENT_TRANSPORT_MARKERS = [
   ...PROVIDER_OVERLOAD_MARKERS,
 ] as const;
 
-// Codex CLI stale-auth signatures: a reused/rotated refresh token or a missing
-// `codex login` is never fixed by re-running the same exec, so the delivery loop
-// must not retry it. Matched against the raw detail because the secret redactor
-// rewrites "token: <word>" sequences, which erases these markers from
-// normalizedDetail (e.g. "Failed to refresh token: ..." loses "token:").
-const CODEX_TERMINAL_AUTH_MARKERS = [
-  'refresh_token_reused',
-  'invalid_grant',
-  'codex_login',
-] as const;
+// Definitive stale-auth signatures are never fixed by re-running the same exec, so the
+// delivery loop must not retry them. Match raw detail because redaction can erase markers.
+const CODEX_TERMINAL_AUTH_MARKERS = ['refresh_token_reused', 'invalid_grant'] as const;
 
-// A bare "failed to refresh token" only reports that the refresh call did not
-// succeed; it does not say the grant is dead. Classifying it as terminal auth
-// regardless of cause strands the teammate with no recovery job whenever the
-// refresh endpoint has a transient outage (e.g. "Failed to refresh token: API
-// Error: 503"), so it counts as auth failure only when nothing else in the signal
-// points at a retryable transport problem.
-const CODEX_REFRESH_FAILURE_MARKERS = ['failed to refresh token'] as const;
+// These markers can describe a dead grant, but Codex also prefixes transient refresh
+// endpoint failures with `codex_login`. They are terminal only when the signal carries no
+// retryable status or transport evidence.
+const CODEX_CONTEXTUAL_AUTH_MARKERS = ['failed to refresh token', 'codex_login'] as const;
 
 function containsAny(value: string, tokens: readonly string[]): boolean {
   return tokens.some((token) => value.includes(token));
@@ -182,7 +172,7 @@ export function classifyRuntimeFailure(signal: RuntimeFailureSignal): RuntimeFai
     containsAny(rawLower, TRANSIENT_TRANSPORT_MARKERS);
   const hasCodexAuthFailureMarker =
     containsAny(rawLower, CODEX_TERMINAL_AUTH_MARKERS) ||
-    (!hasTransientTransportEvidence && containsAny(rawLower, CODEX_REFRESH_FAILURE_MARKERS));
+    (!hasTransientTransportEvidence && containsAny(rawLower, CODEX_CONTEXTUAL_AUTH_MARKERS));
 
   if (signal.phase === 'sdk_retrying') {
     return result('backend_error', 'observe_only', normalizedDetail, {

--- a/test/features/codex-account/core/evaluateCodexLaunchReadiness.test.ts
+++ b/test/features/codex-account/core/evaluateCodexLaunchReadiness.test.ts
@@ -113,6 +113,39 @@ describe('evaluateCodexLaunchReadiness', () => {
     });
   });
 
+  it.each(['chatgpt', 'auto'] as const)(
+    'still allows launch in %s mode when the local legacy auth file is stale but the CLI reports an account',
+    (preferredAuthMode) => {
+      // The legacy-auth freshness gate can only clear localActiveChatgptAccountPresent.
+      // It must never gate launchAllowed: a ChatGPT-only user whose ~/.codex/auth.json
+      // has an old last_refresh is still launchable, because readiness is decided by the
+      // authoritative `codex app-server` account read.
+      const readiness = evaluateCodexLaunchReadiness({
+        preferredAuthMode,
+        managedAccount: {
+          type: 'chatgpt',
+          email: 'user@example.com',
+          planType: 'plus',
+        },
+        apiKey: {
+          available: false,
+          source: null,
+          sourceLabel: null,
+        },
+        appServerState: 'healthy',
+        appServerStatusMessage: null,
+        localActiveChatgptAccountPresent: false,
+      });
+
+      expect(readiness).toMatchObject({
+        state: 'ready_chatgpt',
+        effectiveAuthMode: 'chatgpt',
+        launchAllowed: true,
+        issueMessage: null,
+      });
+    }
+  );
+
   it('fails fast when the Codex runtime is missing entirely', () => {
     const readiness = evaluateCodexLaunchReadiness({
       preferredAuthMode: 'auto',

--- a/test/features/codex-account/main/CodexLoginSessionManager.test.ts
+++ b/test/features/codex-account/main/CodexLoginSessionManager.test.ts
@@ -98,7 +98,10 @@ describe('CodexLoginSessionManager', () => {
     const fakeSession = createSession();
     deferredSession.resolve(fakeSession.session);
 
-    await Promise.all([firstStart, secondStart]);
+    // The duplicate request must report that it did not take ownership of the login, so
+    // callers do not reset login-scoped state (such as the forced token refresh reuse
+    // window) for a request that never touched the credentials.
+    expect(await Promise.all([firstStart, secondStart])).toEqual([true, false]);
 
     expect(fakeSession.request).toHaveBeenCalledTimes(1);
     expect(openExternalMock).not.toHaveBeenCalled();

--- a/test/features/codex-account/main/createCodexAccountFeature.test.ts
+++ b/test/features/codex-account/main/createCodexAccountFeature.test.ts
@@ -132,8 +132,10 @@ vi.mock(
         return structuredClone(loginStateContainer.current);
       }
 
-      async start(): Promise<void> {
-        await loginStartMock();
+      // Mirrors the real manager: `false` means the request was a no-op because a login
+      // was already starting or pending. Tests that do not care opt into a real start.
+      async start(): Promise<boolean> {
+        return (await loginStartMock()) !== false;
       }
 
       async cancel(): Promise<void> {
@@ -1888,6 +1890,46 @@ describe('createCodexAccountFeature', () => {
       expect(loginStartMock).toHaveBeenCalledTimes(1);
       expect(readAccountMock).toHaveBeenCalledTimes(2);
       expect(readAccountMock.mock.calls[1]?.[0]).toMatchObject({ refreshToken: true });
+    } finally {
+      dateNowSpy.mockRestore();
+      await feature.dispose();
+    }
+  });
+
+  it('keeps the reuse window after a duplicate login start the manager ignored', async () => {
+    readAccountMock.mockResolvedValue({
+      account: createAccountResponse(),
+      initialize: {
+        codexHome: '/Users/test/.codex',
+        platformFamily: 'unix',
+        platformOs: 'macos',
+      },
+    });
+    // A second login request while one is already starting or pending is a no-op inside
+    // the manager: no app-server is spawned and the credentials are untouched. Resetting
+    // the reuse window for it would rotate the refresh token again for nothing.
+    loginStartMock.mockResolvedValue(false);
+
+    const feature = createCodexAccountFeature({
+      logger: createLoggerPort(),
+      configManager: createConfigManager('chatgpt'),
+    });
+    const dateNowSpy = vi.spyOn(Date, 'now');
+
+    try {
+      dateNowSpy.mockReturnValue(1_776_000_000_000);
+      await feature.refreshSnapshot({ forceRefreshToken: true });
+
+      dateNowSpy.mockReturnValue(1_776_000_001_000);
+      await feature.startChatgptLogin();
+
+      dateNowSpy.mockReturnValue(1_776_000_010_000);
+      await feature.refreshSnapshot({ forceRefreshToken: true });
+
+      expect(loginStartMock).toHaveBeenCalledTimes(1);
+      expect(readAccountMock).toHaveBeenCalledTimes(2);
+      expect(readAccountMock.mock.calls[0]?.[0]).toMatchObject({ refreshToken: true });
+      expect(readAccountMock.mock.calls[1]?.[0]).toMatchObject({ refreshToken: false });
     } finally {
       dateNowSpy.mockRestore();
       await feature.dispose();

--- a/test/features/codex-account/main/createCodexAccountFeature.test.ts
+++ b/test/features/codex-account/main/createCodexAccountFeature.test.ts
@@ -1780,4 +1780,154 @@ describe('createCodexAccountFeature', () => {
       await feature.dispose();
     }
   });
+
+  it('shares one real token rotation across sequential forced refreshes inside the reuse window', async () => {
+    readAccountMock.mockResolvedValue({
+      account: createAccountResponse(),
+      initialize: {
+        codexHome: '/Users/test/.codex',
+        platformFamily: 'unix',
+        platformOs: 'macos',
+      },
+    });
+
+    const feature = createCodexAccountFeature({
+      logger: createLoggerPort(),
+      configManager: createConfigManager('chatgpt'),
+    });
+    const dateNowSpy = vi.spyOn(Date, 'now');
+
+    try {
+      dateNowSpy.mockReturnValue(1_776_000_000_000);
+      const firstSnapshot = await feature.refreshSnapshot({ forceRefreshToken: true });
+
+      dateNowSpy.mockReturnValue(1_776_000_001_000);
+      const secondSnapshot = await feature.refreshSnapshot({ forceRefreshToken: true });
+      dateNowSpy.mockReturnValue(1_776_000_002_000);
+      const thirdSnapshot = await feature.refreshSnapshot({ forceRefreshToken: true });
+
+      // Past the snapshot cache but still inside the reuse window: a real read happens, yet
+      // the refresh token is not rotated again.
+      dateNowSpy.mockReturnValue(1_776_000_010_000);
+      const fourthSnapshot = await feature.refreshSnapshot({ forceRefreshToken: true });
+
+      for (const snapshot of [firstSnapshot, secondSnapshot, thirdSnapshot, fourthSnapshot]) {
+        expect(snapshot.managedAccount?.email).toBe('user@example.com');
+      }
+      expect(readAccountMock).toHaveBeenCalledTimes(2);
+      expect(readAccountMock.mock.calls[0]?.[0]).toMatchObject({ refreshToken: true });
+      expect(readAccountMock.mock.calls[1]?.[0]).toMatchObject({ refreshToken: false });
+      expect(
+        readAccountMock.mock.calls.filter(
+          (call) => (call[0] as { refreshToken?: boolean } | undefined)?.refreshToken === true
+        )
+      ).toHaveLength(1);
+    } finally {
+      dateNowSpy.mockRestore();
+      await feature.dispose();
+    }
+  });
+
+  it('forces a fresh token rotation once the reuse window has elapsed', async () => {
+    readAccountMock.mockResolvedValue({
+      account: createAccountResponse(),
+      initialize: {
+        codexHome: '/Users/test/.codex',
+        platformFamily: 'unix',
+        platformOs: 'macos',
+      },
+    });
+
+    const feature = createCodexAccountFeature({
+      logger: createLoggerPort(),
+      configManager: createConfigManager('chatgpt'),
+    });
+    const dateNowSpy = vi.spyOn(Date, 'now');
+
+    try {
+      dateNowSpy.mockReturnValue(1_776_000_000_000);
+      await feature.refreshSnapshot({ forceRefreshToken: true });
+
+      dateNowSpy.mockReturnValue(1_776_000_030_001);
+      await feature.refreshSnapshot({ forceRefreshToken: true });
+
+      expect(readAccountMock).toHaveBeenCalledTimes(2);
+      expect(readAccountMock.mock.calls[1]?.[0]).toMatchObject({ refreshToken: true });
+    } finally {
+      dateNowSpy.mockRestore();
+      await feature.dispose();
+    }
+  });
+
+  it('rotates the token again inside the reuse window after an explicit login start', async () => {
+    readAccountMock.mockResolvedValue({
+      account: createAccountResponse(),
+      initialize: {
+        codexHome: '/Users/test/.codex',
+        platformFamily: 'unix',
+        platformOs: 'macos',
+      },
+    });
+
+    const feature = createCodexAccountFeature({
+      logger: createLoggerPort(),
+      configManager: createConfigManager('chatgpt'),
+    });
+    const dateNowSpy = vi.spyOn(Date, 'now');
+
+    try {
+      dateNowSpy.mockReturnValue(1_776_000_000_000);
+      await feature.refreshSnapshot({ forceRefreshToken: true });
+
+      dateNowSpy.mockReturnValue(1_776_000_001_000);
+      await feature.startChatgptLogin();
+
+      dateNowSpy.mockReturnValue(1_776_000_002_000);
+      await feature.refreshSnapshot({ forceRefreshToken: true });
+
+      expect(loginStartMock).toHaveBeenCalledTimes(1);
+      expect(readAccountMock).toHaveBeenCalledTimes(2);
+      expect(readAccountMock.mock.calls[1]?.[0]).toMatchObject({ refreshToken: true });
+    } finally {
+      dateNowSpy.mockRestore();
+      await feature.dispose();
+    }
+  });
+
+  it('rotates the token again inside the reuse window after an explicit logout', async () => {
+    readAccountMock.mockResolvedValue({
+      account: createAccountResponse(),
+      initialize: {
+        codexHome: '/Users/test/.codex',
+        platformFamily: 'unix',
+        platformOs: 'macos',
+      },
+    });
+    readRateLimitsMock.mockResolvedValue(createRateLimitsResponse());
+    logoutMock.mockResolvedValue({});
+
+    const feature = createCodexAccountFeature({
+      logger: createLoggerPort(),
+      configManager: createConfigManager('chatgpt'),
+    });
+    const dateNowSpy = vi.spyOn(Date, 'now');
+
+    try {
+      dateNowSpy.mockReturnValue(1_776_000_000_000);
+      await feature.refreshSnapshot({ forceRefreshToken: true });
+
+      dateNowSpy.mockReturnValue(1_776_000_001_000);
+      await feature.logout();
+
+      expect(logoutMock).toHaveBeenCalledTimes(1);
+      expect(readAccountMock).toHaveBeenCalledTimes(2);
+      expect(readAccountMock.mock.calls[1]?.[0]).toMatchObject({
+        includeRateLimits: true,
+        refreshToken: true,
+      });
+    } finally {
+      dateNowSpy.mockRestore();
+      await feature.dispose();
+    }
+  });
 });

--- a/test/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.test.ts
+++ b/test/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.test.ts
@@ -247,6 +247,61 @@ describe('detectCodexLocalAccountArtifacts', () => {
     });
   });
 
+  it('ignores a stale legacy auth.json without deleting it when the accounts registry is absent', async () => {
+    const { codexHome, accountsDir } = await makeCodexHome();
+    const legacyAuthPath = path.join(codexHome, 'auth.json');
+    await writeFile(
+      legacyAuthPath,
+      JSON.stringify({ auth_mode: 'chatgpt', tokens: { refresh_token: 'legacy-refresh-token' } }),
+      'utf8'
+    );
+    const staleDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    await utimes(legacyAuthPath, staleDate, staleDate);
+
+    await expect(detectCodexLocalAccountState(accountsDir)).resolves.toEqual({
+      hasArtifacts: true,
+      hasActiveChatgptAccount: false,
+    });
+    await expect(resolveCodexActiveChatgptAuthFile(accountsDir)).resolves.toBeNull();
+    await expect(readFile(legacyAuthPath, 'utf8')).resolves.toContain('legacy-refresh-token');
+  });
+
+  it('trusts a stale last_refresh in legacy auth.json content over a fresh file mtime', async () => {
+    const { codexHome, accountsDir } = await makeCodexHome();
+    await writeFile(
+      path.join(codexHome, 'auth.json'),
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        last_refresh: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString(),
+        tokens: { refresh_token: 'legacy-refresh-token' },
+      }),
+      'utf8'
+    );
+
+    await expect(resolveCodexActiveChatgptAuthFile(accountsDir)).resolves.toBeNull();
+  });
+
+  it('accepts a fresh last_refresh in legacy auth.json even when the file mtime is old', async () => {
+    const { codexHome, accountsDir } = await makeCodexHome();
+    const legacyAuthPath = path.join(codexHome, 'auth.json');
+    await writeFile(
+      legacyAuthPath,
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        last_refresh: new Date().toISOString(),
+        tokens: { refresh_token: 'legacy-refresh-token' },
+      }),
+      'utf8'
+    );
+    const staleDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    await utimes(legacyAuthPath, staleDate, staleDate);
+
+    await expect(resolveCodexActiveChatgptAuthFile(accountsDir)).resolves.toMatchObject({
+      authFilePath: legacyAuthPath,
+      source: 'legacy',
+    });
+  });
+
   it('keeps artifact detection true but selected-account detection false when the active auth file is missing', async () => {
     const { accountsDir } = await makeCodexHome();
     await writeFile(

--- a/test/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.test.ts
+++ b/test/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.test.ts
@@ -302,6 +302,31 @@ describe('detectCodexLocalAccountArtifacts', () => {
     });
   });
 
+  it('keeps reporting local artifacts for a 15-day-old legacy login instead of erasing it', async () => {
+    // A legacy login just past the freshness window is withheld as a *trusted* active
+    // account (replaying its refresh token is what trips reuse detection), but it must
+    // still surface as local account data so callers keep the "reconnect" wording and
+    // the file itself is never touched. It is not a signed-out signal: launch readiness
+    // is decided by the authoritative `codex app-server` account read, not by this flag.
+    const { codexHome, accountsDir } = await makeCodexHome();
+    const legacyAuthPath = path.join(codexHome, 'auth.json');
+    await writeFile(
+      legacyAuthPath,
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        last_refresh: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000).toISOString(),
+        tokens: { refresh_token: 'legacy-refresh-token' },
+      }),
+      'utf8'
+    );
+
+    await expect(detectCodexLocalAccountState(accountsDir)).resolves.toEqual({
+      hasArtifacts: true,
+      hasActiveChatgptAccount: false,
+    });
+    await expect(readFile(legacyAuthPath, 'utf8')).resolves.toContain('legacy-refresh-token');
+  });
+
   it('keeps artifact detection true but selected-account detection false when the active auth file is missing', async () => {
     const { accountsDir } = await makeCodexHome();
     await writeFile(

--- a/test/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.test.ts
+++ b/test/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.test.ts
@@ -302,6 +302,22 @@ describe('detectCodexLocalAccountArtifacts', () => {
     });
   });
 
+  it('does not treat a future last_refresh as fresh', async () => {
+    const { codexHome, accountsDir } = await makeCodexHome();
+    const legacyAuthPath = path.join(codexHome, 'auth.json');
+    await writeFile(
+      legacyAuthPath,
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        last_refresh: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        tokens: { refresh_token: 'legacy-refresh-token' },
+      }),
+      'utf8'
+    );
+
+    await expect(resolveCodexActiveChatgptAuthFile(accountsDir)).resolves.toBeNull();
+  });
+
   it('keeps reporting local artifacts for a 15-day-old legacy login instead of erasing it', async () => {
     // A legacy login just past the freshness window is withheld as a *trusted* active
     // account (replaying its refresh token is what trips reuse detection), but it must

--- a/test/features/team-runtime-recovery/core/RuntimeFailureClassifier.test.ts
+++ b/test/features/team-runtime-recovery/core/RuntimeFailureClassifier.test.ts
@@ -73,6 +73,16 @@ describe('classifyRuntimeFailure', () => {
     ['Failed to refresh token: API Error: 429 too many requests', 'rate_limited', 'manual'],
     ['Failed to refresh token: fetch failed', 'network_error', 'retry_transient'],
     ['Failed to refresh token: ETIMEDOUT', 'network_error', 'retry_transient'],
+    [
+      'codex_login: Failed to refresh token: API Error: 503',
+      'provider_overloaded',
+      'retry_transient',
+    ],
+    [
+      'codex_login: Failed to refresh token: fetch failed',
+      'network_error',
+      'retry_transient',
+    ],
   ] as const)(
     'keeps a transient refresh-endpoint outage recoverable: %s => %s/%s',
     (detail, reasonCode, disposition) => {

--- a/test/features/team-runtime-recovery/core/RuntimeFailureClassifier.test.ts
+++ b/test/features/team-runtime-recovery/core/RuntimeFailureClassifier.test.ts
@@ -42,12 +42,28 @@ describe('classifyRuntimeFailure', () => {
     ['API Error: 422 invalid input', undefined, 'client_error', 'manual'],
     ['API Error: 401 invalid API key', undefined, 'auth_error', 'manual'],
     ['API Error: 403 forbidden', undefined, 'auth_error', 'manual'],
+    ['stream error: refresh_token_reused', undefined, 'auth_error', 'manual'],
+    ['run codex_login to continue', undefined, 'auth_error', 'manual'],
     ['ENOSPC: no space left on device', undefined, 'filesystem_error', 'manual'],
     ['unexpected tool execution error', undefined, 'unknown', 'manual'],
   ] as const)('%s => %s/%s', (detail, statusCode, reasonCode, disposition) => {
     expect(classifyRuntimeFailure(signal({ detail, statusCode }))).toMatchObject({
       reasonCode,
       disposition,
+    });
+  });
+
+  it('classifies codex refresh-token failures as auth errors even when redaction erases the marker', () => {
+    // The secret redactor rewrites "token: <word>" sequences, so the phrase
+    // "Failed to refresh token:" no longer exists in normalizedDetail — the
+    // classifier must match the raw detail to avoid an endless retry loop.
+    const classified = classifyRuntimeFailure(
+      signal({ detail: 'Failed to refresh token: unexpected status 400 Bad Request' })
+    );
+    expect(classified).toMatchObject({
+      reasonCode: 'auth_error',
+      disposition: 'manual',
+      actionRequired: true,
     });
   });
 

--- a/test/features/team-runtime-recovery/core/RuntimeFailureClassifier.test.ts
+++ b/test/features/team-runtime-recovery/core/RuntimeFailureClassifier.test.ts
@@ -67,6 +67,39 @@ describe('classifyRuntimeFailure', () => {
     });
   });
 
+  it.each([
+    ['Failed to refresh token: API Error: 503', 'provider_overloaded', 'retry_transient'],
+    ['Failed to refresh token: API Error: 500 internal error', 'backend_error', 'retry_transient'],
+    ['Failed to refresh token: API Error: 429 too many requests', 'rate_limited', 'manual'],
+    ['Failed to refresh token: fetch failed', 'network_error', 'retry_transient'],
+    ['Failed to refresh token: ETIMEDOUT', 'network_error', 'retry_transient'],
+  ] as const)(
+    'keeps a transient refresh-endpoint outage recoverable: %s => %s/%s',
+    (detail, reasonCode, disposition) => {
+      // A bare "failed to refresh token" carrying transient transport evidence is an
+      // outage of the refresh endpoint, not a dead grant. Classifying it as auth_error
+      // would leave the teammate stranded with no recovery job.
+      expect(classifyRuntimeFailure(signal({ detail }))).toMatchObject({
+        reasonCode,
+        disposition,
+      });
+    }
+  );
+
+  it('still classifies refresh-token reuse as terminal auth even behind a transient status', () => {
+    // The kill-loop signature must stay terminal: re-running the same exec replays the
+    // revoked refresh token and re-trips OpenAI's reuse detection.
+    expect(
+      classifyRuntimeFailure(
+        signal({ detail: 'Failed to refresh token: refresh_token_reused (API Error: 503)' })
+      )
+    ).toMatchObject({
+      reasonCode: 'auth_error',
+      disposition: 'manual',
+      actionRequired: true,
+    });
+  });
+
   it('observes active SDK retry without scheduling an outer retry', () => {
     expect(classifyRuntimeFailure(signal({ phase: 'sdk_retrying' }))).toMatchObject({
       disposition: 'observe_only',


### PR DESCRIPTION
## Problem

On Windows with Codex CLI >= 0.151 and a ChatGPT subscription, Agent Teams could put a
perfectly good Codex login into an unrecoverable loop: launching a team revoked the account's
tokens, `codex login` succeeded, and the next launch revoked it again. Members then hung in
the 30-second delivery retry loop instead of reporting an auth problem, so the run looked
"slow" rather than broken.

Three distinct causes stack up:

**1. A stale legacy `~/.codex/auth.json` was treated as a live account.**
Codex >= 0.151 keeps auth in its own store (`~/.codex/accounts/` registry plus its sqlite
state) and no longer rewrites the legacy `auth.json`. A leftover file from an older CLI still
contains a `refresh_token`, so `resolveCodexActiveChatgptAuthFile` happily reported it as the
active ChatGPT account whenever no accounts registry was present. Replaying that
long-rotated refresh token trips OpenAI's **refresh-token reuse detection**, which revokes the
entire token family — including the tokens minted by the fresh login the user had just
performed. The detector never sees the new store, so it keeps re-arming the same landmine.

**2. Rotation bursts inside a single launch preparation.**
`refreshSnapshot({ forceRefreshToken: true })` rotates the ChatGPT refresh token inside its
own `codex app-server` process. One launch preparation reaches that path from several
sequential provider-connection resolution points (blocked-launch re-check, runtime-missing
re-check, and the per-member connection resolution), so a single launch rotated the refresh
token several times within a few seconds. Besides wasting launch time on repeated app-server
spawns, a rotation burst is exactly the shape OpenAI's reuse detection reacts badly to.

**3. The revocation was misclassified as a transient failure.**
`classifyRuntimeFailure` never matched Codex's stale-auth signatures, so
`refresh_token_reused` and `Failed to refresh token: ...` fell through to the generic
transient bucket and were re-fed into the 30s delivery retry loop forever. Worse, the
signatures are matched against `normalizedDetail`, and the secret redactor rewrites
`token: <word>` sequences — so `Failed to refresh token: ...` has the literal marker erased
before classification even gets to look at it.

## Fix

Two commits, one per layer.

### `fix(codex): stop trusting stale legacy auth and classify refresh-token reuse as auth failure`

- `detectCodexLocalAccountArtifacts.ts`: a legacy `auth.json` is only accepted as the active
  ChatGPT account when it is **demonstrably fresh** (14 days). Freshness comes from the
  in-file `last_refresh` / `lastRefresh` timestamp when present, falling back to file mtime;
  unknown freshness counts as stale. This ordering matters — an unrelated tool touching the
  file must not resurrect dead tokens, and a file copied/restored with a new mtime must not
  either.
  The stale file is **ignored, never deleted and never rewritten**: users on older Codex CLIs
  keep working, and nothing destroys data the app does not own. The window is deliberately
  generous (14 days) so that a genuinely-in-use legacy setup is unaffected; the failure mode
  it closes is the months-old leftover.
- `RuntimeFailureClassifier.ts`: `refresh_token_reused`, `failed to refresh token` and
  `codex_login` are classified as `auth_error` with `manual` recovery — surfaced to the user
  instead of retried. These markers are matched against the **raw** detail rather than the
  normalized one, precisely because redaction erases `token:` sequences. That is a deliberate
  exception and is commented as such at the constant; no secret is logged, only the match
  result is used.

### `fix(codex): share one forced ChatGPT token rotation across a launch preparation`

- New pure module `composition/codexSnapshotRefreshOptions.ts` holds the refresh-option policy
  (normalize / merge / cover) that previously lived inline in the facade, plus the new
  `applyForcedTokenRefreshReuseWindow`. Keeping it dependency-free makes the window directly
  unit-testable and keeps `createCodexAccountFeature.ts` from growing.
- A successful forced rotation stamps `lastForcedTokenRefreshAtMs`. A forced call arriving
  within **30s** of that stamp is downgraded to a plain read, which reuses the snapshot from
  the rotation that just happened. So one launch preparation performs exactly one rotation,
  and the later paths get the same fresh token instead of minting another.
- The downgrade is re-evaluated **per drained batch iteration**, not once at enqueue time:
  options queued behind an in-flight rotation must see the stamp that rotation just wrote,
  otherwise the burst simply moves into the queue.
- Explicit `login` start and `logout` reset the stamp to `0`, so user-driven
  re-authentication always rotates immediately — the window must never make a "re-login" button
  feel like it did nothing. `dispose`/reset clears it too.

Chosen as a time window rather than a per-launch token because the forced-refresh call sites
are spread across the provider-connection layer and the renderer settings dialog, and none of
them share a launch-scoped context object; threading one through would have touched far more
surface for the same effect.

## Tests

- `test/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.test.ts`
  (14 tests) — new:
  - ignores a stale legacy `auth.json` **without deleting it** when the accounts registry is absent
  - trusts a stale in-file `last_refresh` over a fresh file mtime
  - accepts a fresh `last_refresh` even when the file mtime is old
- `test/features/team-runtime-recovery/core/RuntimeFailureClassifier.test.ts` (29 tests) — new:
  - classifies codex refresh-token failures as auth errors **even when redaction erases the marker**
    (feeds the classifier the exact post-redaction string that broke in the field)
- `test/features/codex-account/main/createCodexAccountFeature.test.ts` (37 tests) — new:
  - shares one real token rotation across sequential forced refreshes inside the reuse window
  - forces a fresh rotation once the window has elapsed
  - rotates again inside the window after an explicit login start
  - rotates again inside the window after an explicit logout

80 tests across the three files, all passing.

## Tested on

- Windows 11 Pro (26200), Codex CLI 0.151.x, Agent Teams built from source.
- Provider combos actually exercised for this change:
  - **Codex with a ChatGPT subscription (Plus)** — the failing configuration. Reproduced the
    revocation loop with a months-old leftover `~/.codex/auth.json` present, then verified that
    with the fix a fresh login survives repeated team launches and that the stale file is left
    untouched on disk.
  - **Codex-led team and Codex teammates under a Cursor lead** — both launch paths exercised, so
    the reuse window is hit from the provider-connection side as well as the settings dialog.
  - **Codex with an API key** — regression check: the forced-refresh path is ChatGPT-only, and
    API-key launches are unaffected.
- Not exercised for this change: Anthropic/Gemini/local-model paths (they do not reach this
  code), macOS and Linux, and Codex CLI versions older than 0.151 with an actively-used legacy
  `auth.json` — that case is covered by unit tests (fresh `last_refresh` is accepted) but I
  have not run an old CLI end to end.

## References

Fixes #27.

## Validation checklist

- [x] `pnpm typecheck` — exit 0
- [x] `pnpm exec vitest run` on the three touched test files — 80/80 passing
- [x] `pnpm guard:source-file-size` — passing (new file is 75 lines; no baseline change needed)
- [x] `pnpm guard:team-provisioning-architecture` — passing
- [x] Rebased on current `dev`; both commits cherry-picked clean, no conflicts

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely. Full context: Discord thread, Aug 30. Review questions are welcome; answers will come from the same Claude-assisted workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary token rotations during rapid refreshes, helping prevent refresh-token revocation.
  * Legacy Codex authentication files older than 14 days—or with invalid or future-dated timestamps—are now ignored without being deleted.
  * Improved authentication failure classification for refresh-token errors, transient service outages, network failures, and redacted details.
  * Explicit login and logout actions continue to trigger fresh authentication, while duplicate login requests avoid resetting refresh protection.
  * Valid managed accounts can still launch when legacy authentication files are stale.

* **Tests**
  * Added coverage for token refresh reuse, authentication-file freshness, launch readiness, login handling, and authentication error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->