### PR TITLE
fix(team): close headless delivery review gaps

### DIFF
--- a/agent-teams-controller/src/internal/runtime.js
+++ b/agent-teams-controller/src/internal/runtime.js
@@ -447,7 +447,7 @@ async function launchTeam(context, flags = {}) {
     {
       method: 'POST',
       body: request,
-      timeoutMs: normalizeTimeoutMs(flags.waitTimeoutMs || flags['wait-timeout-ms']),
+      timeoutMs: normalizeTimeoutMs(flags.waitTimeoutMs ?? flags['wait-timeout-ms']),
     }
   );
 
@@ -471,7 +471,7 @@ async function launchTeam(context, flags = {}) {
     baseUrls,
     context.teamName,
     launch.runId,
-    normalizeTimeoutMs(flags.waitTimeoutMs || flags['wait-timeout-ms'])
+    normalizeTimeoutMs(flags.waitTimeoutMs ?? flags['wait-timeout-ms'])
   );
 }
 

--- a/agent-teams-controller/test/controller.test.js
+++ b/agent-teams-controller/test/controller.test.js
@@ -3383,7 +3383,7 @@ controller.messages.sendMessage({
     }
   });
 
-  it('applies waitTimeoutMs to the initial launch request before readiness polling', async () => {
+  it('clamps waitTimeoutMs 0 for the initial launch request before readiness polling', async () => {
     const claudeDir = makeClaudeDir();
     const controller = createController({ teamName: 'my-team', claudeDir });
     const calls = [];
@@ -3400,7 +3400,7 @@ controller.messages.sendMessage({
           cwd: '/tmp/project',
           controlUrl: server.baseUrl,
           waitForReady: false,
-          waitTimeoutMs: 1000,
+          waitTimeoutMs: 0,
         })
       ).rejects.toThrow('Timed out calling team control API: /api/teams/my-team/launch');
       expect(calls).toEqual([

--- a/mcp-server/src/tools/taskTools.ts
+++ b/mcp-server/src/tools/taskTools.ts
@@ -2,7 +2,7 @@ import type { FastMCP } from 'fastmcp';
 import { z } from 'zod';
 
 import { agentBlocks, getController } from '../controller';
-import { assertConfiguredTeam } from '../utils/teamConfig';
+import { assertConfiguredTaskActor, assertConfiguredTeam } from '../utils/teamConfig';
 import { jsonTextContent, taskWriteResult, slimTask } from '../utils/format';
 import { taskRefSchema } from '../utils/schemas';
 import {
@@ -40,6 +40,23 @@ function normalizeTaskListLimit(limit: number | undefined): number {
     return DEFAULT_TASK_LIST_LIMIT;
   }
   return Math.min(Math.max(1, Math.floor(limit)), MAX_TASK_LIST_LIMIT);
+}
+
+function resolveTaskCreationActor(params: {
+  teamName: string;
+  claudeDir?: string;
+  createdBy?: string;
+  from?: string;
+}): { createdBy?: string; from?: string } {
+  const explicitActor = params.createdBy?.trim();
+  const fallbackActor = params.from?.trim();
+  const actor = explicitActor || fallbackActor;
+  if (!actor) {
+    return {};
+  }
+
+  const validatedActor = assertConfiguredTaskActor(params.teamName, actor, params.claudeDir);
+  return explicitActor ? { createdBy: validatedActor } : { from: validatedActor };
 }
 
 /** Allowed message source types for task_create_from_message provenance. Fail closed — only explicit user-originated sources. */
@@ -153,12 +170,12 @@ export function registerTaskTools(server: Pick<FastMCP, 'addTool'>) {
       assertConfiguredTeam(teamName, claudeDir);
       const controller = getController(teamName, claudeDir);
       const { taskBoard } = controller;
+      const taskActor = resolveTaskCreationActor({ teamName, claudeDir, createdBy, from });
       const payload = buildCreateTaskPayload({
         subject,
         description,
         owner,
-        createdBy,
-        from,
+        ...taskActor,
         blockedBy,
         related,
         prompt,
@@ -299,11 +316,12 @@ export function registerTaskTools(server: Pick<FastMCP, 'addTool'>) {
       }
 
       // 5. Forward into canonical create-task path
+      const taskActor = resolveTaskCreationActor({ teamName, claudeDir, createdBy });
       const payload = buildCreateTaskPayload({
         subject,
         description,
         owner,
-        createdBy,
+        ...taskActor,
         blockedBy,
         related,
         prompt,

--- a/mcp-server/src/utils/teamConfig.ts
+++ b/mcp-server/src/utils/teamConfig.ts
@@ -12,6 +12,7 @@ function resolveTeamPaths(
   claudeDir?: string
 ): {
   configPath: string;
+  membersMetaPath: string;
   metaPath: string;
 } {
   const controller = getController(teamName, claudeDir) as {
@@ -23,6 +24,7 @@ function resolveTeamPaths(
   }
   return {
     configPath: path.join(teamDir, 'config.json'),
+    membersMetaPath: path.join(teamDir, 'members.meta.json'),
     metaPath: path.join(teamDir, 'team.meta.json'),
   };
 }
@@ -56,9 +58,66 @@ function isDraftTeamMeta(value: Record<string, unknown> | null): boolean {
 export function assertConfiguredTeam(teamName: string, claudeDir?: string): void {
   const { configPath } = resolveTeamPaths(teamName, claudeDir);
   const parsed = readJsonObject(configPath);
-  if (!isConfiguredTeamConfig(parsed)) {
+  if (!parsed || !isConfiguredTeamConfig(parsed)) {
     throw new Error(unknownTeamMessage(teamName));
   }
+}
+
+export function assertConfiguredTaskActor(
+  teamName: string,
+  actor: string,
+  claudeDir?: string
+): string {
+  const normalizedActor = actor.trim();
+  if (normalizedActor.toLowerCase() === 'user') {
+    return 'user';
+  }
+
+  const { configPath, membersMetaPath } = resolveTeamPaths(teamName, claudeDir);
+  const parsed = readJsonObject(configPath);
+  if (!parsed || !isConfiguredTeamConfig(parsed)) {
+    throw new Error(unknownTeamMessage(teamName));
+  }
+
+  const memberNamesByKey = new Map<string, string>();
+  const applyMember = (member: unknown, fromMeta: boolean): void => {
+    if (!member || typeof member !== 'object') {
+      return;
+    }
+    const record = member as Record<string, unknown>;
+    const name = typeof record.name === 'string' ? record.name.trim() : '';
+    if (!name) {
+      return;
+    }
+    const key = name.toLowerCase();
+    if (fromMeta && typeof record.removedAt === 'number') {
+      memberNamesByKey.delete(key);
+      return;
+    }
+    memberNamesByKey.set(key, name);
+  };
+
+  if (Array.isArray(parsed.members)) {
+    for (const member of parsed.members) {
+      applyMember(member, false);
+    }
+  }
+
+  const membersMeta = readJsonObject(membersMetaPath);
+  if (Array.isArray(membersMeta?.members)) {
+    for (const member of membersMeta.members) {
+      applyMember(member, true);
+    }
+  }
+
+  const configuredMemberName = memberNamesByKey.get(normalizedActor.toLowerCase());
+  if (configuredMemberName) {
+    return configuredMemberName;
+  }
+
+  throw new Error(
+    `Unknown task actor "${normalizedActor}". Use "user" or a configured team member name.`
+  );
 }
 
 export function assertConfiguredOrDraftTeam(teamName: string, claudeDir?: string): void {

--- a/mcp-server/test/tools.test.ts
+++ b/mcp-server/test/tools.test.ts
@@ -854,13 +854,13 @@ describe('agent-teams-mcp tools', () => {
         teamName,
         subject: 'Review MCP adapter',
         owner: 'alice',
-        createdBy: 'ui-fixer',
+        createdBy: 'lead',
         descriptionTaskRefs: [dependencyRef],
         promptTaskRefs: [dependencyRef],
       })
     );
     expect(createdTask.status).toBe('pending');
-    expect(createdTask.historyEvents?.[0]?.actor).toBe('ui-fixer');
+    expect(createdTask.historyEvents?.[0]?.actor).toBe('lead');
     expect(createdTask.descriptionTaskRefs).toEqual([dependencyRef]);
     expect(createdTask.promptTaskRefs).toEqual([dependencyRef]);
 
@@ -1325,8 +1325,21 @@ describe('agent-teams-mcp tools', () => {
     const claudeDir = makeClaudeDir();
     const teamName = 'headless-task-create';
     writeTeamConfig(claudeDir, teamName, {
-      members: [{ name: 'lead', role: 'team-lead' }],
+      members: [
+        { name: 'lead', role: 'team-lead' },
+        { name: 'removed-member', role: 'developer' },
+      ],
     });
+    fs.writeFileSync(
+      path.join(claudeDir, 'teams', teamName, 'members.meta.json'),
+      JSON.stringify({
+        version: 1,
+        members: [
+          { name: 'meta-only', role: 'developer' },
+          { name: 'removed-member', removedAt: Date.now() },
+        ],
+      })
+    );
 
     const leadInboxPath = path.join(claudeDir, 'teams', teamName, 'inboxes', 'lead.json');
     const queuedTask = parseJsonToolResult(
@@ -1341,6 +1354,40 @@ describe('agent-teams-mcp tools', () => {
     expect(queuedTask.status).toBe('pending');
     expect(queuedTask.createdBy).toBeUndefined();
     expect(queuedTask.historyEvents?.[0]?.actor).toBeUndefined();
+    expect(fs.existsSync(leadInboxPath)).toBe(false);
+
+    const taskDir = path.join(claudeDir, 'tasks', teamName);
+    const metaActorTask = parseJsonToolResult(
+      await getTool('task_create').execute({
+        claudeDir,
+        teamName,
+        subject: 'Accept canonical metadata actor',
+        createdBy: 'META-ONLY',
+      })
+    );
+    expect(metaActorTask.createdBy).toBe('meta-only');
+    expect(metaActorTask.historyEvents?.[0]?.actor).toBe('meta-only');
+
+    const taskFilesBeforeRejectedActor = fs.readdirSync(taskDir);
+    for (const [actorField, actor] of [
+      ['createdBy', 'external-integration'],
+      ['from', 'external-integration'],
+      ['createdBy', 'removed-member'],
+    ] as const) {
+      await expect(
+        getTool('task_create').execute({
+          claudeDir,
+          teamName,
+          subject: `Reject forged ${actorField} actor`,
+          owner: 'lead',
+          [actorField]: actor,
+          startImmediately: true,
+        })
+      ).rejects.toThrow(
+        `Unknown task actor "${actor}". Use "user" or a configured team member name.`
+      );
+    }
+    expect(fs.readdirSync(taskDir)).toEqual(taskFilesBeforeRejectedActor);
     expect(fs.existsSync(leadInboxPath)).toBe(false);
 
     const activeTask = parseJsonToolResult(
@@ -2229,6 +2276,20 @@ describe('agent-teams-mcp tools', () => {
         timestamp: '2026-03-15T10:00:00.000Z',
         source: 'user_sent',
       });
+
+      const taskDir = path.join(claudeDir, 'tasks', teamName);
+      await expect(
+        getTool('task_create_from_message').execute({
+          claudeDir,
+          teamName,
+          messageId,
+          subject: 'Reject forged message-task actor',
+          createdBy: 'external-integration',
+        })
+      ).rejects.toThrow(
+        'Unknown task actor "external-integration". Use "user" or a configured team member name.'
+      );
+      expect(fs.readdirSync(taskDir)).toEqual([]);
 
       const created = parseJsonToolResult(
         await getTool('task_create_from_message').execute({

--- a/test/main/services/infrastructure/FileWatcherStartupCoordinator.test.ts
+++ b/test/main/services/infrastructure/FileWatcherStartupCoordinator.test.ts
@@ -1,6 +1,5 @@
+import { FileWatcherStartupCoordinator } from '@main/services/infrastructure/FileWatcherStartupCoordinator';
 import { describe, expect, it, vi } from 'vitest';
-
-import { FileWatcherStartupCoordinator } from '../../../../src/main/services/infrastructure/FileWatcherStartupCoordinator';
 
 describe('FileWatcherStartupCoordinator', () => {
   it('starts exactly once when main-process services become ready', () => {


### PR DESCRIPTION
## Summary

- preserve explicit `waitTimeoutMs: 0` through the launch request and readiness polling path
- reject unknown `createdBy`/`from` task actors before task or inbox persistence
- resolve task actors against the canonical config plus `members.meta.json` overlay/tombstone roster
- use the project alias in the watcher startup regression test

## Context

Follow-up to #534 for the two post-merge review findings. The headless OpenCode delivery path and sandbox live proof remain unchanged; this PR tightens boundary validation and the explicit-zero timeout contract.

## Verification

- `pnpm --dir agent-teams-controller test` - 170/170
- `pnpm --dir mcp-server test` - 55/55
- `pnpm --dir mcp-server typecheck`
- `pnpm --dir mcp-server typecheck:test`
- `pnpm typecheck`
- `pnpm vitest run test/main/services/infrastructure/FileWatcherStartupCoordinator.test.ts test/main/services/infrastructure/TeamTaskWatchRegistry.test.ts` - 13/13
- fast lint for changed TypeScript files
- `git diff --check`
- independent xhigh review - no P0-P2 findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit zero-second launch timeouts are now honored and properly clamped.
  * Task creation validates actors against configured team members, metadata, and removal status.
  * Unrecognized or removed actors are rejected without creating tasks or inbox entries.
  * Canonical actor names from team metadata are resolved correctly.

* **Tests**
  * Added coverage for timeout handling and task-actor validation across task creation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->