### PR TITLE
fix(team): stabilize mixed-provider lifecycle e2e

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -239,6 +239,7 @@ import {
 } from './services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
 import { cleanupManagedOpenCodeServeProcesses } from './services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup';
 import { OpenCodeStateChangingBridgeCommandService } from './services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
+import { OpenCodeRuntimeLaunchAuthorityWriter } from './services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
 import { OpenCodeRuntimeManifestEvidenceReader } from './services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import {
   buildTeamControlApiBaseUrl,
@@ -748,6 +749,7 @@ async function createOpenCodeRuntimeAdapterRegistry(
     gitSha: process.env.VITE_GIT_SHA ?? process.env.GIT_SHA ?? null,
     buildId: process.env.VITE_BUILD_ID ?? process.env.BUILD_ID ?? null,
   });
+  const manifestOptions = { teamsBasePath: getTeamsBasePath() };
   const stateChangingCommands = new OpenCodeStateChangingBridgeCommandService({
     expectedClientIdentity: clientIdentity,
     handshakePort: new OpenCodeBridgeCommandHandshakePort({
@@ -761,9 +763,8 @@ async function createOpenCodeRuntimeAdapterRegistry(
       filePath: join(bridgeControlDir, 'command-ledger.json'),
     }),
     bridge: bridgeClient,
-    manifestReader: new OpenCodeRuntimeManifestEvidenceReader({
-      teamsBasePath: getTeamsBasePath(),
-    }),
+    launchAuthorityWriter: new OpenCodeRuntimeLaunchAuthorityWriter(manifestOptions),
+    manifestReader: new OpenCodeRuntimeManifestEvidenceReader(manifestOptions),
   });
   const readinessBridge = new OpenCodeReadinessBridge(bridgeClient, {
     stateChangingCommands,
@@ -776,7 +777,6 @@ async function createOpenCodeRuntimeAdapterRegistry(
     }),
   ]);
 }
-
 async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'): Promise<void> {
   let registryHostPids = new Set<number>();
   let registryCleanupAvailable = false;

--- a/src/main/services/infrastructure/CliInstallerService.ts
+++ b/src/main/services/infrastructure/CliInstallerService.ts
@@ -53,8 +53,11 @@ import { ClaudeBinaryResolver } from '../team/ClaudeBinaryResolver';
 import { getCliFlavorUiOptions, getConfiguredCliFlavor } from '../team/cliFlavor';
 
 import {
+  mergeProviderStatusPublication,
+  retainLatestProviderStatus,
+} from './cliInstallerProviderStatusUpdates';
+import {
   createMismatchedProviderStatus,
-  filterFrontendProviders,
   FRONTEND_PROVIDER_IDS,
   getAuthenticatedFrontendProvider,
   hasAuthenticatedFrontendProvider,
@@ -1069,6 +1072,9 @@ export class CliInstallerService {
           this.checkAuthStatus(binaryPath, r, diag, generation),
           r.supportsSelfUpdate ? this.fetchLatestVersion(r) : Promise.resolve(),
         ]);
