### PR TITLE
test(team): flush fail-closed authority clocks deterministically

### DIFF
--- a/test/renderer/components/team/TeamModelSelectorDisabledState.test.ts
+++ b/test/renderer/components/team/TeamModelSelectorDisabledState.test.ts
@@ -62,6 +62,18 @@ async function hydrateFailClosedAuthorityClocks(): Promise<void> {
   });
 }
 
+// Real-timer counterpart for tests that keep real timers: the fail-closed
+// authority clocks publish their first reading from a setTimeout(0) callback,
+// and that dispatch only flushes when awaited inside act().
+async function flushFailClosedAuthorityClocks(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
 vi.mock('@renderer/components/ui/tabs', () => {
   let currentValue = '';
   let currentOnValueChange: ((value: string) => void) | null = null;
@@ -1811,11 +1823,8 @@ describe('TeamModelSelector disabled Codex models', () => {
     expect(openAiButton?.getAttribute('aria-disabled')).toBe('true');
     expect(openAiButton?.textContent).toContain('Unavailable');
     expect(bigPickleButton).not.toBeNull();
-    await act(async () => {
-      await vi.waitFor(() =>
-        expect(bigPickleButton?.getAttribute('aria-disabled')).toBe('false')
-      );
-    });
+    await flushFailClosedAuthorityClocks();
+    expect(bigPickleButton?.getAttribute('aria-disabled')).toBe('false');
 
     await act(async () => {
       openAiButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -4198,9 +4207,9 @@ describe('TeamModelSelector disabled Codex models', () => {
     ).toBe(true);
     expect(host.textContent).not.toContain('SuperGrok');
 
-    await act(async () => {
-      await vi.waitFor(() => expect(copilotTab?.hasAttribute('disabled')).toBe(false));
-    });
+    await flushFailClosedAuthorityClocks();
+    expect(copilotTab?.hasAttribute('disabled')).toBe(false);
+    expect(copilotTab?.getAttribute('aria-disabled')).toBeNull();
 
     await act(async () => {
       copilotTab?.click();


### PR DESCRIPTION
Fixes the flaky renderer test that keeps failing CI shards at random (seen today on several unrelated PRs).

Root cause: two TeamModelSelectorDisabledState cases keep real timers and wait on aria-disabled through vi.waitFor, but the fail-closed authority clocks publish their first reading from a setTimeout(0) callback. Under IS_REACT_ACT_ENVIRONMENT that dispatch never flushes unless it is awaited inside act(), so in isolation the button stays disabled forever and only scheduler leftovers from neighbouring tests made it pass sometimes - which is exactly the intermittent CI failure.

Fix: a real-timer counterpart of hydrateFailClosedAuthorityClocks that awaits the clock callback inside act(), then asserts synchronously. The dashboard case additionally pins aria-disabled so a non-selectable tab cannot pass as clickable.

Verification: the full file passed 3/3 runs locally where baseline failed 7/8; the target case passed 5/5 in isolation where baseline failed 5/5. Production behavior is untouched - in a real browser the React scheduler flushes continuously and the fail-closed window is ~0ms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for provider-button enablement.
  * Added reliable handling for asynchronous authority clock updates using real timers.
  * Replaced polling-based checks with direct assertions after state updates complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->