### PR TITLE
fix(renderer): new team starts with lead only

### DIFF
--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -28,7 +28,6 @@ import {
   buildMemberDraftSuggestions,
   buildMembersFromDrafts,
   clearMemberModelOverrides,
-  createMemberDraft,
   normalizeLeadProviderForMode,
   normalizeMemberDraftForProviderMode,
   validateMemberNameInline,
@@ -106,6 +105,7 @@ import { AdvancedCliSection } from './AdvancedCliSection';
 import { AnthropicFastModeSelector } from './AnthropicFastModeSelector';
 import { CodexFastModeSelector } from './CodexFastModeSelector';
 import { CodexReconnectPrompt, shouldShowCodexReconnectPrompt } from './CodexReconnectPrompt';
+import { buildInitialRosterMemberDrafts } from './createTeamInitialRoster';
 import {
   getOrganizationPlacementUnitKindKey,
   getOrganizationPlacementUnitOptions,
@@ -271,22 +271,6 @@ interface ValidationResult {
     cwd?: string;
   };
 }
-
-import { CUSTOM_ROLE, PRESET_ROLES } from '@renderer/constants/teamRoles';
-
-const DEFAULT_MEMBERS: { name: string; roleSelection: string; workflowKind?: 'reviewer' }[] = [
-  {
-    name: 'alice',
-    roleSelection: 'reviewer',
-    workflowKind: 'reviewer',
-  },
-  {
-    name: 'tom',
-    roleSelection: 'developer',
-  },
-  { name: 'bob', roleSelection: 'developer' },
-  { name: 'jack', roleSelection: 'developer' },
-];
 
 /** Mirrors Claude CLI's `zuA()` sanitization: non-alphanumeric → `-`, then lowercase. */
 function sanitizeTeamName(name: string): string {
@@ -1569,26 +1553,9 @@ export const CreateTeamDialog = ({
         setSkipPermissionsRaw(initialData.skipPermissions !== false);
       }
       setMembers(
-        initialData.members.map((m) => {
-          const presetRoles: readonly string[] = PRESET_ROLES;
-          const isPreset = m.role != null && presetRoles.includes(m.role);
-          const isCustom = m.role != null && m.role.length > 0 && !isPreset;
-          return normalizeMemberDraftForProviderMode(
-            createMemberDraft({
-              name: m.name,
-              roleSelection: isCustom ? CUSTOM_ROLE : (m.role ?? ''),
-              customRole: isCustom ? m.role : '',
-              workflow: m.workflow,
-              isolation: m.isolation === 'worktree' ? 'worktree' : undefined,
-              providerId: normalizeOptionalTeamProviderId(m.providerId),
-              providerBackendId: m.providerBackendId,
-              model: m.model ?? '',
-              effort: m.effort,
-              fastMode: m.fastMode,
-              mcpPolicy: m.mcpPolicy,
-            }),
-            multimodelEnabled
-          );
+        buildInitialRosterMemberDrafts({
+          copiedMembers: initialData.members,
+          multimodelEnabled,
         })
       );
       setTeammateWorktreeDefault(
@@ -1603,21 +1570,17 @@ export const CreateTeamDialog = ({
       return;
     }
 
-    const nextDefaultMembers = DEFAULT_MEMBERS.map((member) =>
-      createMemberDraft({
-        name: member.name,
-        roleSelection: member.roleSelection,
-        workflow:
-          member.workflowKind === 'reviewer' ? t('create.defaultWorkflows.reviewer') : undefined,
-      })
-    );
+    const initialRosterDrafts = buildInitialRosterMemberDrafts({ multimodelEnabled });
+    if (initialRosterDrafts.length === 0) {
+      return;
+    }
     setMembers(
       syncModelsWithLead
-        ? nextDefaultMembers
-        : applyStoredCreateTeamMemberRuntimePreferences(nextDefaultMembers)
+        ? initialRosterDrafts
+        : applyStoredCreateTeamMemberRuntimePreferences(initialRosterDrafts)
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps -- initialData is checked once on open/draftLoaded
-  }, [open, draftLoaded, t]);
+  }, [open, draftLoaded]);
 
   useEffect(() => {
     if (!open || !draftLoaded || initialData || syncModelsWithLead || members.length === 0) {

--- a/src/renderer/components/team/dialogs/createTeamInitialRoster.test.ts
+++ b/src/renderer/components/team/dialogs/createTeamInitialRoster.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { CUSTOM_ROLE } from '@renderer/constants/teamRoles';
+
+import { buildInitialRosterMemberDrafts } from './createTeamInitialRoster';
+
+import type { TeamProvisioningMemberInput } from '@shared/types';
+
+describe('buildInitialRosterMemberDrafts', () => {
+  it('starts a new team with the lead only (no teammate drafts)', () => {
+    expect(buildInitialRosterMemberDrafts({ multimodelEnabled: true })).toEqual([]);
+    expect(buildInitialRosterMemberDrafts({ multimodelEnabled: false })).toEqual([]);
+  });
+
+  it('keeps an explicitly empty copied roster empty', () => {
+    expect(buildInitialRosterMemberDrafts({ copiedMembers: [], multimodelEnabled: true })).toEqual(
+      []
+    );
+  });
+
+  it('preserves copied members when creating from an existing team', () => {
+    const copiedMembers: TeamProvisioningMemberInput[] = [
+      { name: 'alice', role: 'reviewer', workflow: 'Review incoming changes' },
+      { name: 'bob', role: 'sre-oncall', isolation: 'worktree', providerId: 'opencode' },
+    ];
+
+    const drafts = buildInitialRosterMemberDrafts({ copiedMembers, multimodelEnabled: true });
+
+    expect(drafts).toHaveLength(2);
+    expect(drafts[0]).toMatchObject({
+      name: 'alice',
+      roleSelection: 'reviewer',
+      customRole: '',
+      workflow: 'Review incoming changes',
+    });
+    expect(drafts[1]).toMatchObject({
+      name: 'bob',
+      roleSelection: CUSTOM_ROLE,
+      customRole: 'sre-oncall',
+      isolation: 'worktree',
+      providerId: 'opencode',
+    });
+  });
+});

--- a/src/renderer/components/team/dialogs/createTeamInitialRoster.test.ts
+++ b/src/renderer/components/team/dialogs/createTeamInitialRoster.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it } from 'vitest';
-
 import { CUSTOM_ROLE } from '@renderer/constants/teamRoles';
+import { describe, expect, it } from 'vitest';
 
 import { buildInitialRosterMemberDrafts } from './createTeamInitialRoster';
 

--- a/src/renderer/components/team/dialogs/createTeamInitialRoster.ts
+++ b/src/renderer/components/team/dialogs/createTeamInitialRoster.ts
@@ -1,0 +1,51 @@
+import {
+  createMemberDraft,
+  normalizeMemberDraftForProviderMode,
+} from '@renderer/components/team/members/membersEditorUtils';
+import { CUSTOM_ROLE, PRESET_ROLES } from '@renderer/constants/teamRoles';
+import { normalizeOptionalTeamProviderId } from '@shared/utils/teamProvider';
+
+import type { MemberDraft } from '@renderer/components/team/members/membersEditorTypes';
+import type { TeamProvisioningMemberInput } from '@shared/types';
+
+interface BuildInitialRosterMemberDraftsOptions {
+  /** Members copied from an existing team. Absent when creating a brand-new team. */
+  copiedMembers?: readonly TeamProvisioningMemberInput[];
+  multimodelEnabled: boolean;
+}
+
+/**
+ * Initial teammate roster shown when the Create Team dialog opens.
+ *
+ * A brand-new team starts with the lead only — teammates are added explicitly
+ * via "Add member". Copying an existing team preserves that team's members.
+ */
+export function buildInitialRosterMemberDrafts({
+  copiedMembers,
+  multimodelEnabled,
+}: BuildInitialRosterMemberDraftsOptions): MemberDraft[] {
+  if (!copiedMembers) {
+    return [];
+  }
+  return copiedMembers.map((member) => {
+    const presetRoles: readonly string[] = PRESET_ROLES;
+    const isPreset = member.role != null && presetRoles.includes(member.role);
+    const isCustom = member.role != null && member.role.length > 0 && !isPreset;
+    return normalizeMemberDraftForProviderMode(
+      createMemberDraft({
+        name: member.name,
+        roleSelection: isCustom ? CUSTOM_ROLE : (member.role ?? ''),
+        customRole: isCustom ? member.role : '',
+        workflow: member.workflow,
+        isolation: member.isolation === 'worktree' ? 'worktree' : undefined,
+        providerId: normalizeOptionalTeamProviderId(member.providerId),
+        providerBackendId: member.providerBackendId,
+        model: member.model ?? '',
+        effort: member.effort,
+        fastMode: member.fastMode,
+        mcpPolicy: member.mcpPolicy,
+      }),
+      multimodelEnabled
+    );
+  });
+}

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -1041,6 +1041,52 @@ describe('LaunchTeamDialog', () => {
     await act(async () => root.unmount());
   });
 
+  it('opens a brand-new team with the lead only and no pre-stuffed teammates', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const savedMembers = createTeamDraftMock.state.members;
+    createTeamDraftMock.state.members = [];
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    try {
+      await act(async () => {
+        root.render(
+          React.createElement(CreateTeamDialog, {
+            open: true,
+            canCreate: true,
+            provisioningErrorsByTeam: {},
+            clearProvisioningError: vi.fn(),
+            existingTeamNames: [],
+            provisioningTeamNames: [],
+            activeTeams: [],
+            defaultProjectPath: '/tmp/project',
+            onClose: vi.fn(),
+            onCreate: vi.fn(async () => {}),
+            onOpenTeam: vi.fn(),
+          })
+        );
+        await flush();
+      });
+
+      // The open effect must not invent teammates (previously alice/tom/bob/jack).
+      const rosterWrites = createTeamDraftMock.state.setMembers.mock.calls.map(([next]: any[]) =>
+        typeof next === 'function' ? next([]) : next
+      );
+      expect(rosterWrites.flatMap((roster: any[]) => roster.map((member) => member.name))).toEqual(
+        []
+      );
+      expect(teamRosterEditorSectionMock.lastProps?.members).toEqual([]);
+    } finally {
+      await act(async () => {
+        root.unmount();
+        await flush();
+      });
+      createTeamDraftMock.state.members = savedMembers;
+    }
+  });
+
   it('forces navigation project mode once and then allows a custom path', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     createTeamDraftMock.state.cwdMode = 'custom';


### PR DESCRIPTION
## Problem

Opening **Create team** for a brand-new team pre-filled the roster with four invented teammates — `alice` (reviewer), `tom` (developer), `bob` (developer), `jack` (developer) — hard-coded in `CreateTeamDialog.tsx` as `DEFAULT_MEMBERS`.

Root cause is that the placeholder roster was treated as a default rather than as an example:

* Users who want a different team shape have to delete four rows one at a time before they can start, on every new team.
* Users who do not notice them launch a five-agent team when they wanted one lead. On paid providers that is four extra agents' worth of tokens; with local models it is four extra model slots. Both are silent.
* The invented names collide with real teammate names people then try to add, and the roles (`reviewer`/`developer`) are not meaningful defaults for most projects.
* The same effect also handled the "create from an existing team" path, so the two behaviors — copy this roster / seed a fake roster — were tangled in one inline branch inside the dialog's open effect, and neither was unit-testable.

## Fix

* A brand-new team now starts with the **lead only**. Teammates are added explicitly via **Add member**, which is already the flow for every subsequent roster change.
* Copying an existing team is unchanged: the copied roster is preserved exactly, including role/custom-role classification, workflow, worktree isolation, provider, backend, model, effort, fast mode and MCP policy.
* The roster-seeding logic moves out of the dialog into `src/renderer/components/team/dialogs/createTeamInitialRoster.ts` as a single named builder, `buildInitialRosterMemberDrafts({ copiedMembers, multimodelEnabled })`, so both paths are one pure function with a test.
* The open effect returns early when the builder yields no drafts, so the lead-only path no longer calls `setMembers` with an empty array on every open, and `t` drops out of the effect's dependency list (the only use was the placeholder reviewer workflow string).

`DEFAULT_MEMBERS` and its `CUSTOM_ROLE`/`PRESET_ROLES` import are removed from `CreateTeamDialog.tsx`. The `team.create.defaultWorkflows.reviewer` locale key is intentionally left in place rather than removed across all locale files.

## Tests

* New `src/renderer/components/team/dialogs/createTeamInitialRoster.test.ts` (3 tests): a brand-new team yields an empty teammate roster in both multimodel modes; an explicitly empty copied roster stays empty; a copied roster preserves names, preset vs custom role classification, workflow, isolation and provider.
* `test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts` (25 tests) re-run green — it covers the shared create/launch preflight paths.

## Tested on

Windows 11 (Electron dev build and packaged build).

* Exercised for this change: **Anthropic (OAuth and API key)**, **Codex (ChatGPT and API key)**, **Cursor/opencode lead**, and **local models through opencode**. Created new teams (lead-only start, then adding teammates by hand) and created teams by copying an existing team on each of those provider configurations.
* This is renderer-only roster-seeding logic with no provider branching, so provider coverage is about confirming the copied-roster path keeps per-member provider/model/effort intact per provider.
* Not exercised: **Gemini**, macOS and Linux.

## References

* #113 — create/launch dialogs shipping state the user did not choose

## Validation checklist

- [x] `pnpm typecheck` — exit 0
- [x] Targeted vitest files — 28 tests passing
- [x] `pnpm guard:source-file-size` — passes (`CreateTeamDialog.tsx` drops 3160 -> 3123, well under its frozen cap; the baseline file is deliberately left untouched so this PR does not conflict with the others in this batch)
- [x] `pnpm exec eslint` on touched files — 0 errors
- [x] `pnpm exec prettier --check` on touched files — clean

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely. Full context: Discord thread, Aug 30. Review questions are welcome; answers will come from the same Claude-assisted workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New teams now open with an empty teammate roster instead of automatically adding default members.
  * Copying an existing team preserves member roles, workflows, providers, isolation settings, and other configuration.
  * Empty copied rosters remain empty.

* **Tests**
  * Added coverage for new-team rosters, copied members, custom roles, and configuration preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->