### PR TITLE
fix(opencode): expose managed runtime to passive status

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   '@xmldom/xmldom': 0.8.13
   axios: 1.18.1
   body-parser: 2.3.0
+  browserslist: 4.28.8
   brace-expansion@1: 5.0.9
   brace-expansion@2: 5.0.9
   brace-expansion@5: 5.0.9
@@ -5445,18 +5446,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.28:
-    resolution: {integrity: sha512-Ic44hnOtFIgravCunj1ifSoQPSUrkNiJuH9Mf6jr2jjoA74icqV8wU0KuadXeOR8zuIJMOoTv0GuQjZ9ZYNMeA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.11.14:
     resolution: {integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==}
     engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  baseline-browser-mapping@2.9.14:
-    resolution: {integrity: sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==}
     hasBin: true
 
   bcrypt-pbkdf@1.0.2:
@@ -5507,16 +5499,6 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
-
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
-
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   browserslist@4.28.8:
     resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
@@ -5623,9 +5605,6 @@ packages:
 
   caniuse-lite@1.0.30001764:
     resolution: {integrity: sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==}
-
-  caniuse-lite@1.0.30001781:
-    resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
 
   caniuse-lite@1.0.30001792:
     resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
@@ -6492,12 +6471,6 @@ packages:
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
 
-  electron-to-chromium@1.5.267:
-    resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
-
-  electron-to-chromium@1.5.352:
-    resolution: {integrity: sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==}
-
   electron-to-chromium@1.5.406:
     resolution: {integrity: sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==}
 
@@ -6864,6 +6837,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -8754,12 +8728,6 @@ packages:
 
   node-pty@1.1.0:
     resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
-
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
-
-  node-releases@2.0.38:
-    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   node-releases@2.0.53:
     resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
@@ -11062,17 +11030,11 @@ packages:
     resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
     engines: {node: '>=4'}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
-
   update-browserslist-db@1.3.1:
     resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: 4.28.8
 
   uqr@0.1.3:
     resolution: {integrity: sha512-0rjE8iEJe4YmT9TOhwsZtqCMRLc5DXZUI2UEYUUg63ikBkqqE5EYWaI0etFe/5KUcmcYwLih2RND1kq+hrUJXA==}
@@ -17031,7 +16993,7 @@ snapshots:
 
   autoprefixer@10.4.23(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001764
       fraction.js: 5.3.4
       picocolors: 1.1.1
@@ -17040,7 +17002,7 @@ snapshots:
 
   autoprefixer@10.5.0(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001792
       fraction.js: 5.3.4
       picocolors: 1.1.1
@@ -17122,11 +17084,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.28: {}
-
   baseline-browser-mapping@2.11.14: {}
-
-  baseline-browser-mapping@2.9.14: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -17186,22 +17144,6 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
-
-  browserslist@4.28.1:
-    dependencies:
-      baseline-browser-mapping: 2.9.14
-      caniuse-lite: 1.0.30001781
-      electron-to-chromium: 1.5.267
-      node-releases: 2.0.27
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
-
-  browserslist@4.28.2:
-    dependencies:
-      baseline-browser-mapping: 2.10.28
-      caniuse-lite: 1.0.30001792
-      electron-to-chromium: 1.5.352
-      node-releases: 2.0.38
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   browserslist@4.28.8:
     dependencies:
@@ -17344,14 +17286,12 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.28.2
-      caniuse-lite: 1.0.30001792
+      browserslist: 4.28.8
+      caniuse-lite: 1.0.30001809
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
   caniuse-lite@1.0.30001764: {}
-
-  caniuse-lite@1.0.30001781: {}
 
   caniuse-lite@1.0.30001792: {}
 
@@ -17569,7 +17509,7 @@ snapshots:
 
   core-js-compat@3.49.0:
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
 
   core-js@3.49.0: {}
 
@@ -17648,7 +17588,7 @@ snapshots:
 
   cssnano-preset-default@7.0.17(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       css-declaration-sorter: 7.3.1(postcss@8.5.23)
       cssnano-utils: 5.0.3(postcss@8.5.23)
       postcss: 8.5.23
@@ -18127,10 +18067,6 @@ snapshots:
       mime: 2.6.0
     transitivePeerDependencies:
       - supports-color
-
-  electron-to-chromium@1.5.267: {}
-
-  electron-to-chromium@1.5.352: {}
 
   electron-to-chromium@1.5.406: {}
 
@@ -21195,10 +21131,6 @@ snapshots:
     dependencies:
       node-addon-api: 7.1.1
 
-  node-releases@2.0.27: {}
-
-  node-releases@2.0.38: {}
-
   node-releases@2.0.53: {}
 
   nopt@8.1.0:
@@ -21825,14 +21757,14 @@ snapshots:
   postcss-colormin@7.0.10(postcss@8.5.23):
     dependencies:
       '@colordx/core': 5.4.3
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
   postcss-convert-values@7.0.12(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
@@ -21891,7 +21823,7 @@ snapshots:
 
   postcss-merge-rules@7.0.11(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       cssnano-utils: 5.0.3(postcss@8.5.23)
       postcss: 8.5.23
@@ -21911,14 +21843,14 @@ snapshots:
 
   postcss-minify-params@7.0.9(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       cssnano-utils: 5.0.3(postcss@8.5.23)
       postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
   postcss-minify-selectors@7.1.2(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       cssesc: 3.0.0
       postcss: 8.5.23
@@ -21960,7 +21892,7 @@ snapshots:
 
   postcss-normalize-unicode@7.0.9(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
@@ -21982,7 +21914,7 @@ snapshots:
 
   postcss-reduce-initial@7.0.9(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       postcss: 8.5.23
 
@@ -23192,7 +23124,7 @@ snapshots:
 
   stylehacks@7.0.11(postcss@8.5.23):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.8
       postcss: 8.5.23
       postcss-selector-parser: 7.1.1
 
@@ -23949,18 +23881,6 @@ snapshots:
       node-int64: 0.4.0
 
   upath@2.0.1: {}
-
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
-    dependencies:
-      browserslist: 4.28.1
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
-    dependencies:
-      browserslist: 4.28.2
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.3.1(browserslist@4.28.8):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,7 @@ overrides:
   '@xmldom/xmldom': '0.8.13'
   'axios': '1.18.1'
   'body-parser': '2.3.0'
+  'browserslist': '4.28.8'
   'brace-expansion@1': '5.0.9'
   'brace-expansion@2': '5.0.9'
   'brace-expansion@5': '5.0.9'

--- a/src/main/services/runtime/providerAwareCliEnv.ts
+++ b/src/main/services/runtime/providerAwareCliEnv.ts
@@ -3,6 +3,7 @@ import { getCachedShellEnv } from '@main/utils/shellEnv';
 
 import {
   isSupportedOpenCodeRuntimeBinaryPath,
+  resolveAppManagedOpenCodeRuntimeBinaryPath,
   resolveVerifiedOpenCodeRuntimeBinaryPath,
 } from '../infrastructure/OpenCodeRuntimeInstallerService';
 
@@ -46,10 +47,26 @@ export interface ProviderAwareCliEnvResult {
   providerArgs: string[];
 }
 
+function resolveExplicitOpenCodeBinary(
+  options: Pick<ProviderAwareCliEnvOptions, 'env'>
+): string | null {
+  return (
+    [
+      options.env?.[OPENCODE_RUNTIME_BINARY_PATH_ENV],
+      options.env?.[OPENCODE_LEGACY_BINARY_PATH_ENV],
+      process.env[OPENCODE_RUNTIME_BINARY_PATH_ENV],
+      process.env[OPENCODE_LEGACY_BINARY_PATH_ENV],
+    ]
+      .find((candidate): candidate is string => Boolean(candidate?.trim()))
+      ?.trim() ?? null
+  );
+}
+
 /**
  * Builds the environment for passive runtime status/catalog commands only.
- * Keep this projection synchronous: passive reads must not enter managed-runtime,
- * MCP, credential, auth, or launch-argument resolution.
+ * Keep this projection synchronous: passive reads may project existing managed-runtime
+ * manifest metadata, but must not probe/install runtimes or enter MCP, credential,
+ * auth, or launch-argument resolution.
  */
 export function buildPassiveProviderStatusCliEnv(
   options: Pick<ProviderAwareCliEnvOptions, 'binaryPath' | 'providerId' | 'env' | 'shellEnv'>
@@ -59,6 +76,17 @@ export function buildPassiveProviderStatusCliEnv(
     shellEnv: options.shellEnv ?? getCachedShellEnv() ?? {},
     mergePathFallbacks: true,
   });
+  if (!options.providerId || options.providerId === 'opencode') {
+    const explicitOpenCodeBinary = resolveExplicitOpenCodeBinary(options);
+    const appManagedOpenCodeBinary = resolveAppManagedOpenCodeRuntimeBinaryPath();
+    if (appManagedOpenCodeBinary && !explicitOpenCodeBinary) {
+      // A cached login shell can retain a stale override after the app installs or updates
+      // its managed runtime. Keep only deliberate call/process overrides authoritative.
+      delete env[OPENCODE_RUNTIME_BINARY_PATH_ENV];
+      delete env[OPENCODE_LEGACY_BINARY_PATH_ENV];
+    }
+    applyOpenCodeRuntimeBinaryEnv(env, explicitOpenCodeBinary ?? appManagedOpenCodeBinary);
+  }
   removeGlobalElectronRunAsNodeEnv(env);
   return { env, connectionIssues: {}, providerArgs: [] };
 }
@@ -107,14 +135,7 @@ export async function buildProviderAwareCliEnv(
     mergePathFallbacks: true,
   });
   if (!resolvedProviderId || resolvedProviderId === 'opencode') {
-    const explicitOpenCodeBinary = [
-      options.env?.[OPENCODE_RUNTIME_BINARY_PATH_ENV],
-      options.env?.[OPENCODE_LEGACY_BINARY_PATH_ENV],
-      process.env[OPENCODE_RUNTIME_BINARY_PATH_ENV],
-      process.env[OPENCODE_LEGACY_BINARY_PATH_ENV],
-    ]
-      .find((candidate): candidate is string => Boolean(candidate?.trim()))
-      ?.trim();
+    const explicitOpenCodeBinary = resolveExplicitOpenCodeBinary(options);
     const supportedExplicitOpenCodeBinary =
       explicitOpenCodeBinary &&
       (await isSupportedOpenCodeRuntimeBinaryPath(explicitOpenCodeBinary).catch(() => false))

--- a/test/main/services/runtime/providerAwareCliEnv.test.ts
+++ b/test/main/services/runtime/providerAwareCliEnv.test.ts
@@ -13,6 +13,7 @@ const applyConfiguredConnectionEnvMock = vi.fn();
 const applyAllConfiguredConnectionEnvMock = vi.fn();
 const getConfiguredConnectionIssuesMock = vi.fn();
 const getConfiguredConnectionLaunchArgsMock = vi.fn();
+const resolveAppManagedOpenCodeRuntimeBinaryPathMock = vi.fn();
 const resolveVerifiedOpenCodeRuntimeBinaryPathMock = vi.fn();
 const isSupportedOpenCodeRuntimeBinaryPathMock = vi.fn();
 const resolveVerifiedAppManagedCodexRuntimeBinaryPathMock = vi.fn();
@@ -73,6 +74,8 @@ vi.mock('../../../../src/main/services/runtime/ProviderConnectionService', () =>
 vi.mock('../../../../src/main/services/infrastructure/OpenCodeRuntimeInstallerService', () => ({
   isSupportedOpenCodeRuntimeBinaryPath: (...args: unknown[]) =>
     isSupportedOpenCodeRuntimeBinaryPathMock(...args),
+  resolveAppManagedOpenCodeRuntimeBinaryPath: () =>
+    resolveAppManagedOpenCodeRuntimeBinaryPathMock(),
   resolveVerifiedOpenCodeRuntimeBinaryPath: () => resolveVerifiedOpenCodeRuntimeBinaryPathMock(),
 }));
 
@@ -111,6 +114,7 @@ describe('buildProviderAwareCliEnv', () => {
     );
     getConfiguredConnectionLaunchArgsMock.mockResolvedValue([]);
     getConfiguredConnectionIssuesMock.mockResolvedValue({});
+    resolveAppManagedOpenCodeRuntimeBinaryPathMock.mockReturnValue(null);
     resolveVerifiedOpenCodeRuntimeBinaryPathMock.mockResolvedValue(null);
     isSupportedOpenCodeRuntimeBinaryPathMock.mockResolvedValue(true);
     resolveVerifiedAppManagedCodexRuntimeBinaryPathMock.mockResolvedValue(null);
@@ -140,7 +144,7 @@ describe('buildProviderAwareCliEnv', () => {
     ]);
   });
 
-  it('keeps passive status env out of managed runtime, MCP, auth, and launch resolution', async () => {
+  it('keeps passive status env out of runtime probes, MCP, auth, and launch resolution', async () => {
     const { buildPassiveProviderStatusCliEnv } =
       await import('../../../../src/main/services/runtime/providerAwareCliEnv');
     const mkdirSpy = vi.spyOn(fs.promises, 'mkdir');
@@ -158,6 +162,7 @@ describe('buildProviderAwareCliEnv', () => {
       expect(result.providerArgs).toEqual([]);
       expect(result.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
       expect(result.env.CLAUDE_CODE_ENTRY_PROVIDER).toBe('codex');
+      expect(resolveAppManagedOpenCodeRuntimeBinaryPathMock).not.toHaveBeenCalled();
       expect(resolveVerifiedAppManagedCodexRuntimeBinaryPathMock).not.toHaveBeenCalled();
       expect(resolveVerifiedOpenCodeRuntimeBinaryPathMock).not.toHaveBeenCalled();
       expect(isSupportedOpenCodeRuntimeBinaryPathMock).not.toHaveBeenCalled();
@@ -177,6 +182,67 @@ describe('buildProviderAwareCliEnv', () => {
       copyFileSpy.mockRestore();
       rmSpy.mockRestore();
     }
+  });
+
+  it('projects existing app-managed OpenCode metadata into passive status env', async () => {
+    const managedBinaryPath = path.join('/managed', 'opencode', 'bin', 'opencode');
+    resolveAppManagedOpenCodeRuntimeBinaryPathMock.mockReturnValue(managedBinaryPath);
+    const { buildPassiveProviderStatusCliEnv } =
+      await import('../../../../src/main/services/runtime/providerAwareCliEnv');
+
+    const result = buildPassiveProviderStatusCliEnv({
+      binaryPath: '/mock/runtime',
+      providerId: 'opencode',
+      env: {},
+    });
+
+    expect(resolveAppManagedOpenCodeRuntimeBinaryPathMock).toHaveBeenCalledTimes(1);
+    expect(result.env.CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH).toBe(managedBinaryPath);
+    expect(result.env.OPENCODE_BIN_PATH).toBe(managedBinaryPath);
+    expect(result.env.PATH?.split(path.delimiter)[0]).toBe(path.dirname(managedBinaryPath));
+    expect(resolveVerifiedOpenCodeRuntimeBinaryPathMock).not.toHaveBeenCalled();
+    expect(isSupportedOpenCodeRuntimeBinaryPathMock).not.toHaveBeenCalled();
+    expect(resolveAgentTeamsMcpLaunchSpecMock).not.toHaveBeenCalled();
+    expect(applyConfiguredConnectionEnvMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves an explicit OpenCode binary override for passive status', async () => {
+    const explicitBinaryPath = path.join('/explicit', 'opencode');
+    resolveAppManagedOpenCodeRuntimeBinaryPathMock.mockReturnValue(
+      path.join('/managed', 'opencode')
+    );
+    const { buildPassiveProviderStatusCliEnv } =
+      await import('../../../../src/main/services/runtime/providerAwareCliEnv');
+
+    const result = buildPassiveProviderStatusCliEnv({
+      binaryPath: '/mock/runtime',
+      providerId: 'opencode',
+      env: { CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH: explicitBinaryPath },
+    });
+
+    expect(result.env.CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH).toBe(explicitBinaryPath);
+    expect(result.env.OPENCODE_BIN_PATH).toBe(explicitBinaryPath);
+    expect(result.env.PATH?.split(path.delimiter)[0]).toBe(path.dirname(explicitBinaryPath));
+  });
+
+  it('replaces a stale login-shell OpenCode override with app-managed metadata', async () => {
+    const managedBinaryPath = path.join('/managed', 'opencode');
+    getCachedShellEnvMock.mockReturnValue({
+      OPENCODE_BIN_PATH: path.join('/stale', 'shell', 'opencode'),
+      PATH: '/usr/bin',
+    });
+    resolveAppManagedOpenCodeRuntimeBinaryPathMock.mockReturnValue(managedBinaryPath);
+    const { buildPassiveProviderStatusCliEnv } =
+      await import('../../../../src/main/services/runtime/providerAwareCliEnv');
+
+    const result = buildPassiveProviderStatusCliEnv({
+      binaryPath: '/mock/runtime',
+      providerId: 'opencode',
+    });
+
+    expect(result.env.CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH).toBe(managedBinaryPath);
+    expect(result.env.OPENCODE_BIN_PATH).toBe(managedBinaryPath);
+    expect(result.env.PATH?.split(path.delimiter)[0]).toBe(path.dirname(managedBinaryPath));
   });
 
   it('builds provider-pinned CLI env and returns provider-specific issues', async () => {


### PR DESCRIPTION
## Summary

- project the installed app-managed OpenCode runtime into passive provider status checks
- ignore stale login-shell OpenCode paths when managed metadata is available
- preserve explicit call and process overrides

## Verification

- 98 focused runtime and bridge tests
- pnpm typecheck
- focused fast lint
- packaged macOS arm64 build with fresh orchestrator f4f52875
- CDP production check: managed status visible, models loaded, missing metadata error absent