### PR TITLE
fix(team): make OpenCode task delivery headless-safe

### DIFF
--- a/agent-teams-controller/src/internal/runtime.js
+++ b/agent-teams-controller/src/internal/runtime.js
@@ -447,6 +447,7 @@ async function launchTeam(context, flags = {}) {
     {
       method: 'POST',
       body: request,
+      timeoutMs: normalizeTimeoutMs(flags.waitTimeoutMs || flags['wait-timeout-ms']),
     }
   );
 

--- a/agent-teams-controller/test/controller.test.js
+++ b/agent-teams-controller/test/controller.test.js
@@ -3383,6 +3383,38 @@ controller.messages.sendMessage({
     }
   });
 
+  it('applies waitTimeoutMs to the initial launch request before readiness polling', async () => {
+    const claudeDir = makeClaudeDir();
+    const controller = createController({ teamName: 'my-team', claudeDir });
+    const calls = [];
+
+    const server = await startControlServer(async ({ method, url, body }) => {
+      calls.push({ method, url, body });
+      await new Promise((resolve) => setTimeout(resolve, 1200));
+      return { body: { runId: 'run-too-late' } };
+    });
+
+    try {
+      await expect(
+        controller.runtime.launchTeam({
+          cwd: '/tmp/project',
+          controlUrl: server.baseUrl,
+          waitForReady: false,
+          waitTimeoutMs: 1000,
+        })
+      ).rejects.toThrow('Timed out calling team control API: /api/teams/my-team/launch');
+      expect(calls).toEqual([
+        {
+          method: 'POST',
+          url: '/api/teams/my-team/launch',
+          body: { cwd: '/tmp/project' },
+        },
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+
   it('forwards OpenCode runtime MCP calls to the app control API', async () => {
     const claudeDir = makeClaudeDir();
     const controller = createController({ teamName: 'my-team', claudeDir });

--- a/docs/team-management/debugging-agent-teams.md
+++ b/docs/team-management/debugging-agent-teams.md
@@ -210,6 +210,20 @@ Check `from`, `to`, `messageId`, `relayOfMessageId`, and `taskRefs`. Unknown aut
 
 For OpenCode "message saved but not delivered" cases, inspect the OpenCode prompt-delivery ledger and response proof. Do not synthesize visible replies in the frontend.
 
+Headless task delivery has two separate contracts:
+
+- OpenCode app-managed bootstrap is silent context injection (`noReply: true`). A healthy session with bootstrap evidence and no assistant reply is expected; it is not task-delivery proof.
+- Raw MCP `task_create` does not apply renderer defaults. `owner` alone creates a `pending` task. For immediate headless work, pass `createdBy: "user"` and `startImmediately: true`. The actor/sender must be `user` or a configured team member; arbitrary integration names do not produce an inbox assignment.
+
+The main-process FileWatcher owns inbox-to-runtime relay. It starts when main services are ready,
+does not require an active team tab, and remains active while the renderer reloads or recovers.
+Initial replay is limited to inboxes of explicitly scoped live teams, so durable assignments written
+before watcher readiness are recovered without replaying historical stopped-team inboxes.
+
+When a headless task does not run, check the returned task first. `pending` with no creation actor and
+no owner inbox row is a request-semantics problem. `in_progress` plus an unread owner inbox row is a
+watcher/runtime-delivery problem.
+
 ## Task And Work-Stall Debug Flow
 
 For task stalls:

--- a/docs/team-management/openclaw-agent-teams-integration.md
+++ b/docs/team-management/openclaw-agent-teams-integration.md
@@ -539,12 +539,20 @@ Arguments:
   "subject": "Review OpenClaw latest patch",
   "description": "Check correctness, tests, edge cases, and integration risks. Report concrete findings only.",
   "owner": "reviewer",
-  "createdBy": "openclaw",
+  "createdBy": "user",
   "startImmediately": true
 }
 ```
 
 `task_create` requires a configured team, so launch the team first.
+
+This is the raw headless MCP payload. Headless calls do not receive the desktop UI's user
+defaults: `owner` by itself creates a `pending` task. If `createdBy`/`from` is also omitted,
+the task records no creation actor; assigning it to the team lead produces no inbox row because
+lead self-notification is suppressed. Use `createdBy: "user"` plus `startImmediately: true` when
+the task should be `in_progress` and delivered once to the owner. The actor/sender must be either
+`user` or a configured team member; an arbitrary integration name is rejected and does not create
+an inbox row. A blocked task remains pending even with `startImmediately: true`.
 
 ### 6.6 Send a Message To the Team
 

--- a/mcp-server/src/tools/taskTools.ts
+++ b/mcp-server/src/tools/taskTools.ts
@@ -90,20 +90,36 @@ export function registerTaskTools(server: Pick<FastMCP, 'addTool'>) {
   server.addTool({
     name: 'task_create',
     description:
-      'Create a team task. Always provide a stable idempotencyKey (or commandId UUID) and reuse it only when retrying the exact same request after timeout or response loss. Use a new key for every distinct task intent.',
+      "Create a team task. Raw/headless calls do not inject a user actor or auto-start: owner without createdBy/from/startImmediately creates a pending task with no recorded actor, and assigning it to the lead suppresses the lead's self-notification. For an immediate user-origin assignment, pass createdBy: 'user' and startImmediately: true. Always provide a stable idempotencyKey (or commandId UUID) and reuse it only when retrying the exact same request after timeout or response loss. Use a new key for every distinct task intent.",
     parameters: z.object({
       ...toolContextSchema,
       subject: z.string().min(1),
       description: z.string().optional(),
-      owner: z.string().optional(),
-      createdBy: z.string().optional(),
-      from: z.string().optional(),
+      owner: z
+        .string()
+        .optional()
+        .describe('Configured teammate to assign. An owner alone does not auto-start the task.'),
+      createdBy: z
+        .string()
+        .optional()
+        .describe(
+          "Explicit creation actor and assignment-notification sender. Use 'user' for a user-origin headless assignment."
+        ),
+      from: z
+        .string()
+        .optional()
+        .describe('Legacy actor/sender alternative, used only when createdBy is omitted.'),
       blockedBy: z.array(z.string().min(1)).optional(),
       related: z.array(z.string().min(1)).optional(),
       prompt: z.string().optional(),
       descriptionTaskRefs: z.array(taskRefSchema).optional(),
       promptTaskRefs: z.array(taskRefSchema).optional(),
-      startImmediately: z.boolean().optional(),
+      startImmediately: z
+        .boolean()
+        .optional()
+        .describe(
+          'Opt in to in_progress when an owner is present. Omitted/false stays pending; blocked tasks stay pending.'
+        ),
       commandId: z
         .string()
         .regex(CANONICAL_TASK_UUID_PATTERN, 'Must be a canonical task UUID (version 1-5)')

--- a/mcp-server/test/tools.test.ts
+++ b/mcp-server/test/tools.test.ts
@@ -1321,6 +1321,57 @@ describe('agent-teams-mcp tools', () => {
     );
   });
 
+  it('preserves the raw headless task_create defaults and requires explicit user-origin immediate delivery to the lead', async () => {
+    const claudeDir = makeClaudeDir();
+    const teamName = 'headless-task-create';
+    writeTeamConfig(claudeDir, teamName, {
+      members: [{ name: 'lead', role: 'team-lead' }],
+    });
+
+    const leadInboxPath = path.join(claudeDir, 'teams', teamName, 'inboxes', 'lead.json');
+    const queuedTask = parseJsonToolResult(
+      await getTool('task_create').execute({
+        claudeDir,
+        teamName,
+        subject: 'Queue raw headless work',
+        owner: 'lead',
+      })
+    );
+
+    expect(queuedTask.status).toBe('pending');
+    expect(queuedTask.createdBy).toBeUndefined();
+    expect(queuedTask.historyEvents?.[0]?.actor).toBeUndefined();
+    expect(fs.existsSync(leadInboxPath)).toBe(false);
+
+    const activeTask = parseJsonToolResult(
+      await getTool('task_create').execute({
+        claudeDir,
+        teamName,
+        subject: 'Deliver raw headless work now',
+        owner: 'lead',
+        createdBy: 'user',
+        startImmediately: true,
+      })
+    );
+
+    expect(activeTask.status).toBe('in_progress');
+    expect(activeTask.createdBy).toBe('user');
+    expect(activeTask.historyEvents?.[0]?.actor).toBe('user');
+    const leadInbox = JSON.parse(fs.readFileSync(leadInboxPath, 'utf8'));
+    expect(leadInbox).toHaveLength(1);
+    expect(leadInbox[0]).toMatchObject({
+      from: 'user',
+      to: 'lead',
+      source: 'system_notification',
+    });
+    expect(leadInbox[0].summary).toContain(`#${activeTask.displayId}`);
+
+    expect(getTool('task_create').description).toContain(
+      'Raw/headless calls do not inject a user actor or auto-start'
+    );
+    expect(getTool('task_create').description).toContain("createdBy: 'user'");
+  });
+
   it('uses Codex-native MCP wording for task_create owner notifications', async () => {
     const claudeDir = makeClaudeDir();
     const teamName = 'codex-owner';

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -126,6 +126,7 @@ import {
   setAliveTeamsProvider,
   setTeamWatchScopeChangeListener,
 } from '@main/services/infrastructure/teamWatchScope';
+import { FileWatcherStartupCoordinator } from '@main/services/infrastructure/FileWatcherStartupCoordinator';
 import { JsonScheduleRepository } from '@main/services/schedule/JsonScheduleRepository';
 import { ScheduledTaskExecutor } from '@main/services/schedule/ScheduledTaskExecutor';
 import { SchedulerService } from '@main/services/schedule/SchedulerService';
@@ -1136,7 +1137,6 @@ let rendererRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
 let rendererRecoveryAttempts = 0;
 let servicesReady = false;
 let rendererDidFinishLoad = false;
-let fileWatcherStartupStarted = false;
 let backgroundStartupTasksStarted = false;
 let appStartupHandlersRegistered = false;
 
@@ -1147,6 +1147,13 @@ let teamChangeCleanup: (() => void) | null = null;
 let shutdownPromise: Promise<void> | null = null;
 let shutdownComplete = false;
 const startupTimers = new Set<ReturnType<typeof setTimeout>>();
+const fileWatcherStartupCoordinator = new FileWatcherStartupCoordinator({
+  isServicesReady: () => servicesReady,
+  isShutdownStarted,
+  getActiveContext: () => contextRegistry.getActive(),
+  schedule: scheduleStartupTask,
+  platform: process.platform,
+});
 
 const SHUTDOWN_STEP_TIMEOUT_MS = 5_000;
 const STARTUP_RECOVERY_DELAY_MS = 10_000;
@@ -3243,22 +3250,6 @@ function runPostRendererStartupTasks(): void {
     return;
   }
 
-  if (!fileWatcherStartupStarted) {
-    fileWatcherStartupStarted = true;
-    // Start file watchers after both the visible window and main services are ready.
-    const activeContext = contextRegistry.getActive();
-    if (process.platform === 'win32') {
-      scheduleStartupTask(() => {
-        if (!fileWatcherStartupStarted || !servicesReady || !rendererDidFinishLoad) {
-          return;
-        }
-        activeContext.startFileWatcher();
-      }, 1500);
-    } else if (!isShutdownStarted()) {
-      activeContext.startFileWatcher();
-    }
-  }
-
   if (backgroundStartupTasksStarted) {
     return;
   }
@@ -3571,9 +3562,7 @@ function createWindow(): void {
     }
     markRendererUnavailable(mainWindow);
     rendererDidFinishLoad = false;
-    fileWatcherStartupStarted = false;
     branchStatusService?.resetAllTracking();
-    contextRegistry?.getActive()?.stopFileWatcher();
     if (mainWindow) {
       scheduleRendererRecovery(mainWindow);
     }
@@ -3652,6 +3641,7 @@ void app.whenReady().then(async () => {
       ready: true,
       error: null,
     });
+    fileWatcherStartupCoordinator.startWhenServicesReady();
     runPostRendererStartupTasks();
 
     // Listen for notification click events

--- a/src/main/services/infrastructure/FileWatcher.ts
+++ b/src/main/services/infrastructure/FileWatcher.ts
@@ -591,7 +591,6 @@ export class FileWatcher extends EventEmitter {
         watcherType === 'teams' ? (this.teamInboxWatchScopeProvider?.() ?? null) : null,
       backfillInitialScopedInboxFiles: watcherType === 'teams',
     });
-
     if (watcherType === 'teams') {
       this.teamsRegistry = registry;
     } else {

--- a/src/main/services/infrastructure/FileWatcher.ts
+++ b/src/main/services/infrastructure/FileWatcher.ts
@@ -589,6 +589,7 @@ export class FileWatcher extends EventEmitter {
       getScopedTeamNames: () => this.teamWatchScopeProvider?.() ?? null,
       getScopedInboxTeamNames: () =>
         watcherType === 'teams' ? (this.teamInboxWatchScopeProvider?.() ?? null) : null,
+      backfillInitialScopedInboxFiles: watcherType === 'teams',
     });
 
     if (watcherType === 'teams') {

--- a/src/main/services/infrastructure/FileWatcherStartupCoordinator.ts
+++ b/src/main/services/infrastructure/FileWatcherStartupCoordinator.ts
@@ -1,0 +1,44 @@
+export interface FileWatcherStartupCoordinatorOptions {
+  isServicesReady: () => boolean;
+  isShutdownStarted: () => boolean;
+  getActiveContext: () => { startFileWatcher(): void };
+  schedule: (action: () => void, delayMs: number) => void;
+  platform: NodeJS.Platform;
+}
+
+/**
+ * Starts the active context's FileWatcher once main-process services are ready.
+ *
+ * Renderer lifecycle is intentionally absent from this boundary. Inbox delivery
+ * is a main-process responsibility and must continue while the renderer reloads
+ * or recovers from a crash.
+ */
+export class FileWatcherStartupCoordinator {
+  private startupStarted = false;
+
+  constructor(private readonly options: FileWatcherStartupCoordinatorOptions) {}
+
+  startWhenServicesReady(): void {
+    if (
+      this.startupStarted ||
+      !this.options.isServicesReady() ||
+      this.options.isShutdownStarted()
+    ) {
+      return;
+    }
+
+    this.startupStarted = true;
+
+    if (this.options.platform === 'win32') {
+      this.options.schedule(() => {
+        if (!this.options.isServicesReady() || this.options.isShutdownStarted()) {
+          return;
+        }
+        this.options.getActiveContext().startFileWatcher();
+      }, 1500);
+      return;
+    }
+
+    this.options.getActiveContext().startFileWatcher();
+  }
+}

--- a/src/main/services/infrastructure/ServiceContext.ts
+++ b/src/main/services/infrastructure/ServiceContext.ts
@@ -139,8 +139,8 @@ export class ServiceContext {
 
   /**
    * Starts only cache cleanup, deferring FileWatcher to later.
-   * Use this at app startup so the window appears without waiting for fs.watch().
-   * Call startFileWatcher() separately after the window is visible.
+   * Use this at app startup so service construction does not wait for fs.watch().
+   * Call startFileWatcher() separately after main-process services are ready.
    */
   startCacheOnly(): void {
     if (this.disposed) {

--- a/src/main/services/infrastructure/TeamTaskWatchRegistry.ts
+++ b/src/main/services/infrastructure/TeamTaskWatchRegistry.ts
@@ -31,6 +31,12 @@ export interface TeamTaskWatchRegistryOptions {
    * fallback.
    */
   getScopedInboxTeamNames?: () => ReadonlySet<string> | null;
+  /**
+   * Replay existing inbox files from an explicit initial inbox scope. This is
+   * used for live teams only, so a task written before watcher readiness is not
+   * lost without replaying inboxes from historical stopped teams.
+   */
+  backfillInitialScopedInboxFiles?: boolean;
 }
 
 const RECONCILE_INTERVAL_MS = 30_000;
@@ -67,7 +73,8 @@ const TEAM_ROOT_FILES = new Set([
  *   Team root/task scope and inbox scope can differ: inboxes are normally only
  *   watched for live/running teams.
  * - Do not enable Chokidar polling here. Polling is owned by FileWatcher fallback.
- * - Initial app startup baseline must stay silent to avoid replaying old files.
+ * - Initial app startup baseline stays silent except for explicitly scoped live
+ *   inboxes when backfillInitialScopedInboxFiles is enabled.
  * - Newly discovered targets are scanned once so files created before rebuild
  *   are not lost.
  */
@@ -268,6 +275,19 @@ export class TeamTaskWatchRegistry {
     watcher.on('unlink', (changedPath) => handleEvent('unlink', changedPath));
     watcher.on('addDir', (changedPath) => handleEvent('addDir', changedPath));
     watcher.on('unlinkDir', (changedPath) => handleEvent('unlinkDir', changedPath));
+    watcher.on('ready', () => {
+      if (this.closed || generation !== this.generation) {
+        return;
+      }
+      // Wait until Chokidar has finished its ignored initial scan, then rescan
+      // only explicitly scoped live inboxes. A file created before ready is in
+      // this rescan; a file created after ready is emitted by Chokidar.
+      void this.emitInitialScopedInboxFiles(targets, generation).catch((error: unknown) => {
+        if (!this.closed && generation === this.generation) {
+          this.options.onError(error);
+        }
+      });
+    });
     watcher.on('error', (error) => {
       if (!this.closed && generation === this.generation) {
         this.options.onError(error);
@@ -304,6 +324,29 @@ export class TeamTaskWatchRegistry {
         }
       }
     }
+  }
+
+  private async emitInitialScopedInboxFiles(targets: string[], generation: number): Promise<void> {
+    if (
+      !this.options.backfillInitialScopedInboxFiles ||
+      this.options.kind !== 'teams' ||
+      !this.options.getScopedInboxTeamNames
+    ) {
+      return;
+    }
+
+    const scopedInboxTeams = this.options.getScopedInboxTeamNames();
+    if (scopedInboxTeams === null) {
+      return;
+    }
+
+    const inboxTargets = targets.filter((targetPath) => {
+      if (path.basename(targetPath) !== 'inboxes') {
+        return false;
+      }
+      return scopedInboxTeams.has(path.basename(path.dirname(targetPath)));
+    });
+    await this.emitExistingFilesForNewTargets(inboxTargets, generation);
   }
 
   private async collectTargets(): Promise<string[]> {

--- a/test/main/services/infrastructure/FileWatcher.test.ts
+++ b/test/main/services/infrastructure/FileWatcher.test.ts
@@ -1468,6 +1468,53 @@ describe('FileWatcher', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
+  it('replays an existing inbox file from the explicit initial live-team scope', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'filewatcher-live-inbox-backfill-'));
+    setClaudeBasePathOverride(tempDir);
+    const projectsDir = path.join(tempDir, 'projects');
+    const todosDir = path.join(tempDir, 'todos');
+    const teamsDir = path.join(tempDir, 'teams');
+    const tasksDir = path.join(tempDir, 'tasks');
+    fs.mkdirSync(projectsDir, { recursive: true });
+    fs.mkdirSync(todosDir, { recursive: true });
+    for (const teamName of ['live-team', 'stopped-team']) {
+      fs.mkdirSync(path.join(teamsDir, teamName, 'inboxes'), { recursive: true });
+      fs.mkdirSync(path.join(tasksDir, teamName), { recursive: true });
+      fs.writeFileSync(path.join(teamsDir, teamName, 'config.json'), '{}', 'utf8');
+      fs.writeFileSync(
+        path.join(teamsDir, teamName, 'inboxes', 'team-lead.json'),
+        '[{"read":false}]',
+        'utf8'
+      );
+    }
+    useRealAccess();
+
+    vi.mocked(fs.watch).mockImplementation(() => createFakeWatcher());
+
+    const dataCache = new DataCache(50, 10, false);
+    const watcher = new FileWatcher(dataCache, projectsDir, todosDir);
+    watcher.setTeamWatchScopeProvider(() => new Set(['live-team']));
+    watcher.setTeamInboxWatchScopeProvider(() => new Set(['live-team']));
+    const events: unknown[] = [];
+    watcher.on('team-change', (event) => events.push(event));
+    watcher.start();
+
+    await vi.waitFor(() => expect(chokidarMock.watch).toHaveBeenCalledTimes(2));
+    getChokidarWatcherForRoot(teamsDir).emit('ready');
+    await vi.waitFor(() => expect(events).toHaveLength(1));
+
+    expect(events).toEqual([
+      {
+        type: 'inbox',
+        teamName: 'live-team',
+        detail: 'inboxes/team-lead.json',
+      },
+    ]);
+
+    watcher.stop();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
   it('emits existing files once when reconciliation discovers new team and task directories', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'filewatcher-chokidar-new-files-'));
     setClaudeBasePathOverride(tempDir);

--- a/test/main/services/infrastructure/FileWatcherStartupCoordinator.test.ts
+++ b/test/main/services/infrastructure/FileWatcherStartupCoordinator.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { FileWatcherStartupCoordinator } from '../../../../src/main/services/infrastructure/FileWatcherStartupCoordinator';
+
+describe('FileWatcherStartupCoordinator', () => {
+  it('starts exactly once when main-process services become ready', () => {
+    let servicesReady = false;
+    const startFileWatcher = vi.fn();
+    const coordinator = new FileWatcherStartupCoordinator({
+      isServicesReady: () => servicesReady,
+      isShutdownStarted: () => false,
+      getActiveContext: () => ({ startFileWatcher }),
+      schedule: vi.fn(),
+      platform: 'darwin',
+    });
+
+    coordinator.startWhenServicesReady();
+    expect(startFileWatcher).not.toHaveBeenCalled();
+
+    servicesReady = true;
+    coordinator.startWhenServicesReady();
+    coordinator.startWhenServicesReady();
+
+    expect(startFileWatcher).toHaveBeenCalledOnce();
+  });
+
+  it('does not start during shutdown', () => {
+    const startFileWatcher = vi.fn();
+    const coordinator = new FileWatcherStartupCoordinator({
+      isServicesReady: () => true,
+      isShutdownStarted: () => true,
+      getActiveContext: () => ({ startFileWatcher }),
+      schedule: vi.fn(),
+      platform: 'linux',
+    });
+
+    coordinator.startWhenServicesReady();
+
+    expect(startFileWatcher).not.toHaveBeenCalled();
+  });
+
+  it('keeps the Windows delay but rechecks shutdown before starting', () => {
+    let shutdownStarted = false;
+    const startFileWatcher = vi.fn();
+    const schedule = vi.fn<(action: () => void, delayMs: number) => void>();
+    const coordinator = new FileWatcherStartupCoordinator({
+      isServicesReady: () => true,
+      isShutdownStarted: () => shutdownStarted,
+      getActiveContext: () => ({ startFileWatcher }),
+      schedule,
+      platform: 'win32',
+    });
+
+    coordinator.startWhenServicesReady();
+
+    expect(schedule).toHaveBeenCalledWith(expect.any(Function), 1500);
+    expect(startFileWatcher).not.toHaveBeenCalled();
+
+    shutdownStarted = true;
+    schedule.mock.calls[0]?.[0]();
+    expect(startFileWatcher).not.toHaveBeenCalled();
+  });
+
+  it('starts the current Windows context when it changes during the delay', () => {
+    const firstContextStart = vi.fn();
+    const secondContextStart = vi.fn();
+    let activeContext = { startFileWatcher: firstContextStart };
+    const schedule = vi.fn<(action: () => void, delayMs: number) => void>();
+    const coordinator = new FileWatcherStartupCoordinator({
+      isServicesReady: () => true,
+      isShutdownStarted: () => false,
+      getActiveContext: () => activeContext,
+      schedule,
+      platform: 'win32',
+    });
+
+    coordinator.startWhenServicesReady();
+    activeContext = { startFileWatcher: secondContextStart };
+    schedule.mock.calls[0]?.[0]();
+
+    expect(firstContextStart).not.toHaveBeenCalled();
+    expect(secondContextStart).toHaveBeenCalledOnce();
+  });
+});

--- a/test/main/services/infrastructure/TeamTaskWatchRegistry.test.ts
+++ b/test/main/services/infrastructure/TeamTaskWatchRegistry.test.ts
@@ -212,6 +212,51 @@ describe('TeamTaskWatchRegistry scoping', () => {
     });
   });
 
+  it('backfills only explicitly scoped live inboxes on initial startup', async () => {
+    const events: Array<{ eventType: string; relativePath: string }> = [];
+    const registry = new TeamTaskWatchRegistry({
+      kind: 'teams',
+      rootPath: root,
+      onChange: (eventType, relativePath) => {
+        events.push({ eventType, relativePath });
+      },
+      onError: () => {},
+      getScopedTeamNames: () => new Set(['alpha', 'beta']),
+      getScopedInboxTeamNames: () => new Set(['alpha']),
+      backfillInitialScopedInboxFiles: true,
+    });
+
+    await registry.start();
+    chokidarMock.instances.at(-1)?.emit('ready');
+    await vi.waitFor(() => expect(events).toHaveLength(1));
+    await registry.close();
+
+    expect(events).toEqual([
+      {
+        eventType: 'add',
+        relativePath: path.join('alpha', 'inboxes', 'team-lead.json'),
+      },
+    ]);
+  });
+
+  it('keeps the initial baseline silent when inbox scope falls back to all teams', async () => {
+    const onChange = vi.fn();
+    const registry = new TeamTaskWatchRegistry({
+      kind: 'teams',
+      rootPath: root,
+      onChange,
+      onError: () => {},
+      getScopedInboxTeamNames: () => null,
+      backfillInitialScopedInboxFiles: true,
+    });
+
+    await registry.start();
+    chokidarMock.instances.at(-1)?.emit('ready');
+    await registry.close();
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('coalesces a burst of addDir events into a single incremental watcher update', async () => {
     const registry = new TeamTaskWatchRegistry({
       kind: 'teams',


### PR DESCRIPTION
## Summary

- make FileWatcher startup a main-process responsibility independent of renderer load, reload, or crash recovery
- recover durable assignments written before watcher readiness only for explicitly scoped live-team inboxes
- document raw headless task creation semantics and propagate waitTimeoutMs to the initial team launch request

## Root cause

Raw MCP task_create does not apply desktop defaults. An owner-only assignment remains pending with no creation actor, and an assignment to the lead creates no inbox row because lead self-notification is suppressed. OpenCode bootstrap is intentionally silent with noReply and is not execution proof.

Runtime delivery itself is main-process-owned, but FileWatcher startup and shutdown were tied to renderer lifecycle. Chokidar ignoreInitial also left a readiness gap for inbox files written before the watcher became ready. Separately, the controller initial launch POST used its fixed default timeout instead of the caller-provided waitTimeoutMs.

## Verification

- ran the Electron desktop runtime with pnpm dev:mcp against new disposable /tmp sandbox projects only
- reproduced the owner-only task as pending with no actor and no inbox row
- verified explicit createdBy user plus startImmediately delivery through the OpenCode prompt ledger
- verified the teammate created and read back the required absolute-path file before completing the task
- verified a fresh source MCP launch returned ready after 23 seconds with waitTimeoutMs 120000
- 70 focused infrastructure tests passed
- 55 MCP tests passed
- 170 controller tests passed
- root typecheck, MCP source typecheck, and MCP test typecheck passed
- final xhigh review found no remaining P0-P2 findings after follow-up fixes

No real user project or team was used for runtime verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team launches now honor the configured wait timeout, including during the initial launch request.
  * Improved delivery of existing team inbox tasks when file watching starts.
  * File watching now starts reliably after services are ready and remains active during renderer crashes.

* **Documentation**
  * Expanded guidance for headless task delivery, task creation actors, auto-start behavior, and troubleshooting.

* **Tests**
  * Added coverage for launch timeouts, inbox backfilling, watcher startup, and headless task creation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->