### PR TITLE
fix(team): explain blocked provider launch

### DIFF
--- a/src/features/codex-account/main/composition/createCodexAccountFeature.ts
+++ b/src/features/codex-account/main/composition/createCodexAccountFeature.ts
@@ -244,6 +244,7 @@ async function resolveCodexBinaryForAccountSnapshot(): Promise<string | null> {
 
 export interface CodexAccountFeatureFacade {
   getSnapshot(): Promise<CodexAccountSnapshotDto>;
+  getCachedSnapshot(): CodexAccountSnapshotDto | null;
   refreshSnapshot(options?: {
     includeRateLimits?: boolean;
     forceRefreshToken?: boolean;
@@ -313,6 +314,8 @@ class CodexAccountFeatureFacadeImpl implements CodexAccountFeatureFacade {
   async getSnapshot(): Promise<CodexAccountSnapshotDto> {
     return this.refreshSnapshot();
   }
+
+  getCachedSnapshot = (): CodexAccountSnapshotDto | null => deepClone(this.snapshotCache);
 
   async refreshSnapshot(options?: {
     includeRateLimits?: boolean;

--- a/src/features/workspace-trust/renderer/ui/WorkspaceTrustLaunchControl.tsx
+++ b/src/features/workspace-trust/renderer/ui/WorkspaceTrustLaunchControl.tsx
@@ -13,6 +13,7 @@ export const WorkspaceTrustLaunchControl = (props: {
   status: WorkspaceTrustDisplayStatus;
   isLaunchMode: boolean;
   disabled: boolean;
+  describedBy?: string;
   busy: boolean;
   submittingLabel: string;
   submitLabel: string;
@@ -37,6 +38,7 @@ export const WorkspaceTrustLaunchControl = (props: {
             : 'bg-emerald-600 text-white hover:bg-emerald-700'
         }
         disabled={props.disabled}
+        aria-describedby={props.describedBy}
         onClick={props.onClick}
       >
         {props.busy ? (

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
@@ -1203,10 +1203,14 @@ export class ClaudeMultimodelBridgeService {
     providerId: CliProviderId,
     options: { summary?: boolean; timeoutMs?: number; projectPath?: string | null } = {}
   ): Promise<CliProviderStatus> {
-    const { env, connectionIssues } = buildPassiveProviderStatusCliEnv({
+    const { env: passiveEnv, connectionIssues } = buildPassiveProviderStatusCliEnv({
       binaryPath,
       providerId,
     });
+    const env = await providerConnectionService.applyPassiveProviderStatusConnectionEnv(
+      passiveEnv,
+      providerId
+    );
     return this.getProviderStatusFromRuntimeStatusCommand(
       binaryPath,
       providerId,

--- a/src/main/services/runtime/ProviderConnectionService.ts
+++ b/src/main/services/runtime/ProviderConnectionService.ts
@@ -128,9 +128,8 @@ type CodexCliLoginStatusChecker = (params: {
   env: NodeJS.ProcessEnv;
 }) => Promise<CodexCliLoginStatusCheckResult>;
 
-type CodexAccountSnapshotReader = Pick<CodexAccountFeatureFacade, 'getSnapshot'> & {
-  refreshSnapshot?: CodexAccountFeatureFacade['refreshSnapshot'];
-};
+type CodexAccountSnapshotReader = Pick<CodexAccountFeatureFacade, 'getSnapshot'> &
+  Partial<Pick<CodexAccountFeatureFacade, 'getCachedSnapshot' | 'refreshSnapshot'>>;
 
 interface ProviderStatusEnrichmentOptions {
   hydrateModelCatalog?: boolean;
@@ -809,6 +808,45 @@ export class ProviderConnectionService {
     return env;
   }
 
+  /**
+   * Projects cached Codex account context into a read-only runtime status probe.
+   * This does not decrypt credentials, refresh account state, install runtimes,
+   * or run launch/login commands. The runtime status command remains responsible
+   * for producing authoritative authentication and launch evidence.
+   */
+  async applyPassiveProviderStatusConnectionEnv(
+    env: NodeJS.ProcessEnv,
+    providerId: CliProviderId
+  ): Promise<NodeJS.ProcessEnv> {
+    if (providerId !== 'codex') {
+      return env;
+    }
+
+    const snapshot = this.codexAccountFeature?.getCachedSnapshot?.() ?? null;
+    if (!snapshot) {
+      return env;
+    }
+    applyCodexRuntimeContextEnv(env, snapshot);
+    const readiness = evaluateCodexLaunchReadiness({
+      preferredAuthMode: snapshot.preferredAuthMode,
+      managedAccount: snapshot.managedAccount,
+      apiKey: snapshot.apiKey,
+      appServerState: snapshot.appServerState,
+      appServerStatusMessage: snapshot.appServerStatusMessage,
+      localActiveChatgptAccountPresent: snapshot.localActiveChatgptAccountPresent,
+    });
+
+    if (readiness.effectiveAuthMode === 'chatgpt') {
+      delete env.OPENAI_API_KEY;
+      delete env[CODEX_NATIVE_API_KEY_ENV_VAR];
+      applyCodexForcedLoginMethodEnv(env, 'chatgpt');
+      return env;
+    }
+
+    applyCodexForcedLoginMethodEnv(env, readiness.effectiveAuthMode === 'api_key' ? 'api' : null);
+    return env;
+  }
+
   async applyAllConfiguredConnectionEnv(
     env: NodeJS.ProcessEnv,
     options?: StoredApiKeyAccessOptions
@@ -1112,11 +1150,7 @@ export class ProviderConnectionService {
     const customProvider = this.getConfiguredCodexCustomProvider();
     if (customProvider) {
       const catalog = createCodexCustomProviderCatalog(customProvider);
-      const catalogDisplay = mergeProviderCatalogDisplayAuthority(
-        withConnection,
-        catalog,
-        'ready'
-      );
+      const catalogDisplay = mergeProviderCatalogDisplayAuthority(withConnection, catalog, 'ready');
       const statusMessage =
         withConnection.statusMessage ??
         (withConnection.connection?.apiKeyConfigured

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -125,6 +125,7 @@ import {
 import { loadProjectPathProjects, type ProjectPathProject } from './projectPathProjects';
 import { ProjectPathSelector } from './ProjectPathSelector';
 import { createLaunchGuard, useAuthorityGatedCliStatus } from './providerLaunchAuthority';
+import { ProviderLaunchAuthorityNotice } from './ProviderLaunchAuthorityNotice';
 import { buildProviderPrepareModelCacheKey } from './providerPrepareCacheKey';
 import {
   mergeReusableProviderPrepareModelResults,
@@ -197,6 +198,7 @@ const TEAM_COLOR_NAMES = [
 ] as const;
 
 const APP_TEAM_RUNTIME_DISALLOWED_TOOLS = 'TeamDelete,TodoWrite,TaskCreate,TaskUpdate';
+const CREATE_LAUNCH_AUTHORITY_BLOCKER_ID = 'create-team-launch-authority-blocker';
 
 function getProviderLabel(providerId: TeamProviderId): string {
   return getCatalogTeamProviderLabel(providerId) ?? 'Anthropic';
@@ -809,6 +811,8 @@ export const CreateTeamDialog = ({
     );
   }, [members, multimodelEnabled, selectedProviderId, soloTeam, syncModelsWithLead]);
   const launchGuard = createLaunchGuard(selectedMemberProviders, runtimeProviderStatusById);
+  const launchAuthorityBlockers = launchGuard.blockers(launchTeam);
+  const launchAuthorityBlocked = launchAuthorityBlockers.length > 0;
   const workspaceTrustStatus = useWorkspaceTrustStatus({
     enabled: open && canCreate && launchTeam && selectedMemberProviders.includes('anthropic'),
     projectPath: effectiveCwd || null,
@@ -2983,7 +2987,10 @@ export const CreateTeamDialog = ({
                 />
               </>
             ) : null}
-            {canCreate && launchTeam && effectivePrepare.state === 'ready' ? (
+            {canCreate &&
+            launchTeam &&
+            effectivePrepare.state === 'ready' &&
+            !launchAuthorityBlocked ? (
               <div>
                 <div className="flex items-center gap-1.5 text-xs font-medium text-emerald-400">
                   <CheckCircle2 className="size-3.5 shrink-0" />
@@ -3014,6 +3021,17 @@ export const CreateTeamDialog = ({
                   </div>
                 ) : null}
               </div>
+            ) : null}
+            {canCreate &&
+            launchTeam &&
+            effectivePrepare.state === 'ready' &&
+            launchAuthorityBlocked ? (
+              <ProviderLaunchAuthorityNotice
+                id={CREATE_LAUNCH_AUTHORITY_BLOCKER_ID}
+                action={t('launch.prepare.action.launch')}
+                blockers={launchAuthorityBlockers}
+                onOpenProviderSettings={setProviderSettingsProviderId}
+              />
             ) : null}
             {canCreate && launchTeam && effectivePrepare.state === 'failed' ? (
               <div className="text-xs">
@@ -3102,6 +3120,11 @@ export const CreateTeamDialog = ({
               <Button
                 size="lg"
                 className="min-w-32 text-sm"
+                aria-describedby={
+                  launchAuthorityBlocked && effectivePrepare.state === 'ready'
+                    ? CREATE_LAUNCH_AUTHORITY_BLOCKER_ID
+                    : undefined
+                }
                 disabled={
                   !canCreate ||
                   !draftLoaded ||

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -79,7 +79,6 @@ import { isTeamProviderId, normalizeOptionalTeamProviderId } from '@shared/utils
 import {
   AlertTriangle,
   Check,
-  CheckCircle2,
   ChevronDown,
   ChevronRight,
   ExternalLink,
@@ -124,6 +123,7 @@ import {
 import { loadProjectPathProjects, syntheticProjectFromPath } from './projectPathProjects';
 import { ProjectPathSelector } from './ProjectPathSelector';
 import { createLaunchGuard, useAuthorityGatedCliStatus } from './providerLaunchAuthority';
+import { ProviderLaunchAuthorityNotice } from './ProviderLaunchAuthorityNotice';
 import { buildProviderPrepareModelCacheKey } from './providerPrepareCacheKey';
 import {
   mergeReusableProviderPrepareModelResults,
@@ -131,6 +131,7 @@ import {
   runProviderPrepareDiagnostics,
 } from './providerPrepareDiagnostics';
 import { buildProviderPreparePlans, type ProviderPreparePlan } from './providerPreparePlans';
+import { ProviderPrepareReadyNotice } from './ProviderPrepareReadyNotice';
 import {
   buildProviderPrepareModelChecksSignature,
   buildProviderPrepareRuntimeStatusSignature,
@@ -259,6 +260,7 @@ export type LaunchTeamDialogProps =
   | LaunchDialogScheduleMode;
 
 const APP_TEAM_RUNTIME_DISALLOWED_TOOLS = 'TeamDelete,TodoWrite,TaskCreate,TaskUpdate';
+const LAUNCH_AUTHORITY_BLOCKER_ID = 'launch-team-launch-authority-blocker';
 const ANTHROPIC_AGENT_SDK_CREDIT_ARTICLE_URL =
   'https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan';
 
@@ -527,6 +529,8 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     [effectiveMemberDrafts, multimodelEnabled, selectedProviderId]
   );
   const launchGuard = createLaunchGuard(selectedMemberProviders, runtimeProviderStatusById);
+  const launchAuthorityBlockers = launchGuard.blockers(isLaunchMode);
+  const launchAuthorityBlocked = launchAuthorityBlockers.length > 0;
   const workspaceTrustStatus = useWorkspaceTrustStatus({
     enabled: open && isLaunchMode && selectedMemberProviders.includes('anthropic'),
     projectPath: effectiveCwd || null,
@@ -3170,39 +3174,26 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                 </>
               ) : null}
 
-              {effectivePrepare.state === 'ready' ? (
-                <div>
-                  <div className="flex items-center gap-1.5 text-xs font-medium text-emerald-400">
-                    <CheckCircle2 className="size-3.5 shrink-0" />
-                    <span>
-                      {prepareChecks.some((check) => check.status === 'notes') ||
-                      prepareWarnings.length > 0
-                        ? t('launch.prepare.readyWithNotes')
-                        : t('launch.prepare.ready')}
-                    </span>
-                  </div>
-                  {effectivePrepare.message ? (
-                    <p className="mt-0.5 pl-5 text-[11px] text-[var(--color-text-muted)]">
-                      {effectivePrepare.message}
-                    </p>
-                  ) : null}
-                  <ProvisioningProviderStatusList
-                    checks={prepareChecks}
-                    className="mt-1"
-                    onOpenProviderSettings={(providerId) =>
-                      setProviderSettingsProviderId(providerId)
-                    }
-                  />
-                  {prepareWarnings.length > 0 && prepareChecks.length === 0 ? (
-                    <div className="mt-0.5 space-y-0.5 pl-5">
-                      {prepareWarnings.map((warning, index) => (
-                        <p key={`${index}:${warning}`} className="text-[11px] text-sky-300">
-                          {warning}
-                        </p>
-                      ))}
-                    </div>
-                  ) : null}
-                </div>
+              {effectivePrepare.state === 'ready' && !launchAuthorityBlocked ? (
+                <ProviderPrepareReadyNotice
+                  checks={prepareChecks}
+                  message={effectivePrepare.message}
+                  warnings={prepareWarnings}
+                  onOpenProviderSettings={setProviderSettingsProviderId}
+                />
+              ) : null}
+
+              {effectivePrepare.state === 'ready' && launchAuthorityBlocked ? (
+                <ProviderLaunchAuthorityNotice
+                  id={LAUNCH_AUTHORITY_BLOCKER_ID}
+                  action={
+                    isRelaunch
+                      ? t('launch.prepare.action.relaunch')
+                      : t('launch.prepare.action.launch')
+                  }
+                  blockers={launchAuthorityBlockers}
+                  onOpenProviderSettings={setProviderSettingsProviderId}
+                />
               ) : null}
 
               {effectivePrepare.state === 'failed' ? (
@@ -3304,6 +3295,11 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
             status={workspaceTrustStatus}
             isLaunchMode={isLaunchMode}
             disabled={isDisabled}
+            describedBy={
+              isLaunchMode && launchAuthorityBlocked && effectivePrepare.state === 'ready'
+                ? LAUNCH_AUTHORITY_BLOCKER_ID
+                : undefined
+            }
             busy={isSubmitting || launchInFlight}
             submittingLabel={submittingLabel}
             submitLabel={submitLabel}

--- a/src/renderer/components/team/dialogs/ProviderLaunchAuthorityNotice.tsx
+++ b/src/renderer/components/team/dialogs/ProviderLaunchAuthorityNotice.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { useAppTranslation } from '@features/localization/renderer';
+import { AlertTriangle } from 'lucide-react';
+
+import {
+  getProvisioningProviderBackendSummary,
+  ProvisioningProviderStatusList,
+} from './ProvisioningProviderStatusList';
+
+import type { ProviderLaunchBlocker } from './providerLaunchAuthority';
+import type { TeamProviderId } from '@shared/types';
+
+export const ProviderLaunchAuthorityNotice = ({
+  action,
+  blockers,
+  id,
+  onOpenProviderSettings,
+}: {
+  action: string;
+  blockers: readonly ProviderLaunchBlocker[];
+  id: string;
+  onOpenProviderSettings: (providerId: TeamProviderId) => void;
+}): React.JSX.Element | null => {
+  const { t } = useAppTranslation('team');
+  if (blockers.length === 0) return null;
+
+  const checks = blockers.map((blocker) => ({
+    providerId: blocker.providerId,
+    status: 'failed' as const,
+    backendSummary: getProvisioningProviderBackendSummary(blocker.providerStatus),
+    details: [blocker.detail],
+  }));
+
+  return (
+    <div id={id} role="alert" aria-live="polite" className="text-xs">
+      <div className="flex items-start gap-2 text-red-300">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+        <div className="min-w-0">
+          <p className="font-medium">{t('launch.prepare.blocked', { action })}</p>
+          <p className="mt-0.5 text-red-300/80">{t('launch.prepare.someProvidersNeedAttention')}</p>
+        </div>
+      </div>
+      <ProvisioningProviderStatusList
+        checks={checks}
+        className="mt-2"
+        onOpenProviderSettings={onOpenProviderSettings}
+      />
+    </div>
+  );
+};

--- a/src/renderer/components/team/dialogs/ProviderPrepareReadyNotice.tsx
+++ b/src/renderer/components/team/dialogs/ProviderPrepareReadyNotice.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { useAppTranslation } from '@features/localization/renderer';
+import { CheckCircle2 } from 'lucide-react';
+
+import { ProvisioningProviderStatusList } from './ProvisioningProviderStatusList';
+
+import type { ProvisioningProviderCheck } from './ProvisioningProviderStatusList';
+import type { TeamProviderId } from '@shared/types';
+
+export const ProviderPrepareReadyNotice = ({
+  checks,
+  message,
+  onOpenProviderSettings,
+  warnings,
+}: {
+  checks: ProvisioningProviderCheck[];
+  message: string | null;
+  onOpenProviderSettings: (providerId: TeamProviderId) => void;
+  warnings: string[];
+}): React.JSX.Element => {
+  const { t } = useAppTranslation('team');
+  const hasNotes = checks.some((check) => check.status === 'notes') || warnings.length > 0;
+
+  return (
+    <div>
+      <div className="flex items-center gap-1.5 text-xs font-medium text-emerald-400">
+        <CheckCircle2 className="size-3.5 shrink-0" />
+        <span>{hasNotes ? t('launch.prepare.readyWithNotes') : t('launch.prepare.ready')}</span>
+      </div>
+      {message ? (
+        <p className="mt-0.5 pl-5 text-[11px] text-[var(--color-text-muted)]">{message}</p>
+      ) : null}
+      <ProvisioningProviderStatusList
+        checks={checks}
+        className="mt-1"
+        onOpenProviderSettings={onOpenProviderSettings}
+      />
+      {warnings.length > 0 && checks.length === 0 ? (
+        <div className="mt-0.5 space-y-0.5 pl-5">
+          {warnings.map((warning, index) => (
+            <p key={`${index}:${warning}`} className="text-[11px] text-sky-300">
+              {warning}
+            </p>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/src/renderer/components/team/dialogs/providerLaunchAuthority.ts
+++ b/src/renderer/components/team/dialogs/providerLaunchAuthority.ts
@@ -5,29 +5,91 @@ import {
   hasEffectiveProviderLaunchAuthority,
   useLaunchAuthorityGatedCliStatus,
 } from '@renderer/hooks/useEffectiveCliProviderStatus';
+import {
+  hasAuthoritativeProviderStatusEvidence,
+  isProviderModelCatalogExactReady,
+} from '@shared/utils/providerStatusAuthority';
 
 import type { CliInstallationStatus, CliProviderStatus, TeamProviderId } from '@shared/types';
 
 type RuntimeProviderStatusById = ReadonlyMap<TeamProviderId, CliProviderStatus | null | undefined>;
 
+export interface ProviderLaunchBlocker {
+  providerId: TeamProviderId;
+  providerStatus: CliProviderStatus | null;
+  detail: string;
+}
+
 export interface ProviderLaunchGuard {
   blocked(enabled: boolean, now?: number): boolean;
+  blockers(enabled: boolean, now?: number): ProviderLaunchBlocker[];
   reject(enabled: boolean, onRejected: () => void): boolean;
+}
+
+function getProviderStatusDetail(provider: CliProviderStatus): string | null {
+  return provider.detailMessage?.trim() || provider.statusMessage?.trim() || null;
+}
+
+function getProviderLaunchBlockerDetail(
+  providerId: TeamProviderId,
+  provider: CliProviderStatus | null | undefined,
+  now: number
+): string {
+  if (!provider) {
+    return 'Provider launch status is unavailable. Refresh the provider status.';
+  }
+
+  const statusDetail = getProviderStatusDetail(provider);
+  const connectedCodexAccount =
+    providerId === 'codex' && provider.connection?.codex?.launchAllowed === true;
+  if (connectedCodexAccount) {
+    return (
+      'The ChatGPT account is connected, but the Codex runtime has not confirmed launch ' +
+      'readiness. Refresh Codex status or reconnect ChatGPT in provider settings.'
+    );
+  }
+
+  if (!hasAuthoritativeProviderStatusEvidence(provider)) {
+    return statusDetail ?? 'Provider launch status could not be verified. Refresh provider status.';
+  }
+  if (provider.authenticated !== true) {
+    return statusDetail ?? 'Authentication is required before this provider can launch.';
+  }
+  if (!isProviderModelCatalogExactReady(provider, now)) {
+    return 'The verified model catalog is unavailable or stale. Refresh provider status.';
+  }
+  if (provider.capabilities.teamLaunch !== true) {
+    return statusDetail ?? 'This provider runtime is not available for team launch.';
+  }
+
+  return 'Provider launch readiness could not be confirmed. Refresh provider status.';
 }
 
 export function createLaunchGuard(
   providerIds: readonly TeamProviderId[],
   runtimeProviderStatusById: RuntimeProviderStatusById
 ): ProviderLaunchGuard {
-  const blocked = (enabled: boolean, now?: number): boolean =>
-    enabled &&
-    providerIds.some(
-      (providerId) =>
-        !hasEffectiveProviderLaunchAuthority(runtimeProviderStatusById.get(providerId), now)
-    );
+  const blockers = (enabled: boolean, now: number = Date.now()): ProviderLaunchBlocker[] => {
+    if (!enabled) return [];
+
+    return providerIds.flatMap((providerId) => {
+      const provider = runtimeProviderStatusById.get(providerId) ?? null;
+      return hasEffectiveProviderLaunchAuthority(provider, now)
+        ? []
+        : [
+            {
+              providerId,
+              providerStatus: provider,
+              detail: getProviderLaunchBlockerDetail(providerId, provider, now),
+            },
+          ];
+    });
+  };
+  const blocked = (enabled: boolean, now?: number): boolean => blockers(enabled, now).length > 0;
 
   return {
     blocked,
+    blockers,
     reject(enabled, onRejected) {
       if (!blocked(enabled)) return false;
       onRejected();

--- a/test/features/codex-account/main/createCodexAccountFeature.test.ts
+++ b/test/features/codex-account/main/createCodexAccountFeature.test.ts
@@ -371,6 +371,38 @@ describe('createCodexAccountFeature', () => {
     }
   });
 
+  it('exposes a cloned cached snapshot without refreshing account state', async () => {
+    readAccountMock.mockResolvedValue({
+      account: createAccountResponse(),
+      initialize: {
+        codexHome: '/Users/test/.codex',
+        platformFamily: 'unix',
+        platformOs: 'macos',
+      },
+    });
+
+    const feature = createCodexAccountFeature({
+      logger: createLoggerPort(),
+      configManager: createConfigManager('chatgpt'),
+    });
+
+    try {
+      expect(feature.getCachedSnapshot()).toBeNull();
+      const refreshed = await feature.refreshSnapshot();
+      readAccountMock.mockClear();
+      binaryResolveMock.mockClear();
+
+      const cached = feature.getCachedSnapshot();
+      expect(cached).toEqual(refreshed);
+      expect(cached).not.toBe(refreshed);
+      expect(cached?.runtimeContext).not.toBe(refreshed.runtimeContext);
+      expect(readAccountMock).not.toHaveBeenCalled();
+      expect(binaryResolveMock).not.toHaveBeenCalled();
+    } finally {
+      await feature.dispose();
+    }
+  });
+
   it('retries Codex binary discovery after cold shell env resolves before publishing runtime-missing', async () => {
     getCachedShellEnvMock.mockReturnValue(null);
     binaryResolveMock.mockImplementation(async () =>

--- a/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -22,6 +22,9 @@ const enrichProviderStatusMock = vi.fn((provider, _options?: { hydrateModelCatal
   Promise.resolve(provider)
 );
 const enrichProviderStatusesMock = vi.fn((providers) => Promise.resolve(providers));
+const applyPassiveProviderStatusConnectionEnvMock = vi.fn(
+  (env: NodeJS.ProcessEnv, _providerId: CliProviderId) => Promise.resolve(env)
+);
 
 async function execCliWithAuthoritativeRuntimeFixtures(...args: Parameters<typeof execCliMock>) {
   const result = await execCliMock(...args);
@@ -94,6 +97,9 @@ vi.mock('fs', () => ({
 
 vi.mock('@main/services/runtime/ProviderConnectionService', () => ({
   providerConnectionService: {
+    applyPassiveProviderStatusConnectionEnv: (
+      ...args: Parameters<typeof applyPassiveProviderStatusConnectionEnvMock>
+    ) => applyPassiveProviderStatusConnectionEnvMock(...args),
     enrichProviderStatus: (...args: Parameters<typeof enrichProviderStatusMock>) =>
       enrichProviderStatusMock(...args),
     enrichProviderStatuses: (...args: Parameters<typeof enrichProviderStatusesMock>) =>
@@ -341,6 +347,7 @@ describe('ClaudeMultimodelBridgeService', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    applyPassiveProviderStatusConnectionEnvMock.mockImplementation((env) => Promise.resolve(env));
     resolveInteractiveShellEnvMock.mockResolvedValue({});
     buildProviderAwareCliEnvMock.mockImplementation(
       ({ providerId }: { providerId?: string } = {}) =>
@@ -418,6 +425,47 @@ describe('ClaudeMultimodelBridgeService', () => {
       exitCode: 0,
     };
   }
+
+  it('adds cached ChatGPT context to passive Codex runtime status without using the active env builder', async () => {
+    applyPassiveProviderStatusConnectionEnvMock.mockImplementation(async (env, providerId) => ({
+      ...env,
+      ...(providerId === 'codex'
+        ? {
+            CODEX_CLI_PATH: '/Applications/ChatGPT.app/Contents/Resources/codex',
+            CODEX_HOME: '/Users/tester/.codex',
+            CLAUDE_CODE_CODEX_FORCED_LOGIN_METHOD: 'chatgpt',
+          }
+        : {}),
+    }));
+    execCliMock.mockResolvedValue(statusReply('codex', fullStatusFixture('codex')));
+    const { ClaudeMultimodelBridgeService } =
+      await import('@main/services/runtime/ClaudeMultimodelBridgeService');
+    const service = new ClaudeMultimodelBridgeService();
+
+    const provider = await service.getProviderStatus('/mock/runtime', 'codex');
+
+    expect(provider).toMatchObject({
+      providerId: 'codex',
+      authenticated: true,
+      capabilities: { teamLaunch: true },
+    });
+    expect(applyPassiveProviderStatusConnectionEnvMock).toHaveBeenCalledWith(
+      expect.objectContaining({ CLAUDE_CODE_ENTRY_PROVIDER: 'codex' }),
+      'codex'
+    );
+    expect(execCliMock).toHaveBeenCalledWith(
+      '/mock/runtime',
+      ['runtime', 'status', '--json', '--provider', 'codex', '--summary'],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          CODEX_CLI_PATH: '/Applications/ChatGPT.app/Contents/Resources/codex',
+          CODEX_HOME: '/Users/tester/.codex',
+          CLAUDE_CODE_CODEX_FORCED_LOGIN_METHOD: 'chatgpt',
+        }),
+      })
+    );
+    expect(buildProviderAwareCliEnvMock).not.toHaveBeenCalled();
+  });
 
   it.each(
     (['anthropic', 'codex', 'opencode'] as const).flatMap((providerId) =>

--- a/test/main/services/runtime/ClaudeMultimodelStatusCatalogCore.test.ts
+++ b/test/main/services/runtime/ClaudeMultimodelStatusCatalogCore.test.ts
@@ -27,6 +27,7 @@ vi.mock('@main/services/runtime/providerAwareCliEnv', () => ({
 
 vi.mock('@main/services/runtime/ProviderConnectionService', () => ({
   providerConnectionService: {
+    applyPassiveProviderStatusConnectionEnv: (env: NodeJS.ProcessEnv) => Promise.resolve(env),
     enrichProviderStatus: (...args: Parameters<typeof enrichProviderStatusMock>) =>
       enrichProviderStatusMock(...args),
     enrichProviderStatuses: (providers: unknown) => Promise.resolve(providers),

--- a/test/main/services/runtime/ProviderConnectionService.test.ts
+++ b/test/main/services/runtime/ProviderConnectionService.test.ts
@@ -1453,6 +1453,74 @@ describe('ProviderConnectionService', () => {
     });
   });
 
+  it('projects cached ChatGPT runtime context into passive Codex status probes', async () => {
+    const { ProviderConnectionService } =
+      await import('@main/services/runtime/ProviderConnectionService');
+    const getSnapshot = vi.fn().mockRejectedValue(new Error('passive status must not refresh'));
+    const getCachedSnapshot = vi.fn().mockReturnValue(createCodexSnapshot());
+    const lookupPreferred = vi.fn();
+    const service = new ProviderConnectionService(
+      { lookupPreferred } as never,
+      { getConfig: () => createConfig('auto') } as never
+    );
+    service.setCodexAccountFeature({ getSnapshot, getCachedSnapshot });
+
+    const env = await service.applyPassiveProviderStatusConnectionEnv(
+      {
+        OPENAI_API_KEY: 'must-not-leak-to-chatgpt-status',
+        CODEX_API_KEY: 'must-not-leak-to-chatgpt-status',
+      },
+      'codex'
+    );
+
+    expect(env).toMatchObject({
+      CODEX_CLI_PATH: '/opt/codex/bin/codex',
+      CODEX_HOME: '/Users/tester/.codex-custom',
+      CLAUDE_CODE_CODEX_FORCED_LOGIN_METHOD: 'chatgpt',
+    });
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.CODEX_API_KEY).toBeUndefined();
+    expect(getCachedSnapshot).toHaveBeenCalledTimes(1);
+    expect(getSnapshot).not.toHaveBeenCalled();
+    expect(lookupPreferred).not.toHaveBeenCalled();
+    expect(execCliMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps passive non-Codex status probes free of account resolution', async () => {
+    const { ProviderConnectionService } =
+      await import('@main/services/runtime/ProviderConnectionService');
+    const getSnapshot = vi.fn().mockResolvedValue(createCodexSnapshot());
+    const getCachedSnapshot = vi.fn().mockReturnValue(createCodexSnapshot());
+    const service = new ProviderConnectionService(
+      { lookupPreferred: vi.fn() } as never,
+      { getConfig: () => createConfig('auto') } as never
+    );
+    service.setCodexAccountFeature({ getSnapshot, getCachedSnapshot });
+    const env = { ANTHROPIC_API_KEY: 'existing' };
+
+    expect(await service.applyPassiveProviderStatusConnectionEnv(env, 'anthropic')).toBe(env);
+    expect(getSnapshot).not.toHaveBeenCalled();
+    expect(getCachedSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('leaves passive Codex status env unchanged when no account snapshot is cached', async () => {
+    const { ProviderConnectionService } =
+      await import('@main/services/runtime/ProviderConnectionService');
+    const getSnapshot = vi.fn().mockRejectedValue(new Error('passive status must not refresh'));
+    const getCachedSnapshot = vi.fn().mockReturnValue(null);
+    const service = new ProviderConnectionService(
+      { lookupPreferred: vi.fn() } as never,
+      { getConfig: () => createConfig('auto') } as never
+    );
+    service.setCodexAccountFeature({ getSnapshot, getCachedSnapshot });
+    const env = { CODEX_CLI_PATH: '/existing/codex' };
+
+    expect(await service.applyPassiveProviderStatusConnectionEnv(env, 'codex')).toBe(env);
+    expect(env).toEqual({ CODEX_CLI_PATH: '/existing/codex' });
+    expect(getCachedSnapshot).toHaveBeenCalledTimes(1);
+    expect(getSnapshot).not.toHaveBeenCalled();
+  });
+
   it('mirrors a stored OpenAI key into CODEX_API_KEY for native Codex launches', async () => {
     const lookupPreferred = vi.fn().mockResolvedValue({
       envVarName: 'OPENAI_API_KEY',

--- a/test/main/services/team/Issue443DesktopContract.safe-e2e.test.ts
+++ b/test/main/services/team/Issue443DesktopContract.safe-e2e.test.ts
@@ -54,6 +54,7 @@ vi.mock('@main/services/runtime/providerAwareCliEnv', () => ({
 }));
 vi.mock('@main/services/runtime/ProviderConnectionService', () => ({
   providerConnectionService: {
+    applyPassiveProviderStatusConnectionEnv: (env: NodeJS.ProcessEnv) => Promise.resolve(env),
     enrichProviderStatus: (provider: unknown) => Promise.resolve(provider),
     enrichProviderStatuses: (providers: unknown) => Promise.resolve(providers),
   },

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -305,16 +305,24 @@ vi.mock('@renderer/components/ui/button', () => ({
     type,
     disabled,
     className,
+    'aria-describedby': ariaDescribedBy,
   }: {
     children: React.ReactNode;
     onClick?: () => void;
     type?: 'button' | 'submit' | 'reset';
     disabled?: boolean;
     className?: string;
+    'aria-describedby'?: string;
   }) =>
     React.createElement(
       'button',
-      { type: type ?? 'button', onClick, disabled, className },
+      {
+        type: type ?? 'button',
+        onClick,
+        disabled,
+        className,
+        'aria-describedby': ariaDescribedBy,
+      },
       children
     ),
 }));
@@ -473,7 +481,17 @@ vi.mock('@renderer/components/team/dialogs/provisioningModelIssues', () => ({
 }));
 
 vi.mock('@renderer/components/team/dialogs/ProvisioningProviderStatusList', () => ({
-  ProvisioningProviderStatusList: () => React.createElement('div', null, 'provider-status-list'),
+  ProvisioningProviderStatusList: ({
+    checks,
+  }: {
+    checks: Array<{ providerId: string; details: string[] }>;
+  }) =>
+    React.createElement(
+      'div',
+      null,
+      'provider-status-list ',
+      checks.flatMap((check) => check.details).join(' ')
+    ),
   deriveEffectiveProvisioningPrepareState: ({
     state,
     message,
@@ -820,6 +838,12 @@ describe('LaunchTeamDialog', () => {
     expect(onLaunch).not.toHaveBeenCalled();
     await act(async () => vi.runOnlyPendingTimersAsync());
     expect(launchButton?.disabled).toBe(true);
+    expect(launchHost.textContent).not.toContain('All selected providers are ready.');
+    expect(launchHost.textContent).toContain('Runtime environment is not available');
+    expect(launchHost.textContent).toContain('verified model catalog is unavailable or stale');
+    expect(launchButton?.getAttribute('aria-describedby')).toBe(
+      'launch-team-launch-authority-blocker'
+    );
     await act(async () => launchDialogRoot.unmount());
 
     vi.setSystemTime(baseTime);
@@ -862,6 +886,78 @@ describe('LaunchTeamDialog', () => {
     await act(async () => vi.runOnlyPendingTimersAsync());
     expect(createButton?.disabled).toBe(true);
     await act(async () => createDialogRoot.unmount());
+  });
+
+  it('shows the Codex account/runtime launch mismatch when Create is disabled', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    localStorage.setItem('team:lastSelectedProvider', 'codex');
+    localStorage.setItem('team:lastSelectedModel:codex', 'gpt-5.5');
+    createTeamDraftMock.state.soloTeam = true;
+    const readyCodex = createAuthoritativeProviderStatus('codex', ['gpt-5.5']);
+    storeState.cliStatus = {
+      flavor: 'agent_teams_orchestrator',
+      providers: [
+        {
+          ...readyCodex,
+          authenticated: false,
+          authMethod: null,
+          statusMessage: 'Codex native runtime unavailable',
+          detailMessage: 'Codex native runtime requires CODEX_API_KEY or OPENAI_API_KEY.',
+          capabilities: { ...readyCodex.capabilities, teamLaunch: false },
+          connection: {
+            codex: {
+              effectiveAuthMode: 'chatgpt',
+              launchAllowed: true,
+              launchIssueMessage: null,
+              launchReadinessState: 'ready_chatgpt',
+            },
+          },
+        },
+      ],
+    } as any;
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    await act(async () => {
+      root.render(
+        React.createElement(CreateTeamDialog, {
+          open: true,
+          canCreate: true,
+          provisioningErrorsByTeam: {},
+          existingTeamNames: [],
+          activeTeams: [],
+          defaultProjectPath: '/tmp/project',
+          onClose: vi.fn(),
+          onCreate: vi.fn(async () => {}),
+          onOpenTeam: vi.fn(),
+        })
+      );
+      await flush();
+    });
+    for (
+      let attempt = 0;
+      attempt < 10 && !host.textContent?.includes('runtime has not confirmed launch readiness');
+      attempt += 1
+    ) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await flush();
+      });
+    }
+
+    const createButton = host.querySelector<HTMLButtonElement>(
+      'button[aria-describedby="create-team-launch-authority-blocker"]'
+    );
+    expect(createButton?.disabled).toBe(true);
+    expect(host.textContent).toContain('Runtime environment is not available - launch is blocked');
+    expect(host.textContent).toContain(
+      'ChatGPT account is connected, but the Codex runtime has not confirmed launch readiness'
+    );
+    expect(host.textContent).not.toContain('All selected providers are ready.');
+    expect(host.textContent).not.toContain('CODEX_API_KEY');
+
+    await act(async () => root.unmount());
   });
 
   it('renders relaunch-specific title, warning and submit label', async () => {
@@ -3577,70 +3673,30 @@ describe('LaunchTeamDialog', () => {
       flavor: 'agent_teams_orchestrator',
       providers: [
         {
-          providerId: 'anthropic',
-          supported: true,
-          authenticated: true,
-          authMethod: 'api_key',
-          verificationState: 'verified',
+          ...createAuthoritativeProviderStatus('anthropic', ['haiku']),
           modelVerificationState: 'verified',
-          statusMessage: null,
-          detailMessage: null,
-          models: ['haiku'],
-          modelCatalog: {
-            source: 'live',
-            status: 'ready',
-            models: [{ id: 'haiku' }],
-          },
-          capabilities: {
-            teamLaunch: true,
-            oneShot: true,
-          },
         },
         {
-          providerId: 'codex',
-          supported: true,
-          authenticated: true,
+          ...createAuthoritativeProviderStatus('codex', ['gpt-5.5']),
           authMethod: 'chatgpt',
-          verificationState: 'verified',
           modelVerificationState: 'verified',
-          statusMessage: null,
-          detailMessage: null,
           selectedBackendId: 'codex-native',
           resolvedBackendId: 'codex-native',
-          models: ['gpt-5.5'],
-          modelCatalog: {
-            source: 'app-server',
-            status: 'ready',
-            models: [{ id: 'gpt-5.5' }],
-          },
-          capabilities: {
-            teamLaunch: true,
-            oneShot: true,
-          },
         },
         {
-          providerId: 'opencode',
-          supported: true,
-          authenticated: true,
+          ...createAuthoritativeProviderStatus('opencode', ['opencode/big-pickle']),
           authMethod: 'opencode_managed',
-          verificationState: 'verified',
           modelVerificationState: 'verified',
           statusMessage: 'warming up',
           detailMessage: 'first render',
-          models: ['opencode/big-pickle'],
-          modelCatalog: {
-            source: 'app-server',
-            status: 'ready',
-            models: [{ id: 'opencode/big-pickle' }],
-          },
           capabilities: {
             teamLaunch: true,
             oneShot: false,
+            extensions: createDefaultCliExtensionCapabilities(),
           },
         },
       ],
     } as any;
-
     let resolvePrepare!: (value: {
       status: 'ready';
       warnings: [];
@@ -3717,7 +3773,12 @@ describe('LaunchTeamDialog', () => {
     expect(vi.mocked(runProviderPrepareDiagnostics)).toHaveBeenCalledTimes(
       callsAfterSameSignatureRerender
     );
-    expect(host.textContent).toContain('All selected providers are ready.');
+    expect(host.textContent).not.toContain('All selected providers are ready.');
+    expect(host.textContent).toContain('Runtime environment is not available');
+    const authorityBlockedCreateButton = host.querySelector<HTMLButtonElement>(
+      'button[aria-describedby="create-team-launch-authority-blocker"]'
+    );
+    expect(authorityBlockedCreateButton?.disabled).toBe(true);
 
     await act(async () => {
       root.unmount();

--- a/test/renderer/components/team/dialogs/providerLaunchAuthority.test.ts
+++ b/test/renderer/components/team/dialogs/providerLaunchAuthority.test.ts
@@ -1,0 +1,150 @@
+import { createLaunchGuard } from '@renderer/components/team/dialogs/providerLaunchAuthority';
+import { createDefaultCliExtensionCapabilities } from '@shared/utils/providerExtensionCapabilities';
+import { describe, expect, it } from 'vitest';
+
+import type { CliProviderStatus } from '@shared/types';
+
+const NOW = Date.parse('2026-09-01T20:00:00.000Z');
+
+function createReadyProvider(providerId: 'anthropic' | 'codex'): CliProviderStatus {
+  const modelId = providerId === 'codex' ? 'gpt-5.6-sol' : 'opus';
+  return {
+    providerId,
+    displayName: providerId,
+    supported: true,
+    authenticated: true,
+    authMethod: providerId === 'codex' ? 'chatgpt' : 'api_key',
+    verificationState: 'verified',
+    statusCheckOutcome: 'authoritative',
+    canLoginFromUi: false,
+    statusMessage: null,
+    detailMessage: null,
+    models: [modelId],
+    modelAvailability: [],
+    modelCatalogRefreshState: 'ready',
+    modelCatalog: {
+      schemaVersion: 1,
+      providerId,
+      source: 'app-server',
+      status: 'ready',
+      fetchedAt: '2026-09-01T19:55:00.000Z',
+      staleAt: '2026-09-01T20:05:00.000Z',
+      defaultModelId: modelId,
+      defaultLaunchModel: modelId,
+      models: [
+        {
+          id: modelId,
+          launchModel: modelId,
+          displayName: modelId,
+          hidden: false,
+          supportedReasoningEfforts: [],
+          defaultReasoningEffort: null,
+          inputModalities: ['text'],
+          supportsPersonality: false,
+          isDefault: true,
+          upgrade: false,
+          source: 'app-server',
+        },
+      ],
+      diagnostics: { configReadState: 'ready', appServerState: 'healthy' },
+    },
+    capabilities: {
+      teamLaunch: true,
+      oneShot: true,
+      extensions: createDefaultCliExtensionCapabilities(),
+    },
+  };
+}
+
+describe('createLaunchGuard', () => {
+  it('reports no blockers when every selected provider has current launch authority', () => {
+    const provider = createReadyProvider('anthropic');
+    const guard = createLaunchGuard(['anthropic'], new Map([['anthropic', provider]]));
+
+    expect(guard.blocked(true, NOW)).toBe(false);
+    expect(guard.blockers(true, NOW)).toEqual([]);
+  });
+
+  it('explains the Codex account/runtime mismatch instead of repeating an API-key error', () => {
+    const provider = createReadyProvider('codex');
+    const blockedProvider: CliProviderStatus = {
+      ...provider,
+      authenticated: false,
+      authMethod: null,
+      statusMessage: 'Codex native runtime unavailable',
+      detailMessage: 'Codex native runtime requires CODEX_API_KEY or OPENAI_API_KEY.',
+      capabilities: { ...provider.capabilities, teamLaunch: false },
+      connection: {
+        configurableAuthModes: ['auto', 'chatgpt', 'api_key'],
+        configuredAuthMode: 'auto',
+        supportsOAuth: false,
+        supportsApiKey: true,
+        apiKeyConfigured: false,
+        apiKeySource: null,
+        apiKeySourceLabel: null,
+        compatibleEndpoint: null,
+        codex: {
+          preferredAuthMode: 'auto',
+          effectiveAuthMode: 'chatgpt',
+          appServerState: 'healthy',
+          appServerStatusMessage: null,
+          managedAccount: { type: 'chatgpt', email: 'user@example.com', planType: 'pro' },
+          requiresOpenaiAuth: true,
+          localAccountArtifactsPresent: true,
+          localActiveChatgptAccountPresent: true,
+          login: { status: 'idle', error: null, startedAt: null },
+          rateLimits: null,
+          launchAllowed: true,
+          launchIssueMessage: null,
+          launchReadinessState: 'ready_chatgpt',
+          customProvider: {
+            enabled: false,
+            active: false,
+            baseUrl: '',
+            model: '',
+            issueMessage: null,
+          },
+        },
+      },
+    };
+    const guard = createLaunchGuard(['codex'], new Map([['codex', blockedProvider]]));
+
+    expect(guard.blockers(true, NOW)).toEqual([
+      expect.objectContaining({
+        providerId: 'codex',
+        detail: expect.stringContaining(
+          'ChatGPT account is connected, but the Codex runtime has not confirmed launch readiness'
+        ),
+      }),
+    ]);
+    expect(guard.blockers(true, NOW)[0]?.detail).not.toContain('CODEX_API_KEY');
+  });
+
+  it('does not block non-launch operations', () => {
+    const guard = createLaunchGuard(['codex'], new Map());
+
+    expect(guard.blockers(false, NOW)).toEqual([]);
+    expect(guard.blocked(false, NOW)).toBe(false);
+  });
+
+  it('reports stale catalog authority even when the provider has an unrelated status detail', () => {
+    const provider = createReadyProvider('codex');
+    const staleProvider: CliProviderStatus = {
+      ...provider,
+      statusMessage: 'warming up',
+      detailMessage: 'first render',
+      modelCatalog: {
+        ...provider.modelCatalog!,
+        staleAt: '2026-09-01T19:59:00.000Z',
+      },
+      capabilities: { ...provider.capabilities, teamLaunch: false },
+    };
+    const guard = createLaunchGuard(['codex'], new Map([['codex', staleProvider]]));
+
+    expect(guard.blockers(true, NOW)).toEqual([
+      expect.objectContaining({
+        detail: 'The verified model catalog is unavailable or stale. Refresh provider status.',
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- show the exact provider launch blocker instead of a green ready state beside a disabled Create or Launch button
- pass cached Codex account runtime context into passive status probes without refreshing auth state or elevating non-authoritative evidence
- connect disabled launch controls to the visible blocker through aria-describedby

## Verification

- 220 focused tests
- pnpm typecheck
- focused fast lint (one pre-existing hook dependency warning)
- pnpm build
- independent P0-P2 review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added launch-authority checks to team creation and launch dialogs.
  * Displays provider-specific blockers and links to provider settings when requirements are unmet.
  * Improved passive provider status handling using cached runtime information.
  * Added readiness notices and accessible descriptions for launch controls.
* **Bug Fixes**
  * Prevents launches when provider authentication, runtime readiness, availability, or model data is invalid.
* **Tests**
  * Added coverage for cached snapshots, provider status handling, launch blockers, and accessibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->