+        if (generation === this.statusGatherGeneration) {
+          retainLatestProviderStatus(r, this.latestStatusSnapshot);
+        }
         this.rememberHealthyStatus(r);
         this.publishStatusSnapshotIfCurrent(r, generation);
       } else {
@@ -1226,12 +1232,6 @@ export class CliInstallerService {
     result.authMethod = null;
   }
 
-  /**
-   * Check auth status with retry — covers stale lock files after Ctrl+C interruption.
-   * Wrapped in its own timeout to prevent slow auth from blocking the overall status.
-   * Mutates `r` directly so results survive even if the outer Promise.all hasn't resolved.
-   */
-
   private async checkAuthStatus(
     binaryPath: string,
     result: CliInstallationStatus,
@@ -1241,28 +1241,34 @@ export class CliInstallerService {
     if (result.flavor === 'agent_teams_orchestrator') {
       result.authStatusChecking = true;
       let acceptsHydrationUpdates = true;
-      const applyProviders = (providersSnapshot: CliProviderStatus[], final: boolean): void => {
+      const hydratedProviderIds = new Set<CliProviderId>();
+      const applyProviders = (
+        providersSnapshot: CliProviderStatus[],
+        final: boolean,
+        updatedProviderId?: CliProviderId
+      ): void => {
         if (!acceptsHydrationUpdates || generation !== this.statusGatherGeneration) {
           return;
         }
-
-        const now = this.now();
-        const frontendProviders = filterFrontendProviders(providersSnapshot).map(
-          (provider) => projectProviderAuthority(provider, now)
+        const publication = mergeProviderStatusPublication(
+          providersSnapshot,
+          this.latestStatusSnapshot?.providers ?? result.providers,
+          hydratedProviderIds,
+          final,
+          this.now(),
+          updatedProviderId
         );
-        result.providers = frontendProviders;
-        result.authLoggedIn = hasAuthenticatedFrontendProvider(frontendProviders);
-        result.authMethod = getAuthenticatedFrontendProvider(frontendProviders)?.authMethod ?? null;
+        if (!publication) return;
+        Object.assign(result, publication);
         if (final) {
           result.authStatusChecking = false;
           this.rememberHealthyStatus(result);
         }
         this.publishStatusSnapshot(result);
       };
-
       const completion = this.multimodelBridgeService
-        .getProviderStatuses(binaryPath, (providersSnapshot) => {
-          applyProviders(providersSnapshot, false);
+        .getProviderStatuses(binaryPath, (providersSnapshot, updatedProviderId) => {
+          applyProviders(providersSnapshot, false, updatedProviderId);
         })
         .then((providers) => {
           applyProviders(providers, true);
@@ -1271,14 +1277,13 @@ export class CliInstallerService {
           if (!acceptsHydrationUpdates || generation !== this.statusGatherGeneration) {
             return;
           }
-
           const msg = getErrorMessage(error);
           diag.authLastError = msg;
           result.authStatusChecking = false;
           logger.warn(`Provider status check failed for claude-multimodel: ${msg}`);
+          retainLatestProviderStatus(result, this.latestStatusSnapshot);
           this.publishStatusSnapshot(result);
         });
-
       let timer: ReturnType<typeof setTimeout> | null = null;
       const timeout = new Promise<'timeout'>((resolve) => {
         timer = setTimeout(() => {
@@ -1288,7 +1293,6 @@ export class CliInstallerService {
         }, MULTIMODEL_PROVIDER_STATUS_INITIAL_TIMEOUT_MS);
         timer.unref?.();
       });
-
       const providerInitialWaitStartedAt = Date.now();
       const outcome = await Promise.race([completion.then(() => 'completed' as const), timeout]);
       diag.providerInitialWaitMs = Date.now() - providerInitialWaitStartedAt;
@@ -1297,6 +1301,9 @@ export class CliInstallerService {
       }
 
       if (outcome === 'timeout') {
+        if (generation === this.statusGatherGeneration) {
+          retainLatestProviderStatus(result, this.latestStatusSnapshot);
+        }
         diag.authTimedOut = true;
         logger.warn(
           `Provider status check still running after ${MULTIMODEL_PROVIDER_STATUS_INITIAL_TIMEOUT_MS}ms; returning partial CLI status`

--- a/src/main/services/infrastructure/cliInstallerProviderStatusUpdates.ts
+++ b/src/main/services/infrastructure/cliInstallerProviderStatusUpdates.ts
@@ -1,0 +1,62 @@
+import {
+  filterFrontendProviders,
+  getAuthenticatedFrontendProvider,
+  hasAuthenticatedFrontendProvider,
+  projectProviderAuthority,
+} from './cliInstallerStatusAuthority';
+
+import type { CliInstallationStatus, CliProviderId, CliProviderStatus } from '@shared/types';
+
+/** A hydration delta must never replay other providers from its original summary. */
+export function mergeProviderStatusPublication(
+  incoming: CliProviderStatus[],
+  current: CliProviderStatus[],
+  hydratedProviderIds: Set<CliProviderId>,
+  final: boolean,
+  now: number,
+  updatedProviderId?: CliProviderId
+): Pick<CliInstallationStatus, 'providers' | 'authLoggedIn' | 'authMethod'> | null {
+  let merged = incoming;
+  if (updatedProviderId !== undefined) {
+    if (incoming.length !== 1 || incoming[0].providerId !== updatedProviderId) return null;
+    hydratedProviderIds.add(updatedProviderId);
+    const found = current.some((provider) => provider.providerId === updatedProviderId);
+    merged = found
+      ? current.map((provider) =>
+          provider.providerId === updatedProviderId ? incoming[0] : provider
+        )
+      : [...current, incoming[0]];
+  } else if (final) {
+    // The full command can finish before the aggregate summary promise settles.
+    merged = incoming.map((provider) =>
+      hydratedProviderIds.has(provider.providerId)
+        ? (current.find((latest) => latest.providerId === provider.providerId) ?? provider)
+        : provider
+    );
+  }
+  const providers = filterFrontendProviders(merged).map((provider) =>
+    projectProviderAuthority(provider, now)
+  );
+  return {
+    providers,
+    authLoggedIn: hasAuthenticatedFrontendProvider(providers),
+    authMethod: getAuthenticatedFrontendProvider(providers)?.authMethod ?? null,
+  };
+}
+
+/** Keep a finishing aggregate run from republishing providers captured before a refresh. */
+export function retainLatestProviderStatus(
+  target: CliInstallationStatus,
+  latest: CliInstallationStatus | null
+): void {
+  if (
+    !latest ||
+    target.flavor !== 'agent_teams_orchestrator' ||
+    target.flavor !== latest.flavor ||
+    target.binaryPath !== latest.binaryPath
+  )
+    return;
+  target.providers = latest.providers;
+  target.authLoggedIn = latest.authLoggedIn;
+  target.authMethod = latest.authMethod;
+}

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
@@ -15,7 +15,6 @@ import {
 import {
   canHydrateProviderCatalog,
   markProviderCatalogRefreshFailed,
-  mergeProviderCatalogFields,
 } from './providerCatalogAuthority';
 import { providerConnectionService } from './ProviderConnectionService';
 import {
@@ -25,6 +24,7 @@ import {
   createRuntimeStatusErrorProviderStatus,
   getLegacyProviderStatusCheck,
   mapRuntimeExtensionCapabilities,
+  mergeProviderStatusDisplayEvidence,
   resolveRuntimeProviderStatusCheck,
   type RuntimeExtensionCapabilitiesResponse,
   sanitizeProviderStatusAuthority,
@@ -50,6 +50,12 @@ const LEGACY_PROVIDER_AUTH_TIMEOUT_MS = 15_000;
 const PROVIDER_MODELS_TIMEOUT_MS = 25_000;
 const PROVIDER_STATUS_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
 const PROVIDER_MODELS_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
+
+// Summary updates are snapshots; asynchronous hydration updates contain one provider delta.
+type ProviderStatusesObserver = (
+  providers: CliProviderStatus[],
+  updatedProviderId?: CliProviderId
+) => void;
 
 function getProviderStatusCommandCwd(projectPath: string | null | undefined): string | undefined {
   const normalized = projectPath?.trim();
@@ -1093,12 +1099,13 @@ export class ClaudeMultimodelBridgeService {
   }
 
   private notifyProviderStatuses(
-    onUpdate: ((providers: CliProviderStatus[]) => void) | undefined,
-    providers: CliProviderStatus[]
+    onUpdate: ProviderStatusesObserver | undefined,
+    providers: CliProviderStatus[],
+    updatedProviderId?: CliProviderId
   ): void {
     if (!onUpdate) return;
     try {
-      onUpdate(this.projectProviderStatuses(providers));
+      onUpdate(this.projectProviderStatuses(providers), updatedProviderId);
     } catch (error) {
       logger.warn(
         `Provider status observer failed: ${error instanceof Error ? error.message : String(error)}`
@@ -1307,7 +1314,7 @@ export class ClaudeMultimodelBridgeService {
     binaryPath: string,
     liveProviders: CliProviderStatus[],
     generation: number,
-    onUpdate?: (providers: CliProviderStatus[]) => void
+    onUpdate?: ProviderStatusesObserver
   ): void {
     if (!onUpdate) {
       for (const providerId of DEFAULT_PROVIDER_STATUS_IDS) {
@@ -1354,11 +1361,12 @@ export class ClaudeMultimodelBridgeService {
           }
           providers.set(
             liveProvider.providerId,
-            mergeProviderCatalogFields(currentProvider, hydratedProvider)
+            mergeProviderStatusDisplayEvidence(hydratedProvider, currentProvider)
           );
           this.notifyProviderStatuses(
             onUpdate,
-            this.buildProviderStatusesSnapshot(providers, providerIds)
+            [providers.get(liveProvider.providerId)!],
+            liveProvider.providerId
           );
         })
         .catch((error) => {
@@ -1379,7 +1387,8 @@ export class ClaudeMultimodelBridgeService {
           );
           this.notifyProviderStatuses(
             onUpdate,
-            this.buildProviderStatusesSnapshot(providers, providerIds)
+            [providers.get(liveProvider.providerId)!],
+            liveProvider.providerId
           );
         })
         .finally(() => {
@@ -1527,7 +1536,7 @@ export class ClaudeMultimodelBridgeService {
             )
           ) {
             return sanitizeProviderStatusAuthority(
-              mergeProviderCatalogFields(provider, hydratedProvider)
+              mergeProviderStatusDisplayEvidence(hydratedProvider, provider)
             );
           }
           return sanitizeProviderStatusAuthority(markProviderCatalogRefreshFailed(provider));
@@ -1561,7 +1570,7 @@ export class ClaudeMultimodelBridgeService {
             }
             this.notifyProviderStatus(
               onCatalogUpdate,
-              mergeProviderCatalogFields(provider, hydratedProvider)
+              mergeProviderStatusDisplayEvidence(hydratedProvider, provider)
             );
           })
           .catch((error) => {
@@ -1760,7 +1769,7 @@ export class ClaudeMultimodelBridgeService {
 
   async getProviderStatuses(
     binaryPath: string,
-    onUpdate?: (providers: CliProviderStatus[]) => void
+    onUpdate?: ProviderStatusesObserver
   ): Promise<CliProviderStatus[]> {
     await resolveInteractiveShellEnvBestEffort({
       timeoutMs: 1_500,

--- a/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandContract.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandContract.ts
@@ -129,8 +129,8 @@ export interface OpenCodeStopTeamCommandBody {
   manifestHighWatermark?: number | null;
   reason: string;
   force?: boolean;
+  allowEmptyLaneStop?: boolean;
 }
-
 export interface OpenCodeStopTeamCommandData {
   runId: string;
   stopped: boolean;

--- a/src/main/services/team/opencode/bridge/OpenCodeBridgeHandshakeClient.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeBridgeHandshakeClient.ts
@@ -41,6 +41,11 @@ export class OpenCodeBridgeCommandHandshakePort implements OpenCodeBridgeHandsha
     expectedCapabilitySnapshotId: string | null;
     expectedManifestHighWatermark: number | null;
     cwd?: string;
+    allowEmptyLaneStop?: boolean;
+    selectedModel?: string | null;
+    toolApprovalMode?: 'auto' | 'manual';
+    teamId?: string;
+    laneId?: string | null;
   }): Promise<OpenCodeBridgeHandshake> {
     const result = await this.bridge.execute<
       {
@@ -49,6 +54,11 @@ export class OpenCodeBridgeCommandHandshakePort implements OpenCodeBridgeHandsha
         expectedRunId: string | null;
         expectedCapabilitySnapshotId: string | null;
         expectedManifestHighWatermark: number | null;
+        allowEmptyLaneStop?: boolean;
+        selectedModel?: string | null;
+        toolApprovalMode?: 'auto' | 'manual';
+        teamId?: string;
+        laneId?: string | null;
       },
       OpenCodeBridgeHandshake
     >(
@@ -59,6 +69,13 @@ export class OpenCodeBridgeCommandHandshakePort implements OpenCodeBridgeHandsha
         expectedRunId: input.expectedRunId,
         expectedCapabilitySnapshotId: input.expectedCapabilitySnapshotId,
         expectedManifestHighWatermark: input.expectedManifestHighWatermark,
+        ...(input.allowEmptyLaneStop === true ? { allowEmptyLaneStop: true } : {}),
+        ...(input.selectedModel === undefined ? {} : { selectedModel: input.selectedModel }),
+        ...(input.toolApprovalMode === undefined
+          ? {}
+          : { toolApprovalMode: input.toolApprovalMode }),
+        ...(input.teamId === undefined ? {} : { teamId: input.teamId }),
+        ...(input.laneId === undefined ? {} : { laneId: input.laneId }),
       },
       {
         cwd: input.cwd ?? process.cwd(),

--- a/src/main/services/team/opencode/bridge/OpenCodeLaunchResultHelpers.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeLaunchResultHelpers.ts
@@ -19,6 +19,7 @@ export function isAmbiguousOpenCodeLaunchFailure(result: OpenCodeBridgeResult<un
     (result.error.kind === 'timeout' ||
       result.error.kind === 'transport_watchdog_timeout' ||
       isOpenCodeBridgeEmptyOutputFailure(result) ||
+      result.diagnostics.some((event) => event.type === 'opencode_bridge_unknown_outcome') ||
       result.error.message === 'OpenCode launch result behavior fingerprint mismatch')
   );
 }

--- a/src/main/services/team/opencode/bridge/OpenCodeReadinessBridge.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeReadinessBridge.ts
@@ -1,11 +1,13 @@
 import { randomUUID } from 'crypto';
 
+import { openCodeReadinessArtifactKey } from '../readiness/OpenCodeExpectedBehaviorFingerprint';
 import { normalizeOpenCodeProjectIdentity } from '../readiness/OpenCodeProjectIdentity';
 
 import {
   OPEN_CODE_DELIVERY_ACCEPTANCE_CONTRACT_VERSION,
   stableHash,
 } from './OpenCodeBridgeCommandContract';
+import { OpenCodeBridgeCommandLedgerError } from './OpenCodeBridgeCommandLedgerStore';
 import { buildOpenCodeBridgeSupportDiagnostic } from './OpenCodeBridgeSupportDiagnostics';
 import {
   blockedLaunchData,
@@ -82,14 +84,7 @@ export interface OpenCodeReadinessBridgeCommandBody {
   projectPath: string;
   selectedModel: string | null;
   requireExecutionProbe: boolean;
-}
-
-function openCodeReadinessArtifactKey(input: OpenCodeReadinessBridgeCommandBody): string {
-  return JSON.stringify([
-    normalizeOpenCodeProjectIdentity(input.projectPath),
-    input.selectedModel?.trim() ?? null,
-    input.requireExecutionProbe,
-  ]);
+  skipPermissions?: boolean;
 }
 
 const DEFAULT_READINESS_TIMEOUT_MS = 300_000;
@@ -209,7 +204,8 @@ export class OpenCodeReadinessBridge implements OpenCodeTeamRuntimeBridgePort {
   getLastOpenCodeRuntimeSnapshot(
     projectPath: string,
     selectedModel?: string | null,
-    requireExecutionProbe?: boolean
+    requireExecutionProbe?: boolean,
+    skipPermissions?: boolean
   ): OpenCodeBridgeRuntimeSnapshot | null {
     if (requireExecutionProbe !== undefined) {
       return (
@@ -218,6 +214,7 @@ export class OpenCodeReadinessBridge implements OpenCodeTeamRuntimeBridgePort {
             projectPath,
             selectedModel: selectedModel ?? null,
             requireExecutionProbe,
+            skipPermissions,
           })
         ) ?? null
       );
@@ -844,6 +841,10 @@ function thrownBridgeFailure<TData>(
   error: unknown
 ): OpenCodeBridgeResult<TData> {
   const message = error instanceof Error ? error.message : String(error);
+  const unknownOutcome =
+    error instanceof OpenCodeBridgeCommandLedgerError &&
+    (message === 'OpenCode bridge command outcome must be reconciled before retry' ||
+      message === 'OpenCode bridge command already started');
   const completedAt = new Date().toISOString();
   return {
     ok: false,
@@ -859,10 +860,12 @@ function thrownBridgeFailure<TData>(
     },
     diagnostics: [
       {
-        type: 'opencode_state_changing_bridge_exception',
+        type: unknownOutcome
+          ? 'opencode_bridge_unknown_outcome'
+          : 'opencode_state_changing_bridge_exception',
         providerId: 'opencode',
         runId,
-        severity: 'error',
+        severity: unknownOutcome ? 'warning' : 'error',
         message,
         createdAt: completedAt,
       },

--- a/src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService.ts
@@ -49,7 +49,22 @@ export interface OpenCodeBridgeHandshakePort {
     expectedCapabilitySnapshotId: string | null;
     expectedManifestHighWatermark: number | null;
     cwd?: string;
+    allowEmptyLaneStop?: boolean;
+    selectedModel?: string | null;
+    toolApprovalMode?: 'auto' | 'manual';
+    teamId?: string;
+    laneId?: string | null;
   }): Promise<OpenCodeBridgeHandshake>;
+}
+
+export interface OpenCodeLaunchAuthorityWriter {
+  publish(input: {
+    teamName: string;
+    laneId: string | null;
+    runId: string;
+    capabilitySnapshotId: string;
+    behaviorFingerprint: string;
+  }): Promise<void>;
 }
 
 export interface RuntimeStoreManifestReader {
@@ -67,6 +82,7 @@ export interface OpenCodeStateChangingBridgeCommandServiceOptions {
   ledger: OpenCodeBridgeCommandLedger;
   bridge: OpenCodeBridgeCommandExecutor;
   manifestReader: RuntimeStoreManifestReader;
+  launchAuthorityWriter: OpenCodeLaunchAuthorityWriter;
   diagnostics?: OpenCodeStateChangingBridgeDiagnosticsSink;
   requestIdFactory?: () => string;
   diagnosticIdFactory?: () => string;
@@ -81,6 +97,7 @@ export class OpenCodeStateChangingBridgeCommandService {
   private readonly leaseStore: OpenCodeBridgeCommandLeaseStore;
   private readonly ledger: OpenCodeBridgeCommandLedger;
   private readonly bridge: OpenCodeBridgeCommandExecutor;
+  private readonly launchAuthorityWriter: OpenCodeLaunchAuthorityWriter;
   private readonly manifestReader: RuntimeStoreManifestReader;
   private readonly diagnostics: OpenCodeStateChangingBridgeDiagnosticsSink | null;
   private readonly requestIdFactory: () => string;
@@ -96,6 +113,7 @@ export class OpenCodeStateChangingBridgeCommandService {
     this.ledger = options.ledger;
     this.bridge = options.bridge;
     this.manifestReader = options.manifestReader;
+    this.launchAuthorityWriter = options.launchAuthorityWriter;
     this.diagnostics = options.diagnostics ?? null;
     this.requestIdFactory = options.requestIdFactory ?? (() => `opencode-bridge-${randomUUID()}`);
     this.diagnosticIdFactory =
@@ -120,6 +138,7 @@ export class OpenCodeStateChangingBridgeCommandService {
     assertLaunchBehaviorFingerprint(input.command, input.behaviorFingerprint, input.body);
     const normalizedLaneId = input.laneId ?? null;
     const manifest = await this.manifestReader.read(input.teamName, normalizedLaneId);
+    const { capabilitySnapshotId, body: commandBody } = bindLifecycleManifest(input, manifest);
     const enforceManifestHighWatermark = commandRequiresRuntimeStoreManifestPrecondition(
       input.command
     );
@@ -129,24 +148,37 @@ export class OpenCodeStateChangingBridgeCommandService {
     const handshake = await this.handshakePort.handshake({
       requiredCommand: input.command,
       expectedRunId: input.runId,
-      expectedCapabilitySnapshotId: input.capabilitySnapshotId,
+      expectedCapabilitySnapshotId: capabilitySnapshotId,
       expectedManifestHighWatermark,
       cwd: input.cwd,
+      teamId: input.teamName,
+      laneId: normalizedLaneId,
+      ...(isRecord(commandBody) && commandBody.allowEmptyLaneStop === true
+        ? { allowEmptyLaneStop: true }
+        : {}),
+      ...(input.command === 'opencode.launchTeam' && isRecord(commandBody)
+        ? {
+            selectedModel:
+              typeof commandBody.selectedModel === 'string' ? commandBody.selectedModel : null,
+            toolApprovalMode:
+              commandBody.skipPermissions === false ? ('manual' as const) : ('auto' as const),
+          }
+        : {}),
     });
     const handshakeValidation = validateOpenCodeBridgeHandshake({
       handshake,
       expectedClient: this.expectedClientIdentity,
       requiredCommand: input.command,
-      expectedCapabilitySnapshotId: input.capabilitySnapshotId,
+      expectedCapabilitySnapshotId: capabilitySnapshotId,
       expectedManifestHighWatermark,
       expectedRunId: input.runId,
       requiresDeliveryAcceptanceContract: requiresOpenCodeDeliveryAcceptanceContract(
         input.command,
-        input.body
+        commandBody
       ),
       requiresVideoFilePartsContract: requiresOpenCodeVideoFilePartsContract(
         input.command,
-        input.body
+        commandBody
       ),
     });
 
@@ -159,7 +191,7 @@ export class OpenCodeStateChangingBridgeCommandService {
       teamName: input.teamName,
       laneId: normalizedLaneId,
       runId: input.runId,
-      body: input.body,
+      body: commandBody,
     });
     const commandRequestId = this.requestIdFactory();
     const lease = await this.acquireLease({
@@ -171,11 +203,11 @@ export class OpenCodeStateChangingBridgeCommandService {
     });
 
     try {
-      const bodyWithPreconditions = attachBridgePreconditions(input.body, {
+      const bodyWithPreconditions = attachBridgePreconditions(commandBody, {
         handshakeIdentityHash: handshake.identityHash,
         laneId: normalizedLaneId,
         expectedRunId: input.runId,
-        expectedCapabilitySnapshotId: input.capabilitySnapshotId,
+        expectedCapabilitySnapshotId: capabilitySnapshotId,
         expectedBehaviorFingerprint: input.behaviorFingerprint,
         expectedManifestHighWatermark,
         commandLeaseId: lease.leaseId,
@@ -194,10 +226,10 @@ export class OpenCodeStateChangingBridgeCommandService {
           teamName: input.teamName,
           laneId: normalizedLaneId,
           runId: input.runId,
-          capabilitySnapshotId: input.capabilitySnapshotId,
+          capabilitySnapshotId: capabilitySnapshotId,
           behaviorFingerprint: input.behaviorFingerprint,
           manifestHighWatermark: expectedManifestHighWatermark,
-          body: input.body,
+          body: commandBody,
         }),
       });
 
@@ -248,13 +280,13 @@ export class OpenCodeStateChangingBridgeCommandService {
           requestId: commandRequestId,
           command: input.command,
           runId: input.runId,
-          capabilitySnapshotId: input.capabilitySnapshotId,
+          capabilitySnapshotId: capabilitySnapshotId,
           manifest,
           idempotencyKey,
           enforceManifestHighWatermark,
           allowCapabilitySnapshotRecovery: isOpenCodeLaunchCapabilitySnapshotRecoveryAttempt(
             input.command,
-            input.body
+            commandBody
           ),
         });
         assertLaunchResultBehaviorFingerprint(
@@ -271,11 +303,13 @@ export class OpenCodeStateChangingBridgeCommandService {
             error
           )
         ) {
-          const ambiguousResult = launchFingerprintMismatchResult<TData>(result);
-          await this.ledger.markUnknownAfterTimeout({
-            idempotencyKey,
-            error: ambiguousResult.error.message,
-          });
+          const ambiguousResult = reconciliationRequiredLaunchResult<TData>(result);
+          await this.ledger
+            .markUnknownAfterTimeout({
+              idempotencyKey,
+              error: ambiguousResult.error.message,
+            })
+            .catch(() => undefined); // The existing started ledger entry still fences replay.
           await this.appendUnknownOutcomeDiagnostic({
             result: ambiguousResult,
             teamName: input.teamName,
@@ -284,8 +318,8 @@ export class OpenCodeStateChangingBridgeCommandService {
             command: input.command,
             idempotencyKey,
             leaseId: lease.leaseId,
-          });
-          await this.leaseStore.release(lease.leaseId);
+          }).catch(() => undefined); // Diagnostic storage cannot make a post-effect outcome terminal.
+          await this.leaseStore.release(lease.leaseId).catch(() => undefined);
           return ambiguousResult;
         }
         await this.ledger.markFailed({
@@ -294,6 +328,42 @@ export class OpenCodeStateChangingBridgeCommandService {
           retryable: false,
         });
         throw error;
+      }
+      if (input.command === 'opencode.launchTeam') {
+        try {
+          if (!input.runId || !result.runtime.capabilitySnapshotId || !input.behaviorFingerprint) {
+            throw new Error('Validated OpenCode launch authority is incomplete');
+          }
+          await this.launchAuthorityWriter.publish({
+            teamName: input.teamName,
+            laneId: normalizedLaneId,
+            runId: input.runId,
+            capabilitySnapshotId: result.runtime.capabilitySnapshotId,
+            behaviorFingerprint: input.behaviorFingerprint,
+          });
+        } catch (error) {
+          const ambiguousResult = reconciliationRequiredLaunchResult<TData>(
+            result,
+            `OpenCode launch authority publication failed; reconcile before retry: ${stringifyError(error)}`
+          );
+          await this.ledger
+            .markUnknownAfterTimeout({
+              idempotencyKey,
+              error: ambiguousResult.error.message,
+            })
+            .catch(() => undefined); // The existing started ledger entry still fences replay.
+          await this.appendUnknownOutcomeDiagnostic({
+            result: ambiguousResult,
+            teamName: input.teamName,
+            laneId: normalizedLaneId,
+            runId: input.runId,
+            command: input.command,
+            idempotencyKey,
+            leaseId: lease.leaseId,
+          }).catch(() => undefined); // Diagnostic storage cannot make a post-effect outcome terminal.
+          await this.leaseStore.release(lease.leaseId).catch(() => undefined);
+          return ambiguousResult;
+        }
       }
       await this.ledger.markCompleted({ idempotencyKey, response: result });
       await this.leaseStore.release(lease.leaseId);
@@ -374,6 +444,65 @@ export class OpenCodeStateChangingBridgeCommandService {
       createdAt: completedAt,
     });
   }
+}
+
+function bindLifecycleManifest<TBody>(
+  input: {
+    command: OpenCodeBridgeCommandName;
+    runId: string | null;
+    teamName: string;
+    laneId?: string | null;
+    capabilitySnapshotId: string | null;
+    body: TBody;
+  },
+  manifest: RuntimeStoreManifestEvidence
+): { capabilitySnapshotId: string | null; body: TBody } {
+  if (input.command !== 'opencode.stopTeam' && input.command !== 'opencode.reconcileTeam') {
+    return { capabilitySnapshotId: input.capabilitySnapshotId, body: input.body };
+  }
+  const emptyStop =
+    input.command === 'opencode.stopTeam' &&
+    manifest.activeRunId === null &&
+    manifest.capabilitySnapshotId === null &&
+    input.capabilitySnapshotId === null;
+  if (
+    !emptyStop &&
+    (!input.runId || manifest.activeRunId !== input.runId || !manifest.capabilitySnapshotId)
+  ) {
+    throw new Error(
+      'OpenCode lifecycle command requires the exact persisted lane run and capability snapshot'
+    );
+  }
+  const capabilitySnapshotId = manifest.capabilitySnapshotId;
+  if (capabilitySnapshotId === undefined) {
+    throw new Error('OpenCode lifecycle command requires a persisted lane capability snapshot');
+  }
+  const bodySnapshotId = isRecord(input.body) ? input.body.expectedCapabilitySnapshotId : null;
+  if (
+    (input.capabilitySnapshotId !== null && input.capabilitySnapshotId !== capabilitySnapshotId) ||
+    (bodySnapshotId != null && bodySnapshotId !== capabilitySnapshotId)
+  ) {
+    throw new Error(
+      'OpenCode lifecycle capability snapshot does not match the persisted lane manifest'
+    );
+  }
+  if (
+    !isRecord(input.body) ||
+    input.body.runId !== input.runId ||
+    input.body.teamId !== input.teamName ||
+    input.body.laneId !== (input.laneId ?? 'primary') ||
+    (input.body.allowEmptyLaneStop === true && !emptyStop)
+  ) {
+    throw new Error('OpenCode lifecycle command body does not match its persisted lane identity');
+  }
+  return {
+    capabilitySnapshotId,
+    body: {
+      ...input.body,
+      expectedCapabilitySnapshotId: capabilitySnapshotId,
+      ...(emptyStop ? { allowEmptyLaneStop: true } : {}),
+    },
+  };
 }
 
 function assertLaunchBehaviorFingerprint(
@@ -462,10 +591,14 @@ function requiresOpenCodeVideoFilePartsContract(
 function commandRequiresRuntimeStoreManifestPrecondition(
   command: OpenCodeBridgeCommandName
 ): boolean {
-  // Message delivery has its own durable acceptance evidence. Stop is a
-  // monotonic teardown fenced by exact team/lane/run ownership, so app-owned
-  // manifest evidence must not prevent the runtime from being terminated.
-  return command !== 'opencode.sendMessage' && command !== 'opencode.stopTeam';
+  // App metadata and runtime stores own independent watermarks. Lifecycle commands
+  // are fenced by exact lane/run/capability authority, not cross-domain counters.
+  // Message delivery has its own durable acceptance evidence.
+  return (
+    command !== 'opencode.sendMessage' &&
+    command !== 'opencode.stopTeam' &&
+    command !== 'opencode.reconcileTeam'
+  );
 }
 
 export function resolveOpenCodeBridgeLeaseAcquireTimeoutMs(input: {
@@ -495,8 +628,9 @@ function isLaunchFingerprintEchoMismatch(
   );
 }
 
-function launchFingerprintMismatchResult<TData>(
-  result: Extract<OpenCodeBridgeResult<TData>, { ok: true }>
+function reconciliationRequiredLaunchResult<TData>(
+  result: Extract<OpenCodeBridgeResult<TData>, { ok: true }>,
+  message = 'OpenCode launch result behavior fingerprint mismatch'
 ): Extract<OpenCodeBridgeResult<TData>, { ok: false }> {
   return {
     ok: false,
@@ -507,10 +641,19 @@ function launchFingerprintMismatchResult<TData>(
     durationMs: result.durationMs,
     error: {
       kind: 'contract_violation',
-      message: 'OpenCode launch result behavior fingerprint mismatch',
+      message,
       retryable: false,
     },
-    diagnostics: result.diagnostics,
+    diagnostics: [
+      ...result.diagnostics,
+      {
+        type: 'opencode_bridge_unknown_outcome',
+        providerId: 'opencode',
+        severity: 'warning',
+        message,
+        createdAt: result.completedAt,
+      },
+    ],
   };
 }
 

--- a/src/main/services/team/opencode/readiness/OpenCodeExpectedBehaviorFingerprint.ts
+++ b/src/main/services/team/opencode/readiness/OpenCodeExpectedBehaviorFingerprint.ts
@@ -35,6 +35,7 @@ interface OpenCodeReadinessIdentity {
   projectPath: string;
   selectedModel: string | null;
   requireExecutionProbe: boolean;
+  skipPermissions?: boolean;
 }
 
 export function openCodeReadinessArtifactKey(input: OpenCodeReadinessIdentity): string {
@@ -42,6 +43,7 @@ export function openCodeReadinessArtifactKey(input: OpenCodeReadinessIdentity): 
     normalizeOpenCodeProjectIdentity(input.projectPath),
     input.selectedModel?.trim() ?? null,
     input.requireExecutionProbe,
+    input.skipPermissions === false ? 'manual' : 'auto',
   ]);
 }
 
@@ -62,8 +64,8 @@ export function reusableOpenCodeExecutionProof(
   const expiresAt = Date.parse(proof.expiresAt);
   if (
     proof.modelId !== readiness?.modelId ||
-    normalizeOpenCodeProjectIdentity(proof.projectPath) !==
-      normalizeOpenCodeProjectIdentity(input.projectPath) ||
+    createOpenCodeCanonicalProjectPathFingerprint(proof.projectPath) !==
+      createOpenCodeCanonicalProjectPathFingerprint(input.projectPath) ||
     !Number.isFinite(expiresAt) ||
     expiresAt <= Date.now() + 1_000
   ) {
@@ -93,8 +95,8 @@ export function freshOpenCodeExecutionProof(
     );
   }
   if (
-    normalizeOpenCodeProjectIdentity(proof.projectPath) !==
-      normalizeOpenCodeProjectIdentity(input.projectPath) ||
+    createOpenCodeCanonicalProjectPathFingerprint(proof.projectPath) !==
+      createOpenCodeCanonicalProjectPathFingerprint(input.projectPath) ||
     !Number.isFinite(Date.parse(proof.expiresAt)) ||
     Date.parse(proof.expiresAt) <= Date.now()
   ) {
@@ -225,8 +227,8 @@ export function validateOpenCodeExpectedBehaviorEvidence(input: {
     throw new Error('OpenCode expected behavior evidence project behavior fingerprint mismatch');
   }
   if (
-    normalizeOpenCodeProjectIdentity(input.executionProof.projectPath) !==
-    normalizeOpenCodeProjectIdentity(input.projectPath)
+    createOpenCodeCanonicalProjectPathFingerprint(input.executionProof.projectPath) !==
+    createOpenCodeCanonicalProjectPathFingerprint(input.projectPath)
   ) {
     throw new Error('OpenCode expected behavior evidence execution proof project mismatch');
   }

--- a/src/main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter.ts
+++ b/src/main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter.ts
@@ -1,0 +1,30 @@
+import {
+  getOpenCodeRuntimeManifestPath,
+  withOpenCodeRuntimeLaneLifecycleLock,
+} from './OpenCodeRuntimeManifestEvidenceReader';
+import { createRuntimeStoreManifestStore } from './RuntimeStoreManifest';
+
+import type { OpenCodeLaunchAuthorityWriter } from '../bridge/OpenCodeStateChangingBridgeCommandService';
+
+export class OpenCodeRuntimeLaunchAuthorityWriter implements OpenCodeLaunchAuthorityWriter {
+  constructor(private readonly options: { teamsBasePath: string }) {}
+
+  async publish(input: Parameters<OpenCodeLaunchAuthorityWriter['publish']>[0]): Promise<void> {
+    await withOpenCodeRuntimeLaneLifecycleLock({ ...this.options, ...input }, async () => {
+      const store = createRuntimeStoreManifestStore({
+        filePath: getOpenCodeRuntimeManifestPath(
+          this.options.teamsBasePath,
+          input.teamName,
+          input.laneId
+        ),
+        teamName: input.teamName,
+      });
+      await store.setActiveRun({
+        runId: input.runId,
+        expectedRunId: input.runId,
+        capabilitySnapshotId: input.capabilitySnapshotId,
+        behaviorFingerprint: input.behaviorFingerprint,
+      });
+    });
+  }
+}

--- a/src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader.ts
+++ b/src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader.ts
@@ -891,7 +891,7 @@ async function clearOpenCodeRuntimeLaneStorageUnlocked(params: {
   return true;
 }
 
-function withOpenCodeRuntimeLaneLifecycleLock<T>(
+export function withOpenCodeRuntimeLaneLifecycleLock<T>(
   params: { teamsBasePath: string; teamName: string; laneId?: string | null },
   operation: () => Promise<T>
 ): Promise<T> {

--- a/src/main/services/team/opencode/store/RuntimeStoreManifest.ts
+++ b/src/main/services/team/opencode/store/RuntimeStoreManifest.ts
@@ -3,6 +3,12 @@ import { createHash, randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
 import * as path from 'path';
 
+import {
+  isActiveRunOnlyWatermark,
+  resolveActiveRunAuthority,
+  resolveActiveRunWatermark,
+  resolveCommittedBatchAuthority,
+} from './RuntimeStoreManifestAuthority';
 import { VersionedJsonStore, VersionedJsonStoreError } from './VersionedJsonStore';
 
 import type { FileLockOptions } from '../../fileLock';
@@ -128,6 +134,7 @@ export interface RuntimeStoreWriteBatch {
   capabilitySnapshotId: string | null;
   behaviorFingerprint: string | null;
   reason: RuntimeStoreWriteBatchReason;
+  authorityMode?: 'metadata-only';
   startedAt: string;
   completedAt: string | null;
   state: 'preparing' | 'committing' | 'committed' | 'failed';
@@ -280,51 +287,27 @@ export class RuntimeStoreManifestStore {
     runId: string | null;
     capabilitySnapshotId?: string | null;
     behaviorFingerprint?: string | null;
+    expectedRunId?: string;
   }): Promise<RuntimeStoreManifest> {
-    const normalizedRunId = input.runId?.trim() || null;
     const result = await this.store.updateLocked((manifest) => {
-      const normalizedCapabilitySnapshotId =
-        input.capabilitySnapshotId === undefined
-          ? manifest.activeCapabilitySnapshotId
-          : input.capabilitySnapshotId?.trim() || null;
-      const normalizedBehaviorFingerprint =
-        input.behaviorFingerprint === undefined
-          ? manifest.activeBehaviorFingerprint
-          : input.behaviorFingerprint?.trim() || null;
+      const authority = resolveActiveRunAuthority(manifest, input);
       const changed =
-        manifest.activeRunId !== normalizedRunId ||
-        manifest.activeCapabilitySnapshotId !== normalizedCapabilitySnapshotId ||
-        manifest.activeBehaviorFingerprint !== normalizedBehaviorFingerprint ||
-        this.isActiveRunOnlyWatermark(manifest);
+        manifest.activeRunId !== authority.activeRunId ||
+        manifest.activeCapabilitySnapshotId !== authority.activeCapabilitySnapshotId ||
+        manifest.activeBehaviorFingerprint !== authority.activeBehaviorFingerprint ||
+        isActiveRunOnlyWatermark(manifest);
       if (!changed) {
         return manifest;
       }
 
       return {
         ...manifest,
-        activeRunId: normalizedRunId,
-        activeCapabilitySnapshotId: normalizedCapabilitySnapshotId,
-        activeBehaviorFingerprint: normalizedBehaviorFingerprint,
-        highWatermark: this.resolveActiveRunWatermark(manifest),
+        ...authority,
+        highWatermark: resolveActiveRunWatermark(manifest),
         updatedAt: this.clock().toISOString(),
       };
     });
     return result.data;
-  }
-
-  private isActiveRunOnlyWatermark(manifest: RuntimeStoreManifest): boolean {
-    return (
-      manifest.highWatermark > 0 &&
-      manifest.entries.length === 0 &&
-      manifest.lastCommittedBatchId === null
-    );
-  }
-
-  private resolveActiveRunWatermark(manifest: RuntimeStoreManifest): number {
-    if (this.isActiveRunOnlyWatermark(manifest)) {
-      return 0;
-    }
-    return manifest.highWatermark;
   }
 
   async markBatchPreparing(batch: RuntimeStoreWriteBatch): Promise<void> {
@@ -356,9 +339,7 @@ export class RuntimeStoreManifestStore {
 
       return {
         ...manifest,
-        activeRunId: batch.runId,
-        activeCapabilitySnapshotId: batch.capabilitySnapshotId,
-        activeBehaviorFingerprint: batch.behaviorFingerprint,
+        ...resolveCommittedBatchAuthority(manifest, batch),
         highWatermark: manifest.highWatermark + 1,
         lastCommittedBatchId: batch.batchId,
         lastPreparingBatchId:
@@ -456,19 +437,29 @@ export class RuntimeStoreBatchWriter {
     capabilitySnapshotId: string | null;
     behaviorFingerprint: string | null;
     reason: RuntimeStoreWriteBatchReason;
+    authorityMode?: 'metadata-only';
     writes: {
       descriptor: RuntimeStoreDescriptor;
       data: unknown;
     }[];
   }): Promise<RuntimeStoreWriteBatch> {
+    const authority =
+      input.authorityMode === 'metadata-only'
+        ? resolveCommittedBatchAuthority(await this.manifestStore.read(), input)
+        : null;
     const clock = this.options.clock ?? (() => new Date());
     const batch: RuntimeStoreWriteBatch = {
       batchId: this.options.batchIdFactory?.() ?? `opencode-store-batch-${randomUUID()}`,
       teamName: input.teamName,
       runId: input.runId,
-      capabilitySnapshotId: input.capabilitySnapshotId,
-      behaviorFingerprint: input.behaviorFingerprint,
+      capabilitySnapshotId: authority
+        ? authority.activeCapabilitySnapshotId
+        : input.capabilitySnapshotId,
+      behaviorFingerprint: authority
+        ? authority.activeBehaviorFingerprint
+        : input.behaviorFingerprint,
       reason: input.reason,
+      ...(input.authorityMode ? { authorityMode: input.authorityMode } : {}),
       startedAt: clock().toISOString(),
       completedAt: null,
       state: 'preparing',
@@ -1112,6 +1103,7 @@ function isWriteBatch(value: unknown): value is RuntimeStoreWriteBatch {
     isNullableString(value.runId) &&
     isNullableString(value.capabilitySnapshotId) &&
     isNullableString(value.behaviorFingerprint) &&
+    (value.authorityMode === undefined || value.authorityMode === 'metadata-only') &&
     isWriteBatchReason(value.reason) &&
     isNonEmptyString(value.startedAt) &&
     isNullableString(value.completedAt) &&

--- a/src/main/services/team/opencode/store/RuntimeStoreManifestAuthority.ts
+++ b/src/main/services/team/opencode/store/RuntimeStoreManifestAuthority.ts
@@ -1,0 +1,92 @@
+import type { RuntimeStoreManifest, RuntimeStoreWriteBatch } from './RuntimeStoreManifest';
+
+type Authority = Pick<
+  RuntimeStoreManifest,
+  'activeRunId' | 'activeCapabilitySnapshotId' | 'activeBehaviorFingerprint'
+>;
+
+export function resolveActiveRunAuthority(
+  manifest: RuntimeStoreManifest,
+  input: {
+    runId: string | null;
+    capabilitySnapshotId?: string | null;
+    behaviorFingerprint?: string | null;
+    expectedRunId?: string;
+  }
+): Authority {
+  const runId = input.runId?.trim() || null;
+  const sameRun = manifest.activeRunId === runId;
+  const capabilitySnapshotId =
+    input.capabilitySnapshotId === undefined
+      ? sameRun
+        ? manifest.activeCapabilitySnapshotId
+        : null
+      : input.capabilitySnapshotId?.trim() || null;
+  const behaviorFingerprint =
+    input.behaviorFingerprint === undefined
+      ? sameRun
+        ? manifest.activeBehaviorFingerprint
+        : null
+      : input.behaviorFingerprint?.trim() || null;
+  if (
+    input.expectedRunId !== undefined &&
+    (manifest.activeRunId !== input.expectedRunId ||
+      runId !== input.expectedRunId ||
+      (manifest.activeCapabilitySnapshotId !== null &&
+        manifest.activeCapabilitySnapshotId !== capabilitySnapshotId) ||
+      (manifest.activeBehaviorFingerprint !== null &&
+        manifest.activeBehaviorFingerprint !== behaviorFingerprint))
+  )
+    throw new Error('OpenCode launch authority no longer matches the active lane run or binding');
+  return {
+    activeRunId: runId,
+    activeCapabilitySnapshotId: capabilitySnapshotId,
+    activeBehaviorFingerprint: behaviorFingerprint,
+  };
+}
+
+export function resolveCommittedBatchAuthority(
+  manifest: RuntimeStoreManifest,
+  batch: Pick<
+    RuntimeStoreWriteBatch,
+    'runId' | 'capabilitySnapshotId' | 'behaviorFingerprint' | 'authorityMode'
+  >
+): Authority {
+  if (batch.authorityMode === 'metadata-only') {
+    if (!batch.runId || manifest.activeRunId !== batch.runId) {
+      throw new Error('OpenCode metadata batch no longer matches the active lane run');
+    }
+    if (
+      (batch.capabilitySnapshotId !== null &&
+        batch.capabilitySnapshotId !== manifest.activeCapabilitySnapshotId) ||
+      (batch.behaviorFingerprint !== null &&
+        batch.behaviorFingerprint !== manifest.activeBehaviorFingerprint)
+    ) {
+      throw new Error('OpenCode metadata batch cannot publish launch authority');
+    }
+    return {
+      activeRunId: batch.runId,
+      activeCapabilitySnapshotId:
+        manifest.activeRunId === batch.runId ? manifest.activeCapabilitySnapshotId : null,
+      activeBehaviorFingerprint:
+        manifest.activeRunId === batch.runId ? manifest.activeBehaviorFingerprint : null,
+    };
+  }
+  return {
+    activeRunId: batch.runId,
+    activeCapabilitySnapshotId: batch.capabilitySnapshotId,
+    activeBehaviorFingerprint: batch.behaviorFingerprint,
+  };
+}
+
+export function isActiveRunOnlyWatermark(manifest: RuntimeStoreManifest): boolean {
+  return (
+    manifest.highWatermark > 0 &&
+    manifest.entries.length === 0 &&
+    manifest.lastCommittedBatchId === null
+  );
+}
+
+export function resolveActiveRunWatermark(manifest: RuntimeStoreManifest): number {
+  return isActiveRunOnlyWatermark(manifest) ? 0 : manifest.highWatermark;
+}

--- a/src/main/services/team/provisioning/OpenCodeAggregatePrimaryRestartPolicy.ts
+++ b/src/main/services/team/provisioning/OpenCodeAggregatePrimaryRestartPolicy.ts
@@ -132,6 +132,26 @@ export function getCancelledAggregateLaunchError(teamName: string): Error {
   );
 }
 
+export async function clearCancelledAggregateRestartState(input: {
+  runId: string;
+  restartLease?: OpenCodeAggregatePrimaryRestartLease;
+  clearLaunchState(runId: string): Promise<void>;
+  clearPrimaryLane(runId: string): Promise<void>;
+  onLaunchClearError(runId: string, error: unknown): void;
+}): Promise<void> {
+  const { runId, restartLease } = input;
+  const ownedRunIds =
+    restartLease?.runId === runId && restartLease.cancelRequested && restartLease.candidateRunId
+      ? [runId, restartLease.candidateRunId]
+      : [runId];
+  for (const ownedRunId of ownedRunIds) {
+    await input.clearLaunchState(ownedRunId).catch((error: unknown) => {
+      input.onLaunchClearError(ownedRunId, error);
+    });
+    await input.clearPrimaryLane(ownedRunId);
+  }
+}
+
 export async function clearPersistedAggregateLaunchStateIfOwned(input: {
   teamName: string;
   expectedRunId: string;

--- a/src/main/services/team/provisioning/OpenCodeAggregatePrimaryRestartPolicy.ts
+++ b/src/main/services/team/provisioning/OpenCodeAggregatePrimaryRestartPolicy.ts
@@ -148,7 +148,9 @@ export async function clearCancelledAggregateRestartState(input: {
     await input.clearLaunchState(ownedRunId).catch((error: unknown) => {
       input.onLaunchClearError(ownedRunId, error);
     });
-    await input.clearPrimaryLane(ownedRunId);
+    await input.clearPrimaryLane(ownedRunId).catch((error: unknown) => {
+      input.onLaunchClearError(ownedRunId, error);
+    });
   }
 }
 

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryFacade.ts
@@ -8,6 +8,7 @@ import { OpenCodeAggregatePrimaryProgressPublisher } from './OpenCodeAggregatePr
 import {
   assertAggregatePrimaryStopConfirmed,
   beginAggregatePrimaryRestart,
+  clearCancelledAggregateRestartState,
   clearPersistedAggregateLaunchStateIfOwned,
   getCancelledAggregateLaunchError,
   getCancelledAggregateRestartError,
@@ -50,8 +51,7 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
       this.runtimeAdapterProgressState.setRuntimeAdapterProgress(progress, onProgress),
     enrichRuntimeAdapterProgressTrace: (progress) =>
       this.runtimeAdapterProgressState.enrichRuntimeAdapterProgressTrace(progress),
-    rememberProgress: (progress) =>
-      this.runtimeAdapterProgressByRunId.set(progress.runId, progress),
+    rememberProgress: (progress) => this.runtimeAdapterProgressByRunId.set(progress.runId, progress),
     invalidateRuntimeSnapshotCaches: (teamName) => this.invalidateRuntimeSnapshotCaches(teamName),
   });
   private runAfterInFlightTeamOperation<T>(
@@ -121,18 +121,22 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
   private async clearCancelledOpenCodeAggregateRestartState(
     teamName: string,
     runId: string,
-    confirmedCancelledRestart?: OpenCodeAggregatePrimaryRestartLease
+    cancelledRestart?: OpenCodeAggregatePrimaryRestartLease
   ): Promise<void> {
-    await this.clearPersistedOpenCodeLaunchStateIfOwned(
-      teamName,
+    await clearCancelledAggregateRestartState({
       runId,
-      confirmedCancelledRestart
-    ).catch((error: unknown) => {
-      logger.warn(
-        `[${teamName}] Failed to clear late launch state after cancelled primary restart: ${getErrorMessage(error)}`
-      );
+      restartLease:
+        cancelledRestart ??
+        this.openCodeAggregatePrimaryRestartByTeam.get(teamName.trim().toLowerCase()),
+      clearLaunchState: (ownedId) =>
+        this.clearPersistedOpenCodeLaunchStateIfOwned(teamName, ownedId, cancelledRestart),
+      clearPrimaryLane: (ownedId) =>
+        this.cancellationBoundary.clearOpenCodeRuntimeAdapterPrimaryLaneIfOwned(teamName, ownedId),
+      onLaunchClearError: (ownedId, error) =>
+        logger.warn(
+          `[${teamName}] Failed to clear late launch state for cancelled run ${ownedId}: ${getErrorMessage(error)}`
+        ),
     });
-    await this.cancellationBoundary.clearOpenCodeRuntimeAdapterPrimaryLaneIfOwned(teamName, runId);
   }
 
   private async clearPersistedOpenCodeLaunchStateIfOwned(
@@ -148,8 +152,7 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
       lastWrittenRunIds: this.launchStateWrittenRunIdByTeam,
       restarts: this.openCodeAggregatePrimaryRestartByTeam,
       launchStateStore: this.launchStateStore,
-      withLaunchStateLock: (operation) =>
-        this.enqueueLaunchStateStoreOperation(teamName, operation),
+      withLaunchStateLock: (operation) => this.enqueueLaunchStateStoreOperation(teamName, operation),
       invalidateRuntimeSnapshotCaches: (candidateTeamName) =>
         this.invalidateRuntimeSnapshotCaches(candidateTeamName),
     });

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeBootstrapEvidence.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeBootstrapEvidence.ts
@@ -12,6 +12,7 @@ import {
   type OpenCodeCommittedBootstrapSessionEvidence,
   type OpenCodeCommittedBootstrapSessionRecord,
   readCommittedOpenCodeBootstrapSessionEvidence,
+  withOpenCodeRuntimeLaneLifecycleLock,
 } from '../opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import {
   createRuntimeStoreManifestStore,
@@ -275,6 +276,16 @@ export async function commitOpenCodeRuntimeBootstrapSessionEvidence(
   input: CommitOpenCodeRuntimeBootstrapSessionEvidenceInput,
   ports: OpenCodeRuntimeBootstrapEvidencePorts
 ): Promise<void> {
+  return withOpenCodeRuntimeLaneLifecycleLock(
+    { teamsBasePath: ports.teamsBasePath, ...input },
+    () => commitOpenCodeRuntimeBootstrapSessionEvidenceUnlocked(input, ports)
+  );
+}
+
+async function commitOpenCodeRuntimeBootstrapSessionEvidenceUnlocked(
+  input: CommitOpenCodeRuntimeBootstrapSessionEvidenceInput,
+  ports: OpenCodeRuntimeBootstrapEvidencePorts
+): Promise<void> {
   const paths = getOpenCodeRuntimeSessionStorePaths({
     teamsBasePath: ports.teamsBasePath,
     teamName: input.teamName,
@@ -328,6 +339,7 @@ export async function commitOpenCodeRuntimeBootstrapSessionEvidence(
       runId: input.runId,
       capabilitySnapshotId: null,
       behaviorFingerprint: null,
+      authorityMode: 'metadata-only',
       reason: 'launch_checkpoint',
       writes: [
         {
@@ -353,6 +365,19 @@ export async function commitOpenCodeRuntimeBootstrapSessionEvidence(
 }
 
 export async function stampOpenCodeAppMcpTransportEvidenceIfMissing(
+  session: OpenCodeCommittedBootstrapSessionRecord,
+  ports: OpenCodeRuntimeBootstrapEvidencePorts,
+  options: { overwriteExistingHash?: boolean; runtimeSessionId?: string | null } = {}
+): Promise<void> {
+  await withOpenCodeRuntimeLaneLifecycleLock(
+    { teamsBasePath: ports.teamsBasePath, teamName: session.teamName, laneId: session.laneId },
+    () => stampOpenCodeAppMcpTransportEvidenceIfMissingUnlocked(session, ports, options)
+  ).catch((error) =>
+    ports.warn(`OpenCode app MCP transport evidence update failed: ${getErrorMessage(error)}`)
+  );
+}
+
+async function stampOpenCodeAppMcpTransportEvidenceIfMissingUnlocked(
   session: OpenCodeCommittedBootstrapSessionRecord,
   ports: OpenCodeRuntimeBootstrapEvidencePorts,
   options: {
@@ -441,6 +466,7 @@ export async function stampOpenCodeAppMcpTransportEvidenceIfMissing(
       runId: session.runId,
       capabilitySnapshotId: null,
       behaviorFingerprint: null,
+      authorityMode: 'metadata-only',
       reason: 'delivery_commit',
       writes: [
         {

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeDiagnosticsPolicy.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeDiagnosticsPolicy.ts
@@ -233,6 +233,18 @@ export function selectOpenCodePrepareProviderDiagnostic(
 export function selectOpenCodeModelPreparePrimaryReason(
   prepare: Extract<TeamRuntimePrepareResult, { ok: false }>
 ): string {
+  // A typed terminal auth failure outranks occupancy and cached MCP proof notes
+  // collected earlier during the same execution probe.
+  if (prepare.reason === 'not_authenticated') {
+    const authFailure = selectRuntimeDiagnosticClassification(
+      [...prepare.diagnostics, ...prepare.warnings].filter(
+        (entry) => !isGenericOpenCodePersistedFailureReason(entry)
+      )
+    );
+    return authFailure?.reasonCode === 'auth_error'
+      ? (authFailure.normalizedMessage ?? prepare.reason)
+      : prepare.reason;
+  }
   const providerDiagnostic = selectOpenCodePrepareProviderDiagnostic(prepare);
   if (providerDiagnostic) {
     return providerDiagnostic;
@@ -252,6 +264,7 @@ export function isOpenCodeModelPrepareBusyDeferred(
   const candidates = [primaryReason, prepare.reason, ...prepare.diagnostics, ...prepare.warnings];
   return (
     prepare.retryable &&
+    prepare.reason !== 'not_authenticated' &&
     !candidates.some(isOpenCodeModelVerificationTimeoutDiagnostic) &&
     candidates.some(isRetryableOpenCodePreflightBusyDiagnostic)
   );

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeModelPreparation.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeModelPreparation.ts
@@ -167,7 +167,7 @@ export async function prepareSelectedOpenCodeModelsForProvisioning({
   const supportDiagnostics: TeamProvisioningSupportDiagnostic[] = [];
   const startedAt = Date.now();
 
-  if (modelIds.length === 0 && verificationMode !== 'compatibility') {
+  if (modelIds.length === 0) {
     return { details, warnings, blockingMessages, issues, supportDiagnostics };
   }
 

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeModelPreparation.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeModelPreparation.ts
@@ -1,6 +1,10 @@
 import { getErrorMessage } from '@shared/utils/errorHandling';
 import { parseOpenCodeQualifiedModelRef } from '@shared/utils/opencodeModelRef';
 import { isOpenCodeLocalProviderId } from '@shared/utils/opencodeModelRoute';
+import {
+  hasAuthoritativeProviderStatusEvidence,
+  isProviderModelCatalogExactReady,
+} from '@shared/utils/providerStatusAuthority';
 import { randomUUID } from 'crypto';
 
 import {
@@ -14,7 +18,6 @@ import {
   looksLikeOpenCodeProviderPrepareDiagnostic,
   normalizeOpenCodePrepareDiagnostic,
   selectOpenCodeModelPreparePrimaryReason,
-  selectOpenCodePrepareProviderDiagnostic,
 } from './TeamProvisioningOpenCodeDiagnosticsPolicy';
 
 export {
@@ -26,6 +29,7 @@ export {
 
 import type { TeamLaunchRuntimeAdapter, TeamRuntimePrepareResult } from '../runtime';
 import type {
+  CliProviderStatus,
   TeamProvisioningModelVerificationMode,
   TeamProvisioningPrepareIssue,
   TeamProvisioningSupportDiagnostic,
@@ -68,6 +72,7 @@ export interface OpenCodeLocalModelRuntimeReadiness {
 
 export interface OpenCodeSelectedModelPreparationInput {
   adapter: TeamLaunchRuntimeAdapter;
+  readProviderStatus?: (input: { cwd: string }) => Promise<CliProviderStatus | null>;
   cwd: string;
   modelIds: readonly string[];
   verificationMode: TeamProvisioningModelVerificationMode;
@@ -79,10 +84,6 @@ export interface OpenCodeSelectedModelPreparationInput {
     classificationOnly?: boolean;
   }) => Promise<OpenCodeLocalModelRuntimeReadiness | null>;
 }
-
-type OpenCodeLaunchReadinessProvider = TeamLaunchRuntimeAdapter & {
-  getLastOpenCodeTeamLaunchReadiness?: (cwd: string) => { availableModels?: unknown } | null;
-};
 
 const OPENCODE_PROVIDER_SCOPED_PREPARE_FAILURE_REASONS = new Set([
   'not_installed',
@@ -152,6 +153,7 @@ function buildLocalRuntimeInspectionFailure(
 
 export async function prepareSelectedOpenCodeModelsForProvisioning({
   adapter,
+  readProviderStatus,
   cwd,
   modelIds,
   verificationMode,
@@ -165,21 +167,18 @@ export async function prepareSelectedOpenCodeModelsForProvisioning({
   const supportDiagnostics: TeamProvisioningSupportDiagnostic[] = [];
   const startedAt = Date.now();
 
-  if (modelIds.length === 0) {
+  if (modelIds.length === 0 && verificationMode !== 'compatibility') {
     return { details, warnings, blockingMessages, issues, supportDiagnostics };
   }
 
   if (verificationMode === 'compatibility') {
-    const sharedCompatibilityPrepare = await prepareSelectedOpenCodeModelsCompatibilityBatch({
-      adapter,
+    return prepareSelectedOpenCodeModelsCompatibilityBatch({
+      readProviderStatus,
       cwd,
       modelIds,
       appendPreflightDebugLog,
       inspectLocalModelRuntime,
     });
-    if (sharedCompatibilityPrepare) {
-      return sharedCompatibilityPrepare;
-    }
   }
 
   const results = new Array<
@@ -206,7 +205,7 @@ export async function prepareSelectedOpenCodeModelsForProvisioning({
         cwd,
         providerId: 'opencode',
         model: modelId,
-        runtimeOnly: verificationMode === 'compatibility',
+        runtimeOnly: false,
         skipPermissions: true,
         expectedMembers: [],
         previousLaunchState: null,
@@ -322,7 +321,7 @@ export async function prepareSelectedOpenCodeModelsForProvisioning({
     const prepare = await prepareModel(modelId);
     results[index] = { modelId, prepare, localRuntimeReadiness };
 
-    if (verificationMode === 'compatibility' || prepare.ok) {
+    if (prepare.ok) {
       continue;
     }
 
@@ -384,11 +383,9 @@ export async function prepareSelectedOpenCodeModelsForProvisioning({
         continue;
       }
       details.push(
-        verificationMode === 'compatibility'
-          ? `Selected model ${modelId} is compatible. Deep verification pending.`
-          : localRuntimeReadiness?.severity === 'ready'
-            ? `Selected model ${modelId} verified for launch with Agent Teams tool coordination.`
-            : `Selected model ${modelId} verified for launch.`
+        localRuntimeReadiness?.severity === 'ready'
+          ? `Selected model ${modelId} verified for launch with Agent Teams tool coordination.`
+          : `Selected model ${modelId} verified for launch.`
       );
       if (verificationMode === 'deep') {
         if (localRuntimeReadiness?.severity === 'ready') {
@@ -449,8 +446,7 @@ export async function prepareSelectedOpenCodeModelsForProvisioning({
 
     const unavailableLine = `Selected model ${modelId} is unavailable. ${primaryReason}`;
     const verificationWarningLine = `Selected model ${modelId} could not be verified. ${primaryReason}`;
-    const issueSeverity =
-      prepare.retryable && verificationMode !== 'compatibility' ? 'warning' : 'blocking';
+    const issueSeverity = prepare.retryable ? 'warning' : 'blocking';
     issues.push({
       providerId: 'opencode',
       modelId,
@@ -461,13 +457,7 @@ export async function prepareSelectedOpenCodeModelsForProvisioning({
     });
     if (prepare.retryable) {
       warnings.push(verificationWarningLine);
-      if (verificationMode === 'compatibility') {
-        blockingMessages.push(verificationWarningLine);
-      }
     } else {
-      if (verificationMode === 'compatibility') {
-        details.push(unavailableLine);
-      }
       blockingMessages.push(unavailableLine);
     }
   }
@@ -513,18 +503,18 @@ export function isProviderScopedOpenCodePrepareFailure(
 }
 
 async function prepareSelectedOpenCodeModelsCompatibilityBatch({
-  adapter,
+  readProviderStatus,
   cwd,
   modelIds,
   appendPreflightDebugLog,
   inspectLocalModelRuntime,
 }: {
-  adapter: TeamLaunchRuntimeAdapter;
+  readProviderStatus?: OpenCodeSelectedModelPreparationInput['readProviderStatus'];
   cwd: string;
   modelIds: readonly string[];
   appendPreflightDebugLog: (event: string, data: Record<string, unknown>) => void;
   inspectLocalModelRuntime?: OpenCodeSelectedModelPreparationInput['inspectLocalModelRuntime'];
-}): Promise<OpenCodeSelectedModelPreparationResult | null> {
+}): Promise<OpenCodeSelectedModelPreparationResult> {
   const details: string[] = [];
   const warnings: string[] = [];
   const blockingMessages: string[] = [];
@@ -563,7 +553,7 @@ async function prepareSelectedOpenCodeModelsCompatibilityBatch({
   for (const modelId of configuredLocalModelIds) {
     details.push(`Selected model ${modelId} is compatible. Deep verification pending.`);
   }
-  if (catalogModelIds.length === 0) {
+  if (catalogModelIds.length === 0 && modelIds.length > 0) {
     appendPreflightDebugLog('opencode_compatibility_batch_local_routes_deferred', {
       cwd,
       modelIds,
@@ -571,113 +561,65 @@ async function prepareSelectedOpenCodeModelsCompatibilityBatch({
     return { details, warnings, blockingMessages, issues, supportDiagnostics };
   }
 
-  let sharedPrepare = await prepareOpenCodeCompatibilityModel(adapter, cwd, catalogModelIds[0]);
-  if (!sharedPrepare.ok && sharedPrepare.reason === 'not_authenticated') {
-    const failedReadiness = getLastOpenCodeTeamLaunchReadiness(adapter, cwd);
-    const failedAvailableModels = normalizeAvailableModelIds(failedReadiness?.availableModels);
-    const failedAvailableProviderIds = new Set(
-      getOpenCodeCatalogProviderIds(failedAvailableModels)
-    );
-    const deferredModelIds = catalogModelIds.filter((modelId) =>
-      isOpenCodeUnknownProviderRoute(modelId, failedAvailableProviderIds)
-    );
-    if (failedAvailableModels.length > 0 && deferredModelIds.includes(catalogModelIds[0])) {
-      const catalogModelId = catalogModelIds.find((modelId) => !deferredModelIds.includes(modelId));
-      if (!catalogModelId) {
-        for (const modelId of deferredModelIds) {
-          details.push(`Selected model ${modelId} is compatible. Deep verification pending.`);
-        }
-        appendPreflightDebugLog('opencode_compatibility_batch_authless_provider_deferred', {
-          cwd,
-          modelIds: deferredModelIds,
-        });
-        return { details, warnings, blockingMessages, issues, supportDiagnostics };
-      }
-      sharedPrepare = await prepareOpenCodeCompatibilityModel(adapter, cwd, catalogModelId);
-    }
+  let provider: CliProviderStatus | null = null;
+  let catalogError =
+    'OpenCode compatibility requires a fresh project-scoped provider catalog. Refresh provider status and retry.';
+  try {
+    provider = (await readProviderStatus?.({ cwd })) ?? null;
+  } catch (error) {
+    catalogError = `OpenCode provider catalog could not be read: ${getErrorMessage(error)}`;
   }
-
-  const sharedPrepareReason = sharedPrepare.ok ? undefined : sharedPrepare.reason;
-  warnings.push(
-    ...sharedPrepare.warnings.map((warning) =>
-      normalizeOpenCodePrepareDiagnostic(warning, sharedPrepareReason)
-    )
-  );
-  appendPreflightDebugLog('opencode_compatibility_batch_shared_prepare', {
-    cwd,
-    modelIds,
-    durationMs: Date.now() - startedAt,
-    ok: sharedPrepare.ok,
-    reason: sharedPrepare.ok ? null : sharedPrepare.reason,
-    diagnostics: sharedPrepare.diagnostics,
-    supportDiagnostics: sharedPrepare.supportDiagnostics?.map((diagnostic) => ({
-      id: diagnostic.id,
-      kind: diagnostic.kind,
-      title: diagnostic.title,
-    })),
-  });
-
-  if (!sharedPrepare.ok) {
-    pushUniqueSupportDiagnostics(supportDiagnostics, sharedPrepare.supportDiagnostics);
-    const providerDiagnostic = selectOpenCodePrepareProviderDiagnostic(sharedPrepare);
-    const primaryReason = normalizeOpenCodePrepareDiagnostic(
-      providerDiagnostic ??
-        sharedPrepare.diagnostics.find((entry) => entry.trim().length > 0) ??
-        sharedPrepare.reason,
-      sharedPrepare.reason
-    );
-    if (isOpenCodeModelPrepareBusyDeferred(sharedPrepare, primaryReason)) {
-      const providerBusyLine = buildOpenCodeProviderVerificationDeferredLine(primaryReason);
-      pushUniqueLine(warnings, providerBusyLine);
-      issues.push({
-        providerId: 'opencode',
-        scope: 'provider',
-        severity: 'warning',
-        code: sharedPrepare.reason,
-        message: providerBusyLine,
-      });
-      appendPreflightDebugLog('opencode_compatibility_batch_busy_deferred', {
-        cwd,
-        modelIds,
-        reason: primaryReason,
-      });
-      return { details, warnings, blockingMessages, issues, supportDiagnostics };
-    }
-    if (primaryReason.trim().length > 0) {
-      details.push(primaryReason);
-      blockingMessages.push(primaryReason);
-    } else {
-      blockingMessages.push(`OpenCode: ${sharedPrepare.reason}`);
-    }
+  if (
+    !provider ||
+    provider.providerId !== 'opencode' ||
+    !provider.supported ||
+    !hasAuthoritativeProviderStatusEvidence(provider) ||
+    !provider.authenticated ||
+    !isProviderModelCatalogExactReady(provider)
+  ) {
+    blockingMessages.push(catalogError);
     issues.push({
       providerId: 'opencode',
       scope: 'provider',
       severity: 'blocking',
-      code: sharedPrepare.reason,
-      message: primaryReason.trim() || `OpenCode: ${sharedPrepare.reason}`,
+      code: 'catalog_unavailable',
+      message: catalogError,
     });
     return { details, warnings, blockingMessages, issues, supportDiagnostics };
   }
-
-  const latestReadiness = getLastOpenCodeTeamLaunchReadiness(adapter, cwd);
-  const availableModels = normalizeAvailableModelIds(latestReadiness?.availableModels);
+  const catalog = provider.modelCatalog!;
+  const availableModels = catalog.models.map((model) => model.launchModel);
   const availableProviderIds = new Set(getOpenCodeCatalogProviderIds(availableModels));
   appendPreflightDebugLog('opencode_compatibility_batch_catalog', {
     cwd,
     modelIds,
     availableModelCount: availableModels.length,
-    availableModelsSample: availableModels.slice(0, 20),
-    fellBackToPerModelPrepare: availableModels.length === 0,
   });
-
-  if (availableModels.length === 0) {
-    return null;
-  }
 
   for (const modelId of catalogModelIds) {
     const resolvedModel = resolveOpenCodeCompatibilityModel(modelId, availableModels);
     if (resolvedModel.ok) {
-      details.push(`Selected model ${modelId} is compatible. Deep verification pending.`);
+      const route = catalog.models.find(
+        (model) => model.launchModel === resolvedModel.resolvedModelId
+      )?.metadata?.opencode;
+      if (
+        route?.accessKind === 'not_authenticated' ||
+        route?.accessKind === 'execution_failed' ||
+        route?.proofState === 'failed'
+      ) {
+        const message = route.reason || `OpenCode access verification failed for ${modelId}.`;
+        blockingMessages.push(message);
+        issues.push({
+          providerId: 'opencode',
+          modelId,
+          scope: 'model',
+          severity: 'blocking',
+          code: route.accessKind,
+          message,
+        });
+      } else {
+        details.push(`Selected model ${modelId} is compatible. Deep verification pending.`);
+      }
       continue;
     }
 
@@ -718,57 +660,6 @@ async function prepareSelectedOpenCodeModelsCompatibilityBatch({
   });
 
   return { details, warnings, blockingMessages, issues, supportDiagnostics };
-}
-
-async function prepareOpenCodeCompatibilityModel(
-  adapter: TeamLaunchRuntimeAdapter,
-  cwd: string,
-  model: string
-): Promise<TeamRuntimePrepareResult> {
-  try {
-    return await adapter.prepare({
-      runId: `prepare-${randomUUID()}`,
-      teamName: '__prepare_opencode__',
-      cwd,
-      providerId: 'opencode',
-      model,
-      runtimeOnly: true,
-      skipPermissions: true,
-      expectedMembers: [],
-      previousLaunchState: null,
-    });
-  } catch (error) {
-    const message = getErrorMessage(error).trim() || 'OpenCode model verification failed';
-    return {
-      ok: false,
-      providerId: 'opencode',
-      reason: 'unknown_error',
-      retryable: false,
-      diagnostics: [message],
-      warnings: [],
-    };
-  }
-}
-
-function getLastOpenCodeTeamLaunchReadiness(
-  adapter: TeamLaunchRuntimeAdapter,
-  cwd: string
-): { availableModels?: unknown } | null {
-  const readinessProvider = adapter as OpenCodeLaunchReadinessProvider;
-  return typeof readinessProvider.getLastOpenCodeTeamLaunchReadiness === 'function'
-    ? readinessProvider.getLastOpenCodeTeamLaunchReadiness(cwd)
-    : null;
-}
-
-function normalizeAvailableModelIds(value: unknown): string[] {
-  return Array.from(
-    new Set(
-      (Array.isArray(value) ? value : [])
-        .filter((modelId: unknown): modelId is string => typeof modelId === 'string')
-        .map((modelId: string) => modelId.trim())
-        .filter((modelId: string) => modelId.length > 0)
-    )
-  );
 }
 
 function pushUniqueLine(lines: string[], line: string): void {

--- a/src/main/services/team/provisioning/TeamProvisioningPrepareCoordinator.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningPrepareCoordinator.ts
@@ -148,6 +148,7 @@ export interface TeamProvisioningPrepareCoordinatorPorts {
     providerArgs: string[],
     limitContext: boolean
   ): Promise<string | null>;
+  readOpenCodeProviderStatus?: OpenCodeSelectedModelPreparationInput['readProviderStatus'];
   inspectOpenCodeLocalModelRuntime?: OpenCodeSelectedModelPreparationInput['inspectLocalModelRuntime'];
   info(message: string): void;
   warn(message: string): void;
@@ -263,6 +264,7 @@ export class TeamProvisioningPrepareCoordinator {
         : selectedModelIds;
 
       if (providerId === 'opencode') {
+        const verificationMode = opts?.modelVerificationMode ?? 'deep';
         const adapter = this.ports.getOpenCodeRuntimeAdapter();
         if (!adapter) {
           blockingMessages.push(
@@ -270,8 +272,7 @@ export class TeamProvisioningPrepareCoordinator {
           );
           continue;
         }
-
-        if (providerSelectedModelIds.length === 0) {
+        if (providerSelectedModelIds.length === 0 && verificationMode !== 'compatibility') {
           const prepare = await adapter.prepare({
             runId: `prepare-${randomUUID()}`,
             teamName: '__prepare_opencode__',
@@ -305,13 +306,13 @@ export class TeamProvisioningPrepareCoordinator {
           }
           continue;
         }
-
         const openCodeModelPrepare = await prepareSelectedOpenCodeModelsForProvisioning({
           adapter,
           cwd: targetCwd,
           modelIds: providerSelectedModelIds,
-          verificationMode: opts?.modelVerificationMode ?? 'deep',
+          verificationMode,
           appendPreflightDebugLog,
+          readProviderStatus: this.ports.readOpenCodeProviderStatus,
           inspectLocalModelRuntime: this.ports.inspectOpenCodeLocalModelRuntime,
         });
         details.push(...openCodeModelPrepare.details);
@@ -321,7 +322,6 @@ export class TeamProvisioningPrepareCoordinator {
         pushUniqueSupportDiagnostics(supportDiagnostics, openCodeModelPrepare.supportDiagnostics);
         continue;
       }
-
       const cached = this.getFreshCachedProbeResult(targetCwdForValidation, providerId);
       const probeResult = cached
         ? cachedProviderProbeResultToProbeResult(cached)

--- a/src/main/services/team/provisioning/TeamProvisioningPrepareFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningPrepareFacade.ts
@@ -1,4 +1,5 @@
 import { type TeamRuntimeLanePlan } from '@features/team-runtime-lanes';
+import { ClaudeMultimodelBridgeService } from '@main/services/runtime/ClaudeMultimodelBridgeService';
 import { execCli as defaultExecCli } from '@main/utils/childProcess';
 
 import { ClaudeBinaryResolver } from '../ClaudeBinaryResolver';
@@ -67,6 +68,7 @@ export interface TeamProvisioningPrepareFacadePorts {
   }): Promise<{ worktreePath: string }>;
   providerProbeCache?: ProviderProbeCachePort;
   execCli?: TeamProvisioningPrepareCoordinatorPorts['execCli'];
+  readOpenCodeProviderStatus?: TeamProvisioningPrepareCoordinatorPorts['readOpenCodeProviderStatus'];
   inspectOpenCodeLocalModelRuntime?: TeamProvisioningPrepareCoordinatorPorts['inspectOpenCodeLocalModelRuntime'];
   planRuntimeLanesOrThrow(
     leadProviderId: TeamProviderId | undefined,
@@ -101,6 +103,7 @@ export interface TeamProvisioningPrepareFacadeServiceHostOptions
         TeamProvisioningPrepareFacadePorts,
         | 'execCli'
         | 'inspectOpenCodeLocalModelRuntime'
+        | 'readOpenCodeProviderStatus'
         | 'providerProbeCache'
         | 'resolveClaudeBinaryPath'
       >
@@ -129,6 +132,7 @@ export function createTeamProvisioningPrepareFacadeFromService(
     ensureMemberWorktree: (input) => service.memberWorktreeManager.ensureMemberWorktree(input),
     providerProbeCache: options.providerProbeCache,
     execCli: options.execCli,
+    readOpenCodeProviderStatus: options.readOpenCodeProviderStatus,
     inspectOpenCodeLocalModelRuntime: options.inspectOpenCodeLocalModelRuntime,
     planRuntimeLanesOrThrow: (leadProviderId, members, baseCwd) =>
       service.planRuntimeLanesOrThrow(leadProviderId, members, baseCwd),
@@ -144,6 +148,7 @@ export class TeamProvisioningPrepareFacade {
   constructor(private readonly ports: TeamProvisioningPrepareFacadePorts) {
     this.resolveClaudeBinaryPath =
       ports.resolveClaudeBinaryPath ?? (() => ClaudeBinaryResolver.resolve());
+    const providerStatusBridge = new ClaudeMultimodelBridgeService();
     const execCli = ports.execCli ?? defaultExecCli;
     this.coordinator = new TeamProvisioningPrepareCoordinator({
       providerProbeCache: ports.providerProbeCache ?? createInMemoryProviderProbeCachePort(),
@@ -158,6 +163,16 @@ export class TeamProvisioningPrepareFacade {
         ports.probeClaudeRuntime(claudePath, cwd, env, providerId, providerArgs),
       ensureMemberWorktree: (input) => ports.ensureMemberWorktree(input),
       execCli: (command, args, opts) => execCli(command, args, opts),
+      readOpenCodeProviderStatus:
+        ports.readOpenCodeProviderStatus ??
+        (async ({ cwd }) => {
+          const binaryPath = await this.resolveClaudeBinaryPath();
+          return binaryPath
+            ? providerStatusBridge.getProviderStatus(binaryPath, 'opencode', undefined, {
+                projectPath: cwd,
+              })
+            : null;
+        }),
       inspectOpenCodeLocalModelRuntime: ports.inspectOpenCodeLocalModelRuntime,
       info: (message) => ports.info(message),
       warn: (message) => ports.warn(message),

--- a/src/main/services/team/provisioning/TeamProvisioningServiceMemberLifecycleFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningServiceMemberLifecycleFacade.ts
@@ -94,6 +94,7 @@ const logger = createLogger('Service:TeamProvisioning');
 export interface OpenCodeAggregatePrimaryRestartLease {
   teamName: string;
   runId: string;
+  candidateRunId?: string;
   memberName: string;
   completion: Promise<void>;
   precedingLifecycleOperations: Promise<void>[];
@@ -443,6 +444,9 @@ export abstract class TeamProvisioningServiceMemberLifecycleFacade extends TeamP
     sourceWarning?: string;
     onProgress: (progress: TeamProvisioningProgress) => void;
   }): Promise<TeamLaunchResponse> {
+    const restartLease = this.openCodeAggregatePrimaryRestartByTeam.get(
+      input.request.teamName.trim().toLowerCase()
+    );
     const configuredLanePlan = this.planRuntimeLanesOrThrow(
       input.request.providerId,
       input.members,
@@ -456,6 +460,13 @@ export abstract class TeamProvisioningServiceMemberLifecycleFacade extends TeamP
     return super.runOpenCodeTeamRuntimeAdapterLaunch({
       ...input,
       members: runtimeLaunchMembers,
+      onProgress: (progress) => {
+        // The initial callback precedes candidate persistence and any caller cancellation.
+        if (restartLease && progress.runId !== restartLease.runId) {
+          restartLease.candidateRunId ??= progress.runId;
+        }
+        input.onProgress(progress);
+      },
     });
   }
 }

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeCheckin.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeCheckin.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { describe, expect, it, vi } from 'vitest';
 
+import { setOpenCodeRuntimeActiveRunManifest } from '../../opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import { RuntimeStaleEvidenceError } from '../../opencode/store/RuntimeRunTombstoneStore';
 import { createPersistedLaunchSnapshot } from '../../TeamLaunchStateEvaluator';
 import { createDefaultOpenCodeRuntimeBootstrapEvidencePorts } from '../TeamProvisioningOpenCodeBootstrapEvidence';
@@ -562,6 +563,12 @@ describe('TeamProvisioningOpenCodeRuntimeCheckin', () => {
     });
 
     try {
+      await setOpenCodeRuntimeActiveRunManifest({
+        teamsBasePath,
+        teamName: 'Team',
+        laneId: 'primary',
+        runId: 'run-1',
+      });
       const checkin = recordOpenCodeRuntimeBootstrapCheckin(
         {
           teamName: 'Team',
@@ -640,6 +647,12 @@ describe('TeamProvisioningOpenCodeRuntimeCheckin', () => {
       });
 
       try {
+        await setOpenCodeRuntimeActiveRunManifest({
+          teamsBasePath,
+          teamName: 'Team',
+          laneId: 'primary',
+          runId: 'run-current',
+        });
         await expect(
           recordOpenCodeRuntimeBootstrapCheckin(
             {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningPrepareCoordinator.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningPrepareCoordinator.test.ts
@@ -306,6 +306,37 @@ describe('TeamProvisioningPrepareCoordinator', () => {
     expect(execCli).not.toHaveBeenCalled();
   });
 
+  it('does not report ready when terminal OAuth failure follows an incidental busy status', async () => {
+    const prepare = vi.fn().mockResolvedValue({
+      ok: false,
+      providerId: 'opencode',
+      reason: 'not_authenticated',
+      retryable: true,
+      diagnostics: ['OpenCode session status busy', 'Token refresh failed: 401'],
+      warnings: [],
+    });
+    const coordinator = createCoordinator({
+      getOpenCodeRuntimeAdapter: () => ({
+        providerId: 'opencode',
+        prepare,
+        launch: vi.fn(),
+        reconcile: vi.fn(),
+        stop: vi.fn(),
+      }),
+    });
+    const result = await coordinator.prepareForProvisioning('/sandbox/oauth-expired', {
+      providerId: 'opencode',
+      modelIds: ['openai/gpt-5.4'],
+      modelVerificationMode: 'deep',
+    });
+    expect(result.ready).toBe(false);
+    expect(result.message).toBe('Token refresh failed: 401');
+    expect(result.issues).toEqual([
+      expect.objectContaining({ severity: 'blocking', code: 'not_authenticated' }),
+    ]);
+    expect(result.warnings?.join(' ')).not.toContain('busy');
+  });
+
   it('blocks selected local models that fail the injected runtime-readiness gate', async () => {
     const prepare = vi.fn().mockResolvedValue({
       ok: true,

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningPrepareFacade.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningPrepareFacade.test.ts
@@ -162,6 +162,43 @@ describe('TeamProvisioningPrepareFacade', () => {
     expect(probeClaudeRuntime).toHaveBeenCalledTimes(2);
   });
 
+  it('maps a rejected Claude binary lookup to unavailable OpenCode catalog readiness', async () => {
+    const cwd = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'prepare-facade-catalog-'));
+    const resolveClaudeBinaryPath = vi.fn().mockRejectedValue(new Error('binary lookup failed'));
+    const facade = createFacade({
+      resolveClaudeBinaryPath,
+      getOpenCodeRuntimeAdapter: vi.fn(
+        () =>
+          ({
+            providerId: 'opencode' as const,
+            prepare: vi.fn(),
+            launch: vi.fn(),
+            reconcile: vi.fn(),
+            stop: vi.fn(),
+          })
+      ),
+    });
+
+    const result = await facade.prepareForProvisioning(cwd, {
+      providerId: 'opencode',
+      modelIds: ['openai/gpt-5.6-sol'],
+      modelVerificationMode: 'compatibility',
+    });
+
+    expect(resolveClaudeBinaryPath).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      ready: false,
+      issues: [
+        expect.objectContaining({
+          providerId: 'opencode',
+          severity: 'blocking',
+          code: 'catalog_unavailable',
+          message: 'OpenCode provider catalog could not be read: binary lookup failed',
+        }),
+      ],
+    });
+  });
+
   it('prepares OpenCode runtime adapter launches through explicit facade ports', async () => {
     const cwd = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'prepare-facade-opencode-'));
     const buildProvisioningEnv = vi.fn().mockResolvedValue({

--- a/src/main/services/team/runtime/OpenCodeTeamRuntimeAdapter.ts
+++ b/src/main/services/team/runtime/OpenCodeTeamRuntimeAdapter.ts
@@ -67,11 +67,13 @@ export interface OpenCodeTeamRuntimeBridgePort {
     projectPath: string;
     selectedModel: string | null;
     requireExecutionProbe: boolean;
+    skipPermissions?: boolean;
   }): Promise<OpenCodeTeamLaunchReadiness>;
   getLastOpenCodeRuntimeSnapshot?(
     projectPath: string,
     selectedModel?: string | null,
-    requireExecutionProbe?: boolean
+    requireExecutionProbe?: boolean,
+    skipPermissions?: boolean
   ): OpenCodeBridgeRuntimeSnapshot | null;
   launchOpenCodeTeam?(input: OpenCodeLaunchTeamCommandBody): Promise<OpenCodeLaunchTeamCommandData>;
   reconcileOpenCodeTeam?(
@@ -191,6 +193,7 @@ export class OpenCodeTeamRuntimeAdapter implements TeamLaunchRuntimeAdapter {
         projectPath: input.cwd,
         selectedModel: input.model ?? null,
         requireExecutionProbe: !runtimeOnly,
+        skipPermissions: input.skipPermissions,
       },
       forceReadinessRefresh
     );
@@ -377,19 +380,20 @@ export class OpenCodeTeamRuntimeAdapter implements TeamLaunchRuntimeAdapter {
       projectPath: input.cwd,
       selectedModel: input.model ?? null,
       requireExecutionProbe: true,
+      skipPermissions: input.skipPermissions,
     };
     let runtimeSnapshot = skipReadinessPreflight
       ? null
       : (this.bridge.getLastOpenCodeRuntimeSnapshot?.(
           input.cwd,
           readinessInput.selectedModel,
-          readinessInput.requireExecutionProbe
+          readinessInput.requireExecutionProbe,
+          readinessInput.skipPermissions
         ) ?? null);
     let proofBinding: ReturnType<typeof freshOpenCodeExecutionProof>;
     try {
       proofBinding = freshOpenCodeExecutionProof(
-        this.lastReadinessByArtifactKey.get(openCodeReadinessArtifactKey(readinessInput)) ??
-          this.lastReadinessByProjectPath.get(normalizeOpenCodeProjectIdentity(input.cwd)),
+        this.lastReadinessByArtifactKey.get(openCodeReadinessArtifactKey(readinessInput)),
         { projectPath: input.cwd, fullModelId: selectedModel }
       );
     } catch (error) {
@@ -493,14 +497,14 @@ export class OpenCodeTeamRuntimeAdapter implements TeamLaunchRuntimeAdapter {
         this.bridge.getLastOpenCodeRuntimeSnapshot?.(
           input.cwd,
           readinessInput.selectedModel,
-          readinessInput.requireExecutionProbe
+          readinessInput.requireExecutionProbe,
+          readinessInput.skipPermissions
         ) ?? null;
       if (refreshedSnapshot?.capabilitySnapshotId) {
         runtimeSnapshot = refreshedSnapshot;
         try {
           proofBinding = freshOpenCodeExecutionProof(
-            this.lastReadinessByArtifactKey.get(openCodeReadinessArtifactKey(readinessInput)) ??
-              this.lastReadinessByProjectPath.get(normalizeOpenCodeProjectIdentity(input.cwd)),
+            this.lastReadinessByArtifactKey.get(openCodeReadinessArtifactKey(readinessInput)),
             { projectPath: input.cwd, fullModelId: selectedModel }
           );
           executionProof = proofBinding.proof;
@@ -570,16 +574,14 @@ export class OpenCodeTeamRuntimeAdapter implements TeamLaunchRuntimeAdapter {
     if (this.bridge.reconcileOpenCodeTeam) {
       const projectPath =
         input.expectedMembers[0]?.cwd ?? this.lastProjectPathByTeamName.get(input.teamName);
-      const runtimeSnapshot = projectPath
-        ? (this.bridge.getLastOpenCodeRuntimeSnapshot?.(projectPath) ?? null)
-        : null;
       const data = await this.bridge.reconcileOpenCodeTeam({
         runId: input.runId,
         laneId: input.laneId?.trim() || 'primary',
         teamId: input.teamName,
         teamName: input.teamName,
         projectPath,
-        expectedCapabilitySnapshotId: runtimeSnapshot?.capabilitySnapshotId ?? null,
+        // The command service binds the persisted lane manifest, never a project-latest probe.
+        expectedCapabilitySnapshotId: null,
         manifestHighWatermark: null,
         reconcileAttemptId: `opencode-reconcile-${randomUUID()}`,
         expectedMembers: input.expectedMembers.map((member) => ({
@@ -807,16 +809,14 @@ export class OpenCodeTeamRuntimeAdapter implements TeamLaunchRuntimeAdapter {
   async stop(input: TeamRuntimeStopInput): Promise<TeamRuntimeStopResult> {
     if (this.bridge.stopOpenCodeTeam) {
       const projectPath = input.cwd ?? this.lastProjectPathByTeamName.get(input.teamName);
-      const runtimeSnapshot = projectPath
-        ? (this.bridge.getLastOpenCodeRuntimeSnapshot?.(projectPath) ?? null)
-        : null;
       const data = await this.bridge.stopOpenCodeTeam({
         runId: input.runId,
         laneId: input.laneId?.trim() || 'primary',
         teamId: input.teamName,
         teamName: input.teamName,
         projectPath,
-        expectedCapabilitySnapshotId: runtimeSnapshot?.capabilitySnapshotId ?? null,
+        // The command service binds the persisted lane manifest, never a project-latest probe.
+        expectedCapabilitySnapshotId: null,
         manifestHighWatermark: null,
         reason: input.reason,
         force: input.force,

--- a/src/renderer/components/team/dialogs/TeamModelSelector.tsx
+++ b/src/renderer/components/team/dialogs/TeamModelSelector.tsx
@@ -31,6 +31,7 @@ import {
 import { useEffectiveCliProviderStatus } from '@renderer/hooks/useEffectiveCliProviderStatus';
 import { cn } from '@renderer/lib/utils';
 import { useStore } from '@renderer/store';
+import { shouldHydrateCodexModelCatalog } from '@renderer/utils/codexCatalogHydration';
 import { isCodexModelCatalogFallbackActive } from '@renderer/utils/codexModelCatalogFallback';
 import {
   GEMINI_UI_DISABLED_BADGE_LABEL,
@@ -662,12 +663,7 @@ function shouldHydrateProviderModelCatalog(
   }
 
   if (providerId === 'codex') {
-    const catalog = providerStatus?.modelCatalog;
-    return (
-      providerStatus?.runtimeCapabilities?.modelCatalog?.dynamic === true &&
-      catalog?.providerId !== 'codex' &&
-      (providerStatus.models.length === 0 || providerStatus.modelCatalogRefreshState === 'idle')
-    );
+    return shouldHydrateCodexModelCatalog(providerStatus);
   }
 
   return false;

--- a/src/renderer/store/slices/cliInstallerSlice.ts
+++ b/src/renderer/store/slices/cliInstallerSlice.ts
@@ -276,7 +276,7 @@ export function reconcileMultimodelProviderLoading(
       return {
         ...nextLoading,
         [providerId]: provider
-          ? incompleteProviderIds.has(providerId)
+          ? currentLoading[providerId] === true && incompleteProviderIds.has(providerId)
           : currentLoading[providerId] === true,
       };
     },
@@ -1016,7 +1016,8 @@ export const createCliInstallerSlice: StateCreator<AppState, [], [], CliInstalle
     const providerLoading = Object.fromEntries(
       MULTIMODEL_PROVIDER_IDS.map((providerId) => [
         providerId,
-        initialStatus.installed &&
+        hydrateProviders &&
+          initialStatus.installed &&
           !isHydratedMultimodelProviderStatus(
             initialStatus.providers.find((provider) => provider.providerId === providerId)
           ),
@@ -1067,9 +1068,10 @@ export const createCliInstallerSlice: StateCreator<AppState, [], [], CliInstalle
         const nextProviderLoading = Object.fromEntries(
           MULTIMODEL_PROVIDER_IDS.map((providerId) => [
             providerId,
-            !isHydratedMultimodelProviderStatus(
-              nextCliStatus.providers.find((provider) => provider.providerId === providerId)
-            ),
+            hydrateProviders &&
+              !isHydratedMultimodelProviderStatus(
+                nextCliStatus.providers.find((provider) => provider.providerId === providerId)
+              ),
           ])
         ) as Partial<Record<CliProviderId, boolean>>;
         pendingProviderIds = MULTIMODEL_PROVIDER_IDS.filter(

--- a/src/renderer/utils/codexCatalogHydration.ts
+++ b/src/renderer/utils/codexCatalogHydration.ts
@@ -1,0 +1,39 @@
+import { CLI_PROVIDER_STATUS_DEFERRED_MESSAGE } from '@shared/types/cliInstaller';
+
+import type { CliProviderStatus } from '@shared/types';
+
+/** Selected-provider passive hydration; completed failures require an explicit retry. */
+export function shouldHydrateCodexModelCatalog(provider: CliProviderStatus): boolean {
+  if (
+    provider.providerId !== 'codex' ||
+    provider.statusCheckOutcome === 'transient_error' ||
+    (provider.statusCheckErrorCode != null &&
+      !(
+        provider.statusCheckOutcome === 'pending' &&
+        provider.statusCheckErrorCode === 'partial_response'
+      )) ||
+    provider.verificationState === 'error' ||
+    provider.verificationState === 'offline' ||
+    provider.modelCatalogRefreshState === 'error' ||
+    (provider.statusCheckOutcome === 'authoritative' &&
+      (!provider.supported || !provider.authenticated))
+  )
+    return false;
+
+  if (
+    provider.statusCheckOutcome === 'pending' ||
+    (provider.statusCheckOutcome == null &&
+      !provider.supported &&
+      !provider.authenticated &&
+      provider.verificationState === 'unknown' &&
+      (provider.statusMessage === CLI_PROVIDER_STATUS_DEFERRED_MESSAGE ||
+        provider.statusMessage === 'Checking...'))
+  )
+    return true;
+
+  return (
+    provider.runtimeCapabilities?.modelCatalog?.dynamic === true &&
+    provider.modelCatalog?.providerId !== 'codex' &&
+    (provider.models.length === 0 || provider.modelCatalogRefreshState === 'idle')
+  );
+}

--- a/test/features/team-runtime-recovery/main/TeamRuntimeRecoveryFeature.live-e2e.test.ts
+++ b/test/features/team-runtime-recovery/main/TeamRuntimeRecoveryFeature.live-e2e.test.ts
@@ -15,6 +15,8 @@ import {
 } from '@main/services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
 import { OpenCodeReadinessBridge } from '@main/services/team/opencode/bridge/OpenCodeReadinessBridge';
 import { OpenCodeStateChangingBridgeCommandService } from '@main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
+import { OpenCodeRuntimeLaunchAuthorityWriter } from '@main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
+import { OpenCodeRuntimeManifestEvidenceReader } from '@main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import { OpenCodeTeamRuntimeAdapter } from '@main/services/team/runtime/OpenCodeTeamRuntimeAdapter';
 import { TeamRuntimeAdapterRegistry } from '@main/services/team/runtime/TeamRuntimeAdapter';
 import { TeamInboxReader } from '@main/services/team/TeamInboxReader';
@@ -25,8 +27,6 @@ import { getTeamsBasePath, setClaudeBasePathOverride } from '@main/utils/pathDec
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { TeamRuntimeRecoveryFeatureFacade } from '@features/team-runtime-recovery/main/composition/createTeamRuntimeRecoveryFeature';
-import type { RuntimeStoreManifestEvidence } from '@main/services/team/opencode/bridge/OpenCodeBridgeCommandContract';
-import type { RuntimeStoreManifestReader } from '@main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import type { OpenCodeBridgeCommandExecutor } from '@main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import type { TeamNotificationPayload } from '@main/utils/teamNotificationBuilder';
 
@@ -285,18 +285,13 @@ function createStateChangingCommands(input: {
       filePath: path.join(input.controlDir, 'ledger.json'),
     }),
     bridge: input.bridge,
-    manifestReader: new StaticManifestReader(),
+    manifestReader: new OpenCodeRuntimeManifestEvidenceReader({
+      teamsBasePath: getTeamsBasePath(),
+    }),
+    launchAuthorityWriter: new OpenCodeRuntimeLaunchAuthorityWriter({
+      teamsBasePath: getTeamsBasePath(),
+    }),
   });
-}
-
-class StaticManifestReader implements RuntimeStoreManifestReader {
-  async read(): Promise<RuntimeStoreManifestEvidence> {
-    return {
-      highWatermark: 0,
-      activeRunId: null,
-      capabilitySnapshotId: null,
-    };
-  }
 }
 
 function createStableBridgeEnv(): NodeJS.ProcessEnv {

--- a/test/main/services/infrastructure/CliInstallerService.test.ts
+++ b/test/main/services/infrastructure/CliInstallerService.test.ts
@@ -297,6 +297,219 @@ describe('CliInstallerService', () => {
       await Promise.resolve();
     });
 
+    it.each(['success', 'failure'] as const)(
+      'does not replay revoked auth when another aggregate hydration finishes with %s',
+      async (outcome) => {
+        allowConsoleLogs();
+        vi.mocked(getConfiguredCliFlavor).mockReturnValue('agent_teams_orchestrator');
+        vi.mocked(getCliFlavorUiOptions).mockReturnValue({
+          displayName: 'Runtime',
+          supportsSelfUpdate: false,
+          showVersionDetails: false,
+          showBinaryPath: false,
+        });
+        vi.mocked(ClaudeBinaryResolver.resolve).mockResolvedValue('/mock/hydration-runtime');
+        const wireProvider = (providerId: CliProviderId) => {
+          const provider = createTestProviderStatus(providerId, true, 'test-session');
+          return {
+            ...provider,
+            capabilities: { ...provider.capabilities, extensions: {} },
+            runtimeCapabilities: { modelCatalog: { dynamic: true, source: 'app-server' } },
+          };
+        };
+        const reply = (providerId: CliProviderId, provider: unknown) => ({
+          stdout: JSON.stringify({ schemaVersion: 2, providers: { [providerId]: provider } }),
+          stderr: '',
+        });
+        let resolveA!: (value: ReturnType<typeof reply>) => void;
+        let resolveB!: (value: ReturnType<typeof reply>) => void;
+        let rejectB!: (reason: Error) => void;
+        const pendingA = new Promise<ReturnType<typeof reply>>((resolve) => {
+          resolveA = resolve;
+        });
+        const pendingB = new Promise<ReturnType<typeof reply>>((resolve, reject) => {
+          resolveB = resolve;
+          rejectB = reject;
+        });
+        let revoked = false;
+        vi.mocked(execCli).mockImplementation(async (_binaryPath, args) => {
+          if (args.includes('--version')) return { stdout: '0.0.45', stderr: '' };
+          const providerId = args[args.indexOf('--provider') + 1] as CliProviderId;
+          const full = wireProvider(providerId);
+          if (args.includes('--summary'))
+            return reply(providerId, {
+              ...full,
+              modelCatalog: null,
+              ...(providerId === 'opencode' || (providerId === 'anthropic' && revoked)
+                ? { authenticated: false, authMethod: null, runtimeCapabilities: null }
+                : {}),
+            });
+          return providerId === 'anthropic' ? pendingA : pendingB;
+        });
+        const listeners: ((status: import('@shared/types').CliInstallationStatus) => void)[] = [];
+        const nextStatus = (
+          predicate: (status: import('@shared/types').CliInstallationStatus) => boolean
+        ) =>
+          new Promise<import('@shared/types').CliInstallationStatus>((resolve) => {
+            listeners.push((status) => {
+              if (predicate(status)) resolve(status);
+            });
+          });
+        const mockWindow = {
+          isDestroyed: () => false,
+          webContents: {
+            isDestroyed: () => false,
+            send: (_channel: string, progress: import('@shared/types').CliInstallerProgress) => {
+              const status = progress.status;
+              if (progress.type === 'status' && status)
+                listeners.forEach((listener) => listener(status));
+            },
+          },
+        };
+        service.setMainWindow(mockWindow as unknown as import('electron').BrowserWindow);
+        await service.getStatus();
+        const aReady = nextStatus((status) =>
+          status.providers.some(
+            (provider) => provider.providerId === 'anthropic' && provider.capabilities.teamLaunch
+          )
+        );
+        resolveA(reply('anthropic', wireProvider('anthropic')));
+        await aReady;
+        revoked = true;
+        expect(await service.getProviderStatus('anthropic')).toMatchObject({
+          authenticated: false,
+          capabilities: { teamLaunch: false },
+        });
+        const bFinished = nextStatus((status) =>
+          status.providers.some(
+            (provider) =>
+              provider.providerId === 'codex' &&
+              provider.modelCatalogRefreshState === (outcome === 'success' ? 'ready' : 'error')
+          )
+        );
+        if (outcome === 'success') resolveB(reply('codex', wireProvider('codex')));
+        else rejectB(new Error('Test-only full status unavailable'));
+        const published = await bFinished;
+        for (const snapshot of [published, service.getLatestStatusSnapshot()!]) {
+          expect(
+            snapshot.providers.find((provider) => provider.providerId === 'anthropic')
+          ).toMatchObject({
+            authenticated: false,
+            authMethod: null,
+            capabilities: { teamLaunch: false },
+          });
+          expect(
+            snapshot.providers.find((provider) => provider.providerId === 'codex')?.capabilities
+              .teamLaunch
+          ).toBe(outcome === 'success');
+        }
+        vi.mocked(execCli).mockReset().mockRejectedValue(new Error('execCli not configured'));
+      }
+    );
+
+    it('preserves an early full hydration when the aggregate summary promise resolves', async () => {
+      allowConsoleLogs();
+      vi.mocked(getConfiguredCliFlavor).mockReturnValue('agent_teams_orchestrator');
+      vi.mocked(getCliFlavorUiOptions).mockReturnValue({
+        displayName: 'Runtime',
+        supportsSelfUpdate: false,
+        showVersionDetails: false,
+        showBinaryPath: false,
+      });
+      vi.mocked(ClaudeBinaryResolver.resolve).mockResolvedValue('/mock/hydration-runtime');
+      vi.mocked(execCli).mockResolvedValueOnce({ stdout: '0.0.45', stderr: '' });
+      const ready = createTestProviderStatus('codex', true, 'test-session');
+      const summary = {
+        ...ready,
+        modelCatalog: null,
+        capabilities: { ...ready.capabilities, teamLaunch: false },
+      };
+      const spy = vi
+        .spyOn(ClaudeMultimodelBridgeService.prototype, 'getProviderStatuses')
+        .mockImplementation(async (_binaryPath, onUpdate) => {
+          onUpdate?.([summary]);
+          onUpdate?.([ready], 'codex');
+          onUpdate?.([summary], 'opencode');
+          onUpdate?.([summary, summary], 'codex');
+          onUpdate?.([], 'codex');
+          expect(service.getLatestStatusSnapshot()?.providers).toHaveLength(1);
+          expect(service.getLatestStatusSnapshot()?.providers[0].capabilities.teamLaunch).toBe(
+            true
+          );
+          return [summary];
+        });
+      try {
+        const result = await service.getStatus();
+        for (const snapshot of [result, service.getLatestStatusSnapshot()!]) {
+          expect(snapshot.providers[0]).toMatchObject({
+            authenticated: true,
+            capabilities: { teamLaunch: true },
+            modelCatalog: { status: 'ready' },
+          });
+          expect(snapshot.authStatusChecking).toBe(false);
+        }
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('does not copy newer runtime authority into an older finishing status gather', async () => {
+      allowConsoleLogs();
+      vi.mocked(getConfiguredCliFlavor).mockReturnValue('agent_teams_orchestrator');
+      vi.mocked(getCliFlavorUiOptions).mockReturnValue({
+        displayName: 'Runtime',
+        supportsSelfUpdate: false,
+        showVersionDetails: false,
+        showBinaryPath: false,
+      });
+      vi.mocked(ClaudeBinaryResolver.resolve).mockResolvedValue('/mock/old-runtime');
+      vi.mocked(execCli).mockResolvedValue({ stdout: '0.0.45', stderr: '' });
+      let resolveOld!: (providers: CliProviderStatus[]) => void;
+      let started!: () => void;
+      const oldStarted = new Promise<void>((resolve) => {
+        started = resolve;
+      });
+      const oldProviders = new Promise<CliProviderStatus[]>((resolve) => {
+        resolveOld = resolve;
+      });
+      const newer = createTestProviderStatus('codex', true, 'new-runtime-session');
+      const spy = vi
+        .spyOn(ClaudeMultimodelBridgeService.prototype, 'getProviderStatuses')
+        .mockImplementation(async (binaryPath) => {
+          if (binaryPath === '/mock/old-runtime') {
+            started();
+            return oldProviders;
+          }
+          return [newer];
+        });
+      try {
+        const oldResult = service.getStatus();
+        await oldStarted;
+        service.invalidateStatusCache();
+        vi.mocked(ClaudeBinaryResolver.resolve).mockResolvedValue('/mock/new-runtime');
+        await service.getStatus();
+        resolveOld([createTestProviderStatus('codex', false, null)]);
+        const result = await oldResult;
+        expect(result.binaryPath).toBe('/mock/old-runtime');
+        expect(result.providers.every((provider) => !provider.capabilities.teamLaunch)).toBe(true);
+        expect(
+          result.providers.every((provider) => provider.authMethod !== 'new-runtime-session')
+        ).toBe(true);
+        expect(service.getLatestStatusSnapshot()).toMatchObject({
+          binaryPath: '/mock/new-runtime',
+          providers: [
+            expect.objectContaining({
+              authMethod: 'new-runtime-session',
+              capabilities: expect.objectContaining({ teamLaunch: true }),
+            }),
+          ],
+        });
+      } finally {
+        spy.mockRestore();
+        vi.mocked(execCli).mockReset().mockRejectedValue(new Error('execCli not configured'));
+      }
+    });
+
     it('includes frontend-visible providers in unavailable multimodel bootstrap status', async () => {
       allowConsoleLogs();
       vi.mocked(getConfiguredCliFlavor).mockReturnValue('agent_teams_orchestrator');

--- a/test/main/services/infrastructure/CliInstallerService.test.ts
+++ b/test/main/services/infrastructure/CliInstallerService.test.ts
@@ -346,64 +346,67 @@ describe('CliInstallerService', () => {
             });
           return providerId === 'anthropic' ? pendingA : pendingB;
         });
-        const listeners: ((status: import('@shared/types').CliInstallationStatus) => void)[] = [];
-        const nextStatus = (
-          predicate: (status: import('@shared/types').CliInstallationStatus) => boolean
-        ) =>
-          new Promise<import('@shared/types').CliInstallationStatus>((resolve) => {
-            listeners.push((status) => {
-              if (predicate(status)) resolve(status);
+        try {
+          const listeners: ((status: import('@shared/types').CliInstallationStatus) => void)[] = [];
+          const nextStatus = (
+            predicate: (status: import('@shared/types').CliInstallationStatus) => boolean
+          ) =>
+            new Promise<import('@shared/types').CliInstallationStatus>((resolve) => {
+              listeners.push((status) => {
+                if (predicate(status)) resolve(status);
+              });
             });
-          });
-        const mockWindow = {
-          isDestroyed: () => false,
-          webContents: {
+          const mockWindow = {
             isDestroyed: () => false,
-            send: (_channel: string, progress: import('@shared/types').CliInstallerProgress) => {
-              const status = progress.status;
-              if (progress.type === 'status' && status)
-                listeners.forEach((listener) => listener(status));
+            webContents: {
+              isDestroyed: () => false,
+              send: (_channel: string, progress: import('@shared/types').CliInstallerProgress) => {
+                const status = progress.status;
+                if (progress.type === 'status' && status)
+                  listeners.forEach((listener) => listener(status));
+              },
             },
-          },
-        };
-        service.setMainWindow(mockWindow as unknown as import('electron').BrowserWindow);
-        await service.getStatus();
-        const aReady = nextStatus((status) =>
-          status.providers.some(
-            (provider) => provider.providerId === 'anthropic' && provider.capabilities.teamLaunch
-          )
-        );
-        resolveA(reply('anthropic', wireProvider('anthropic')));
-        await aReady;
-        revoked = true;
-        expect(await service.getProviderStatus('anthropic')).toMatchObject({
-          authenticated: false,
-          capabilities: { teamLaunch: false },
-        });
-        const bFinished = nextStatus((status) =>
-          status.providers.some(
-            (provider) =>
-              provider.providerId === 'codex' &&
-              provider.modelCatalogRefreshState === (outcome === 'success' ? 'ready' : 'error')
-          )
-        );
-        if (outcome === 'success') resolveB(reply('codex', wireProvider('codex')));
-        else rejectB(new Error('Test-only full status unavailable'));
-        const published = await bFinished;
-        for (const snapshot of [published, service.getLatestStatusSnapshot()!]) {
-          expect(
-            snapshot.providers.find((provider) => provider.providerId === 'anthropic')
-          ).toMatchObject({
+          };
+          service.setMainWindow(mockWindow as unknown as import('electron').BrowserWindow);
+          await service.getStatus();
+          const aReady = nextStatus((status) =>
+            status.providers.some(
+              (provider) => provider.providerId === 'anthropic' && provider.capabilities.teamLaunch
+            )
+          );
+          resolveA(reply('anthropic', wireProvider('anthropic')));
+          await aReady;
+          revoked = true;
+          expect(await service.getProviderStatus('anthropic')).toMatchObject({
             authenticated: false,
-            authMethod: null,
             capabilities: { teamLaunch: false },
           });
-          expect(
-            snapshot.providers.find((provider) => provider.providerId === 'codex')?.capabilities
-              .teamLaunch
-          ).toBe(outcome === 'success');
+          const bFinished = nextStatus((status) =>
+            status.providers.some(
+              (provider) =>
+                provider.providerId === 'codex' &&
+                provider.modelCatalogRefreshState === (outcome === 'success' ? 'ready' : 'error')
+            )
+          );
+          if (outcome === 'success') resolveB(reply('codex', wireProvider('codex')));
+          else rejectB(new Error('Test-only full status unavailable'));
+          const published = await bFinished;
+          for (const snapshot of [published, service.getLatestStatusSnapshot()!]) {
+            expect(
+              snapshot.providers.find((provider) => provider.providerId === 'anthropic')
+            ).toMatchObject({
+              authenticated: false,
+              authMethod: null,
+              capabilities: { teamLaunch: false },
+            });
+            expect(
+              snapshot.providers.find((provider) => provider.providerId === 'codex')?.capabilities
+                .teamLaunch
+            ).toBe(outcome === 'success');
+          }
+        } finally {
+          vi.mocked(execCli).mockReset().mockRejectedValue(new Error('execCli not configured'));
         }
-        vi.mocked(execCli).mockReset().mockRejectedValue(new Error('execCli not configured'));
       }
     );
 

--- a/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -10,7 +10,7 @@ import { readFile as readFileFixture, writeFile } from 'fs/promises';
 import * as path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { CliProviderStatus } from '@shared/types';
+import type { CliProviderId, CliProviderStatus } from '@shared/types';
 import type { PathLike } from 'fs';
 
 const execCliMock = vi.fn();
@@ -375,6 +375,186 @@ describe('ClaudeMultimodelBridgeService', () => {
       return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
     });
   });
+
+  function fullStatusFixture(providerId: CliProviderId) {
+    const modelId = `${providerId}-test-model`;
+    return {
+      providerId,
+      supported: true,
+      authenticated: true,
+      authMethod: 'test-session',
+      verificationState: 'verified',
+      statusCheckOutcome: 'authoritative',
+      canLoginFromUi: true,
+      statusMessage: null,
+      detailMessage: null,
+      models: [modelId],
+      capabilities: { teamLaunch: true, oneShot: true, extensions: {} },
+      selectedBackendId: null,
+      resolvedBackendId: null,
+      availableBackends: [],
+      externalRuntimeDiagnostics: [],
+      backend: null,
+      runtimeCapabilities: { modelCatalog: { dynamic: true, source: 'app-server' } },
+      modelCatalog: {
+        schemaVersion: 1,
+        providerId,
+        source: 'app-server',
+        status: 'ready',
+        fetchedAt: new Date(Date.now() - 1_000).toISOString(),
+        staleAt: new Date(Date.now() + 60_000).toISOString(),
+        defaultModelId: modelId,
+        defaultLaunchModel: modelId,
+        models: [{ id: modelId, launchModel: modelId, displayName: modelId }],
+        diagnostics: { configReadState: 'ready', appServerState: 'healthy' },
+      },
+    };
+  }
+
+  function statusReply(providerId: CliProviderId, provider: unknown) {
+    return {
+      stdout: JSON.stringify({ schemaVersion: 2, providers: { [providerId]: provider } }),
+      stderr: '',
+      exitCode: 0,
+    };
+  }
+
+  it.each(
+    (['anthropic', 'codex', 'opencode'] as const).flatMap((providerId) =>
+      (['aggregate', 'single', 'project'] as const).map((entrypoint) => ({
+        providerId,
+        entrypoint,
+      }))
+    )
+  )(
+    'restores $providerId launch from a full reply via $entrypoint',
+    async ({ providerId, entrypoint }) => {
+      execCliMock.mockImplementation((_binaryPath, args) => {
+        const requestedId = args[args.indexOf('--provider') + 1] as CliProviderId;
+        const full = fullStatusFixture(requestedId);
+        return Promise.resolve(
+          statusReply(
+            requestedId,
+            args.includes('--summary')
+              ? {
+                  ...full,
+                  modelCatalog: null,
+                  ...(requestedId === 'opencode'
+                    ? { statusCheckOutcome: 'model_only', authenticated: false }
+                    : {}),
+                }
+              : full
+          )
+        );
+      });
+      const { ClaudeMultimodelBridgeService } =
+        await import('@main/services/runtime/ClaudeMultimodelBridgeService');
+      const service = new ClaudeMultimodelBridgeService();
+      let resolveReady!: (provider: CliProviderStatus) => void;
+      const ready = new Promise<CliProviderStatus>((resolve) => {
+        resolveReady = resolve;
+      });
+      const onUpdate = (provider: CliProviderStatus) => {
+        if (provider.providerId === providerId && provider.capabilities.teamLaunch)
+          resolveReady(provider);
+      };
+      let hydrated: CliProviderStatus;
+      if (entrypoint === 'project') {
+        hydrated = await service.getProviderStatus('/mock/runtime', providerId, undefined, {
+          projectPath: '/tmp/status-hydration-test-project',
+        });
+        expect(
+          execCliMock.mock.calls.every(
+            (call) => call[2].cwd === '/tmp/status-hydration-test-project'
+          )
+        ).toBe(true);
+      } else {
+        const initial =
+          entrypoint === 'aggregate'
+            ? (
+                await service.getProviderStatuses('/mock/runtime', (providers) =>
+                  providers.forEach(onUpdate)
+                )
+              ).find((provider) => provider.providerId === providerId)!
+            : await service.getProviderStatus('/mock/runtime', providerId, onUpdate);
+        expect(initial.capabilities.teamLaunch).toBe(false);
+        expect(initial.modelCatalog).toBeNull();
+        hydrated = await ready;
+      }
+      expect(hydrated).toMatchObject({
+        authenticated: true,
+        statusCheckOutcome: 'authoritative',
+        capabilities: { teamLaunch: true },
+        modelCatalogRefreshState: 'ready',
+        modelCatalog: { providerId, status: 'ready' },
+      });
+    }
+  );
+
+  it.each([
+    'logged_out',
+    'disabled',
+    'model_only',
+    'transient_error',
+    'empty',
+    'expired',
+    'malformed',
+    'mismatch',
+  ] as const)(
+    'keeps a later %s full response fail-closed after a ready response',
+    async (condition) => {
+      const full = fullStatusFixture('codex');
+      const revoked = {
+        ...full,
+        ...(condition === 'logged_out' ? { authenticated: false, authMethod: null } : {}),
+        ...(condition === 'disabled'
+          ? { capabilities: { ...full.capabilities, teamLaunch: false } }
+          : {}),
+        ...(['model_only', 'transient_error'].includes(condition)
+          ? { statusCheckOutcome: condition }
+          : {}),
+        ...(condition === 'empty' ? { modelCatalog: { ...full.modelCatalog, models: [] } } : {}),
+        ...(condition === 'expired'
+          ? {
+              modelCatalog: {
+                ...full.modelCatalog,
+                staleAt: new Date(Date.now() - 1).toISOString(),
+              },
+            }
+          : {}),
+        ...(condition === 'malformed' ? { capabilities: null } : {}),
+        ...(condition === 'mismatch' ? { providerId: 'opencode' } : {}),
+      };
+      let fullCalls = 0;
+      execCliMock.mockImplementation((_binaryPath, args) =>
+        Promise.resolve(
+          statusReply(
+            'codex',
+            args.includes('--summary')
+              ? { ...full, modelCatalog: null }
+              : ++fullCalls === 1
+                ? full
+                : revoked
+          )
+        )
+      );
+      const { ClaudeMultimodelBridgeService } =
+        await import('@main/services/runtime/ClaudeMultimodelBridgeService');
+      const service = new ClaudeMultimodelBridgeService();
+      const options = { projectPath: '/tmp/status-hydration-test-project' };
+      expect(
+        (await service.getProviderStatus('/mock/runtime', 'codex', undefined, options)).capabilities
+          .teamLaunch
+      ).toBe(true);
+      const result = await service.getProviderStatus('/mock/runtime', 'codex', undefined, options);
+      expect(result.capabilities.teamLaunch).toBe(false);
+      if (result.modelCatalog) expect(result.modelCatalog.status).toBe('stale');
+      if (condition === 'logged_out')
+        expect(result).toMatchObject({ authenticated: false, authMethod: null });
+      if (condition === 'disabled') expect(result.authenticated).toBe(true);
+      expect(fullCalls).toBe(2);
+    }
+  );
 
   it('keeps Gemini out of frontend aggregate status and scopes explicit summary failure', async () => {
     execCliMock.mockImplementation((_binaryPath, args, options) => {
@@ -1309,7 +1489,7 @@ describe('ClaudeMultimodelBridgeService', () => {
     expect(onUpdate.mock.calls.at(-1)?.[0]).toEqual(providers);
   });
 
-  it('rejects contradictory catalog hydration without overwriting live summary auth state', async () => {
+  it('publishes authoritative auth revocation from aggregate full status hydration', async () => {
     const summaryPayloads = {
       anthropic: {
         supported: true,
@@ -1367,7 +1547,7 @@ describe('ClaudeMultimodelBridgeService', () => {
                 ...summaryPayloads.codex,
                 authenticated: false,
                 authMethod: null,
-                statusMessage: 'stale full status should not win',
+                statusMessage: 'Full status reports logged out',
                 modelCatalog: {
                   schemaVersion: 1,
                   providerId: 'codex',
@@ -1455,9 +1635,9 @@ describe('ClaudeMultimodelBridgeService', () => {
     const hydratedProviders = await hydrated;
     const hydratedCodex = hydratedProviders.find((provider) => provider.providerId === 'codex');
     expect(hydratedCodex).toMatchObject({
-      authenticated: true,
-      authMethod: 'api_key',
-      statusMessage: null,
+      authenticated: false,
+      authMethod: null,
+      statusMessage: 'Full status reports logged out',
       capabilities: { teamLaunch: false },
       modelCatalogRefreshState: 'error',
       modelCatalog: { status: 'stale' },
@@ -1480,7 +1660,7 @@ describe('ClaudeMultimodelBridgeService', () => {
     expect(buildProviderAwareCliEnvMock).not.toHaveBeenCalled();
   });
 
-  it('does not promote OpenCode auth from catalog hydration', async () => {
+  it('accepts newer authoritative OpenCode auth from full status hydration', async () => {
     execCliMock.mockImplementation((_binaryPath, args) => {
       const normalizedArgs = Array.isArray(args) ? args.join(' ') : '';
 
@@ -1593,17 +1773,17 @@ describe('ClaudeMultimodelBridgeService', () => {
       expect(onCatalogUpdate).toHaveBeenCalledTimes(1);
     });
     expect(onCatalogUpdate.mock.calls[0]?.[0]).toMatchObject({
-      authenticated: false,
-      authMethod: null,
-      statusMessage: 'No OpenCode providers connected',
-      capabilities: { teamLaunch: false },
-      modelCatalogRefreshState: 'error',
-      modelCatalog: { status: 'stale' },
-      backend: { authMethodDetail: null },
+      authenticated: true,
+      authMethod: 'opencode_builtin_free',
+      statusMessage: null,
+      capabilities: { teamLaunch: true },
+      modelCatalogRefreshState: 'ready',
+      modelCatalog: { status: 'ready' },
+      backend: { authMethodDetail: 'built-in free models' },
     });
   });
 
-  it('rejects a contradictory single-provider catalog after summary refresh', async () => {
+  it('publishes authoritative auth revocation from single-provider full status hydration', async () => {
     execCliMock.mockImplementation((_binaryPath, args) => {
       const normalizedArgs = Array.isArray(args) ? args.join(' ') : '';
 
@@ -1645,7 +1825,7 @@ describe('ClaudeMultimodelBridgeService', () => {
                 authMethod: 'oauth_token',
                 verificationState: 'verified',
                 canLoginFromUi: false,
-                statusMessage: 'full status should not overwrite live summary',
+                statusMessage: 'Full status reports logged out',
                 models: ['gpt-5.4'],
                 capabilities: { teamLaunch: true, oneShot: true },
                 runtimeCapabilities: { modelCatalog: { dynamic: true, source: 'app-server' } },
@@ -1696,9 +1876,9 @@ describe('ClaudeMultimodelBridgeService', () => {
       expect(onCatalogUpdate).toHaveBeenCalledTimes(1);
     });
     expect(onCatalogUpdate.mock.calls[0]?.[0]).toMatchObject({
-      authenticated: true,
-      authMethod: 'api_key',
-      statusMessage: null,
+      authenticated: false,
+      authMethod: 'oauth_token',
+      statusMessage: 'Full status reports logged out',
       capabilities: { teamLaunch: false },
       modelCatalogRefreshState: 'error',
       modelCatalog: {
@@ -1772,7 +1952,7 @@ describe('ClaudeMultimodelBridgeService', () => {
                 authMethod: null,
                 verificationState: 'verified',
                 canLoginFromUi: false,
-                statusMessage: 'fresh full status should not overwrite live summary',
+                statusMessage: 'Fresh full status',
                 models: ['gpt-5.4'],
                 capabilities: { teamLaunch: true, oneShot: true },
                 runtimeCapabilities: { modelCatalog: { dynamic: true, source: 'app-server' } },
@@ -1829,7 +2009,7 @@ describe('ClaudeMultimodelBridgeService', () => {
             authMethod: null,
             verificationState: 'unknown',
             canLoginFromUi: false,
-            statusMessage: 'full status should not overwrite live summary',
+            statusMessage: 'Full status reports logged out',
             models: ['gpt-5.4'],
             capabilities: { teamLaunch: true, oneShot: true },
             runtimeCapabilities: { modelCatalog: { dynamic: true, source: 'app-server' } },
@@ -1861,9 +2041,9 @@ describe('ClaudeMultimodelBridgeService', () => {
     expect(fullStatusCalls).toBe(2);
     expect(firstUpdate).not.toHaveBeenCalled();
     expect(secondUpdate.mock.calls[0]?.[0]).toMatchObject({
-      authenticated: true,
-      authMethod: 'api_key',
-      statusMessage: null,
+      authenticated: false,
+      authMethod: null,
+      statusMessage: 'Fresh full status',
       capabilities: { teamLaunch: false },
       modelCatalogRefreshState: 'error',
       modelCatalog: {
@@ -1912,7 +2092,13 @@ describe('ClaudeMultimodelBridgeService', () => {
                   staleAt: '2100-01-01T00:00:00.000Z',
                   defaultModelId,
                   defaultLaunchModel: defaultModelId,
-                  models: [],
+                  models: [
+                    {
+                      id: defaultModelId,
+                      launchModel: defaultModelId,
+                      displayName: defaultModelId,
+                    },
+                  ],
                   diagnostics: {
                     configReadState: 'ready',
                     appServerState: 'healthy',
@@ -1967,7 +2153,8 @@ describe('ClaudeMultimodelBridgeService', () => {
       )
     ).toHaveLength(2);
     expect(scopedStatus).toMatchObject({
-      modelCatalog: { defaultModelId: 'ollama/qwen2.5-coder:0.5b' },
+      modelCatalog: { defaultModelId: 'ollama/qwen2.5-coder:0.5b', status: 'ready' },
+      capabilities: { teamLaunch: true },
     });
 
     resolveGlobalHydration({
@@ -1979,11 +2166,12 @@ describe('ClaudeMultimodelBridgeService', () => {
       expect(globalUpdate).toHaveBeenCalledTimes(1);
     });
     expect(globalUpdate.mock.calls[0]?.[0]).toMatchObject({
-      modelCatalog: { defaultModelId: 'opencode/big-pickle' },
+      modelCatalog: { defaultModelId: 'opencode/big-pickle', status: 'ready' },
+      capabilities: { teamLaunch: true },
     });
   });
 
-  it('does not borrow Anthropic rate-limit evidence from a non-authoritative catalog result', async () => {
+  it('publishes full Anthropic status and rate limits together while keeping revoked auth closed', async () => {
     execCliMock.mockImplementation((_binaryPath, args) => {
       const normalizedArgs = Array.isArray(args) ? args.join(' ') : '';
 
@@ -2028,7 +2216,7 @@ describe('ClaudeMultimodelBridgeService', () => {
                 authMethod: 'oauth_token',
                 verificationState: 'verified',
                 canLoginFromUi: true,
-                statusMessage: 'full status should not overwrite live summary',
+                statusMessage: 'Full status reports logged out',
                 models: ['sonnet'],
                 capabilities: { teamLaunch: true, oneShot: true },
                 runtimeCapabilities: {
@@ -2086,11 +2274,14 @@ describe('ClaudeMultimodelBridgeService', () => {
       expect(onCatalogUpdate).toHaveBeenCalledTimes(1);
     });
     expect(onCatalogUpdate.mock.calls[0]?.[0]).toMatchObject({
-      authenticated: true,
+      authenticated: false,
       authMethod: 'oauth_token',
-      statusMessage: null,
+      statusMessage: 'Full status reports logged out',
       capabilities: { teamLaunch: false },
-      subscriptionRateLimits: null,
+      subscriptionRateLimits: {
+        primary: { usedPercent: 42, windowDurationMins: 300, resetsAt: 1_800 },
+        secondary: null,
+      },
       modelCatalogRefreshState: 'error',
       modelCatalog: { status: 'stale' },
     });
@@ -2195,7 +2386,7 @@ describe('ClaudeMultimodelBridgeService', () => {
             ...codex,
             authenticated: false,
             authMethod: null,
-            statusMessage: 'full status should not overwrite live summary',
+            statusMessage: 'Full status reports logged out',
             modelCatalog: {
               schemaVersion: 1,
               providerId: 'codex',
@@ -2222,9 +2413,9 @@ describe('ClaudeMultimodelBridgeService', () => {
       expect(onCodexCatalogUpdate).toHaveBeenCalledTimes(1);
     });
     expect(onCodexCatalogUpdate.mock.calls[0]?.[0]).toMatchObject({
-      authenticated: true,
-      authMethod: 'api_key',
-      statusMessage: null,
+      authenticated: false,
+      authMethod: null,
+      statusMessage: 'Full status reports logged out',
       capabilities: { teamLaunch: false },
       modelCatalogRefreshState: 'error',
       modelCatalog: { status: 'stale' },
@@ -2345,7 +2536,7 @@ describe('ClaudeMultimodelBridgeService', () => {
                 ...codexSummaryDisconnected,
                 authenticated: true,
                 authMethod: 'api_key',
-                statusMessage: 'fresh full status should not overwrite live summary',
+                statusMessage: 'Fresh full status',
                 modelCatalog: {
                   schemaVersion: 1,
                   providerId: 'codex',
@@ -2419,7 +2610,7 @@ describe('ClaudeMultimodelBridgeService', () => {
               staleAt: '2100-01-01T00:00:00.000Z',
               defaultModelId: 'old-model',
               defaultLaunchModel: 'old-model',
-              models: [],
+              models: [{ id: 'old-model', launchModel: 'old-model', displayName: 'Old model' }],
               diagnostics: {
                 configReadState: 'skipped',
                 appServerState: 'healthy',

--- a/test/main/services/runtime/ClaudeMultimodelStatusCatalogCore.test.ts
+++ b/test/main/services/runtime/ClaudeMultimodelStatusCatalogCore.test.ts
@@ -309,7 +309,7 @@ describe('ClaudeMultimodelBridgeService status/catalog core', () => {
     expect(result.capabilities.teamLaunch).toBe(false);
   });
 
-  it('normalizes an exact project cwd and merges only catalog fields', async () => {
+  it('normalizes an exact project cwd and atomically publishes the full status', async () => {
     execCliMock.mockImplementation((_binary, args, options) => {
       const isSummary = (args as string[]).includes('--summary');
       return commandResult(
@@ -348,13 +348,13 @@ describe('ClaudeMultimodelBridgeService status/catalog core', () => {
       '/projects/beta',
     ]);
     expect(result).toMatchObject({
-      authenticated: false,
-      authMethod: null,
-      verificationState: 'unknown',
-      statusCheckOutcome: 'model_only',
+      authenticated: true,
+      authMethod: 'catalog-must-not-promote-auth',
+      verificationState: 'verified',
+      statusCheckOutcome: 'authoritative',
       models: ['project/model'],
       modelCatalog: { defaultModelId: 'project/model' },
-      capabilities: { teamLaunch: false },
+      capabilities: { teamLaunch: true },
     });
   });
 
@@ -403,7 +403,7 @@ describe('ClaudeMultimodelBridgeService status/catalog core', () => {
   });
 
   it.each(['unknown', 'error'] as const)(
-    'preserves verified summary authority when catalog hydration verification is %s',
+    'revokes summary authority when the newer full status verification is %s',
     async (verificationState) => {
       execCliMock.mockImplementation((_binary, args) => {
         const isSummary = (args as string[]).includes('--summary');
@@ -441,12 +441,12 @@ describe('ClaudeMultimodelBridgeService status/catalog core', () => {
       );
 
       expect(result).toMatchObject({
-        authenticated: true,
-        authMethod: 'builtin_free',
-        verificationState: 'verified',
+        authenticated: false,
+        authMethod: null,
+        verificationState,
         statusCheckOutcome: 'authoritative',
-        statusMessage: null,
-        detailMessage: null,
+        statusMessage: 'Hydration verification incomplete',
+        detailMessage: `Hydration verification is ${verificationState}`,
         capabilities: { teamLaunch: false },
         modelCatalogRefreshState: 'error',
         modelCatalog: {
@@ -553,8 +553,8 @@ describe('ClaudeMultimodelBridgeService status/catalog core', () => {
 
     expect(one.modelCatalog?.defaultModelId).toBe('project-one/model');
     expect(two.modelCatalog?.defaultModelId).toBe('project-two/model');
-    expect(one.authenticated).toBe(false);
-    expect(two.authenticated).toBe(false);
+    expect(one).toMatchObject({ authenticated: true, statusCheckOutcome: 'authoritative' });
+    expect(two).toMatchObject({ authenticated: true, statusCheckOutcome: 'authoritative' });
     expect(execCliMock.mock.calls.filter((call) => call[2]?.cwd === '/projects/one')).toHaveLength(
       2
     );

--- a/test/main/services/team/Issue443DesktopContract.safe-e2e.test.ts
+++ b/test/main/services/team/Issue443DesktopContract.safe-e2e.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { chmod, copyFile, mkdir, mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
+import { chmod, copyFile, mkdir, mkdtemp, readdir, readFile, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -20,6 +20,11 @@ import { OpenCodeStateChangingBridgeCommandService } from '@main/services/team/o
 import {
   createOpenCodeExpectedBehaviorFingerprint,
 } from '@main/services/team/opencode/readiness/OpenCodeExpectedBehaviorFingerprint';
+import { OpenCodeRuntimeLaunchAuthorityWriter } from '@main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
+import {
+  OpenCodeRuntimeManifestEvidenceReader,
+  setOpenCodeRuntimeActiveRunManifest,
+} from '@main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import { OpenCodeTeamRuntimeAdapter } from '@main/services/team/runtime/OpenCodeTeamRuntimeAdapter';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -124,9 +129,9 @@ describe('issue #443 Desktop real child-process wire contract', () => {
 
   it('crosses the real Desktop child boundary with exact v2 proof bindings and framing', async () => {
     const harness = await realContractHarness('valid');
-    const result = await harness.adapter.launch(launchInput('run-valid', harness.fake.project));
+    const result = await harness.launch(launchInput('run-valid', harness.fake.project));
 
-    expect(result.teamLaunchState).toBe('clean_success');
+    expect(result.teamLaunchState, JSON.stringify(result)).toBe('clean_success');
     expect(result.members.alice).toMatchObject({
       launchState: 'confirmed_alive',
       bootstrapConfirmed: true,
@@ -158,6 +163,7 @@ describe('issue #443 Desktop real child-process wire contract', () => {
       projectPath: harness.fake.project,
       selectedModel: MODEL,
       requireExecutionProbe: true,
+      skipPermissions: true,
     });
     const handshakeEnvelope = traces[1].envelope as unknown as {
       body: {
@@ -211,7 +217,7 @@ describe('issue #443 Desktop real child-process wire contract', () => {
     ['handshake fingerprint v1', 'handshake-v1', 0],
   ] as const)('fails closed for %s', async (_label, scenario, expectedLaunches) => {
     const harness = await realContractHarness(scenario);
-    const result = await harness.adapter.launch(launchInput(`run-${scenario}`, harness.fake.project));
+    const result = await harness.launch(launchInput(`run-${scenario}`, harness.fake.project));
 
     expect(result.teamLaunchState).not.toBe('clean_success');
     expect(result.members.alice).not.toMatchObject({ runtimeAlive: true, bootstrapConfirmed: true });
@@ -224,7 +230,7 @@ describe('issue #443 Desktop real child-process wire contract', () => {
 
   it('retains a launch with a mismatched fingerprint echo for reconciliation', async () => {
     const harness = await realContractHarness('mismatch-echo');
-    const result = await harness.adapter.launch(
+    const result = await harness.launch(
       launchInput('run-mismatch-echo', harness.fake.project)
     );
 
@@ -243,9 +249,30 @@ describe('issue #443 Desktop real child-process wire contract', () => {
     assertProcessesExited(traces);
   });
 
+  it('keeps a committed launch pending when authority publication fails without redispatching', async () => {
+    const harness = await realContractHarness('valid', new Error('fixture authority write failed'));
+    const result = await harness.launch(launchInput('run-publication-failed', harness.fake.project));
+
+    expect(result.teamLaunchState, JSON.stringify(result)).toBe('partial_pending');
+    expect(result.members.alice).toMatchObject({
+      launchState: 'runtime_pending_bootstrap',
+      runtimeAlive: false,
+      bootstrapConfirmed: false,
+      hardFailure: false,
+    });
+    expect(harness.ledger.markUnknownAfterTimeout).toHaveBeenCalledTimes(1);
+    expect(harness.ledger.markFailed).not.toHaveBeenCalled();
+    expect(harness.ledger.markCompleted).not.toHaveBeenCalled();
+    const traces = await harness.fake.traces();
+    const launches = traces.filter((trace) => trace.envelope?.command === 'opencode.launchTeam');
+    expect(launches).toHaveLength(1);
+    expect(launches[0].sideEffectCommitted).toBe(true);
+    assertProcessesExited(traces);
+  });
+
   it('treats an unknown launch outcome as non-retryable without duplicating the side effect', async () => {
     const harness = await realContractHarness('unknown-outcome');
-    const result = await harness.adapter.launch(launchInput('run-unknown', harness.fake.project));
+    const result = await harness.launch(launchInput('run-unknown', harness.fake.project));
 
     expect(result.teamLaunchState).toBe('partial_pending');
     expect(result.members.alice).toMatchObject({
@@ -296,7 +323,7 @@ describe('issue #443 Desktop real child-process wire contract', () => {
   });
 });
 
-async function realContractHarness(scenario: string) {
+async function realContractHarness(scenario: string, publicationFailure?: Error) {
   const fake = await createFake(scenario);
   const bridge = new OpenCodeBridgeCommandClient({
     binaryPath: fake.executable,
@@ -333,13 +360,19 @@ async function realContractHarness(scenario: string) {
     })),
     release: vi.fn().mockResolvedValue(undefined),
   } as unknown as OpenCodeBridgeCommandLeaseStore;
+  const teamsBasePath = path.join(fake.sandbox, 'teams');
+  const launchAuthorityWriter = new OpenCodeRuntimeLaunchAuthorityWriter({ teamsBasePath });
+  if (publicationFailure) {
+    vi.spyOn(launchAuthorityWriter, 'publish').mockRejectedValue(publicationFailure);
+  }
   const stateChanging = new OpenCodeStateChangingBridgeCommandService({
     expectedClientIdentity: clientIdentity,
     handshakePort: new OpenCodeBridgeCommandHandshakePort({ bridge, clientIdentity, timeoutMs: 1_000 }),
     leaseStore,
     ledger,
     bridge,
-    manifestReader: { read: async () => ({ highWatermark: 0, activeRunId: null, capabilitySnapshotId: 'issue443-capability-v2' }) },
+    manifestReader: new OpenCodeRuntimeManifestEvidenceReader({ teamsBasePath }),
+    launchAuthorityWriter,
     requestIdFactory: sequentialIds('state-change'),
     diagnosticIdFactory: sequentialIds('state-diagnostic'),
     clock: () => new Date(NOW),
@@ -349,11 +382,24 @@ async function realContractHarness(scenario: string) {
     launchTimeoutMs: 1_000,
     stateChangingCommands: stateChanging,
   });
-  return { fake, ledger, adapter: new OpenCodeTeamRuntimeAdapter(readiness) };
+  const adapter = new OpenCodeTeamRuntimeAdapter(readiness);
+  return {
+    fake,
+    ledger,
+    async launch(input: TeamRuntimeLaunchInput) {
+      await setOpenCodeRuntimeActiveRunManifest({
+        teamsBasePath,
+        teamName: input.teamName,
+        laneId: input.laneId?.trim() || 'primary',
+        runId: input.runId,
+      });
+      return adapter.launch(input);
+    },
+  };
 }
 
 async function createFake(scenario: string) {
-  const sandbox = await mkdtemp(path.join(tmpdir(), 'issue443-desktop-wire-'));
+  const sandbox = await realpath(await mkdtemp(path.join(tmpdir(), 'issue443-desktop-wire-')));
   sandboxes.push(sandbox);
   const project = path.join(sandbox, 'project');
   const bridgeTemp = path.join(sandbox, 'bridge-inputs');

--- a/test/main/services/team/OpenCodeAggregatePrimaryRestartPolicy.test.ts
+++ b/test/main/services/team/OpenCodeAggregatePrimaryRestartPolicy.test.ts
@@ -1,0 +1,46 @@
+import { clearCancelledAggregateRestartState } from '@main/services/team/provisioning/OpenCodeAggregatePrimaryRestartPolicy';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('OpenCodeAggregatePrimaryRestartPolicy', () => {
+  it('cleans every cancelled restart run without letting cleanup failures mask cancellation', async () => {
+    const operations: string[] = [];
+    const launchError = new Error('launch cleanup failed');
+    const primaryError = new Error('primary cleanup failed');
+    const onLaunchClearError = vi.fn<(runId: string, error: unknown) => void>();
+
+    await expect(
+      clearCancelledAggregateRestartState({
+        runId: 'run-current',
+        restartLease: {
+          teamName: 'team-a',
+          runId: 'run-current',
+          candidateRunId: 'run-candidate',
+          memberName: 'alice',
+          completion: Promise.resolve(),
+          precedingLifecycleOperations: [],
+          cancelRequested: true,
+        },
+        clearLaunchState: async (runId) => {
+          operations.push(`launch:${runId}`);
+          if (runId === 'run-current') throw launchError;
+        },
+        clearPrimaryLane: async (runId) => {
+          operations.push(`primary:${runId}`);
+          if (runId === 'run-current') throw primaryError;
+        },
+        onLaunchClearError,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(operations).toEqual([
+      'launch:run-current',
+      'primary:run-current',
+      'launch:run-candidate',
+      'primary:run-candidate',
+    ]);
+    expect(onLaunchClearError.mock.calls).toEqual([
+      ['run-current', launchError],
+      ['run-current', primaryError],
+    ]);
+  });
+});

--- a/test/main/services/team/OpenCodeBridgeCommandLedgerStore.test.ts
+++ b/test/main/services/team/OpenCodeBridgeCommandLedgerStore.test.ts
@@ -80,6 +80,7 @@ describe('OpenCodeBridgeCommandLedgerStore', () => {
               capabilitySnapshotId: 'cap-1',
             }),
           },
+          launchAuthorityWriter: { publish: async () => undefined },
           requestIdFactory: () => `restart-request-${nextRequestId++}`,
           clock: () => now,
         });

--- a/test/main/services/team/OpenCodeExpectedBehaviorFingerprint.test.ts
+++ b/test/main/services/team/OpenCodeExpectedBehaviorFingerprint.test.ts
@@ -1,11 +1,21 @@
-import { readFileSync } from 'fs';
-import { resolve } from 'path';
-import { describe, expect, it } from 'vitest';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   createOpenCodeCanonicalProjectPathFingerprint,
   createOpenCodeExecutionProofHash,
   createOpenCodeExpectedBehaviorFingerprint,
+  freshOpenCodeExecutionProof,
   parseOpenCodeExpectedBehaviorEvidence,
   reusableOpenCodeExecutionProof,
   validateOpenCodeExpectedBehaviorEvidence,
@@ -26,6 +36,104 @@ interface GoldenCase {
 }
 
 describe('OpenCodeExpectedBehaviorFingerprint', () => {
+  const sandboxes: string[] = [];
+  afterEach(() => {
+    for (const sandbox of sandboxes.splice(0)) rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  function projectAlias() {
+    const sandbox = mkdtempSync(join(tmpdir(), 'opencode-proof-path-test-'));
+    sandboxes.push(sandbox);
+    const project = join(sandbox, 'project');
+    const otherProject = join(sandbox, 'other-project');
+    const alias = join(sandbox, 'alias');
+    mkdirSync(project);
+    mkdirSync(otherProject);
+    symlinkSync(project, alias, process.platform === 'win32' ? 'junction' : 'dir');
+    return { project: realpathSync(project), otherProject, alias };
+  }
+
+  function proofForProject(projectPath: string) {
+    const tuple = {
+      ...validEvidence(),
+      canonicalProjectPathFingerprint: createOpenCodeCanonicalProjectPathFingerprint(projectPath),
+    };
+    const expectedBehaviorEvidence = {
+      ...tuple,
+      expectedBehaviorFingerprint: createOpenCodeExpectedBehaviorFingerprint(tuple),
+    };
+    return changedProof({ projectPath, expectedBehaviorEvidence });
+  }
+
+  it('accepts a canonical proof through a real project alias without rewriting signed fields', () => {
+    const { project, alias } = projectAlias();
+    const proof = proofForProject(project);
+    const originalHash = proof.proofHash;
+    const readiness = cachedReadiness(proof);
+    expect(
+      reusableOpenCodeExecutionProof(readiness, { ...validReuseInput(), projectPath: alias })
+    ).toBe(proof);
+    expect(
+      freshOpenCodeExecutionProof(readiness, { projectPath: alias, fullModelId: proof.modelId })
+        .proof
+    ).toBe(proof);
+    expect(
+      validateOpenCodeExpectedBehaviorEvidence({
+        evidence: proof.expectedBehaviorEvidence,
+        executionProof: proof,
+        projectPath: alias,
+        fullModelId: proof.modelId,
+      })
+    ).toEqual(proof.expectedBehaviorEvidence);
+    expect(proof.projectPath).toBe(project);
+    expect(proof.proofHash).toBe(originalHash);
+  });
+
+  it.each(['different directory', 'retargeted alias'] as const)(
+    'rejects proof reuse for a %s',
+    (condition) => {
+      const { project, otherProject, alias } = projectAlias();
+      // With a signed alias path, retargeting changes both live path comparisons;
+      // the original evidence fingerprint must still bind the old canonical target.
+      const proof = proofForProject(condition === 'retargeted alias' ? alias : project);
+      let projectPath = otherProject;
+      if (condition === 'retargeted alias') {
+        unlinkSync(alias);
+        symlinkSync(otherProject, alias, process.platform === 'win32' ? 'junction' : 'dir');
+        projectPath = alias;
+      }
+      const readiness = cachedReadiness(proof);
+      expect(
+        reusableOpenCodeExecutionProof(readiness, { ...validReuseInput(), projectPath })
+      ).toBeNull();
+      expect(() =>
+        freshOpenCodeExecutionProof(readiness, { projectPath, fullModelId: proof.modelId })
+      ).toThrow(/project/);
+      expect(() =>
+        validateOpenCodeExpectedBehaviorEvidence({
+          evidence: proof.expectedBehaviorEvidence,
+          executionProof: proof,
+          projectPath,
+          fullModelId: proof.modelId,
+        })
+      ).toThrow(/project mismatch/);
+    }
+  );
+
+  it('rejects expired proof through an otherwise valid canonical project alias', () => {
+    const { project, alias } = projectAlias();
+    const { proofHash: _hash, ...unsigned } = proofForProject(project);
+    const expired = { ...unsigned, expiresAt: '2020-01-01T00:00:00.000Z' };
+    const proof = { ...expired, proofHash: createOpenCodeExecutionProofHash(expired) };
+    const readiness = cachedReadiness(proof);
+    expect(
+      reusableOpenCodeExecutionProof(readiness, { ...validReuseInput(), projectPath: alias })
+    ).toBeNull();
+    expect(() =>
+      freshOpenCodeExecutionProof(readiness, { projectPath: alias, fullModelId: proof.modelId })
+    ).toThrow(/stale/);
+  });
+
   it('produces every committed issue 443 golden digest exactly', () => {
     const fixture = JSON.parse(
       readFileSync(
@@ -141,23 +249,48 @@ describe('OpenCodeExpectedBehaviorFingerprint', () => {
 
   it.each([
     ['missing evidence', () => changedProof({ expectedBehaviorEvidence: undefined }), {}],
-    ['uppercase evidence', () => changedProof({
-      expectedBehaviorEvidence: { ...validEvidence(), effectiveConfigFingerprint: 'A'.repeat(64) },
-    }), {}],
+    [
+      'uppercase evidence',
+      () =>
+        changedProof({
+          expectedBehaviorEvidence: {
+            ...validEvidence(),
+            effectiveConfigFingerprint: 'A'.repeat(64),
+          },
+        }),
+      {},
+    ],
     ['malformed evidence', () => changedProof({ expectedBehaviorEvidence: null }), {}],
-    ['extra-field evidence', () => changedProof({
-      expectedBehaviorEvidence: { ...validEvidence(), unexpected: true },
-    }), {}],
-    ['digest mismatch', () => changedProof({
-      expectedBehaviorEvidence: { ...validEvidence(), expectedBehaviorFingerprint: 'f'.repeat(64) },
-    }), {}],
+    [
+      'extra-field evidence',
+      () =>
+        changedProof({
+          expectedBehaviorEvidence: { ...validEvidence(), unexpected: true },
+        }),
+      {},
+    ],
+    [
+      'digest mismatch',
+      () =>
+        changedProof({
+          expectedBehaviorEvidence: {
+            ...validEvidence(),
+            expectedBehaviorFingerprint: 'f'.repeat(64),
+          },
+        }),
+      {},
+    ],
     ['requested project mismatch', () => validProof(), { projectPath: '/different/project' }],
     ['requested full-model mismatch', () => validProof(), { selectedModel: 'deepinfra/other' }],
-    ['requested provider mismatch', () => {
-      const evidence = { ...validEvidence(), modelProviderId: 'custom' };
-      evidence.expectedBehaviorFingerprint = createOpenCodeExpectedBehaviorFingerprint(evidence);
-      return changedProof({ expectedBehaviorEvidence: evidence });
-    }, {}],
+    [
+      'requested provider mismatch',
+      () => {
+        const evidence = { ...validEvidence(), modelProviderId: 'custom' };
+        evidence.expectedBehaviorFingerprint = createOpenCodeExpectedBehaviorFingerprint(evidence);
+        return changedProof({ expectedBehaviorEvidence: evidence });
+      },
+      {},
+    ],
     ['proofHash mismatch', () => ({ ...validProof(), proofHash: '9'.repeat(64) }), {}],
     ['expired proof', () => changedProof({ expiresAt: '2020-01-01T00:00:00.000Z' }), {}],
   ])('rejects cached %s', (_name, buildProof, inputChanges) => {
@@ -171,7 +304,10 @@ describe('OpenCodeExpectedBehaviorFingerprint', () => {
   });
 
   it('rejects stale config or auth evidence after either fingerprint changes', () => {
-    for (const field of ['effectiveConfigFingerprint', 'effectiveSelectedAuthFingerprint'] as const) {
+    for (const field of [
+      'effectiveConfigFingerprint',
+      'effectiveSelectedAuthFingerprint',
+    ] as const) {
       expect(() =>
         parseOpenCodeExpectedBehaviorEvidence({ ...validEvidence(), [field]: '0'.repeat(64) })
       ).toThrow('digest mismatch');

--- a/test/main/services/team/OpenCodeMixedRecovery.live.test.ts
+++ b/test/main/services/team/OpenCodeMixedRecovery.live.test.ts
@@ -1,3 +1,10 @@
+import { OpenCodeRuntimeLaunchAuthorityWriter } from '@main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
+import {
+  OpenCodeRuntimeManifestEvidenceReader,
+  readOpenCodeRuntimeLaneIndex,
+  setOpenCodeRuntimeActiveRunManifest,
+  upsertOpenCodeRuntimeLaneIndexEntry,
+} from '@main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import { constants as fsConstants, promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -15,13 +22,6 @@ import {
 } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
 import { OpenCodeReadinessBridge } from '../../../../src/main/services/team/opencode/bridge/OpenCodeReadinessBridge';
 import { OpenCodeStateChangingBridgeCommandService } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
-import { OpenCodeRuntimeLaunchAuthorityWriter } from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
-import {
-  OpenCodeRuntimeManifestEvidenceReader,
-  readOpenCodeRuntimeLaneIndex,
-  setOpenCodeRuntimeActiveRunManifest,
-  upsertOpenCodeRuntimeLaneIndexEntry,
-} from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import { OpenCodeTeamRuntimeAdapter } from '../../../../src/main/services/team/runtime/OpenCodeTeamRuntimeAdapter';
 import { TeamRuntimeAdapterRegistry } from '../../../../src/main/services/team/runtime/TeamRuntimeAdapter';
 import { getTeamBootstrapStatePath } from '../../../../src/main/services/team/TeamBootstrapStateReader';

--- a/test/main/services/team/OpenCodeMixedRecovery.live.test.ts
+++ b/test/main/services/team/OpenCodeMixedRecovery.live.test.ts
@@ -15,8 +15,11 @@ import {
 } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
 import { OpenCodeReadinessBridge } from '../../../../src/main/services/team/opencode/bridge/OpenCodeReadinessBridge';
 import { OpenCodeStateChangingBridgeCommandService } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
+import { OpenCodeRuntimeLaunchAuthorityWriter } from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
 import {
+  OpenCodeRuntimeManifestEvidenceReader,
   readOpenCodeRuntimeLaneIndex,
+  setOpenCodeRuntimeActiveRunManifest,
   upsertOpenCodeRuntimeLaneIndexEntry,
 } from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import { OpenCodeTeamRuntimeAdapter } from '../../../../src/main/services/team/runtime/OpenCodeTeamRuntimeAdapter';
@@ -31,8 +34,6 @@ import {
   setClaudeBasePathOverride,
 } from '../../../../src/main/utils/pathDecoder';
 
-import type { RuntimeStoreManifestEvidence } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeCommandContract';
-import type { RuntimeStoreManifestReader } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import type { OpenCodeBridgeCommandExecutor } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import type {
   TeamRuntimeLaunchInput,
@@ -119,6 +120,12 @@ liveDescribe('OpenCode mixed recovery live e2e', () => {
         selectedModel,
       });
       launchedLanes.push(launchInput);
+      await setOpenCodeRuntimeActiveRunManifest({
+        teamsBasePath: getTeamsBasePath(),
+        teamName,
+        laneId: launchInput.laneId,
+        runId: launchInput.runId,
+      });
       const rawLaunchResult = await adapter.launch(launchInput);
       const launchResult = await commitMixedOpenCodeLaunchResult({
         service: svc,
@@ -234,6 +241,12 @@ liveDescribe('OpenCode mixed recovery live e2e', () => {
             selectedModel,
           });
           launchedLanes.push(launchInput);
+          await setOpenCodeRuntimeActiveRunManifest({
+            teamsBasePath: getTeamsBasePath(),
+            teamName,
+            laneId: launchInput.laneId,
+            runId: launchInput.runId,
+          });
           const rawLaunchResult = await adapter.launch(launchInput);
           const launchResult = await commitMixedOpenCodeLaunchResult({
             service: svc,
@@ -464,18 +477,13 @@ function createStateChangingCommands(input: {
       filePath: path.join(input.controlDir, 'ledger.json'),
     }),
     bridge: input.bridge,
-    manifestReader: new StaticManifestReader(),
+    manifestReader: new OpenCodeRuntimeManifestEvidenceReader({
+      teamsBasePath: getTeamsBasePath(),
+    }),
+    launchAuthorityWriter: new OpenCodeRuntimeLaunchAuthorityWriter({
+      teamsBasePath: getTeamsBasePath(),
+    }),
   });
-}
-
-class StaticManifestReader implements RuntimeStoreManifestReader {
-  async read(): Promise<RuntimeStoreManifestEvidence> {
-    return {
-      highWatermark: 0,
-      activeRunId: null,
-      capabilitySnapshotId: null,
-    };
-  }
 }
 
 async function assertExecutable(filePath: string): Promise<void> {

--- a/test/main/services/team/OpenCodeReadinessBridge.test.ts
+++ b/test/main/services/team/OpenCodeReadinessBridge.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { OpenCodeBridgeCommandLedgerError } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeCommandLedgerStore';
 import {
   OpenCodeReadinessBridge,
   type OpenCodeReadinessBridgeCommandExecutor,
   type OpenCodeReadinessBridgeOptions,
 } from '../../../../src/main/services/team/opencode/bridge/OpenCodeReadinessBridge';
-import {
-  REQUIRED_AGENT_TEAMS_APP_TOOL_IDS,
-} from '../../../../src/main/services/team/opencode/mcp/OpenCodeMcpToolAvailability';
+import { REQUIRED_AGENT_TEAMS_APP_TOOL_IDS } from '../../../../src/main/services/team/opencode/mcp/OpenCodeMcpToolAvailability';
 
 import type {
   OpenCodeBridgeCommandName,
@@ -54,6 +53,48 @@ describe('OpenCodeReadinessBridge', () => {
       capabilitySnapshotId: 'cap-1',
       version: '1.14.19',
     });
+  });
+
+  it('keeps manual and automatic selected-profile snapshots separate', async () => {
+    const autoResult = bridgeSuccess(readiness({ state: 'ready', launchAllowed: true }));
+    const manualResult = {
+      ...autoResult,
+      runtime: { ...autoResult.runtime, capabilitySnapshotId: 'cap-manual' },
+    };
+    const executor = fakeExecutor(autoResult);
+    vi.mocked(executor.execute)
+      .mockResolvedValueOnce(autoResult)
+      .mockResolvedValueOnce(manualResult);
+    const bridge = new OpenCodeReadinessBridge(executor);
+    const input = {
+      projectPath: '/repo',
+      selectedModel: 'openai/gpt-5.4-mini',
+      requireExecutionProbe: true,
+    };
+    await bridge.checkOpenCodeTeamLaunchReadiness({ ...input, skipPermissions: true });
+    expect(
+      bridge.getLastOpenCodeRuntimeSnapshot('/repo', input.selectedModel, true, false)
+    ).toBeNull();
+    await bridge.checkOpenCodeTeamLaunchReadiness({ ...input, skipPermissions: false });
+    expect(
+      bridge.getLastOpenCodeRuntimeSnapshot('/repo', input.selectedModel, true, false)
+        ?.capabilitySnapshotId
+    ).toBe('cap-manual');
+    expect(
+      bridge.getLastOpenCodeRuntimeSnapshot('/repo', input.selectedModel, true, true)
+        ?.capabilitySnapshotId
+    ).toBe('cap-1');
+    expect(
+      bridge.getLastOpenCodeRuntimeSnapshot('/other-project', input.selectedModel, true, false)
+    ).toBeNull();
+    expect(
+      bridge.getLastOpenCodeRuntimeSnapshot('/repo', 'openai/other-model', true, false)
+    ).toBeNull();
+    expect(executor.execute).toHaveBeenLastCalledWith(
+      'opencode.readiness',
+      expect.objectContaining({ skipPermissions: false }),
+      expect.anything()
+    );
   });
 
   it('maps bridge failures into fail-closed readiness', async () => {
@@ -146,9 +187,7 @@ describe('OpenCodeReadinessBridge', () => {
         summary: 'OpenCode readiness bridge exited without returning diagnostic JSON.',
       }),
     ]);
-    expect(result.supportDiagnostics?.[0]?.copyText).toContain(
-      'Agent Teams OpenCode diagnostics'
-    );
+    expect(result.supportDiagnostics?.[0]?.copyText).toContain('Agent Teams OpenCode diagnostics');
     expect(result.supportDiagnostics?.[0]?.copyText).toContain('outputReadError: ENOENT');
     expect(result.supportDiagnostics?.[0]?.copyText).toContain('appVersion: 1.3.0-test');
     expect(result.supportDiagnostics?.[0]?.copyText).toContain('selectedModel: qwen3.6-2b');
@@ -477,11 +516,13 @@ describe('OpenCodeReadinessBridge', () => {
   });
 
   it('does not fall back to observed mode when forced session refresh contract is missing', async () => {
-    const execute = vi.fn().mockRejectedValueOnce(
-      new Error(
-        'OpenCode delivery acceptance mode is required, but the orchestrator does not advertise contract version 2.'
-      )
-    );
+    const execute = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          'OpenCode delivery acceptance mode is required, but the orchestrator does not advertise contract version 2.'
+        )
+      );
     const executor = {
       execute: execute as unknown as OpenCodeReadinessBridgeCommandExecutor['execute'] &
         ReturnType<typeof vi.fn>,
@@ -738,7 +779,9 @@ describe('OpenCodeReadinessBridge', () => {
           status: 'unknown',
           safeToRetry: false,
           accepted: false,
-          diagnostics: ['No orchestrator-side command outcome record matched the requested OpenCode command.'],
+          diagnostics: [
+            'No orchestrator-side command outcome record matched the requested OpenCode command.',
+          ],
         },
       }),
     ]);
@@ -1241,6 +1284,33 @@ describe('OpenCodeReadinessBridge', () => {
         expectedBehaviorFingerprint: body.expectedBehaviorFingerprint,
       });
       expect(stateChangingExecute).toHaveBeenCalledTimes(1);
+      expect(executor.execute).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    [true, 'OpenCode bridge command outcome must be reconciled before retry'],
+    [true, 'OpenCode bridge command already started'],
+    [false, 'OpenCode bridge command outcome must be reconciled before retry'],
+    [false, 'OpenCode bridge command already started'],
+  ] as const)(
+    'only preserves typed ledger unknown outcomes as pending (%s, %s)',
+    async (typed, message) => {
+      const execute = vi.fn(async () => {
+        throw typed ? new OpenCodeBridgeCommandLedgerError(message) : new Error(message);
+      });
+      const executor = fakeExecutor(bridgeFailure('internal_error', 'must not redispatch', []));
+      const bridge = new OpenCodeReadinessBridge(executor, { stateChangingCommands: { execute } });
+
+      await expect(bridge.launchOpenCodeTeam(launchCommandBody())).resolves.toMatchObject({
+        teamLaunchState: typed ? 'launching' : 'failed',
+        diagnostics: expect.arrayContaining([
+          expect.objectContaining({
+            code: typed ? 'opencode_launch_reconciliation_required' : 'internal_error',
+          }),
+        ]),
+      });
+      expect(execute).toHaveBeenCalledTimes(1);
       expect(executor.execute).not.toHaveBeenCalled();
     }
   );

--- a/test/main/services/team/OpenCodeRuntimeManifestEvidenceReader.test.ts
+++ b/test/main/services/team/OpenCodeRuntimeManifestEvidenceReader.test.ts
@@ -1,17 +1,16 @@
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  OpenCodeRuntimeManifestEvidenceReader,
-  getOpenCodeRuntimeManifestPath,
   getOpenCodeLaneScopedRuntimeFilePath,
   getOpenCodeRuntimeLaneIndexPath,
+  getOpenCodeRuntimeManifestPath,
   getOpenCodeTeamRuntimeDirectory,
   inspectOpenCodeRuntimeLaneStorage,
   migrateLegacyOpenCodeRuntimeState,
+  OpenCodeRuntimeManifestEvidenceReader,
   prepareOpenCodeRuntimeLaneForLaunchGeneration,
   readCommittedOpenCodeBootstrapSessionEvidence,
   readOpenCodeRuntimeLaneIndex,
@@ -20,11 +19,11 @@ import {
   upsertOpenCodeRuntimeLaneIndexEntry,
 } from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import {
+  createDefaultRuntimeStoreManifest,
   createRuntimeStoreManifestStore,
   createRuntimeStoreReceiptStore,
   OPENCODE_RUNTIME_STORE_DESCRIPTORS,
   RuntimeStoreBatchWriter,
-  createDefaultRuntimeStoreManifest,
 } from '../../../../src/main/services/team/opencode/store/RuntimeStoreManifest';
 
 describe('OpenCodeRuntimeManifestEvidenceReader migration', () => {
@@ -616,7 +615,7 @@ describe('OpenCodeRuntimeManifestEvidenceReader migration', () => {
     });
   });
 
-  it('updates raw legacy runtime manifests without dropping existing capability metadata', async () => {
+  it('clears raw legacy launch authority when advancing to a new active run', async () => {
     const teamName = 'team-iota';
     const laneId = 'secondary:opencode:alice';
     const manifestPath = getOpenCodeRuntimeManifestPath(tempDir, teamName, laneId);
@@ -642,8 +641,19 @@ describe('OpenCodeRuntimeManifestEvidenceReader migration', () => {
       new OpenCodeRuntimeManifestEvidenceReader({ teamsBasePath: tempDir }).read(teamName, laneId)
     ).resolves.toMatchObject({
       activeRunId: 'run-new',
-      capabilitySnapshotId: 'cap-existing',
+      capabilitySnapshotId: null,
       highWatermark: 0,
+    });
+    await expect(
+      createRuntimeStoreManifestStore({
+        filePath: manifestPath,
+        teamName,
+        clock: () => now,
+      }).read()
+    ).resolves.toMatchObject({
+      activeRunId: 'run-new',
+      activeCapabilitySnapshotId: null,
+      activeBehaviorFingerprint: null,
     });
   });
 

--- a/test/main/services/team/OpenCodeStateChangingBridgeCommandService.test.ts
+++ b/test/main/services/team/OpenCodeStateChangingBridgeCommandService.test.ts
@@ -1,3 +1,4 @@
+import { OpenCodeBridgeCommandHandshakePort } from '@main/services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
 import { OpenCodeRuntimeLaunchAuthorityWriter } from '@main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
 import {
   getOpenCodeRuntimeManifestPath,
@@ -42,7 +43,6 @@ import {
   type OpenCodeBridgeCommandLeaseStore,
   type OpenCodeBridgeCommandLedger,
 } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeCommandLedgerStore';
-import { OpenCodeBridgeCommandHandshakePort } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
 import {
   type OpenCodeBridgeCommandExecutor,
   type OpenCodeBridgeHandshakePort,

--- a/test/main/services/team/OpenCodeStateChangingBridgeCommandService.test.ts
+++ b/test/main/services/team/OpenCodeStateChangingBridgeCommandService.test.ts
@@ -1,3 +1,22 @@
+import { OpenCodeRuntimeLaunchAuthorityWriter } from '@main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
+import {
+  getOpenCodeRuntimeManifestPath,
+  OpenCodeRuntimeManifestEvidenceReader,
+  readCommittedOpenCodeBootstrapSessionEvidence,
+  setOpenCodeRuntimeActiveRunManifest,
+} from '@main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
+import {
+  createRuntimeStoreManifestStore,
+  createRuntimeStoreReceiptStore,
+  OPENCODE_RUNTIME_STORE_DESCRIPTORS,
+  RuntimeStoreFileInspector,
+  RuntimeStoreRecoveryPlanner,
+} from '@main/services/team/opencode/store/RuntimeStoreManifest';
+import {
+  commitOpenCodeRuntimeBootstrapSessionEvidence,
+  createDefaultOpenCodeRuntimeBootstrapEvidencePorts,
+  stampOpenCodeAppMcpTransportEvidenceIfMissing,
+} from '@main/services/team/provisioning/TeamProvisioningOpenCodeBootstrapEvidence';
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -23,9 +42,11 @@ import {
   type OpenCodeBridgeCommandLeaseStore,
   type OpenCodeBridgeCommandLedger,
 } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeCommandLedgerStore';
+import { OpenCodeBridgeCommandHandshakePort } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
 import {
   type OpenCodeBridgeCommandExecutor,
   type OpenCodeBridgeHandshakePort,
+  type OpenCodeLaunchAuthorityWriter,
   OpenCodeStateChangingBridgeCommandService,
   type OpenCodeStateChangingBridgeDiagnosticsSink,
   resolveOpenCodeBridgeLeaseAcquireTimeoutMs,
@@ -42,6 +63,7 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
   let handshakePort: FakeHandshakePort;
   let manifestReader: FakeManifestReader;
   let diagnostics: FakeDiagnosticsSink;
+  let launchAuthorityWriter: OpenCodeLaunchAuthorityWriter;
   let clientIdentity: OpenCodeBridgePeerIdentity;
 
   beforeEach(async () => {
@@ -57,11 +79,14 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
       idFactory: () => `lease-${nextLeaseId++}`,
       clock: () => now,
     });
+    launchAuthorityWriter = { publish: vi.fn(async () => {}) };
     clientIdentity = peerIdentity('claude_team');
-    handshakePort = new FakeHandshakePort(buildHandshake({
-      client: clientIdentity,
-      server: peerIdentity('agent_teams_orchestrator'),
-    }));
+    handshakePort = new FakeHandshakePort(
+      buildHandshake({
+        client: clientIdentity,
+        server: peerIdentity('agent_teams_orchestrator'),
+      })
+    );
     manifestReader = new FakeManifestReader();
     bridge = new FakeBridgeExecutor();
     diagnostics = new FakeDiagnosticsSink();
@@ -70,6 +95,416 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
   afterEach(async () => {
     vi.useRealTimers();
     await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('publishes validated launch authority before completion and preserves it through bootstrap, transport and stop', async () => {
+    const teamsBasePath = path.join(tempDir, 'teams');
+    const laneId = 'secondary:opencode:alice';
+    const scope = { teamsBasePath, teamName: 'team-a', laneId, runId: 'run-1' };
+    await setOpenCodeRuntimeActiveRunManifest(scope); // Normal provisioning reserves only the run.
+    const manifestPath = getOpenCodeRuntimeManifestPath(teamsBasePath, scope.teamName, laneId);
+    const manifestStore = createRuntimeStoreManifestStore({
+      filePath: manifestPath,
+      teamName: scope.teamName,
+    });
+    const ports = createDefaultOpenCodeRuntimeBootstrapEvidencePorts({ teamsBasePath });
+    const bootstrap = {
+      teamName: scope.teamName,
+      laneId,
+      runId: scope.runId,
+      memberName: 'alice',
+      runtimeSessionId: 'session-alice',
+      observedAt: now.toISOString(),
+    };
+    await commitOpenCodeRuntimeBootstrapSessionEvidence(bootstrap, ports);
+    expect(await manifestStore.read()).toMatchObject({
+      activeRunId: 'run-1',
+      activeCapabilitySnapshotId: null,
+    });
+    const reader = new OpenCodeRuntimeManifestEvidenceReader({ teamsBasePath });
+    const authorityWriter = new OpenCodeRuntimeLaunchAuthorityWriter({ teamsBasePath });
+    const service = createService({
+      manifestReader: reader,
+      launchAuthorityWriter: authorityWriter,
+    });
+    bridge.resultFactory = ({ command, body, options }) =>
+      bridgeSuccess({
+        command,
+        requestId: options.requestId,
+        data: {
+          runId: 'run-1',
+          idempotencyKey: body.preconditions.idempotencyKey,
+          expectedBehaviorFingerprint: 'a'.repeat(64),
+          runtimeStoreManifestHighWatermark: 10,
+        },
+      });
+    const launch = buildLaunchInput();
+    launch.laneId = laneId;
+    await expect(service.execute(launch)).resolves.toMatchObject({ ok: true });
+    expect(await reader.read(scope.teamName, laneId)).toMatchObject({
+      capabilitySnapshotId: 'cap-1',
+    });
+    expect((await manifestStore.read()).entries[0]?.capabilitySnapshotId).toBeNull(); // No retroactive proof promotion.
+    await commitOpenCodeRuntimeBootstrapSessionEvidence(
+      { ...bootstrap, memberName: 'bob', runtimeSessionId: 'session-bob' },
+      ports
+    );
+    const session = (await readCommittedOpenCodeBootstrapSessionEvidence(scope)).sessions.find(
+      (entry) => entry.memberName === 'bob'
+    )!;
+    ports.getCurrentAgentTeamsMcpHttpTransportEvidence = () => ({
+      schemaVersion: 1,
+      transport: 'httpStream',
+      host: '127.0.0.1',
+      port: 19000,
+      endpoint: '/mcp',
+      url: 'http://127.0.0.1:19000/mcp',
+      urlHash: 'sandbox-transport',
+      generation: 1,
+      observedAt: now.toISOString(),
+    });
+    await stampOpenCodeAppMcpTransportEvidenceIfMissing(session, ports);
+    const persisted = await manifestStore.read();
+    expect(persisted).toMatchObject({
+      activeRunId: 'run-1',
+      activeCapabilitySnapshotId: 'cap-1',
+      activeBehaviorFingerprint: 'a'.repeat(64),
+    });
+    expect(persisted.entries[0]).toMatchObject({
+      capabilitySnapshotId: 'cap-1',
+      behaviorFingerprint: 'a'.repeat(64),
+    });
+    const sessionDescriptor = OPENCODE_RUNTIME_STORE_DESCRIPTORS.find(
+      (entry) => entry.schemaName === 'opencode.sessionStore'
+    )!;
+    const directory = path.dirname(manifestPath);
+    const planner = new RuntimeStoreRecoveryPlanner(
+      [sessionDescriptor],
+      manifestStore,
+      createRuntimeStoreReceiptStore({
+        filePath: path.join(directory, 'opencode-runtime-receipts.json'),
+      }),
+      new RuntimeStoreFileInspector(directory)
+    );
+    await expect(
+      planner.buildPlan({
+        teamName: scope.teamName,
+        expectedRunId: 'run-1',
+        expectedCapabilitySnapshotId: 'cap-1',
+        expectedBehaviorFingerprint: 'a'.repeat(64),
+      })
+    ).resolves.toMatchObject({ readinessImpact: 'none', diagnostics: [] });
+    const stop = buildStopInput();
+    stop.laneId = laneId;
+    stop.capabilitySnapshotId = null;
+    stop.body = { ...(stop.body as object), laneId, expectedCapabilitySnapshotId: null };
+    await expect(service.execute(stop)).resolves.toMatchObject({ ok: true });
+    expect(handshakePort.calls.at(-1)).toMatchObject({
+      expectedCapabilitySnapshotId: 'cap-1',
+      laneId,
+    });
+    // A later run cannot inherit authority, and an old callback cannot rewrite its files or binding.
+    await setOpenCodeRuntimeActiveRunManifest({ ...scope, runId: 'run-2' });
+    expect(await manifestStore.read()).toMatchObject({
+      activeRunId: 'run-2',
+      activeCapabilitySnapshotId: null,
+      activeBehaviorFingerprint: null,
+    });
+    const oldSessionBytes = await fs.readFile(
+      path.join(directory, sessionDescriptor.relativePath),
+      'utf8'
+    );
+    await expect(commitOpenCodeRuntimeBootstrapSessionEvidence(bootstrap, ports)).rejects.toThrow(
+      'active lane run'
+    );
+    expect(await fs.readFile(path.join(directory, sessionDescriptor.relativePath), 'utf8')).toBe(
+      oldSessionBytes
+    );
+    await expect(
+      authorityWriter.publish({
+        teamName: scope.teamName,
+        laneId,
+        runId: 'run-1',
+        capabilitySnapshotId: 'cap-1',
+        behaviorFingerprint: 'a'.repeat(64),
+      })
+    ).rejects.toThrow('active lane run');
+  });
+
+  it('keeps a successful runtime launch uncertain when publishing authority fails', async () => {
+    vi.mocked(launchAuthorityWriter.publish).mockRejectedValue(new Error('active run changed'));
+    const service = createService();
+    const result = await service.execute(buildLaunchInput());
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        kind: 'contract_violation',
+        retryable: false,
+        message: expect.stringContaining('reconcile before retry'),
+      },
+      diagnostics: [expect.objectContaining({ type: 'opencode_bridge_unknown_outcome' })],
+    });
+    expect(await ledger.list()).toMatchObject([{ status: 'unknown_after_timeout' }]);
+    await expect(service.execute(buildLaunchInput())).rejects.toThrow(
+      'must be reconciled before retry'
+    );
+    expect(bridge.calls).toHaveLength(1);
+  });
+
+  it('keeps post-effect uncertainty when ledger and diagnostic storage also fail', async () => {
+    vi.mocked(launchAuthorityWriter.publish).mockRejectedValue(new Error('disk unavailable'));
+    vi.spyOn(ledger, 'markUnknownAfterTimeout').mockRejectedValue(new Error('disk unavailable'));
+    vi.spyOn(diagnostics, 'append').mockRejectedValue(new Error('disk unavailable'));
+    const service = createService();
+    await expect(service.execute(buildLaunchInput())).resolves.toMatchObject({
+      ok: false,
+      error: { retryable: false },
+      diagnostics: [expect.objectContaining({ type: 'opencode_bridge_unknown_outcome' })],
+    });
+    expect(await ledger.list()).toMatchObject([{ status: 'started' }]);
+    await expect(service.execute(buildLaunchInput())).rejects.toThrow('already started');
+    expect(bridge.calls).toHaveLength(1);
+  });
+
+  it.each([true, false])(
+    'forwards exact launch model and approval scope to the handshake (%s)',
+    async (skipPermissions) => {
+      const input = buildLaunchInput();
+      input.body = { ...(input.body as object), selectedModel: 'openai/gpt-5.4', skipPermissions };
+      await createService().execute(input);
+      expect(handshakePort.calls[0]).toMatchObject({
+        selectedModel: 'openai/gpt-5.4',
+        toolApprovalMode: skipPermissions ? 'auto' : 'manual',
+        teamId: 'team-a',
+        laneId: null,
+        cwd: '/tmp/project',
+        expectedCapabilitySnapshotId: 'cap-1',
+      });
+    }
+  );
+
+  it.each(['wrong-model-snapshot', 'wrong-approval-snapshot'])(
+    'rejects %s before any launch effect',
+    async (capabilitySnapshotId) => {
+      handshakePort.nextHandshake = buildHandshake({
+        client: clientIdentity,
+        server: peerIdentity('agent_teams_orchestrator', { capabilitySnapshotId }),
+      });
+      const input = buildLaunchInput();
+      input.body = {
+        ...(input.body as object),
+        selectedModel: 'openai/gpt-5.4',
+        skipPermissions: false,
+      };
+      await expect(createService().execute(input)).rejects.toThrow('capability snapshot mismatch');
+      expect(bridge.calls).toHaveLength(0);
+      await expect(ledger.list()).resolves.toEqual([]);
+      await expect(leaseStore.getActive('team-a')).resolves.toBeNull();
+    }
+  );
+
+  it('serializes selected profile and exact lane identity onto the handshake wire', async () => {
+    bridge.resultFactory = ({ options }) =>
+      bridgeSuccess({
+        requestId: options.requestId,
+        command: 'opencode.handshake',
+        data: handshakePort.nextHandshake,
+      });
+    const port = new OpenCodeBridgeCommandHandshakePort({ bridge, clientIdentity });
+    await port.handshake({
+      requiredCommand: 'opencode.launchTeam',
+      expectedRunId: 'run-1',
+      expectedCapabilitySnapshotId: 'cap-1',
+      expectedManifestHighWatermark: 10,
+      cwd: '/tmp/project',
+      teamId: 'team-a',
+      laneId: 'primary',
+      selectedModel: 'openai/gpt-5.4',
+      toolApprovalMode: 'manual',
+    });
+    expect(bridge.calls[0]).toMatchObject({
+      command: 'opencode.handshake',
+      body: {
+        teamId: 'team-a',
+        laneId: 'primary',
+        selectedModel: 'openai/gpt-5.4',
+        toolApprovalMode: 'manual',
+        expectedRunId: 'run-1',
+        expectedCapabilitySnapshotId: 'cap-1',
+      },
+      options: { cwd: '/tmp/project' },
+    });
+  });
+
+  it('binds stop to the persisted lane manifest without guessing the project latest model', async () => {
+    const input = buildStopInput();
+    input.capabilitySnapshotId = null;
+    input.body = { ...(input.body as object), expectedCapabilitySnapshotId: null };
+    bridge.resultFactory = ({ command, body, options }) =>
+      bridgeSuccess({
+        command,
+        requestId: options.requestId,
+        data: {
+          runId: 'run-1',
+          idempotencyKey: body.preconditions.idempotencyKey,
+          runtimeStoreManifestHighWatermark: 10,
+        },
+      });
+    await createService().execute(input);
+    expect(handshakePort.calls[0]).toMatchObject({
+      expectedCapabilitySnapshotId: 'cap-1',
+      teamId: 'team-a',
+      laneId: 'primary',
+    });
+    expect(handshakePort.calls[0]).not.toHaveProperty('selectedModel');
+    expect(bridge.calls[0].body).toMatchObject({
+      expectedCapabilitySnapshotId: 'cap-1',
+      preconditions: { expectedCapabilitySnapshotId: 'cap-1' },
+    });
+  });
+
+  it('binds two lanes in one project to their own persisted snapshots', async () => {
+    const readManifest = vi
+      .spyOn(manifestReader, 'read')
+      .mockResolvedValueOnce({
+        highWatermark: 10,
+        activeRunId: 'run-1',
+        capabilitySnapshotId: 'cap-1',
+      })
+      .mockResolvedValueOnce({
+        highWatermark: 10,
+        activeRunId: 'run-1',
+        capabilitySnapshotId: 'cap-2',
+      });
+    let activeCapability = 'cap-1';
+    bridge.resultFactory = ({ command, body, options }) =>
+      bridgeSuccess({
+        command,
+        requestId: options.requestId,
+        runtime: {
+          ...peerIdentity('agent_teams_orchestrator').runtime,
+          capabilitySnapshotId: activeCapability,
+        },
+        data: {
+          runId: 'run-1',
+          idempotencyKey: body.preconditions.idempotencyKey,
+          runtimeStoreManifestHighWatermark: 10,
+        },
+      });
+    const service = createService();
+    for (const laneId of ['lane-a', 'lane-b']) {
+      activeCapability = laneId === 'lane-a' ? 'cap-1' : 'cap-2';
+      handshakePort.nextHandshake = buildHandshake({
+        client: clientIdentity,
+        server: peerIdentity('agent_teams_orchestrator', {
+          capabilitySnapshotId: activeCapability,
+        }),
+      });
+      const input = buildStopInput();
+      input.laneId = laneId;
+      input.capabilitySnapshotId = null;
+      input.body = { ...(input.body as object), laneId, expectedCapabilitySnapshotId: null };
+      await service.execute(input);
+    }
+    expect(readManifest.mock.calls).toEqual([
+      ['team-a', 'lane-a'],
+      ['team-a', 'lane-b'],
+    ]);
+    expect(handshakePort.calls).toMatchObject([
+      { laneId: 'lane-a', expectedCapabilitySnapshotId: 'cap-1' },
+      { laneId: 'lane-b', expectedCapabilitySnapshotId: 'cap-2' },
+    ]);
+    expect(bridge.calls.map((call) => call.body)).toMatchObject([
+      { laneId: 'lane-a', expectedCapabilitySnapshotId: 'cap-1' },
+      { laneId: 'lane-b', expectedCapabilitySnapshotId: 'cap-2' },
+    ]);
+  });
+
+  it('reconciles with independent app/runtime counters while retaining exact run and capability fences', async () => {
+    clientIdentity.bridgeProtocol.supportedCommands.push('opencode.reconcileTeam');
+    const server = peerIdentity('agent_teams_orchestrator', {
+      runtimeStoreManifestHighWatermark: 0,
+    });
+    server.bridgeProtocol.supportedCommands.push('opencode.reconcileTeam');
+    handshakePort.nextHandshake = buildHandshakeWithAcceptedCommands(
+      { client: clientIdentity, server },
+      ['opencode.reconcileTeam']
+    );
+    bridge.resultFactory = ({ command, body, options }) =>
+      bridgeSuccess({
+        command,
+        requestId: options.requestId,
+        data: {
+          runId: 'run-1',
+          idempotencyKey: body.preconditions.idempotencyKey,
+          runtimeStoreManifestHighWatermark: 0,
+        },
+      });
+    const input = { ...buildStopInput(), command: 'opencode.reconcileTeam' as const };
+    const service = createService();
+    await expect(service.execute(input)).resolves.toMatchObject({ ok: true });
+    expect(handshakePort.calls[0]).toMatchObject({
+      expectedManifestHighWatermark: null,
+      expectedRunId: 'run-1',
+      expectedCapabilitySnapshotId: 'cap-1',
+    });
+    await expect(service.execute({ ...input, runId: 'stale-run' })).rejects.toThrow(
+      'persisted lane'
+    );
+    await expect(service.execute({ ...input, capabilitySnapshotId: 'wrong-cap' })).rejects.toThrow(
+      'persisted lane'
+    );
+    expect(bridge.calls).toHaveLength(1);
+  });
+
+  it('marks an empty persisted-lane stop explicitly on handshake and dispatch', async () => {
+    manifestReader.manifest = { highWatermark: 0, activeRunId: null, capabilitySnapshotId: null };
+    const input = buildStopInput();
+    input.capabilitySnapshotId = null;
+    input.body = { ...(input.body as object), expectedCapabilitySnapshotId: null };
+    bridge.resultFactory = ({ command, body, options }) =>
+      bridgeSuccess({
+        command,
+        requestId: options.requestId,
+        data: {
+          runId: 'run-1',
+          idempotencyKey: body.preconditions.idempotencyKey,
+          runtimeStoreManifestHighWatermark: 0,
+        },
+      });
+    await createService().execute(input);
+    expect(handshakePort.calls[0]).toMatchObject({
+      allowEmptyLaneStop: true,
+      expectedCapabilitySnapshotId: null,
+    });
+    expect(bridge.calls[0].body).toMatchObject({
+      allowEmptyLaneStop: true,
+      expectedCapabilitySnapshotId: null,
+    });
+  });
+
+  it.each([
+    'wrong-run',
+    'wrong-caller-snapshot',
+    'wrong-body-snapshot',
+    'missing-snapshot',
+    'wrong-body-lane',
+    'forged-empty-stop',
+  ])('rejects lifecycle %s before handshake or mutation', async (failure) => {
+    const input = buildStopInput();
+    if (failure === 'wrong-run') input.runId = 'another-run';
+    if (failure === 'wrong-caller-snapshot') input.capabilitySnapshotId = 'another-cap';
+    if (failure === 'wrong-body-snapshot')
+      input.body = { ...(input.body as object), expectedCapabilitySnapshotId: 'another-cap' };
+    if (failure === 'forged-empty-stop')
+      input.body = { ...(input.body as object), allowEmptyLaneStop: true };
+    if (failure === 'missing-snapshot') manifestReader.manifest.capabilitySnapshotId = null;
+    if (failure === 'wrong-body-lane')
+      input.body = { ...(input.body as object), laneId: 'other-lane' };
+    await expect(createService().execute(input)).rejects.toThrow(/persisted lane/);
+    expect(handshakePort.calls).toHaveLength(0);
+    expect(bridge.calls).toHaveLength(0);
+    await expect(ledger.list()).resolves.toEqual([]);
   });
 
   it('blocks an old orchestrator before state-changing launch dispatch', async () => {
@@ -250,8 +685,7 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
     );
     expect(bridge.calls).toHaveLength(0);
 
-    server.bridgeProtocol.opencodeFilePartsContractVersion =
-      OPEN_CODE_FILE_PARTS_CONTRACT_VERSION;
+    server.bridgeProtocol.opencodeFilePartsContractVersion = OPEN_CODE_FILE_PARTS_CONTRACT_VERSION;
     handshakePort.nextHandshake = buildHandshakeWithAcceptedCommands(
       { client: clientIdentity, server },
       ['opencode.launchTeam', 'opencode.stopTeam', 'opencode.sendMessage']
@@ -306,12 +740,13 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
         /^opencode:opencode\.sendMessage:team-a:secondary_opencode_bob:run-1:/
       ),
     });
-    await expect(ledger.getByIdempotencyKey(bridge.calls[0].body.preconditions.idempotencyKey))
-      .resolves.toMatchObject({
-        requestId: 'cmd-1',
-        status: 'completed',
-        retryable: false,
-      });
+    await expect(
+      ledger.getByIdempotencyKey(bridge.calls[0].body.preconditions.idempotencyKey)
+    ).resolves.toMatchObject({
+      requestId: 'cmd-1',
+      status: 'completed',
+      retryable: false,
+    });
     await expect(leaseStore.getActive('team-a')).resolves.toBeNull();
   });
 
@@ -409,13 +844,14 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
         ),
       },
     });
-    await expect(ledger.getByIdempotencyKey(bridge.calls[0].body.preconditions.idempotencyKey))
-      .resolves.toMatchObject({
-        requestId: 'cmd-1',
-        status: 'completed',
-        retryable: false,
-        completedAt: '2026-04-21T12:00:00.000Z',
-      });
+    await expect(
+      ledger.getByIdempotencyKey(bridge.calls[0].body.preconditions.idempotencyKey)
+    ).resolves.toMatchObject({
+      requestId: 'cmd-1',
+      status: 'completed',
+      retryable: false,
+      completedAt: '2026-04-21T12:00:00.000Z',
+    });
     await expect(leaseStore.getActive('team-a')).resolves.toBeNull();
   });
 
@@ -522,6 +958,7 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
       ledger,
       bridge,
       manifestReader,
+      launchAuthorityWriter,
       diagnostics,
       requestIdFactory: () => 'cmd-1',
       diagnosticIdFactory: () => 'diag-1',
@@ -609,21 +1046,22 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
   );
 
   it('records empty bridge output as unknown outcome and blocks duplicate retry', async () => {
-    bridge.resultFactory = ({ body, command, options }) => ({
-      ok: false,
-      schemaVersion: 1,
-      requestId: options.requestId,
-      command,
-      completedAt: '2026-04-21T12:00:10.000Z',
-      durationMs: 100,
-      error: {
-        kind: 'contract_violation',
-        message: 'Bridge stdout was empty',
-        retryable: false,
-      },
-      diagnostics: [],
-      data: body,
-    } as OpenCodeBridgeResult<unknown>);
+    bridge.resultFactory = ({ body, command, options }) =>
+      ({
+        ok: false,
+        schemaVersion: 1,
+        requestId: options.requestId,
+        command,
+        completedAt: '2026-04-21T12:00:10.000Z',
+        durationMs: 100,
+        error: {
+          kind: 'contract_violation',
+          message: 'Bridge stdout was empty',
+          retryable: false,
+        },
+        diagnostics: [],
+        data: body,
+      }) as OpenCodeBridgeResult<unknown>;
     const service = createService();
 
     const first = await service.execute(buildLaunchInput());
@@ -641,7 +1079,8 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
     expect(diagnostics.append).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'opencode_bridge_unknown_outcome',
-        message: 'OpenCode bridge command exited without output; outcome must be reconciled before retry',
+        message:
+          'OpenCode bridge command exited without output; outcome must be reconciled before retry',
       })
     );
 
@@ -770,6 +1209,12 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
     });
 
     expect(result.ok).toBe(true);
+    expect(launchAuthorityWriter.publish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capabilitySnapshotId: 'cap-2',
+        behaviorFingerprint: 'a'.repeat(64),
+      })
+    );
     const idempotencyKey = bridge.calls[0].body.preconditions.idempotencyKey;
     await expect(ledger.getByIdempotencyKey(idempotencyKey)).resolves.toMatchObject({
       status: 'completed',
@@ -780,6 +1225,8 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
     overrides: {
       leaseAcquireTimeoutMs?: number;
       leaseAcquireRetryDelayMs?: number;
+      manifestReader?: RuntimeStoreManifestReader;
+      launchAuthorityWriter?: OpenCodeLaunchAuthorityWriter;
     } = {}
   ): OpenCodeStateChangingBridgeCommandService {
     return new OpenCodeStateChangingBridgeCommandService({
@@ -789,6 +1236,7 @@ describe('OpenCodeStateChangingBridgeCommandService', () => {
       ledger,
       bridge,
       manifestReader,
+      launchAuthorityWriter,
       diagnostics,
       requestIdFactory: () => 'cmd-1',
       diagnosticIdFactory: () => 'diag-1',
@@ -909,8 +1357,7 @@ function peerIdentity(
         'opencode.launchTeam',
         'opencode.stopTeam',
       ],
-      opencodeAppManagedBootstrapContractVersion:
-        OPEN_CODE_APP_MANAGED_BOOTSTRAP_CONTRACT_VERSION,
+      opencodeAppManagedBootstrapContractVersion: OPEN_CODE_APP_MANAGED_BOOTSTRAP_CONTRACT_VERSION,
       expectedBehaviorFingerprintSchemaVersion:
         OPEN_CODE_EXPECTED_BEHAVIOR_FINGERPRINT_SCHEMA_VERSION,
     },

--- a/test/main/services/team/OpenCodeTeamProvisioning.live.test.ts
+++ b/test/main/services/team/OpenCodeTeamProvisioning.live.test.ts
@@ -1,3 +1,8 @@
+import { OpenCodeRuntimeLaunchAuthorityWriter } from '@main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
+import {
+  OpenCodeRuntimeManifestEvidenceReader,
+  readOpenCodeRuntimeLaneIndex,
+} from '@main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import { constants as fsConstants, promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -15,11 +20,6 @@ import {
 } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
 import { OpenCodeReadinessBridge } from '../../../../src/main/services/team/opencode/bridge/OpenCodeReadinessBridge';
 import { OpenCodeStateChangingBridgeCommandService } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
-import { OpenCodeRuntimeLaunchAuthorityWriter } from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
-import {
-  OpenCodeRuntimeManifestEvidenceReader,
-  readOpenCodeRuntimeLaneIndex,
-} from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import { OpenCodeTeamRuntimeAdapter } from '../../../../src/main/services/team/runtime/OpenCodeTeamRuntimeAdapter';
 import { TeamRuntimeAdapterRegistry } from '../../../../src/main/services/team/runtime/TeamRuntimeAdapter';
 import { resolveAgentTeamsMcpLaunchSpec } from '../../../../src/main/services/team/TeamMcpConfigBuilder';

--- a/test/main/services/team/OpenCodeTeamProvisioning.live.test.ts
+++ b/test/main/services/team/OpenCodeTeamProvisioning.live.test.ts
@@ -15,7 +15,11 @@ import {
 } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
 import { OpenCodeReadinessBridge } from '../../../../src/main/services/team/opencode/bridge/OpenCodeReadinessBridge';
 import { OpenCodeStateChangingBridgeCommandService } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
-import { readOpenCodeRuntimeLaneIndex } from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
+import { OpenCodeRuntimeLaunchAuthorityWriter } from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
+import {
+  OpenCodeRuntimeManifestEvidenceReader,
+  readOpenCodeRuntimeLaneIndex,
+} from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import { OpenCodeTeamRuntimeAdapter } from '../../../../src/main/services/team/runtime/OpenCodeTeamRuntimeAdapter';
 import { TeamRuntimeAdapterRegistry } from '../../../../src/main/services/team/runtime/TeamRuntimeAdapter';
 import { resolveAgentTeamsMcpLaunchSpec } from '../../../../src/main/services/team/TeamMcpConfigBuilder';
@@ -25,8 +29,6 @@ import {
   setClaudeBasePathOverride,
 } from '../../../../src/main/utils/pathDecoder';
 
-import type { RuntimeStoreManifestEvidence } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeCommandContract';
-import type { RuntimeStoreManifestReader } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import type { OpenCodeBridgeCommandExecutor } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import type { TeamProvisioningProgress } from '../../../../src/shared/types';
 
@@ -415,18 +417,13 @@ function createStateChangingCommands(input: {
       filePath: path.join(input.controlDir, 'ledger.json'),
     }),
     bridge: input.bridge,
-    manifestReader: new StaticManifestReader(),
+    manifestReader: new OpenCodeRuntimeManifestEvidenceReader({
+      teamsBasePath: getTeamsBasePath(),
+    }),
+    launchAuthorityWriter: new OpenCodeRuntimeLaunchAuthorityWriter({
+      teamsBasePath: getTeamsBasePath(),
+    }),
   });
-}
-
-class StaticManifestReader implements RuntimeStoreManifestReader {
-  async read(): Promise<RuntimeStoreManifestEvidence> {
-    return {
-      highWatermark: 0,
-      activeRunId: null,
-      capabilitySnapshotId: null,
-    };
-  }
 }
 
 async function waitUntil(

--- a/test/main/services/team/OpenCodeTeamRuntimeAdapter.test.ts
+++ b/test/main/services/team/OpenCodeTeamRuntimeAdapter.test.ts
@@ -40,6 +40,7 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
       projectPath: '/repo',
       selectedModel: 'openai/gpt-5.4-mini',
       requireExecutionProbe: true,
+      skipPermissions: true,
     });
     expect(bridge.checkOpenCodeTeamLaunchReadiness).toHaveBeenCalledTimes(1);
   });
@@ -60,6 +61,7 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
       projectPath: '/repo',
       selectedModel: null,
       requireExecutionProbe: false,
+      skipPermissions: true,
     });
   });
 
@@ -215,6 +217,7 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
       projectPath: '/repo',
       selectedModel: 'cursor-acp/auto',
       requireExecutionProbe: true,
+      skipPermissions: true,
     });
   });
 
@@ -351,6 +354,7 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
       projectPath: '/repo',
       selectedModel: 'ollama/qwen3:8b',
       requireExecutionProbe: true,
+      skipPermissions: true,
     });
     expect(launchOpenCodeTeam).not.toHaveBeenCalled();
     expect(result).toMatchObject({
@@ -567,6 +571,7 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
       projectPath: worktreePath,
       selectedModel: 'openai/gpt-5.4-mini',
       requireExecutionProbe: true,
+      skipPermissions: true,
     });
     expect(launchOpenCodeTeam).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -720,14 +725,19 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
     const adapter = new OpenCodeTeamRuntimeAdapter({
       checkOpenCodeTeamLaunchReadiness: checkReadiness,
     });
-    const expectedMembers = ['lead', 'researcher', 'implementer', 'reviewer', 'tester', 'writer'].map(
-      (name) => ({
-        name,
-        providerId: 'opencode' as const,
-        model: 'openai/gpt-5.4-mini',
-        cwd: '/repo',
-      })
-    );
+    const expectedMembers = [
+      'lead',
+      'researcher',
+      'implementer',
+      'reviewer',
+      'tester',
+      'writer',
+    ].map((name) => ({
+      name,
+      providerId: 'opencode' as const,
+      model: 'openai/gpt-5.4-mini',
+      cwd: '/repo',
+    }));
 
     await expect(adapter.prepare(launchInput({ expectedMembers }))).resolves.toEqual({
       ok: false,
@@ -916,6 +926,7 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
     expect(getLastOpenCodeRuntimeSnapshot).toHaveBeenCalledWith(
       '/repo',
       'openai/gpt-5.4-mini',
+      true,
       true
     );
     expect(launchOpenCodeTeam).toHaveBeenCalledWith(
@@ -953,9 +964,8 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
   });
 
   it('rejects readiness evidence for a different requested model before launch', async () => {
-    const launchOpenCodeTeam = vi.fn<
-      NonNullable<OpenCodeTeamRuntimeBridgePort['launchOpenCodeTeam']>
-    >();
+    const launchOpenCodeTeam =
+      vi.fn<NonNullable<OpenCodeTeamRuntimeBridgePort['launchOpenCodeTeam']>>();
     const adapter = new OpenCodeTeamRuntimeAdapter({
       checkOpenCodeTeamLaunchReadiness: vi.fn(async () =>
         readiness({
@@ -979,9 +989,8 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
   });
 
   it('rejects an initial execution proof from a stale capability snapshot', async () => {
-    const launchOpenCodeTeam = vi.fn<
-      NonNullable<OpenCodeTeamRuntimeBridgePort['launchOpenCodeTeam']>
-    >();
+    const launchOpenCodeTeam =
+      vi.fn<NonNullable<OpenCodeTeamRuntimeBridgePort['launchOpenCodeTeam']>>();
     const adapter = new OpenCodeTeamRuntimeAdapter({
       checkOpenCodeTeamLaunchReadiness: vi.fn(async () =>
         readiness({
@@ -1028,9 +1037,8 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
   });
 
   it('blocks missing behavior evidence before state-changing dispatch', async () => {
-    const launchOpenCodeTeam = vi.fn<
-      NonNullable<OpenCodeTeamRuntimeBridgePort['launchOpenCodeTeam']>
-    >();
+    const launchOpenCodeTeam =
+      vi.fn<NonNullable<OpenCodeTeamRuntimeBridgePort['launchOpenCodeTeam']>>();
     const adapter = new OpenCodeTeamRuntimeAdapter({
       checkOpenCodeTeamLaunchReadiness: vi.fn(async () =>
         readiness({ state: 'ready', launchAllowed: true, executionProof: undefined })
@@ -1131,9 +1139,22 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
     const adapter = new OpenCodeTeamRuntimeAdapter(bridge);
 
     await adapter.prepare(launchInput());
-    await adapter.prepare(launchInput());
+    await adapter.prepare(launchInput({ skipPermissions: undefined }));
 
     expect(bridge.checkOpenCodeTeamLaunchReadiness).toHaveBeenCalledTimes(1);
+  });
+
+  it('never reuses readiness across approval modes', async () => {
+    const bridge = bridgePort(
+      readiness({ state: 'ready', launchAllowed: true, executionProof: reusableExecutionProof() })
+    );
+    const adapter = new OpenCodeTeamRuntimeAdapter(bridge);
+    await adapter.prepare(launchInput({ skipPermissions: true }));
+    await adapter.prepare(launchInput({ skipPermissions: false }));
+    expect(bridge.checkOpenCodeTeamLaunchReadiness).toHaveBeenCalledTimes(2);
+    expect(bridge.checkOpenCodeTeamLaunchReadiness).toHaveBeenLastCalledWith(
+      expect.objectContaining({ skipPermissions: false })
+    );
   });
 
   it('refreshes readiness instead of returning cached launch-ready state after proof rejection', async () => {
@@ -1163,14 +1184,15 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
     const launchOpenCodeTeam = vi.fn<
       NonNullable<OpenCodeTeamRuntimeBridgePort['launchOpenCodeTeam']>
     >(() => Promise.resolve(successfulOpenCodeLaunchData()));
+    const checkReadiness = vi.fn(async () =>
+      readiness({
+        state: 'ready',
+        launchAllowed: true,
+        executionProof: executionProofFor('/repo', 'openai/gpt-5.4-mini', 'cap-manual'),
+      })
+    );
     const adapter = new OpenCodeTeamRuntimeAdapter({
-      checkOpenCodeTeamLaunchReadiness: vi.fn(async () =>
-        readiness({
-          state: 'ready',
-          launchAllowed: true,
-          executionProof: executionProofFor('/repo', 'openai/gpt-5.4-mini', 'cap-manual'),
-        })
-      ),
+      checkOpenCodeTeamLaunchReadiness: checkReadiness,
       getLastOpenCodeRuntimeSnapshot: vi.fn(() => runtimeSnapshot('cap-manual')),
       launchOpenCodeTeam,
     });
@@ -1179,6 +1201,9 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
       teamLaunchState: 'clean_success',
     });
 
+    expect(checkReadiness).toHaveBeenCalledWith(
+      expect.objectContaining({ skipPermissions: false })
+    );
     expect(launchOpenCodeTeam).toHaveBeenCalledWith(
       expect.objectContaining({
         skipPermissions: false,
@@ -1671,11 +1696,7 @@ describe('OpenCodeTeamRuntimeAdapter', () => {
           readiness({
             state: 'ready',
             launchAllowed: true,
-            executionProof: executionProofFor(
-              '/repo',
-              'openai/gpt-5.4-mini',
-              capabilitySnapshotId
-            ),
+            executionProof: executionProofFor('/repo', 'openai/gpt-5.4-mini', capabilitySnapshotId),
           })
         );
       }
@@ -2832,11 +2853,7 @@ async function launchWithStaleCapabilitySnapshotRecovery(message: string) {
         readiness({
           state: 'ready',
           launchAllowed: true,
-          executionProof: executionProofFor(
-            '/repo',
-            'openai/gpt-5.4-mini',
-            capabilitySnapshotId
-          ),
+          executionProof: executionProofFor('/repo', 'openai/gpt-5.4-mini', capabilitySnapshotId),
         })
       );
     }

--- a/test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts
+++ b/test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts
@@ -56,6 +56,7 @@ import {
   type OpenCodeBridgeCommandExecutor,
   OpenCodeStateChangingBridgeCommandService,
 } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
+import { OpenCodeRuntimeLaunchAuthorityWriter } from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
 import {
   getOpenCodeRuntimeLaneIndexPath,
   getOpenCodeRuntimeManifestPath,
@@ -311,6 +312,11 @@ describe(
     let originalClaudeCliPath: string | undefined;
     let originalWorkspaceTrustEnv: Partial<Record<WorkspaceTrustTestEnvName, string | undefined>>;
 
+    const blockedMixedLaunches: {
+      adapter: { releaseLaunches(): void };
+      run: { mixedSecondaryLaneLaunchQueue?: Promise<void> };
+    }[] = [];
+
     beforeEach(async () => {
       TeamConfigReader.clearCacheForTests();
       ClaudeBinaryResolver.clearCache();
@@ -325,12 +331,25 @@ describe(
     });
 
     afterEach(async () => {
+      // Drain these mocked launches before changing the global sandbox path, even on failure.
+      const launchesToDrain = blockedMixedLaunches.splice(0);
+      for (const { adapter } of launchesToDrain) {
+        adapter.releaseLaunches();
+      }
+      const launchResults = await Promise.allSettled(
+        launchesToDrain.map(({ run }) => run.mixedSecondaryLaneLaunchQueue)
+      );
       TeamConfigReader.clearCacheForTests();
       restoreOptionalEnvValue('CLAUDE_CLI_PATH', originalClaudeCliPath);
       restoreWorkspaceTrustTestEnv(originalWorkspaceTrustEnv);
       ClaudeBinaryResolver.clearCache();
       setClaudeBasePathOverride(null);
       await removeTempDirWithRetries(tempDir);
+      for (const result of launchResults) {
+        if (result.status === 'rejected') {
+          throw result.reason;
+        }
+      }
     });
 
     it('launches a pure OpenCode team through the runtime adapter and exposes live members', async () => {
@@ -455,60 +474,143 @@ describe(
       expect(svc.isTeamAlive(teamName)).toBe(true);
     });
 
-    it('does not resurrect an untracked pure OpenCode restart cancelled during persistence', async () => {
-      const teamName = 'pure-opencode-untracked-restart-persist-stop-safe-e2e';
-      const adapter = new FakeOpenCodeRuntimeAdapter();
-      const svc = new TeamProvisioningService();
-      svc.setRuntimeAdapterRegistry(new TeamRuntimeAdapterRegistry([adapter]));
+    it.each([
+      { publication: 'before', preserveSuccessor: false },
+      { publication: 'after', preserveSuccessor: false },
+      { publication: 'after', preserveSuccessor: true },
+    ] as const)(
+      'cancels an untracked OpenCode restart $publication snapshot publication (preserve successor: $preserveSuccessor)',
+      async ({ publication, preserveSuccessor }) => {
+        const teamName = 'pure-opencode-untracked-restart-persist-stop-safe-e2e';
+        const adapter = new FakeOpenCodeRuntimeAdapter();
+        const svc = new TeamProvisioningService();
+        svc.setRuntimeAdapterRegistry(new TeamRuntimeAdapterRegistry([adapter]));
 
-      await svc.createTeam(
-        {
-          teamName,
-          cwd: projectPath,
-          providerId: 'opencode',
-          model: 'xai/grok-4.5',
-          skipPermissions: true,
-          members: [{ name: 'alice', role: 'Reviewer', providerId: 'opencode' }],
-        },
-        () => undefined
-      );
+        await svc.createTeam(
+          {
+            teamName,
+            cwd: projectPath,
+            providerId: 'opencode',
+            model: 'xai/grok-4.5',
+            skipPermissions: true,
+            members: [{ name: 'alice', role: 'Reviewer', providerId: 'opencode' }],
+          },
+          () => undefined
+        );
 
-      let markPersistenceEntered!: () => void;
-      let releasePersistence!: () => void;
-      const persistenceEntered = new Promise<void>((resolve) => {
-        markPersistenceEntered = resolve;
-      });
-      const persistenceReleased = new Promise<void>((resolve) => {
-        releasePersistence = resolve;
-      });
-      const originalPersist = (svc as any).persistOpenCodeRuntimeAdapterLaunchResult.bind(svc);
-      vi.spyOn(svc as any, 'persistOpenCodeRuntimeAdapterLaunchResult').mockImplementation(
-        async (...args: unknown[]) => {
-          markPersistenceEntered();
-          await persistenceReleased;
-          return originalPersist(...args);
+        let markPersistenceEntered!: () => void;
+        let releasePersistence!: () => void;
+        const persistenceEntered = new Promise<void>((resolve) => {
+          markPersistenceEntered = resolve;
+        });
+        const persistenceReleased = new Promise<void>((resolve) => {
+          releasePersistence = resolve;
+        });
+        let markCleanupEntered!: () => void;
+        let releaseCleanup!: () => void;
+        const cleanupEntered = new Promise<void>((resolve) => {
+          markCleanupEntered = resolve;
+        });
+        const cleanupReleased = new Promise<void>((resolve) => {
+          releaseCleanup = resolve;
+        });
+        const lifecycle = svc as unknown as {
+          persistOpenCodeRuntimeAdapterLaunchResult(...args: unknown[]): Promise<unknown>;
+          clearPersistedOpenCodeLaunchStateIfOwned(...args: unknown[]): Promise<void>;
+          openCodeAggregatePrimaryRestartByTeam: Map<string, { candidateRunId?: string }>;
+          runTracking: { getTrackedRunId(teamName: string): string | null };
+          launchStateWrittenRunIdByTeam: Map<string, string>;
+          writeLaunchStateSnapshot(
+            teamName: string,
+            snapshot: unknown,
+            options: { runId: string }
+          ): Promise<unknown>;
+        };
+        const originalPersist = lifecycle.persistOpenCodeRuntimeAdapterLaunchResult.bind(svc);
+        vi.spyOn(lifecycle, 'persistOpenCodeRuntimeAdapterLaunchResult').mockImplementation(
+          async (...args: unknown[]) => {
+            const persisted = publication === 'after' ? await originalPersist(...args) : null;
+            markPersistenceEntered();
+            await persistenceReleased;
+            return persisted ?? originalPersist(...args);
+          }
+        );
+        if (preserveSuccessor) {
+          const originalClear = lifecycle.clearPersistedOpenCodeLaunchStateIfOwned.bind(svc);
+          vi.spyOn(lifecycle, 'clearPersistedOpenCodeLaunchStateIfOwned').mockImplementation(
+            async (...args: unknown[]) => {
+              markCleanupEntered();
+              await cleanupReleased;
+              return originalClear(...args);
+            }
+          );
         }
-      );
 
-      const restartExpectation = expect(svc.restartMember(teamName, 'alice')).rejects.toThrow(
-        'was cancelled because team "pure-opencode-untracked-restart-persist-stop-safe-e2e" is no longer running'
-      );
-      await persistenceEntered;
-      const stopPromise = svc.stopTeam(teamName);
-      releasePersistence();
+        const restartExpectation = expect(svc.restartMember(teamName, 'alice')).rejects.toThrow(
+          'was cancelled because team "pure-opencode-untracked-restart-persist-stop-safe-e2e" is no longer running'
+        );
+        let stopPromise: Promise<void> | undefined;
+        const launchStatePath = path.join(getTeamsBasePath(), teamName, 'launch-state.json');
+        try {
+          await persistenceEntered;
+          const candidateRunId = adapter.launchInputs.at(-1)?.runId;
+          expect(candidateRunId).toBeTruthy();
+          expect(candidateRunId).not.toBe(adapter.launchInputs[0]?.runId);
+          const lease = lifecycle.openCodeAggregatePrimaryRestartByTeam.get(teamName);
+          expect(lease?.candidateRunId).toBe(candidateRunId);
+          const publishedSnapshot =
+            publication === 'after' ? JSON.parse(await fs.readFile(launchStatePath, 'utf8')) : null;
+          if (publishedSnapshot) {
+            expect(publishedSnapshot.members.alice.runtimeRunId).toBe(candidateRunId);
+          }
 
-      await stopPromise;
-      await restartExpectation;
-      expect(svc.isTeamAlive(teamName)).toBe(false);
-      await expect(
-        readOpenCodeRuntimeLaneIndex(getTeamsBasePath(), teamName)
-      ).resolves.toMatchObject({
-        lanes: {},
-      });
-      await expect(
-        fs.readFile(path.join(getTeamsBasePath(), teamName, 'launch-state.json'), 'utf8')
-      ).rejects.toMatchObject({ code: 'ENOENT' });
-    });
+          stopPromise = svc.stopTeam(teamName);
+          await stopPromise;
+          releasePersistence();
+          let successorSnapshot: typeof publishedSnapshot = null;
+          if (preserveSuccessor) {
+            await cleanupEntered;
+            expect(lifecycle.runTracking.getTrackedRunId(teamName)).toBeNull();
+            const successorRunId = `${candidateRunId}-successor`;
+            successorSnapshot = {
+              ...publishedSnapshot,
+              members: Object.fromEntries(
+                Object.entries(publishedSnapshot.members).map(([name, member]) => [
+                  name,
+                  { ...(member as Record<string, unknown>), runtimeRunId: successorRunId },
+                ])
+              ),
+            };
+            await lifecycle.writeLaunchStateSnapshot(teamName, successorSnapshot, {
+              runId: successorRunId,
+            });
+            expect(lifecycle.launchStateWrittenRunIdByTeam.get(teamName)).toBe(successorRunId);
+            expect(lifecycle.runTracking.getTrackedRunId(teamName)).toBeNull();
+            releaseCleanup();
+          }
+
+          await stopPromise;
+          await restartExpectation;
+          expect(svc.isTeamAlive(teamName)).toBe(false);
+          await expect(
+            readOpenCodeRuntimeLaneIndex(getTeamsBasePath(), teamName)
+          ).resolves.toMatchObject({ lanes: {} });
+          if (preserveSuccessor) {
+            expect(JSON.parse(await fs.readFile(launchStatePath, 'utf8'))).toEqual(
+              successorSnapshot
+            );
+          } else {
+            await expect(fs.readFile(launchStatePath, 'utf8')).rejects.toMatchObject({
+              code: 'ENOENT',
+            });
+          }
+        } finally {
+          releasePersistence();
+          releaseCleanup();
+          await Promise.allSettled([stopPromise, restartExpectation]);
+        }
+      }
+    );
 
     it('keeps the OpenCode lead in primary when teammates use separate model lanes', async () => {
       const teamName = 'pure-opencode-lead-distinct-model-lanes-safe-e2e';
@@ -2663,17 +2765,26 @@ describe(
         () => undefined
       );
 
+      // Keep lane ownership exact; only the bridge watermark is deliberately behind.
+      const capabilitySnapshotId = 'stale-watermark-stop-capability';
+      await createRuntimeStoreManifestStore({
+        filePath: getOpenCodeRuntimeManifestPath(getTeamsBasePath(), teamName, 'primary'),
+        teamName,
+      }).setActiveRun({ runId, capabilitySnapshotId });
+
       const manifestReader = new OpenCodeRuntimeManifestEvidenceReader({
         teamsBasePath: getTeamsBasePath(),
       });
       const manifestBeforeStop = await manifestReader.read(teamName, 'primary');
-      expect(manifestBeforeStop).toMatchObject({ activeRunId: runId });
+      expect(manifestBeforeStop).toMatchObject({ activeRunId: runId, capabilitySnapshotId });
       expect(manifestBeforeStop.highWatermark).toBeGreaterThan(0);
       expect(svc.isTeamAlive(teamName)).toBe(true);
 
       const stopFixture = createStaleWatermarkStopAdapterFixture({
         controlDir: path.join(tempDir, 'opencode-stale-stop-control'),
         manifestReader,
+        runId,
+        capabilitySnapshotId,
       });
       svc.setRuntimeAdapterRegistry(new TeamRuntimeAdapterRegistry([stopFixture.adapter]));
       const app = Fastify();
@@ -4529,31 +4640,39 @@ describe(
       run.child = { kill: () => undefined };
       trackLiveRun(svc, run);
 
-      await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
-      await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
+      let stopAllPromise: Promise<void> | undefined;
+      try {
+        await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
+        await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
-      svc.stopAllTeams();
+        stopAllPromise = svc.stopAllTeams();
 
-      await waitForCondition(() => adapter.stopInputs.length === 1);
-      expect(adapter.stopInputs.map((input) => input.laneId).sort()).toEqual([
-        'secondary:opencode:bob',
-      ]);
-      expect(svc.isTeamAlive(teamName)).toBe(false);
+        await waitForCondition(() => adapter.stopInputs.length === 1);
+        expect(adapter.stopInputs.map((input) => input.laneId).sort()).toEqual([
+          'secondary:opencode:bob',
+        ]);
+        expect(svc.isTeamAlive(teamName)).toBe(false);
 
-      adapter.releaseLaunches();
-      await waitForCondition(() => adapter.rejectedLaunchCount === 1);
+        adapter.releaseLaunches();
+        await stopAllPromise;
+        await waitForMixedSecondaryLaunchQueue(run);
+        await waitForCondition(() => adapter.rejectedLaunchCount === 1);
 
-      await expect(
-        readOpenCodeRuntimeLaneIndex(getTeamsBasePath(), teamName)
-      ).resolves.toMatchObject({
-        lanes: {},
-      });
-      const statuses = await svc.getMemberSpawnStatuses(teamName);
-      expect(statuses.teamLaunchState).not.toBe('partial_failure');
-      expect(statuses.statuses.bob).toMatchObject({ hardFailure: false });
-      expect(statuses.statuses.bob?.launchState).not.toBe('failed_to_start');
-      expect(statuses.statuses.tom).toMatchObject({ hardFailure: false });
-      expect(statuses.statuses.tom?.launchState).not.toBe('failed_to_start');
+        await expect(
+          readOpenCodeRuntimeLaneIndex(getTeamsBasePath(), teamName)
+        ).resolves.toMatchObject({
+          lanes: {},
+        });
+        const statuses = await svc.getMemberSpawnStatuses(teamName);
+        expect(statuses.teamLaunchState).not.toBe('partial_failure');
+        expect(statuses.statuses.bob).toMatchObject({ hardFailure: false });
+        expect(statuses.statuses.bob?.launchState).not.toBe('failed_to_start');
+        expect(statuses.statuses.tom).toMatchObject({ hardFailure: false });
+        expect(statuses.statuses.tom?.launchState).not.toBe('failed_to_start');
+      } finally {
+        adapter.releaseLaunches();
+        await Promise.allSettled([stopAllPromise, run.mixedSecondaryLaneLaunchQueue]);
+      }
     });
 
     it('allows fresh mixed OpenCode secondary lanes after stopAllTeams cancelled in-flight handoff', async () => {
@@ -12328,7 +12447,7 @@ describe(
       run.child = { kill: () => undefined };
       trackLiveRun(svc, run);
 
-      svc.stopTeam(teamName);
+      await svc.stopTeam(teamName);
 
       expect(svc.isTeamAlive(teamName)).toBe(false);
       await expect(svc.restartMember(teamName, 'bob')).rejects.toThrow(
@@ -12354,7 +12473,7 @@ describe(
       trackLiveRun(svc, firstRun);
       trackLiveRun(svc, secondRun);
 
-      svc.stopTeam(firstTeamName);
+      await svc.stopTeam(firstTeamName);
 
       expect(svc.isTeamAlive(firstTeamName)).toBe(false);
       expect(svc.isTeamAlive(secondTeamName)).toBe(true);
@@ -18207,7 +18326,7 @@ describe(
         runId: run.runId,
       });
 
-      svc.stopTeam(teamName);
+      await svc.stopTeam(teamName);
 
       expect(svc.getLeadActivityState(teamName)).toEqual({
         state: 'offline',
@@ -19849,10 +19968,11 @@ describe(
       const run = createMixedLiveRun({ teamName, projectPath });
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
-      svc.stopTeam(teamName);
+      await svc.stopTeam(teamName);
 
       await waitForCondition(() => !svc.isTeamAlive(teamName));
       await waitForCondition(() => adapter.stopInputs.length === 1);
@@ -19861,6 +19981,7 @@ describe(
       ]);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.launchInputs.length === 1);
 
       const statuses = await svc.getMemberSpawnStatuses(teamName);
@@ -19882,10 +20003,11 @@ describe(
       const run = createMixedLiveRun({ teamName, projectPath, primaryProviderId: 'anthropic' });
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
-      svc.stopTeam(teamName);
+      await svc.stopTeam(teamName);
 
       await waitForCondition(() => !svc.isTeamAlive(teamName));
       await waitForCondition(() => adapter.stopInputs.length === 1);
@@ -19894,6 +20016,7 @@ describe(
       ]);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.launchInputs.length === 1);
 
       const statuses = await svc.getMemberSpawnStatuses(teamName);
@@ -19960,10 +20083,11 @@ describe(
       });
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
-      svc.stopTeam(teamName);
+      await svc.stopTeam(teamName);
 
       await waitForCondition(() => !svc.isTeamAlive(teamName));
       await waitForCondition(() => adapter.stopInputs.length === 1);
@@ -19972,6 +20096,7 @@ describe(
       ]);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.launchInputs.length === 1);
 
       const statuses = await svc.getMemberSpawnStatuses(teamName);
@@ -20009,13 +20134,15 @@ describe(
       trackLiveRun(svc, stoppedRun);
       trackLiveRun(svc, survivingRun);
 
+      blockedMixedLaunches.push({ adapter, run: stoppedRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(stoppedRun);
+      blockedMixedLaunches.push({ adapter, run: survivingRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(survivingRun);
       await waitForCondition(() =>
         adapter.pendingLaunchInputs.some((input) => input.teamName === stoppedTeamName)
       );
 
-      svc.stopTeam(stoppedTeamName);
+      await svc.stopTeam(stoppedTeamName);
 
       await waitForCondition(
         () => adapter.stopInputs.filter((input) => input.teamName === stoppedTeamName).length === 1
@@ -20025,6 +20152,8 @@ describe(
       expect(svc.isTeamAlive(survivingTeamName)).toBe(true);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(stoppedRun);
+      await waitForMixedSecondaryLaunchQueue(survivingRun);
       await waitForCondition(() => adapter.launchInputs.length === 3);
       await waitForCondition(() =>
         survivingRun.mixedSecondaryLanes.every(
@@ -20062,10 +20191,11 @@ describe(
       const oldRun = createMixedLiveRun({ teamName, projectPath });
       trackLiveRun(svc, oldRun);
 
+      blockedMixedLaunches.push({ adapter, run: oldRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(oldRun);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
-      svc.stopTeam(teamName);
+      await svc.stopTeam(teamName);
       await waitForCondition(() => !svc.isTeamAlive(teamName));
       await waitForCondition(() => adapter.stopInputs.length === 1);
 
@@ -20115,6 +20245,7 @@ describe(
       });
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(oldRun);
       await waitForCondition(() => adapter.launchInputs.length === 1);
 
       const statuses = await svc.getMemberSpawnStatuses(teamName);
@@ -20146,10 +20277,11 @@ describe(
       const oldRun = createMixedLiveRun({ teamName, projectPath, primaryProviderId: 'anthropic' });
       trackLiveRun(svc, oldRun);
 
+      blockedMixedLaunches.push({ adapter, run: oldRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(oldRun);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
-      svc.stopTeam(teamName);
+      await svc.stopTeam(teamName);
       await waitForCondition(() => !svc.isTeamAlive(teamName));
       await waitForCondition(() => adapter.stopInputs.length === 1);
 
@@ -20198,6 +20330,7 @@ describe(
       });
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(oldRun);
       await waitForCondition(() => adapter.launchInputs.length === 1);
 
       const statuses = await svc.getMemberSpawnStatuses(teamName);
@@ -20267,10 +20400,11 @@ describe(
       });
       trackLiveRun(svc, oldRun);
 
+      blockedMixedLaunches.push({ adapter, run: oldRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(oldRun);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
-      svc.stopTeam(teamName);
+      await svc.stopTeam(teamName);
       await waitForCondition(() => !svc.isTeamAlive(teamName));
       await waitForCondition(() => adapter.stopInputs.length === 1);
 
@@ -20331,6 +20465,7 @@ describe(
       });
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(oldRun);
       await waitForCondition(() => adapter.launchInputs.length === 1);
 
       const statuses = await svc.getMemberSpawnStatuses(teamName);
@@ -20365,14 +20500,16 @@ describe(
       const run = createMixedLiveRun({ teamName, projectPath });
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
-      svc.stopTeam(teamName);
+      await svc.stopTeam(teamName);
       await waitForCondition(() => !svc.isTeamAlive(teamName));
       await waitForCondition(() => adapter.stopInputs.length === 1);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.rejectedLaunchCount === 1);
 
       await expect(
@@ -20403,14 +20540,16 @@ describe(
       const run = createMixedLiveRun({ teamName, projectPath, primaryProviderId: 'anthropic' });
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
-      svc.stopTeam(teamName);
+      await svc.stopTeam(teamName);
       await waitForCondition(() => !svc.isTeamAlive(teamName));
       await waitForCondition(() => adapter.stopInputs.length === 1);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.rejectedLaunchCount === 1);
 
       await expect(
@@ -20481,14 +20620,16 @@ describe(
       });
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
-      svc.stopTeam(teamName);
+      await svc.stopTeam(teamName);
       await waitForCondition(() => !svc.isTeamAlive(teamName));
       await waitForCondition(() => adapter.stopInputs.length === 1);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.rejectedLaunchCount === 1);
 
       await expect(
@@ -20526,6 +20667,7 @@ describe(
       const run = createMixedLiveRun({ teamName, projectPath });
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
@@ -20538,6 +20680,7 @@ describe(
       expect(svc.isTeamAlive(teamName)).toBe(false);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.launchInputs.length === 1);
 
       const statuses = await svc.getMemberSpawnStatuses(teamName);
@@ -20558,6 +20701,7 @@ describe(
       const run = createMixedLiveRun({ teamName, projectPath, primaryProviderId: 'anthropic' });
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
@@ -20570,6 +20714,7 @@ describe(
       expect(svc.isTeamAlive(teamName)).toBe(false);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.launchInputs.length === 1);
 
       const statuses = await svc.getMemberSpawnStatuses(teamName);
@@ -20604,6 +20749,7 @@ describe(
       addGeminiPrimaryToMixedRun(run);
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
@@ -20616,6 +20762,7 @@ describe(
       expect(svc.isTeamAlive(teamName)).toBe(false);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.launchInputs.length === 1);
 
       const statuses = await svc.getMemberSpawnStatuses(teamName);
@@ -20657,6 +20804,7 @@ describe(
       addGeminiPrimaryToMixedRun(cancelledRun);
       trackLiveRun(svc, cancelledRun);
 
+      blockedMixedLaunches.push({ adapter, run: cancelledRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(cancelledRun);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
@@ -20669,6 +20817,7 @@ describe(
       expect(svc.isTeamAlive(teamName)).toBe(false);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(cancelledRun);
       await waitForCondition(() => adapter.launchInputs.length === 1);
 
       const cancelledStatuses = await svc.getMemberSpawnStatuses(teamName);
@@ -20688,7 +20837,9 @@ describe(
       addGeminiPrimaryToMixedRun(freshRun);
       trackLiveRun(svc, freshRun);
 
+      blockedMixedLaunches.push({ adapter, run: freshRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(freshRun);
+      await waitForMixedSecondaryLaunchQueue(freshRun);
       await waitForCondition(() => adapter.launchInputs.length === 3);
       await waitForCondition(() =>
         freshRun.mixedSecondaryLanes.every((lane: { state: string }) => lane.state === 'finished')
@@ -20740,7 +20891,9 @@ describe(
       trackLiveRun(svc, cancelledRun);
       trackLiveRun(svc, survivingRun);
 
+      blockedMixedLaunches.push({ adapter, run: cancelledRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(cancelledRun);
+      blockedMixedLaunches.push({ adapter, run: survivingRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(survivingRun);
       await waitForCondition(() =>
         adapter.pendingLaunchInputs.some((input) => input.teamName === cancelledTeamName)
@@ -20757,6 +20910,8 @@ describe(
       expect(svc.isTeamAlive(survivingTeamName)).toBe(true);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(cancelledRun);
+      await waitForMixedSecondaryLaunchQueue(survivingRun);
       await waitForCondition(() => adapter.launchInputs.length === 3);
       await waitForCondition(() =>
         survivingRun.mixedSecondaryLanes.every(
@@ -20830,7 +20985,9 @@ describe(
       trackLiveRun(svc, cancelledRun);
       trackLiveRun(svc, survivingRun);
 
+      blockedMixedLaunches.push({ adapter, run: cancelledRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(cancelledRun);
+      blockedMixedLaunches.push({ adapter, run: survivingRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(survivingRun);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 2);
 
@@ -20845,6 +21002,8 @@ describe(
       expect(svc.isTeamAlive(survivingTeamName)).toBe(true);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(cancelledRun);
+      await waitForMixedSecondaryLaunchQueue(survivingRun);
       await waitForCondition(() => adapter.launchInputs.length === 3);
       await waitForCondition(() =>
         survivingRun.mixedSecondaryLanes.every(
@@ -20897,7 +21056,9 @@ describe(
       trackLiveRun(svc, cancelledRun);
       trackLiveRun(svc, survivingRun);
 
+      blockedMixedLaunches.push({ adapter, run: cancelledRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(cancelledRun);
+      blockedMixedLaunches.push({ adapter, run: survivingRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(survivingRun);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 2);
 
@@ -20910,6 +21071,8 @@ describe(
       expect(adapter.stopInputs.some((input) => input.teamName === survivingTeamName)).toBe(false);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(cancelledRun);
+      await waitForMixedSecondaryLaunchQueue(survivingRun);
       await waitForCondition(() => adapter.launchInputs.length === 3);
       await waitForCondition(() =>
         survivingRun.mixedSecondaryLanes.every(
@@ -20923,7 +21086,9 @@ describe(
       freshRun.child = { kill: () => undefined };
       trackLiveRun(svc, freshRun);
 
+      blockedMixedLaunches.push({ adapter, run: freshRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(freshRun);
+      await waitForMixedSecondaryLaunchQueue(freshRun);
       await waitForCondition(() => adapter.launchInputs.length === 5);
       await waitForCondition(() =>
         freshRun.mixedSecondaryLanes.every((lane: { state: string }) => lane.state === 'finished')
@@ -21003,7 +21168,9 @@ describe(
       trackLiveRun(svc, cancelledRun);
       trackLiveRun(svc, survivingRun);
 
+      blockedMixedLaunches.push({ adapter, run: cancelledRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(cancelledRun);
+      blockedMixedLaunches.push({ adapter, run: survivingRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(survivingRun);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 2);
 
@@ -21016,6 +21183,8 @@ describe(
       expect(adapter.stopInputs.some((input) => input.teamName === survivingTeamName)).toBe(false);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(cancelledRun);
+      await waitForMixedSecondaryLaunchQueue(survivingRun);
       await waitForCondition(() => adapter.launchInputs.length === 3);
       await waitForCondition(() =>
         survivingRun.mixedSecondaryLanes.every(
@@ -21034,7 +21203,9 @@ describe(
       addGeminiPrimaryToMixedRun(freshRun);
       trackLiveRun(svc, freshRun);
 
+      blockedMixedLaunches.push({ adapter, run: freshRun });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(freshRun);
+      await waitForMixedSecondaryLaunchQueue(freshRun);
       await waitForCondition(() => adapter.launchInputs.length === 5);
       await waitForCondition(() =>
         freshRun.mixedSecondaryLanes.every((lane: { state: string }) => lane.state === 'finished')
@@ -21087,6 +21258,7 @@ describe(
       const run = createMixedLiveRun({ teamName, projectPath });
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
@@ -21094,6 +21266,7 @@ describe(
       await waitForCondition(() => adapter.stopInputs.length === 1);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.rejectedLaunchCount === 1);
 
       await expect(
@@ -21124,6 +21297,7 @@ describe(
       const run = createMixedLiveRun({ teamName, projectPath, primaryProviderId: 'anthropic' });
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
@@ -21131,6 +21305,7 @@ describe(
       await waitForCondition(() => adapter.stopInputs.length === 1);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.rejectedLaunchCount === 1);
 
       await expect(
@@ -21175,6 +21350,7 @@ describe(
       addGeminiPrimaryToMixedRun(run);
       trackLiveRun(svc, run);
 
+      blockedMixedLaunches.push({ adapter, run });
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await waitForCondition(() => adapter.pendingLaunchInputs.length === 1);
 
@@ -21182,6 +21358,7 @@ describe(
       await waitForCondition(() => adapter.stopInputs.length === 1);
 
       adapter.releaseLaunches();
+      await waitForMixedSecondaryLaunchQueue(run);
       await waitForCondition(() => adapter.rejectedLaunchCount === 1);
 
       await expect(
@@ -21677,7 +21854,7 @@ describe(
         pendingPermissionRequestIds: ['perm-alice'],
       });
 
-      svc.stopTeam('pending-then-relaunch-opencode-safe-e2e');
+      await svc.stopTeam('pending-then-relaunch-opencode-safe-e2e');
       await waitForCondition(() => adapter.stopInputs.length === 1);
       adapter.setLaunchResult('clean_success');
 
@@ -21713,6 +21890,8 @@ type MixedPrimaryProviderId = 'anthropic' | 'codex';
 function createStaleWatermarkStopAdapterFixture(input: {
   controlDir: string;
   manifestReader: OpenCodeRuntimeManifestEvidenceReader;
+  runId: string;
+  capabilitySnapshotId: string;
 }): {
   adapter: OpenCodeTeamRuntimeAdapter;
   handshakeExpectedWatermarks: Array<number | null>;
@@ -21747,6 +21926,10 @@ function createStaleWatermarkStopAdapterFixture(input: {
           expectedRunId: string | null;
           expectedManifestHighWatermark: number | null;
         };
+        expect(request).toMatchObject({
+          expectedRunId: input.runId,
+          expectedCapabilitySnapshotId: input.capabilitySnapshotId,
+        });
         handshakeExpectedWatermarks.push(request.expectedManifestHighWatermark);
         const server: OpenCodeBridgePeerIdentity = {
           ...clientIdentity,
@@ -21757,9 +21940,9 @@ function createStaleWatermarkStopAdapterFixture(input: {
             binaryPath: 'fixture-opencode',
             binaryFingerprint: 'fixture-opencode-1.18.22',
             version: '1.18.22',
-            capabilitySnapshotId: null,
+            capabilitySnapshotId: input.capabilitySnapshotId,
             runtimeStoreManifestHighWatermark: 0,
-            activeRunId: null,
+            activeRunId: input.runId,
           },
         };
         const handshakeWithoutHash: Omit<OpenCodeBridgeHandshake, 'identityHash'> = {
@@ -21796,6 +21979,14 @@ function createStaleWatermarkStopAdapterFixture(input: {
             idempotencyKey: string;
           };
         };
+        expect(request).toMatchObject({
+          runId: input.runId,
+          expectedCapabilitySnapshotId: input.capabilitySnapshotId,
+          preconditions: {
+            expectedRunId: input.runId,
+            expectedCapabilitySnapshotId: input.capabilitySnapshotId,
+          },
+        });
         stopExpectedWatermarks.push(request.preconditions.expectedManifestHighWatermark);
         stoppedRunIds.push(request.runId);
         return {
@@ -21810,7 +22001,7 @@ function createStaleWatermarkStopAdapterFixture(input: {
             binaryPath: 'fixture-opencode',
             binaryFingerprint: 'fixture-opencode-1.18.22',
             version: '1.18.22',
-            capabilitySnapshotId: null,
+            capabilitySnapshotId: input.capabilitySnapshotId,
           },
           diagnostics: [],
           data: {
@@ -21843,6 +22034,9 @@ function createStaleWatermarkStopAdapterFixture(input: {
     }),
     bridge: executor,
     manifestReader: input.manifestReader,
+    launchAuthorityWriter: new OpenCodeRuntimeLaunchAuthorityWriter({
+      teamsBasePath: getTeamsBasePath(),
+    }),
   });
   const bridge = new OpenCodeReadinessBridge(executor, {
     stateChangingCommands,
@@ -22362,6 +22556,14 @@ class BlockingOpenCodeRuntimeAdapter extends FakeOpenCodeRuntimeAdapter {
   releaseLaunches(): void {
     this.releaseGate?.();
   }
+}
+
+async function waitForMixedSecondaryLaunchQueue(run: {
+  mixedSecondaryLaneLaunchQueue?: Promise<void>;
+}): Promise<void> {
+  const queue = run.mixedSecondaryLaneLaunchQueue;
+  expect(queue).toBeInstanceOf(Promise);
+  await queue;
 }
 
 function latestOpenCodeLaunchRunId(

--- a/test/main/services/team/TeamProvisioningOpenCodeDiagnosticsPolicy.test.ts
+++ b/test/main/services/team/TeamProvisioningOpenCodeDiagnosticsPolicy.test.ts
@@ -77,9 +77,9 @@ describe('TeamProvisioningOpenCodeDiagnosticsPolicy', () => {
         makeMember({ runtimeDiagnostic: 'OpenCode bridge reported member launch failure' })
       )
     ).toBe(false);
-    expect(hasRealOpenCodeLaunchDiagnostic(makeMember({ hardFailureReason: 'model not found' }))).toBe(
-      true
-    );
+    expect(
+      hasRealOpenCodeLaunchDiagnostic(makeMember({ hardFailureReason: 'model not found' }))
+    ).toBe(true);
   });
 
   it('redacts secrets and bounds app-managed briefing text', () => {
@@ -87,9 +87,9 @@ describe('TeamProvisioningOpenCodeDiagnosticsPolicy', () => {
       ' failed  --api-key sk-abcdefghijklmnopqrstuvwxyz  Bearer ABC123._+/=-  '
     );
     expect(normalized).toBe('failed --api-key [redacted] Bearer [redacted]');
-    expect(isGenericOpenCodePersistedFailureReason('OpenCode bridge reported member launch failure')).toBe(
-      true
-    );
+    expect(
+      isGenericOpenCodePersistedFailureReason('OpenCode bridge reported member launch failure')
+    ).toBe(true);
 
     const longBriefing = `${'x'.repeat(12_005)} --token secret-token`;
     const bounded = boundOpenCodeAppManagedBriefingText(longBriefing);
@@ -226,6 +226,35 @@ describe('TeamProvisioningOpenCodeDiagnosticsPolicy', () => {
     expect(selectOpenCodePrepareProviderDiagnostic(mcpPrepare)).toBe('mcp_unavailable');
     expect(selectOpenCodeModelPreparePrimaryReason(mcpPrepare)).toBe('mcp_unavailable');
   });
+
+  it.each([
+    ['OpenCode session status busy', 'Token refresh failed: 401'],
+    [
+      'opencode_app_mcp_tool_proof_persisted_cache_hit',
+      'OpenCode session status busy',
+      'Token refresh failed: 401',
+    ],
+    ['OpenCode session status busy'],
+  ])(
+    'keeps typed terminal authentication failures above incidental busy diagnostics: %j',
+    (...diagnostics) => {
+      const prepare = {
+        ok: false,
+        providerId: 'opencode',
+        reason: 'not_authenticated',
+        retryable: true,
+        warnings: [],
+        diagnostics,
+      } satisfies Extract<TeamRuntimePrepareResult, { ok: false }>;
+      const reason = selectOpenCodeModelPreparePrimaryReason(prepare);
+      expect(reason).toBe(
+        diagnostics.includes('Token refresh failed: 401')
+          ? 'Token refresh failed: 401'
+          : 'not_authenticated'
+      );
+      expect(isOpenCodeModelPrepareBusyDeferred(prepare, reason)).toBe(false);
+    }
+  );
 
   it('defers retryable busy prepare failures without hiding model verification timeouts', () => {
     const busyPrepare = {

--- a/test/main/services/team/TeamProvisioningOpenCodeModelPreparation.test.ts
+++ b/test/main/services/team/TeamProvisioningOpenCodeModelPreparation.test.ts
@@ -7,19 +7,25 @@ import {
 } from '@main/services/team/provisioning/TeamProvisioningOpenCodeModelPreparation';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 
+import { openCodeProviderStatus } from './fixtures/openCodeProviderStatus';
+
 import type { TeamLaunchRuntimeAdapter } from '@main/services/team/runtime';
 
 type PrepareMock = Mock<TeamLaunchRuntimeAdapter['prepare']>;
 
 type TestAdapter = TeamLaunchRuntimeAdapter & {
   prepare: PrepareMock;
-  getLastOpenCodeTeamLaunchReadiness?: Mock<(cwd: string) => { availableModels?: unknown[] }>;
+  readProviderStatus: Mock;
+  getLastOpenCodeTeamLaunchReadiness?: Mock<(cwd: string) => { availableModels?: string[] }>;
 };
 
-function createAdapter(input: { prepare: PrepareMock; availableModels?: unknown[] }): TestAdapter {
+function createAdapter(input: { prepare: PrepareMock; availableModels?: string[] }): TestAdapter {
   return {
     providerId: 'opencode',
     prepare: input.prepare,
+    readProviderStatus: vi
+      .fn()
+      .mockResolvedValue(openCodeProviderStatus(input.availableModels ?? [])),
     launch: vi.fn(),
     reconcile: vi.fn(),
     stop: vi.fn(),
@@ -94,22 +100,22 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['openrouter/qwen/qwen3-coder', 'missing-model'],
       verificationMode: 'compatibility',
       appendPreflightDebugLog: (event) => debugEvents.push(event),
     });
 
-    expect(prepare).toHaveBeenCalledTimes(1);
-    expect(prepare.mock.calls[0]?.[0]).toMatchObject({
-      model: 'openrouter/qwen/qwen3-coder',
-      runtimeOnly: true,
+    expect(prepare).not.toHaveBeenCalled();
+    expect(adapter.readProviderStatus).toHaveBeenCalledExactlyOnceWith({
+      cwd: '/workspace/project',
     });
     expect(result.details).toEqual([
       'Selected model openrouter/qwen/qwen3-coder is compatible. Deep verification pending.',
       'Selected model missing-model is unavailable. Selected model missing-model was not found in the live provider catalog.',
     ]);
-    expect(result.warnings).toEqual(['runtime note']);
+    expect(result.warnings).toEqual([]);
     expect(result.blockingMessages).toEqual([
       'Selected model missing-model is unavailable. Selected model missing-model was not found in the live provider catalog.',
     ]);
@@ -117,46 +123,131 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
     expect(debugEvents).toContain('opencode_compatibility_batch_complete');
   });
 
-  it('defers shared compatibility checks when OpenCode is busy', async () => {
-    const prepare = vi.fn<TeamLaunchRuntimeAdapter['prepare']>().mockResolvedValue({
-      ok: false,
-      providerId: 'opencode',
-      reason: 'unknown_error',
-      retryable: true,
-      diagnostics: ['OpenCode session status busy'],
-      warnings: [],
+  it.each([
+    'stale',
+    'malformed',
+    'empty',
+    'null',
+    'error',
+    'wrong-provider',
+    'unauthenticated',
+    'non-authoritative',
+    'refresh-error',
+  ])('fails closed for %s catalog without consulting launch readiness', async (kind) => {
+    const prepare = vi.fn<TeamLaunchRuntimeAdapter['prepare']>();
+    const adapter = createAdapter({ prepare, availableModels: ['anthropic/sonnet'] });
+    const provider = openCodeProviderStatus(['anthropic/sonnet']);
+    if (kind === 'stale') provider.modelCatalog!.staleAt = new Date(0).toISOString();
+    if (kind === 'malformed') provider.modelCatalog!.models[0].launchModel = '';
+    if (kind === 'empty') provider.modelCatalog!.models = [];
+    if (kind === 'wrong-provider') provider.providerId = 'codex';
+    if (kind === 'unauthenticated') provider.authenticated = false;
+    if (kind === 'non-authoritative') provider.statusCheckOutcome = 'model_only';
+    if (kind === 'refresh-error') provider.modelCatalogRefreshState = 'error';
+    adapter.readProviderStatus.mockResolvedValue(kind === 'null' ? null : provider);
+    if (kind === 'error')
+      adapter.readProviderStatus.mockRejectedValue(new Error('catalog timed out'));
+    const result = await prepareSelectedOpenCodeModelsForProvisioning({
+      adapter,
+      readProviderStatus: adapter.readProviderStatus,
+      cwd: '/workspace/project',
+      modelIds: ['anthropic/sonnet'],
+      verificationMode: 'compatibility',
     });
-    const adapter = createAdapter({ prepare });
-    const debugEvents: string[] = [];
+    expect(result.blockingMessages).toHaveLength(1);
+    expect(prepare).not.toHaveBeenCalled();
+    expect(adapter.getLastOpenCodeTeamLaunchReadiness).not.toHaveBeenCalled();
+  });
 
+  it('never promotes a previous launch snapshot when the catalog reader is missing', async () => {
+    const adapter = createAdapter({ prepare: vi.fn(), availableModels: ['anthropic/sonnet'] });
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
       cwd: '/workspace/project',
-      modelIds: ['first-model', 'second-model'],
+      modelIds: ['anthropic/sonnet'],
       verificationMode: 'compatibility',
-      appendPreflightDebugLog: (event) => debugEvents.push(event),
     });
+    expect(result.blockingMessages).toHaveLength(1);
+    expect(adapter.prepare).not.toHaveBeenCalled();
+    expect(adapter.getLastOpenCodeTeamLaunchReadiness).not.toHaveBeenCalled();
+  });
 
-    expect(prepare).toHaveBeenCalledTimes(1);
-    expect(prepare.mock.calls[0]?.[0]).toMatchObject({
-      model: 'first-model',
-      runtimeOnly: true,
+  it('reads a fresh catalog for each project instead of reusing another project snapshot', async () => {
+    const adapter = createAdapter({ prepare: vi.fn(), availableModels: ['anthropic/sonnet'] });
+    adapter.readProviderStatus
+      .mockResolvedValueOnce(openCodeProviderStatus(['anthropic/sonnet']))
+      .mockResolvedValueOnce(openCodeProviderStatus(['anthropic/haiku']));
+    const first = await prepareSelectedOpenCodeModelsForProvisioning({
+      adapter,
+      readProviderStatus: adapter.readProviderStatus,
+      cwd: '/sandbox/first',
+      modelIds: ['anthropic/sonnet'],
+      verificationMode: 'compatibility',
+    });
+    const second = await prepareSelectedOpenCodeModelsForProvisioning({
+      adapter,
+      readProviderStatus: adapter.readProviderStatus,
+      cwd: '/sandbox/second',
+      modelIds: ['anthropic/sonnet'],
+      verificationMode: 'compatibility',
+    });
+    expect(first.blockingMessages).toEqual([]);
+    expect(second.blockingMessages).toHaveLength(1);
+    expect(adapter.readProviderStatus.mock.calls).toEqual([
+      [{ cwd: '/sandbox/first' }],
+      [{ cwd: '/sandbox/second' }],
+    ]);
+    expect(adapter.prepare).not.toHaveBeenCalled();
+  });
+
+  it('keeps deep execution separate and invokes its strict adapter once', async () => {
+    const prepare = vi.fn<TeamLaunchRuntimeAdapter['prepare']>().mockResolvedValue({
+      ok: true,
+      providerId: 'opencode',
+      modelId: 'anthropic/sonnet',
+      diagnostics: [],
+      warnings: [],
+    });
+    const adapter = createAdapter({ prepare });
+    const result = await prepareSelectedOpenCodeModelsForProvisioning({
+      adapter,
+      readProviderStatus: adapter.readProviderStatus,
+      cwd: '/sandbox/project',
+      modelIds: ['anthropic/sonnet'],
+      verificationMode: 'deep',
     });
     expect(result.blockingMessages).toEqual([]);
-    expect(result.warnings).toEqual([
-      'OpenCode is currently busy with another session. Deep model verification will retry when OpenCode is idle.',
-    ]);
-    expect(result.issues).toEqual([
-      {
-        providerId: 'opencode',
-        scope: 'provider',
-        severity: 'warning',
-        code: 'unknown_error',
-        message:
-          'OpenCode is currently busy with another session. Deep model verification will retry when OpenCode is idle.',
+    expect(prepare).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ runtimeOnly: false, model: 'anthropic/sonnet' })
+    );
+    expect(adapter.readProviderStatus).not.toHaveBeenCalled();
+  });
+
+  it('blocks selected route access failures in an otherwise healthy catalog', async () => {
+    const adapter = createAdapter({ prepare: vi.fn(), availableModels: ['anthropic/sonnet'] });
+    const provider = openCodeProviderStatus(['anthropic/sonnet']);
+    provider.modelCatalog!.models[0].metadata = {
+      opencode: {
+        providerId: 'anthropic',
+        modelId: 'sonnet',
+        sourceLabel: null,
+        accessKind: 'not_authenticated',
+        routeKind: 'connected_provider',
+        proofState: 'failed',
+        requiresExecutionProof: true,
+        reason: 'Credentials revoked',
       },
-    ]);
-    expect(debugEvents).toContain('opencode_compatibility_batch_busy_deferred');
+    };
+    adapter.readProviderStatus.mockResolvedValue(provider);
+    const result = await prepareSelectedOpenCodeModelsForProvisioning({
+      adapter,
+      readProviderStatus: adapter.readProviderStatus,
+      cwd: '/workspace/project',
+      modelIds: ['anthropic/sonnet'],
+      verificationMode: 'compatibility',
+    });
+    expect(result.blockingMessages).toEqual(['Credentials revoked']);
+    expect(adapter.prepare).not.toHaveBeenCalled();
   });
 
   it.each(['ollama/qwen3-coder:30b', 'cursor-acp/auto', 'kiro/auto'])(
@@ -170,6 +261,7 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
       const result = await prepareSelectedOpenCodeModelsForProvisioning({
         adapter,
+        readProviderStatus: adapter.readProviderStatus,
         cwd: '/workspace/project',
         modelIds: [modelId],
         verificationMode: 'compatibility',
@@ -184,7 +276,7 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
     }
   );
 
-  it('uses a provider-backed route for shared auth when Cursor also is selected', async () => {
+  it('reads catalog without starting a host when Cursor and cloud models are selected', async () => {
     const prepare = vi.fn<TeamLaunchRuntimeAdapter['prepare']>().mockResolvedValue({
       ok: true,
       providerId: 'opencode',
@@ -199,14 +291,13 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['cursor-acp/auto', 'openrouter/qwen/qwen3-coder'],
       verificationMode: 'compatibility',
     });
 
-    expect(prepare).toHaveBeenCalledWith(
-      expect.objectContaining({ model: 'openrouter/qwen/qwen3-coder', runtimeOnly: true })
-    );
+    expect(prepare).not.toHaveBeenCalled();
     expect(result.blockingMessages).toEqual([]);
     expect(result.details).toEqual([
       'Selected model cursor-acp/auto is compatible. Deep verification pending.',
@@ -238,6 +329,7 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['local-lab/team-model'],
       verificationMode: 'compatibility',
@@ -283,20 +375,22 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
       availableModels: ['anthropic/claude-sonnet'],
     });
 
+    adapter.readProviderStatus.mockResolvedValue({
+      ...openCodeProviderStatus(['anthropic/claude-sonnet']),
+      authenticated: false,
+    });
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['local-lab/team-model', 'anthropic/claude-sonnet'],
       verificationMode: 'compatibility',
     });
 
-    expect(prepare.mock.calls.map(([input]) => input.model)).toEqual([
-      'local-lab/team-model',
-      'anthropic/claude-sonnet',
-    ]);
-    expect(result.blockingMessages).toEqual(['No connected OpenCode provider found']);
+    expect(prepare).not.toHaveBeenCalled();
+    expect(result.blockingMessages).toHaveLength(1);
     expect(result.issues).toEqual([
-      expect.objectContaining({ code: 'not_authenticated', severity: 'blocking' }),
+      expect.objectContaining({ code: 'catalog_unavailable', severity: 'blocking' }),
     ]);
   });
 
@@ -315,6 +409,7 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['local-lab/missing-model'],
       verificationMode: 'compatibility',
@@ -332,6 +427,42 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
     ]);
   });
 
+  it('blocks expired OAuth despite busy and cached-proof notes from the same execution probe', async () => {
+    const authFailure =
+      'Latest assistant message failed with UnknownError - Token refresh failed: 401';
+    const prepare = vi.fn<TeamLaunchRuntimeAdapter['prepare']>().mockResolvedValue({
+      ok: false,
+      providerId: 'opencode',
+      reason: 'not_authenticated',
+      retryable: true,
+      diagnostics: [
+        'OpenCode session status busy',
+        authFailure,
+        'OpenCode retry/error payload exposed a terminal provider failure before polling completed in 5490ms',
+        'opencode_app_mcp_tool_proof_persisted_cache_hit',
+        'Token refresh failed: 401',
+      ],
+      warnings: [],
+    });
+    const result = await prepareSelectedOpenCodeModelsForProvisioning({
+      adapter: createAdapter({ prepare }),
+      cwd: '/sandbox/project',
+      modelIds: ['openai/gpt-5.4'],
+      verificationMode: 'deep',
+    });
+    expect(result.blockingMessages).toEqual(['Token refresh failed: 401']);
+    expect(result.warnings).toEqual([]);
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        code: 'not_authenticated',
+        scope: 'provider',
+        severity: 'blocking',
+        message: 'Token refresh failed: 401',
+      }),
+    ]);
+    expect(prepare).toHaveBeenCalledTimes(1);
+  });
+
   it('defers remaining deep verification when OpenCode is busy', async () => {
     const prepare = vi.fn<TeamLaunchRuntimeAdapter['prepare']>().mockResolvedValue({
       ok: false,
@@ -345,6 +476,7 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['first-model', 'second-model'],
       verificationMode: 'deep',
@@ -390,6 +522,7 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['zai-coding-plan/glm-5.1'],
       verificationMode: 'deep',
@@ -420,6 +553,7 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['ollama/qwen2.5:0.5b'],
       verificationMode: 'deep',
@@ -466,6 +600,7 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['ollama/qwen2.5:0.5b'],
       verificationMode: 'deep',
@@ -517,6 +652,7 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['ollama/qwen3:8b'],
       verificationMode: 'deep',
@@ -546,6 +682,7 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['ollama/qwen3:8b'],
       verificationMode: 'deep',
@@ -586,6 +723,7 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
 
     const result = await prepareSelectedOpenCodeModelsForProvisioning({
       adapter,
+      readProviderStatus: adapter.readProviderStatus,
       cwd: '/workspace/project',
       modelIds: ['local-lab/team-model'],
       verificationMode: 'deep',

--- a/test/main/services/team/TeamProvisioningOpenCodeModelPreparation.test.ts
+++ b/test/main/services/team/TeamProvisioningOpenCodeModelPreparation.test.ts
@@ -123,6 +123,35 @@ describe('TeamProvisioningOpenCodeModelPreparation', () => {
     expect(debugEvents).toContain('opencode_compatibility_batch_complete');
   });
 
+  it('skips all compatibility processing when no models are selected', async () => {
+    const prepare = vi.fn<TeamLaunchRuntimeAdapter['prepare']>();
+    const adapter = createAdapter({ prepare, availableModels: ['anthropic/sonnet'] });
+    const inspectLocalModelRuntime = vi.fn();
+    const appendPreflightDebugLog = vi.fn();
+
+    const result = await prepareSelectedOpenCodeModelsForProvisioning({
+      adapter,
+      readProviderStatus: adapter.readProviderStatus,
+      cwd: '/workspace/project',
+      modelIds: [],
+      verificationMode: 'compatibility',
+      inspectLocalModelRuntime,
+      appendPreflightDebugLog,
+    });
+
+    expect(result).toEqual({
+      details: [],
+      warnings: [],
+      blockingMessages: [],
+      issues: [],
+      supportDiagnostics: [],
+    });
+    expect(prepare).not.toHaveBeenCalled();
+    expect(adapter.readProviderStatus).not.toHaveBeenCalled();
+    expect(inspectLocalModelRuntime).not.toHaveBeenCalled();
+    expect(appendPreflightDebugLog).not.toHaveBeenCalled();
+  });
+
   it.each([
     'stale',
     'malformed',

--- a/test/main/services/team/TeamProvisioningService.test.ts
+++ b/test/main/services/team/TeamProvisioningService.test.ts
@@ -15601,6 +15601,11 @@ describe('TeamProvisioningService', () => {
         memberName: 'bob',
         cwd: '/tmp/mixed-team',
       });
+      await seedOpenCodeRuntimeLaneCurrentRunForTest({
+        teamName,
+        laneId,
+        runId,
+      });
 
       await expect(
         svc.recordOpenCodeRuntimeBootstrapCheckin({

--- a/test/main/services/team/TeamProvisioningServicePrepare.test.ts
+++ b/test/main/services/team/TeamProvisioningServicePrepare.test.ts
@@ -1824,15 +1824,16 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
     ]);
   });
 
-  it('uses project catalog without starting OpenCode when compatibility has no selected model', async () => {
+  it('skips project catalog and OpenCode runtime when compatibility has no selected model', async () => {
     const readCatalog = vi
       .spyOn(ClaudeMultimodelBridgeService.prototype, 'getProviderStatus')
       .mockResolvedValue(openCodeProviderStatus(['anthropic/sonnet']));
     const prepare = vi.fn();
+    const launch = vi.fn();
     const svc = new TeamProvisioningService();
     svc.setRuntimeAdapterRegistry(
       new TeamRuntimeAdapterRegistry([
-        { providerId: 'opencode', prepare, launch: vi.fn(), reconcile: vi.fn(), stop: vi.fn() },
+        { providerId: 'opencode', prepare, launch, reconcile: vi.fn(), stop: vi.fn() },
       ])
     );
     const result = await svc.prepareForProvisioning(tempRoot, {
@@ -1840,10 +1841,9 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
       modelVerificationMode: 'compatibility',
     });
     expect(result.ready).toBe(true);
-    expect(readCatalog).toHaveBeenCalledExactlyOnceWith('/fake/claude', 'opencode', undefined, {
-      projectPath: tempRoot,
-    });
+    expect(readCatalog).not.toHaveBeenCalled();
     expect(prepare).not.toHaveBeenCalled();
+    expect(launch).not.toHaveBeenCalled();
   });
 
   it('runs OpenCode compatibility-only selected model checks without the deep execution probe', async () => {

--- a/test/main/services/team/TeamProvisioningServicePrepare.test.ts
+++ b/test/main/services/team/TeamProvisioningServicePrepare.test.ts
@@ -1,4 +1,5 @@
 import { buildCodexWorkspaceTrustSettingsArgs } from '@features/workspace-trust/core/domain';
+import { ClaudeMultimodelBridgeService } from '@main/services/runtime/ClaudeMultimodelBridgeService';
 import {
   OPENCODE_WINDOWS_ACCESS_DENIED_MESSAGE,
   OPENCODE_WINDOWS_NODE_MODULES_SYMLINK_PERMISSION_MESSAGE,
@@ -10,6 +11,8 @@ import * as os from 'os';
 import * as path from 'path';
 import { PassThrough } from 'stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openCodeProviderStatus } from './fixtures/openCodeProviderStatus';
 
 vi.mock('@main/services/team/ClaudeBinaryResolver', () => ({
   ClaudeBinaryResolver: { resolve: vi.fn() },
@@ -1173,6 +1176,7 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await removeTempRoot(tempRoot);
   });
 
@@ -1485,25 +1489,15 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
 
   it('coalesces duplicate OpenCode compatibility preflight requests while prepare is in flight', async () => {
     const prepareGate: { release?: () => void } = {};
-    const prepare = vi.fn(
-      async () =>
-        new Promise<{
-          ok: true;
-          providerId: 'opencode';
-          modelId: null;
-          diagnostics: string[];
-          warnings: string[];
-        }>((resolve) => {
-          prepareGate.release = () =>
-            resolve({
-              ok: true,
-              providerId: 'opencode',
-              modelId: null,
-              diagnostics: [],
-              warnings: [],
-            });
-        })
-    );
+    const prepare = vi.fn();
+    const readCatalog = vi
+      .spyOn(ClaudeMultimodelBridgeService.prototype, 'getProviderStatus')
+      .mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            prepareGate.release = () => resolve(openCodeProviderStatus(['opencode/big-pickle']));
+          })
+      );
     const registry = new TeamRuntimeAdapterRegistry([
       {
         providerId: 'opencode',
@@ -1541,16 +1535,17 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
     const first = svc.prepareForProvisioning(tempRoot, opts);
     const second = svc.prepareForProvisioning(tempRoot, opts);
 
-    for (let attempt = 0; attempt < 20 && prepare.mock.calls.length === 0; attempt += 1) {
+    for (let attempt = 0; attempt < 20 && readCatalog.mock.calls.length === 0; attempt += 1) {
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
-    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(readCatalog).toHaveBeenCalledTimes(1);
     expect(prepareGate.release).toBeTypeOf('function');
     prepareGate.release?.();
 
     const [firstResult, secondResult] = await Promise.all([first, second]);
 
-    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(readCatalog).toHaveBeenCalledTimes(1);
+    expect(prepare).not.toHaveBeenCalled();
     expect(firstResult).not.toBe(secondResult);
     expect(firstResult.ready).toBe(true);
     expect(secondResult.ready).toBe(true);
@@ -1829,6 +1824,28 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
     ]);
   });
 
+  it('uses project catalog without starting OpenCode when compatibility has no selected model', async () => {
+    const readCatalog = vi
+      .spyOn(ClaudeMultimodelBridgeService.prototype, 'getProviderStatus')
+      .mockResolvedValue(openCodeProviderStatus(['anthropic/sonnet']));
+    const prepare = vi.fn();
+    const svc = new TeamProvisioningService();
+    svc.setRuntimeAdapterRegistry(
+      new TeamRuntimeAdapterRegistry([
+        { providerId: 'opencode', prepare, launch: vi.fn(), reconcile: vi.fn(), stop: vi.fn() },
+      ])
+    );
+    const result = await svc.prepareForProvisioning(tempRoot, {
+      providerId: 'opencode',
+      modelVerificationMode: 'compatibility',
+    });
+    expect(result.ready).toBe(true);
+    expect(readCatalog).toHaveBeenCalledExactlyOnceWith('/fake/claude', 'opencode', undefined, {
+      projectPath: tempRoot,
+    });
+    expect(prepare).not.toHaveBeenCalled();
+  });
+
   it('runs OpenCode compatibility-only selected model checks without the deep execution probe', async () => {
     const prepare = vi.fn(async (input: { model?: string; runtimeOnly?: boolean }) => ({
       ok: true as const,
@@ -1869,6 +1886,11 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
         stop: vi.fn(),
       } as any,
     ]);
+    const readCatalog = vi
+      .spyOn(ClaudeMultimodelBridgeService.prototype, 'getProviderStatus')
+      .mockResolvedValue(
+        openCodeProviderStatus(['opencode/minimax-m2.5-free', 'opencode/nemotron-3-super-free'])
+      );
     const svc = new TeamProvisioningService();
     svc.setRuntimeAdapterRegistry(registry);
 
@@ -1884,14 +1906,10 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
       'Selected model opencode/minimax-m2.5-free is compatible. Deep verification pending.',
       'Selected model opencode/nemotron-3-super-free is compatible. Deep verification pending.',
     ]);
-    expect(prepare).toHaveBeenCalledTimes(1);
-    expect(prepare).toHaveBeenCalledWith(
-      expect.objectContaining({
-        providerId: 'opencode',
-        model: 'opencode/minimax-m2.5-free',
-        runtimeOnly: true,
-      })
-    );
+    expect(prepare).not.toHaveBeenCalled();
+    expect(readCatalog).toHaveBeenCalledExactlyOnceWith('/fake/claude', 'opencode', undefined, {
+      projectPath: tempRoot,
+    });
   });
 
   it('accepts OpenRouter-selected models when OpenCode reports the nested model id without provider prefix', async () => {
@@ -1934,6 +1952,9 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
         stop: vi.fn(),
       } as any,
     ]);
+    const readCatalog = vi
+      .spyOn(ClaudeMultimodelBridgeService.prototype, 'getProviderStatus')
+      .mockResolvedValue(openCodeProviderStatus(['qwen/qwen3-coder']));
     const svc = new TeamProvisioningService();
     svc.setRuntimeAdapterRegistry(registry);
 
@@ -1948,7 +1969,10 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
     expect(result.details).toEqual([
       'Selected model openrouter/qwen/qwen3-coder is compatible. Deep verification pending.',
     ]);
-    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(prepare).not.toHaveBeenCalled();
+    expect(readCatalog).toHaveBeenCalledExactlyOnceWith('/fake/claude', 'opencode', undefined, {
+      projectPath: tempRoot,
+    });
   });
 
   it('accepts saved nested OpenRouter model ids when OpenCode reports the provider-scoped id', async () => {
@@ -1991,6 +2015,9 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
         stop: vi.fn(),
       } as any,
     ]);
+    const readCatalog = vi
+      .spyOn(ClaudeMultimodelBridgeService.prototype, 'getProviderStatus')
+      .mockResolvedValue(openCodeProviderStatus(['openrouter/qwen/qwen3-coder']));
     const svc = new TeamProvisioningService();
     svc.setRuntimeAdapterRegistry(registry);
 
@@ -2005,7 +2032,10 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
     expect(result.details).toEqual([
       'Selected model qwen/qwen3-coder is compatible. Deep verification pending.',
     ]);
-    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(prepare).not.toHaveBeenCalled();
+    expect(readCatalog).toHaveBeenCalledExactlyOnceWith('/fake/claude', 'opencode', undefined, {
+      projectPath: tempRoot,
+    });
   });
 
   it('explains OpenRouter selected-model failures when the current OpenCode catalog has no OpenRouter provider', async () => {
@@ -2048,6 +2078,9 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
         stop: vi.fn(),
       } as any,
     ]);
+    const readCatalog = vi
+      .spyOn(ClaudeMultimodelBridgeService.prototype, 'getProviderStatus')
+      .mockResolvedValue(openCodeProviderStatus(['opencode/minimax-m2.5-free', 'openai/gpt-5.4']));
     const svc = new TeamProvisioningService();
     svc.setRuntimeAdapterRegistry(registry);
 
@@ -2064,7 +2097,10 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
     );
     expect(result.message).toContain('Live catalog providers: openai, opencode.');
     expect(result.message).toContain('Connect OpenRouter in OpenCode provider management');
-    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(prepare).not.toHaveBeenCalled();
+    expect(readCatalog).toHaveBeenCalledExactlyOnceWith('/fake/claude', 'opencode', undefined, {
+      projectPath: tempRoot,
+    });
   });
 
   it('keeps deep OpenCode runtime failures provider-scoped instead of model-scoped', async () => {
@@ -2132,6 +2168,10 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
         stop: vi.fn(),
       } as any,
     ]);
+    vi.spyOn(ClaudeMultimodelBridgeService.prototype, 'getProviderStatus').mockResolvedValue({
+      ...openCodeProviderStatus(['opencode/minimax-m2.5-free']),
+      authenticated: false,
+    });
     const svc = new TeamProvisioningService();
     svc.setRuntimeAdapterRegistry(registry);
 
@@ -2143,21 +2183,19 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
     });
 
     expect(result.ready).toBe(false);
-    expect(result.message).toBe('OpenCode provider authentication failed');
-    expect(result.details).toEqual(['OpenCode provider authentication failed']);
-    expect(result.warnings).toEqual(['OpenCode provider authentication failed']);
+    expect(result.message).toContain('fresh project-scoped provider catalog');
     expect(result.issues).toEqual([
-      {
+      expect.objectContaining({
         providerId: 'opencode',
         scope: 'provider',
         severity: 'blocking',
-        code: 'not_authenticated',
-        message: 'OpenCode provider authentication failed',
-      },
+        code: 'catalog_unavailable',
+      }),
     ]);
+    expect(prepare).not.toHaveBeenCalled();
   });
 
-  it('keeps shared OpenCode MCP compatibility failures provider-scoped', async () => {
+  it('keeps deep OpenCode MCP failures provider-scoped', async () => {
     const normalizedRuntimeFailure =
       'OpenCode app MCP is unreachable. Retry launch to refresh the app MCP bridge. Details: Unable to connect. Is the computer able to access the url?';
     const prepare = vi.fn(async () => ({
@@ -2186,7 +2224,7 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
       providerId: 'opencode',
       forceFresh: true,
       modelIds: ['opencode/big-pickle'],
-      modelVerificationMode: 'compatibility',
+      modelVerificationMode: 'deep',
     });
 
     expect(result.ready).toBe(false);
@@ -2231,7 +2269,7 @@ describe('TeamProvisioningService prepare/auth behavior', () => {
       providerId: 'opencode',
       forceFresh: true,
       modelIds: ['opencode/big-pickle'],
-      modelVerificationMode: 'compatibility',
+      modelVerificationMode: 'deep',
     });
 
     expect(result.ready).toBe(false);

--- a/test/main/services/team/fixtures/openCodeProviderStatus.ts
+++ b/test/main/services/team/fixtures/openCodeProviderStatus.ts
@@ -1,0 +1,50 @@
+import type { CliProviderStatus } from '@shared/types';
+
+export function openCodeProviderStatus(models: string[]): CliProviderStatus {
+  return {
+    providerId: 'opencode',
+    displayName: 'OpenCode',
+    supported: true,
+    authenticated: true,
+    authMethod: 'provider',
+    canLoginFromUi: false,
+    capabilities: {
+      teamLaunch: true,
+      oneShot: true,
+      extensions: {
+        plugins: { status: 'supported', ownership: 'provider-scoped' },
+        mcp: { status: 'supported', ownership: 'provider-scoped' },
+        skills: { status: 'supported', ownership: 'provider-scoped' },
+        apiKeys: { status: 'supported', ownership: 'provider-scoped' },
+      },
+    },
+    verificationState: 'verified',
+    statusCheckOutcome: 'authoritative',
+    models: [],
+    modelCatalogRefreshState: 'ready',
+    modelCatalog: {
+      schemaVersion: 1,
+      providerId: 'opencode',
+      source: 'app-server',
+      status: 'ready',
+      fetchedAt: new Date(Date.now() - 1000).toISOString(),
+      staleAt: new Date(Date.now() + 60_000).toISOString(),
+      defaultModelId: null,
+      defaultLaunchModel: null,
+      diagnostics: { configReadState: 'ready', appServerState: 'healthy' },
+      models: models.map((model) => ({
+        id: model,
+        launchModel: model,
+        displayName: model,
+        hidden: false,
+        supportedReasoningEfforts: [],
+        defaultReasoningEffort: null,
+        inputModalities: ['text'],
+        supportsPersonality: false,
+        isDefault: false,
+        upgrade: false,
+        source: 'app-server',
+      })),
+    },
+  };
+}

--- a/test/main/services/team/openCodeLiveTestHarness.ts
+++ b/test/main/services/team/openCodeLiveTestHarness.ts
@@ -1,3 +1,9 @@
+import { OpenCodeRuntimeLaunchAuthorityWriter } from '@main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
+import {
+  OpenCodeRuntimeManifestEvidenceReader,
+  readCommittedOpenCodeBootstrapSessionEvidence,
+  readOpenCodeRuntimeLaneIndex,
+} from '@main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import Fastify from 'fastify';
 import { constants as fsConstants, promises as fs } from 'fs';
 import * as os from 'os';
@@ -21,12 +27,6 @@ import {
   type OpenCodeBridgeCommandExecutor,
   OpenCodeStateChangingBridgeCommandService,
 } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
-import { OpenCodeRuntimeLaunchAuthorityWriter } from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
-import {
-  OpenCodeRuntimeManifestEvidenceReader,
-  readCommittedOpenCodeBootstrapSessionEvidence,
-  readOpenCodeRuntimeLaneIndex,
-} from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import {
   OpenCodeTeamRuntimeAdapter,
   type OpenCodeTeamRuntimeAdapterOptions,

--- a/test/main/services/team/openCodeLiveTestHarness.ts
+++ b/test/main/services/team/openCodeLiveTestHarness.ts
@@ -20,9 +20,10 @@ import { OpenCodeReadinessBridge } from '../../../../src/main/services/team/open
 import {
   type OpenCodeBridgeCommandExecutor,
   OpenCodeStateChangingBridgeCommandService,
-  type RuntimeStoreManifestReader,
 } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
+import { OpenCodeRuntimeLaunchAuthorityWriter } from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
 import {
+  OpenCodeRuntimeManifestEvidenceReader,
   readCommittedOpenCodeBootstrapSessionEvidence,
   readOpenCodeRuntimeLaneIndex,
 } from '../../../../src/main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
@@ -36,7 +37,6 @@ import { TeamProvisioningService } from '../../../../src/main/services/team/Team
 import { getClaudeBasePath, getTeamsBasePath } from '../../../../src/main/utils/pathDecoder';
 
 import type { HttpServices } from '../../../../src/main/http';
-import type { RuntimeStoreManifestEvidence } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeCommandContract';
 import type { TaskRef } from '../../../../src/shared/types';
 
 const DEFAULT_ORCHESTRATOR_CLI =
@@ -432,18 +432,13 @@ function createStateChangingCommands(input: {
       filePath: path.join(input.controlDir, 'ledger.json'),
     }),
     bridge: input.bridge,
-    manifestReader: new StaticManifestReader(),
+    manifestReader: new OpenCodeRuntimeManifestEvidenceReader({
+      teamsBasePath: getTeamsBasePath(),
+    }),
+    launchAuthorityWriter: new OpenCodeRuntimeLaunchAuthorityWriter({
+      teamsBasePath: getTeamsBasePath(),
+    }),
   });
-}
-
-class StaticManifestReader implements RuntimeStoreManifestReader {
-  async read(): Promise<RuntimeStoreManifestEvidence> {
-    return {
-      highWatermark: 0,
-      activeRunId: null,
-      capabilitySnapshotId: null,
-    };
-  }
 }
 
 async function assertExecutable(filePath: string): Promise<void> {

--- a/test/renderer/components/team/TeamModelSelectorDisabledState.test.ts
+++ b/test/renderer/components/team/TeamModelSelectorDisabledState.test.ts
@@ -240,6 +240,50 @@ describe('TeamModelSelector disabled Codex models', () => {
     vi.unstubAllGlobals();
   });
 
+  it('requests only the selected deferred Codex provider once across rerenders', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const providers = ['anthropic', 'codex', 'opencode'].map((providerId) => ({
+      providerId,
+      supported: false,
+      authenticated: false,
+      authMethod: null,
+      verificationState: 'unknown',
+      statusMessage: 'Provider status will refresh when needed.',
+      models: [],
+      capabilities: { teamLaunch: false, oneShot: false },
+      modelCatalogRefreshState: 'idle',
+      runtimeCapabilities: null,
+      backend: null,
+    }));
+    storeState.cliStatus = { flavor: 'agent_teams_orchestrator', installed: true, providers };
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const props = {
+      providerId: 'codex' as const,
+      onProviderChange: () => undefined,
+      value: '',
+      onValueChange: () => undefined,
+    };
+    await act(async () => {
+      root.render(React.createElement(TeamModelSelector, props));
+      await Promise.resolve();
+    });
+    await flushFailClosedAuthorityClocks();
+    await act(async () => {
+      root.render(React.createElement(TeamModelSelector, props));
+      await Promise.resolve();
+    });
+    expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(1);
+    expect(storeState.fetchCliProviderStatus).toHaveBeenCalledWith('codex', {
+      silent: false,
+      checkReason: 'launch_preflight',
+    });
+    expect(
+      providers.every((provider) => !provider.capabilities.teamLaunch && !provider.authenticated)
+    ).toBe(true);
+  });
+
   it('shows only Default while Codex runtime models are still loading', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     Object.defineProperty(window, 'electronAPI', { value: {}, configurable: true });

--- a/test/renderer/store/cliInstallerSlice.test.ts
+++ b/test/renderer/store/cliInstallerSlice.test.ts
@@ -509,9 +509,9 @@ describe('cliInstallerSlice', () => {
           opencode: false,
         })
       ).toEqual({
-        anthropic: true,
-        codex: true,
-        opencode: true,
+        anthropic: false,
+        codex: false,
+        opencode: false,
       });
     });
 
@@ -1251,11 +1251,11 @@ describe('cliInstallerSlice', () => {
       expect(api.cliInstaller.getProviderStatus).not.toHaveBeenCalled();
       expect(useStore.getState().cliStatusLoading).toBe(false);
       expect(useStore.getState().cliProviderStatusLoading).toEqual({
-        anthropic: true,
-        codex: true,
-        opencode: true,
+        anthropic: false,
+        codex: false,
+        opencode: false,
       });
-      expect(useStore.getState().cliStatus?.authStatusChecking).toBe(true);
+      expect(useStore.getState().cliStatus?.authStatusChecking).toBe(false);
       expect(
         useStore.getState().cliStatus?.providers.map((provider) => provider.statusMessage)
       ).toEqual([
@@ -1264,6 +1264,85 @@ describe('cliInstallerSlice', () => {
         CLI_PROVIDER_STATUS_DEFERRED_MESSAGE,
       ]);
     });
+
+    it.each(['timeout', 'malformed', 'invalidated'] as const)(
+      'settles only the requested provider after deferred startup and a %s result',
+      async (outcome) => {
+        const deferredStatus = createMultimodelStatus([
+          createDeferredProvider('anthropic', 'Anthropic'),
+          createDeferredProvider('codex', 'Codex'),
+          createDeferredProvider('opencode', 'OpenCode'),
+        ]);
+        vi.mocked(api.cliInstaller.getStatus).mockResolvedValue(deferredStatus);
+        await useStore.getState().bootstrapCliStatus({
+          multimodelEnabled: true,
+          providerStatusMode: 'defer',
+        });
+        expect(api.cliInstaller.getProviderStatus).not.toHaveBeenCalled();
+        expect(useStore.getState().cliStatus?.authStatusChecking).toBe(false);
+
+        const response = createDeferredValue<CliInstallationStatus['providers'][number] | null>();
+        vi.mocked(api.cliInstaller.getProviderStatus).mockReturnValueOnce(response.promise);
+        const request = useStore.getState().fetchCliProviderStatus('codex', {
+          silent: false,
+          checkReason: 'launch_preflight',
+        });
+        expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(1);
+        expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledWith('codex');
+        expect(useStore.getState().cliProviderStatusLoading).toEqual({
+          anthropic: false,
+          codex: true,
+          opencode: false,
+        });
+        expect(
+          reconcileMultimodelProviderLoading(
+            deferredStatus,
+            useStore.getState().cliProviderStatusLoading
+          ).codex
+        ).toBe(true);
+
+        if (outcome === 'invalidated') await useStore.getState().invalidateCliStatus();
+        response.resolve(
+          outcome === 'malformed'
+            ? null
+            : createMultimodelProvider({
+                providerId: 'codex',
+                displayName: 'Codex',
+                supported: false,
+                authenticated: false,
+                verificationState: 'error',
+                statusCheckOutcome: 'transient_error',
+                statusCheckErrorCode: 'timeout',
+                statusMessage: CLI_PROVIDER_STATUS_UNAVAILABLE_MESSAGE,
+              })
+        );
+        await request;
+        expect(useStore.getState().cliProviderStatusLoading.codex).not.toBe(true);
+
+        // This is the same reconciliation used for an unrelated provider's status push.
+        useStore.setState((state) => {
+          const status = reconcileCliStatus(state.cliStatus, deferredStatus);
+          return {
+            cliStatus: status,
+            cliProviderStatusLoading: reconcileMultimodelProviderLoading(
+              status,
+              state.cliProviderStatusLoading
+            ),
+          };
+        });
+        expect(useStore.getState().cliProviderStatusLoading).toEqual({
+          anthropic: false,
+          codex: false,
+          opencode: false,
+        });
+        expect(
+          useStore
+            .getState()
+            .cliStatus?.providers.every((provider) => !provider.capabilities.teamLaunch)
+        ).toBe(true);
+        expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(1);
+      }
+    );
 
     it('keeps the current snapshot intact while a full bootstrap loads metadata', async () => {
       const currentStatus = createMultimodelStatus([
@@ -1335,9 +1414,9 @@ describe('cliInstallerSlice', () => {
 
       expect(api.cliInstaller.getProviderStatus).not.toHaveBeenCalled();
       expect(useStore.getState().cliProviderStatusLoading).toEqual({
-        anthropic: true,
-        codex: true,
-        opencode: true,
+        anthropic: false,
+        codex: false,
+        opencode: false,
       });
       expect(useStore.getState().cliStatus?.providers[0]).toMatchObject({ authenticated: false });
       expect(useStore.getState().cliStatus?.providers[2]).toMatchObject({ authenticated: false });

--- a/test/renderer/utils/codexCatalogHydration.test.ts
+++ b/test/renderer/utils/codexCatalogHydration.test.ts
@@ -1,0 +1,83 @@
+import { shouldHydrateCodexModelCatalog } from '@renderer/utils/codexCatalogHydration';
+import { CLI_PROVIDER_STATUS_DEFERRED_MESSAGE } from '@shared/types/cliInstaller';
+import { createDefaultCliExtensionCapabilities } from '@shared/utils/providerExtensionCapabilities';
+import { describe, expect, it } from 'vitest';
+
+import type { CliProviderStatus } from '@shared/types';
+
+function snapshot(changes: Partial<CliProviderStatus> = {}): CliProviderStatus {
+  return {
+    providerId: 'codex',
+    displayName: 'Codex',
+    supported: false,
+    authenticated: false,
+    authMethod: null,
+    verificationState: 'unknown',
+    statusMessage: CLI_PROVIDER_STATUS_DEFERRED_MESSAGE,
+    models: [],
+    canLoginFromUi: true,
+    capabilities: {
+      teamLaunch: false,
+      oneShot: false,
+      extensions: createDefaultCliExtensionCapabilities(),
+    },
+    modelCatalogRefreshState: 'idle',
+    runtimeCapabilities: null,
+    ...changes,
+  };
+}
+
+describe('shouldHydrateCodexModelCatalog', () => {
+  it('hydrates the typed pending partial-response status emitted before a runtime probe', () => {
+    expect(
+      shouldHydrateCodexModelCatalog(
+        snapshot({
+          statusCheckOutcome: 'pending',
+          statusCheckErrorCode: 'partial_response',
+          statusMessage: 'Checking...',
+        })
+      )
+    ).toBe(true);
+  });
+
+  it.each([undefined, 'pending'] as const)(
+    'hydrates a selected deferred snapshot with outcome %s',
+    (statusCheckOutcome) => {
+      const provider = snapshot({ statusCheckOutcome });
+      expect(shouldHydrateCodexModelCatalog(provider)).toBe(true);
+      expect(provider.authenticated).toBe(false);
+      expect(provider.capabilities.teamLaunch).toBe(false);
+    }
+  );
+
+  it.each<Partial<CliProviderStatus>>([
+    { statusCheckOutcome: 'transient_error', statusCheckErrorCode: 'timeout' },
+    { statusCheckOutcome: 'transient_error', statusCheckErrorCode: 'runtime_missing' },
+    { verificationState: 'error' },
+    { modelCatalogRefreshState: 'error' },
+    { statusCheckOutcome: 'authoritative', verificationState: 'verified', supported: false },
+    {
+      statusCheckOutcome: 'authoritative',
+      verificationState: 'verified',
+      supported: true,
+      authenticated: false,
+    },
+    { providerId: 'anthropic' },
+  ])('does not automatically retry a completed or unrelated snapshot %#', (changes) => {
+    expect(shouldHydrateCodexModelCatalog(snapshot(changes))).toBe(false);
+  });
+
+  it('still hydrates a connected dynamic catalog when only the summary is present', () => {
+    expect(
+      shouldHydrateCodexModelCatalog(
+        snapshot({
+          supported: true,
+          authenticated: true,
+          verificationState: 'verified',
+          statusCheckOutcome: 'authoritative',
+          runtimeCapabilities: { modelCatalog: { dynamic: true, source: 'app-server' } },
+        })
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Mixed Codex, Claude, and OpenCode teams could pass readiness and complete work, but their lifecycle authority was not preserved consistently across provider status hydration, strict launch publication, cancellation, Stop, and relaunch. Neutral bootstrap updates could clear validated capability data, a single-provider status refresh could replay stale authority for another provider, and post-effect storage errors could be misclassified as safe to retry. The safe E2E also reset fixtures before the real secondary launch and Stop queues had drained.

Together these gaps made the first launch look successful while Stop or a fresh launch of the same team failed later.

## Changes

- hydrate provider authority atomically and prevent cross-provider stale replay
- keep deferred Codex catalog state out of a fake loading loop and refresh it once when selected
- use fresh project-scoped OpenCode catalog data while retaining deep model and launch proof requirements
- normalize macOS `/tmp` and `/private/tmp` proof paths without weakening signatures, expiry, or symlink-retarget checks
- publish validated run, capability, and behavior authority atomically into the active lane manifest
- preserve that authority across bootstrap and transport batches
- keep unknown post-effect outcomes fenced from automatic retry
- scope cancellation cleanup to the old run and its owned candidate so a successor cannot be removed
- await real Stop and mixed secondary queues in safe E2E teardown

This PR contains 1,044 changed production LOC. Most of the remaining diff is expanded fail-closed matrix and regression coverage for the cross-process lifecycle contract.

## Runtime dependency

Requires 777genius/agent_teams_orchestrator#52 for the terminal session receipt and safe same-team relaunch contract.

## Validation

- safe launch matrix plus latest secondary queue/lane regression suites: 366/366 passed
- provider slice, model selector, and deferred catalog UI suites: 146/146 passed
- review follow-up focused suites: 120/120 passed
- `pnpm typecheck`: passed
- source-size and provisioning-boundary guards: passed
- live sandbox Electron cycle with `gpt-5.6-sol`, Claude Sonnet 4.6, and `opencode/big-pickle`:
  - all three teammates joined
  - four assigned tasks stayed completed
  - Stop removed all launch-owned processes and the sandbox OpenCode host
  - a second launch created a different OpenCode run and session
  - the second Stop also completed cleanly
  - project files remained unchanged during the lifecycle-only verification

## Safety

- strict runtime, capability, behavior, auth, model, project, MCP, run, and command preconditions remain fail-closed
- unknown outcomes are not retried automatically
- only a disposable sandbox project and isolated app/runtime data roots were used
- no real user project or team was opened for runtime testing
- no credentials or local evidence artifacts are included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual and automatic permission modes for OpenCode readiness checks.
  * Compatibility checks now use fresh, project-specific provider catalogs.
  * Added safer support for stopping empty team lanes.
  * Launches now preserve runtime authority and provide clearer recovery outcomes.

* **Bug Fixes**
  * Prevented stale provider authentication and loading states from overwriting newer results.
  * Improved authentication failure and ambiguous launch handling.
  * Improved project matching for symbolic links and alternate paths.
  * Prevented readiness results from being reused across permission modes.
  * Deferred provider loading remains inactive until explicitly requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
