### PR TITLE
fix(team): honor model sync preference and polish provider UI

### DIFF
--- a/src/features/localization/renderer/locales/ar/dashboard.json
+++ b/src/features/localization/renderer/locales/ar/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "تم حفظ SuperGrok OAuth",
       "superGrokDescription": "استخدم اشتراك SuperGrok الخاص بك من خلال OpenCode OAuth.",
       "switchToSuperGrok": "قم بالتبديل إلى SuperGrok",
-      "title": "مقدمو الخدمات والخطط الاختيارية",
+      "title": "مقدمو الخدمات والخطط",
       "unavailable": "غير متاح",
       "updateForSuperGrok": "تحديث OpenCode لـ OAuth",
       "updateOpenCode": "تحديث الكود المفتوح",

--- a/src/features/localization/renderer/locales/bn/dashboard.json
+++ b/src/features/localization/renderer/locales/bn/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth সংরক্ষিত",
       "superGrokDescription": "OpenCode OAuth এর মাধ্যমে আপনার SuperGrok সদস্যতা ব্যবহার করুন।",
       "switchToSuperGrok": "SuperGrok এ স্যুইচ করুন",
-      "title": "ঐচ্ছিক প্রদানকারী এবং পরিকল্পনা",
+      "title": "প্রদানকারী এবং পরিকল্পনা",
       "unavailable": "অনুপলব্ধ",
       "updateForSuperGrok": "OAuth এর জন্য OpenCode আপডেট করুন",
       "updateOpenCode": "OpenCode আপডেট করুন",

--- a/src/features/localization/renderer/locales/de/dashboard.json
+++ b/src/features/localization/renderer/locales/de/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth gespeichert",
       "superGrokDescription": "Nutzen Sie Ihr SuperGrok-Abonnement über OpenCode OAuth.",
       "switchToSuperGrok": "Wechseln Sie zu SuperGrok",
-      "title": "Optionale Anbieter und Pläne",
+      "title": "Anbieter und Pläne",
       "unavailable": "Nicht verfügbar",
       "updateForSuperGrok": "Aktualisieren Sie OpenCode für OAuth",
       "updateOpenCode": "OpenCode aktualisieren",

--- a/src/features/localization/renderer/locales/en/dashboard.json
+++ b/src/features/localization/renderer/locales/en/dashboard.json
@@ -179,7 +179,7 @@
       "superGrokConnected": "SuperGrok OAuth saved",
       "superGrokDescription": "Use your SuperGrok subscription through OpenCode OAuth.",
       "switchToSuperGrok": "Switch to SuperGrok",
-      "title": "Optional providers & plans",
+      "title": "Providers & plans",
       "unavailable": "Unavailable",
       "updateForSuperGrok": "Update OpenCode for OAuth",
       "updateOpenCode": "Update OpenCode",

--- a/src/features/localization/renderer/locales/es/dashboard.json
+++ b/src/features/localization/renderer/locales/es/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth guardado",
       "superGrokDescription": "Utilice su suscripción a SuperGrok a través de OpenCode OAuth.",
       "switchToSuperGrok": "Cambiar a SuperGrok",
-      "title": "Proveedores y planes opcionales",
+      "title": "Proveedores y planes",
       "unavailable": "No disponible",
       "updateForSuperGrok": "Actualizar OpenCode para OAuth",
       "updateOpenCode": "Actualizar código abierto",

--- a/src/features/localization/renderer/locales/fa/dashboard.json
+++ b/src/features/localization/renderer/locales/fa/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth ذخیره شد",
       "superGrokDescription": "از اشتراک SuperGrok خود از طریق OpenCode OAuth استفاده کنید.",
       "switchToSuperGrok": "به SuperGrok بروید",
-      "title": "ارائه دهندگان و طرح های اختیاری",
+      "title": "ارائه دهندگان و طرح ها",
       "unavailable": "در دسترس نیست",
       "updateForSuperGrok": "OpenCode را برای OAuth به روز کنید",
       "updateOpenCode": "OpenCode را به روز کنید",

--- a/src/features/localization/renderer/locales/fil/dashboard.json
+++ b/src/features/localization/renderer/locales/fil/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "Na-save ang SuperGrok OAuth",
       "superGrokDescription": "Gamitin ang iyong subscription sa SuperGrok sa pamamagitan ng OpenCode OAuth.",
       "switchToSuperGrok": "Lumipat sa SuperGrok",
-      "title": "Mga opsyonal na provider at plano",
+      "title": "Mga provider at plano",
       "unavailable": "Hindi magagamit",
       "updateForSuperGrok": "I-update ang OpenCode para sa OAuth",
       "updateOpenCode": "I-update ang OpenCode",

--- a/src/features/localization/renderer/locales/fr/dashboard.json
+++ b/src/features/localization/renderer/locales/fr/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth enregistré",
       "superGrokDescription": "Utilisez votre abonnement SuperGrok via OpenCode OAuth.",
       "switchToSuperGrok": "Passer à SuperGrok",
-      "title": "Fournisseurs et forfaits optionnels",
+      "title": "Fournisseurs et forfaits",
       "unavailable": "Indisponible",
       "updateForSuperGrok": "Mettre à jour OpenCode pour OAuth",
       "updateOpenCode": "Mettre à jour OpenCode",

--- a/src/features/localization/renderer/locales/hi/dashboard.json
+++ b/src/features/localization/renderer/locales/hi/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "सुपरग्रोक OAuth सहेजा गया",
       "superGrokDescription": "OpenCode OAuth के माध्यम से अपनी सुपरग्रोक सदस्यता का उपयोग करें।",
       "switchToSuperGrok": "सुपरग्रोक पर स्विच करें",
-      "title": "वैकल्पिक प्रदाता और योजनाएँ",
+      "title": "प्रदाता और योजनाएँ",
       "unavailable": "अनुपलब्ध",
       "updateForSuperGrok": "OAuth के लिए OpenCode अपडेट करें",
       "updateOpenCode": "ओपनकोड अपडेट करें",

--- a/src/features/localization/renderer/locales/id/dashboard.json
+++ b/src/features/localization/renderer/locales/id/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth disimpan",
       "superGrokDescription": "Gunakan langganan SuperGrok Anda melalui OpenCode OAuth.",
       "switchToSuperGrok": "Beralih ke SuperGrok",
-      "title": "Penyedia & paket opsional",
+      "title": "Penyedia & paket",
       "unavailable": "Tidak tersedia",
       "updateForSuperGrok": "Perbarui OpenCode untuk OAuth",
       "updateOpenCode": "Perbarui OpenCode",

--- a/src/features/localization/renderer/locales/it/dashboard.json
+++ b/src/features/localization/renderer/locales/it/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth salvato",
       "superGrokDescription": "Utilizza il tuo abbonamento SuperGrok tramite OpenCode OAuth.",
       "switchToSuperGrok": "Passa a SuperGrok",
-      "title": "Fornitori e piani opzionali",
+      "title": "Fornitori e piani",
       "unavailable": "Non disponibile",
       "updateForSuperGrok": "Aggiorna OpenCode per OAuth",
       "updateOpenCode": "Aggiorna OpenCode",

--- a/src/features/localization/renderer/locales/ja/dashboard.json
+++ b/src/features/localization/renderer/locales/ja/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth が保存されました",
       "superGrokDescription": "OpenCode OAuth を通じて SuperGrok サブスクリプションを使用します。",
       "switchToSuperGrok": "スーパーグロックに切り替える",
-      "title": "オプションのプロバイダーとプラン",
+      "title": "プロバイダーとプラン",
       "unavailable": "利用不可",
       "updateForSuperGrok": "OAuth 用に OpenCode を更新する",
       "updateOpenCode": "オープンコードを更新する",

--- a/src/features/localization/renderer/locales/ko/dashboard.json
+++ b/src/features/localization/renderer/locales/ko/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth가 저장되었습니다.",
       "superGrokDescription": "OpenCode OAuth를 통해 SuperGrok 구독을 사용하세요.",
       "switchToSuperGrok": "SuperGrok으로 전환",
-      "title": "선택적 공급자 및 계획",
+      "title": "공급자 및 계획",
       "unavailable": "이용 불가",
       "updateForSuperGrok": "OAuth용 OpenCode 업데이트",
       "updateOpenCode": "오픈코드 업데이트",

--- a/src/features/localization/renderer/locales/mr/dashboard.json
+++ b/src/features/localization/renderer/locales/mr/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth सेव्ह केले",
       "superGrokDescription": "OpenCode OAuth द्वारे तुमची SuperGrok सदस्यता वापरा.",
       "switchToSuperGrok": "SuperGrok वर स्विच करा",
-      "title": "पर्यायी प्रदाता आणि योजना",
+      "title": "प्रदाते आणि योजना",
       "unavailable": "अनुपलब्ध",
       "updateForSuperGrok": "OAuth साठी OpenCode अपडेट करा",
       "updateOpenCode": "OpenCode अपडेट करा",

--- a/src/features/localization/renderer/locales/ms/dashboard.json
+++ b/src/features/localization/renderer/locales/ms/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth disimpan",
       "superGrokDescription": "Gunakan langganan SuperGrok anda melalui OpenCode OAuth.",
       "switchToSuperGrok": "Tukar kepada SuperGrok",
-      "title": "Pembekal & pelan pilihan",
+      "title": "Pembekal & pelan",
       "unavailable": "Tidak tersedia",
       "updateForSuperGrok": "Kemas kini OpenCode untuk OAuth",
       "updateOpenCode": "Kemas kini OpenCode",

--- a/src/features/localization/renderer/locales/nl/dashboard.json
+++ b/src/features/localization/renderer/locales/nl/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth opgeslagen",
       "superGrokDescription": "Gebruik je SuperGrok-abonnement via OpenCode OAuth.",
       "switchToSuperGrok": "Overschakelen naar SuperGrok",
-      "title": "Optionele providers en abonnementen",
+      "title": "Providers en abonnementen",
       "unavailable": "Niet beschikbaar",
       "updateForSuperGrok": "OpenCode bijwerken voor OAuth",
       "updateOpenCode": "OpenCode bijwerken",

--- a/src/features/localization/renderer/locales/pl/dashboard.json
+++ b/src/features/localization/renderer/locales/pl/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "Zapisano OAuth SuperGrok",
       "superGrokDescription": "Korzystaj z subskrypcji SuperGrok przez OAuth OpenCode.",
       "switchToSuperGrok": "Przełącz na SuperGrok",
-      "title": "Opcjonalni dostawcy i plany",
+      "title": "Dostawcy i plany",
       "unavailable": "Niedostępne",
       "updateForSuperGrok": "Zaktualizuj OpenCode dla OAuth",
       "updateOpenCode": "Zaktualizuj OpenCode",

--- a/src/features/localization/renderer/locales/pt/dashboard.json
+++ b/src/features/localization/renderer/locales/pt/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "OAuth do SuperGrok guardado",
       "superGrokDescription": "Use a sua subscrição SuperGrok através do OAuth do OpenCode.",
       "switchToSuperGrok": "Mudar para SuperGrok",
-      "title": "Fornecedores e planos opcionais",
+      "title": "Fornecedores e planos",
       "unavailable": "Indisponível",
       "updateForSuperGrok": "Atualizar o OpenCode para OAuth",
       "updateOpenCode": "Atualizar o OpenCode",

--- a/src/features/localization/renderer/locales/ro/dashboard.json
+++ b/src/features/localization/renderer/locales/ro/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "OAuth SuperGrok a fost salvat",
       "superGrokDescription": "Folosește abonamentul SuperGrok prin OAuth OpenCode.",
       "switchToSuperGrok": "Comută la SuperGrok",
-      "title": "Furnizori și planuri opționale",
+      "title": "Furnizori și planuri",
       "unavailable": "Indisponibil",
       "updateForSuperGrok": "Actualizează OpenCode pentru OAuth",
       "updateOpenCode": "Actualizează OpenCode",

--- a/src/features/localization/renderer/locales/ru/dashboard.json
+++ b/src/features/localization/renderer/locales/ru/dashboard.json
@@ -178,7 +178,7 @@
       "superGrokConnected": "OAuth SuperGrok сохранён",
       "superGrokDescription": "Используйте подписку SuperGrok через OAuth OpenCode.",
       "switchToSuperGrok": "Переключиться на SuperGrok",
-      "title": "Дополнительные провайдеры и планы",
+      "title": "Провайдеры и планы",
       "unavailable": "Недоступно",
       "updateForSuperGrok": "Обновить OpenCode для OAuth",
       "updateOpenCode": "Обновить OpenCode",

--- a/src/features/localization/renderer/locales/sw/dashboard.json
+++ b/src/features/localization/renderer/locales/sw/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "OAuth ya SuperGrok imehifadhiwa",
       "superGrokDescription": "Tumia usajili wako wa SuperGrok kupitia OAuth ya OpenCode.",
       "switchToSuperGrok": "Badilisha hadi SuperGrok",
-      "title": "Watoa huduma na mipango ya hiari",
+      "title": "Watoa huduma na mipango",
       "unavailable": "Haipatikani",
       "updateForSuperGrok": "Sasisha OpenCode kwa OAuth",
       "updateOpenCode": "Sasisha OpenCode",

--- a/src/features/localization/renderer/locales/ta/dashboard.json
+++ b/src/features/localization/renderer/locales/ta/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth சேமிக்கப்பட்டது",
       "superGrokDescription": "OpenCode OAuth வழியாக உங்கள் SuperGrok சந்தாவைப் பயன்படுத்தவும்.",
       "switchToSuperGrok": "SuperGrok-க்கு மாறவும்",
-      "title": "விருப்ப வழங்குநர்கள் மற்றும் திட்டங்கள்",
+      "title": "வழங்குநர்கள் மற்றும் திட்டங்கள்",
       "unavailable": "கிடைக்கவில்லை",
       "updateForSuperGrok": "OAuth-க்காக OpenCode-ஐப் புதுப்பிக்கவும்",
       "updateOpenCode": "OpenCode-ஐப் புதுப்பிக்கவும்",

--- a/src/features/localization/renderer/locales/te/dashboard.json
+++ b/src/features/localization/renderer/locales/te/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth సేవ్ అయింది",
       "superGrokDescription": "OpenCode OAuth ద్వారా మీ SuperGrok సబ్‌స్క్రిప్షన్‌ను ఉపయోగించండి.",
       "switchToSuperGrok": "SuperGrokకు మారండి",
-      "title": "ఐచ్ఛిక ప్రొవైడర్లు మరియు ప్లాన్‌లు",
+      "title": "ప్రొవైడర్లు మరియు ప్లాన్‌లు",
       "unavailable": "అందుబాటులో లేదు",
       "updateForSuperGrok": "OAuth కోసం OpenCodeను అప్‌డేట్ చేయండి",
       "updateOpenCode": "OpenCodeను అప్‌డేట్ చేయండి",

--- a/src/features/localization/renderer/locales/th/dashboard.json
+++ b/src/features/localization/renderer/locales/th/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "บันทึก OAuth ของ SuperGrok แล้ว",
       "superGrokDescription": "ใช้การสมัคร SuperGrok ผ่าน OAuth ของ OpenCode",
       "switchToSuperGrok": "สลับไปใช้ SuperGrok",
-      "title": "ผู้ให้บริการและแผนเสริม",
+      "title": "ผู้ให้บริการและแผน",
       "unavailable": "ไม่พร้อมใช้งาน",
       "updateForSuperGrok": "อัปเดต OpenCode สำหรับ OAuth",
       "updateOpenCode": "อัปเดต OpenCode",

--- a/src/features/localization/renderer/locales/tr/dashboard.json
+++ b/src/features/localization/renderer/locales/tr/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth kaydedildi",
       "superGrokDescription": "SuperGrok aboneliğinizi OpenCode OAuth üzerinden kullanın.",
       "switchToSuperGrok": "SuperGrok'a geç",
-      "title": "İsteğe bağlı sağlayıcılar ve planlar",
+      "title": "Sağlayıcılar ve planlar",
       "unavailable": "Kullanılamıyor",
       "updateForSuperGrok": "OAuth için OpenCode'u güncelle",
       "updateOpenCode": "OpenCode'u güncelle",

--- a/src/features/localization/renderer/locales/uk/dashboard.json
+++ b/src/features/localization/renderer/locales/uk/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "OAuth SuperGrok збережено",
       "superGrokDescription": "Використовуйте підписку SuperGrok через OAuth OpenCode.",
       "switchToSuperGrok": "Перейти на SuperGrok",
-      "title": "Додаткові провайдери та плани",
+      "title": "Провайдери та плани",
       "unavailable": "Недоступно",
       "updateForSuperGrok": "Оновити OpenCode для OAuth",
       "updateOpenCode": "Оновити OpenCode",

--- a/src/features/localization/renderer/locales/ur/dashboard.json
+++ b/src/features/localization/renderer/locales/ur/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "SuperGrok OAuth محفوظ ہے",
       "superGrokDescription": "اپنی SuperGrok سبسکرپشن OpenCode OAuth کے ذریعے استعمال کریں۔",
       "switchToSuperGrok": "SuperGrok پر جائیں",
-      "title": "اختیاری فراہم کنندگان اور پلان",
+      "title": "فراہم کنندگان اور پلان",
       "unavailable": "دستیاب نہیں",
       "updateForSuperGrok": "OAuth کے لیے OpenCode اپ ڈیٹ کریں",
       "updateOpenCode": "OpenCode اپ ڈیٹ کریں",

--- a/src/features/localization/renderer/locales/vi/dashboard.json
+++ b/src/features/localization/renderer/locales/vi/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "Đã lưu OAuth SuperGrok",
       "superGrokDescription": "Sử dụng gói đăng ký SuperGrok qua OAuth của OpenCode.",
       "switchToSuperGrok": "Chuyển sang SuperGrok",
-      "title": "Nhà cung cấp và gói tùy chọn",
+      "title": "Nhà cung cấp và gói",
       "unavailable": "Không khả dụng",
       "updateForSuperGrok": "Cập nhật OpenCode cho OAuth",
       "updateOpenCode": "Cập nhật OpenCode",

--- a/src/features/localization/renderer/locales/zh/dashboard.json
+++ b/src/features/localization/renderer/locales/zh/dashboard.json
@@ -176,7 +176,7 @@
       "superGrokConnected": "已保存 SuperGrok OAuth",
       "superGrokDescription": "通过 OpenCode OAuth 使用您的 SuperGrok 订阅。",
       "switchToSuperGrok": "切换到 SuperGrok",
-      "title": "可选提供商和套餐",
+      "title": "提供商和套餐",
       "unavailable": "不可用",
       "updateForSuperGrok": "更新 OpenCode 以支持 OAuth",
       "updateOpenCode": "更新 OpenCode",

--- a/src/features/localization/renderer/resources.d.ts
+++ b/src/features/localization/renderer/resources.d.ts
@@ -1106,7 +1106,7 @@ export default interface Resources {
         superGrokConnected: 'SuperGrok OAuth saved';
         superGrokDescription: 'Use your SuperGrok subscription through OpenCode OAuth.';
         switchToSuperGrok: 'Switch to SuperGrok';
-        title: 'Optional providers & plans';
+        title: 'Providers & plans';
         unavailable: 'Unavailable';
         updateForSuperGrok: 'Update OpenCode for OAuth';
         updateOpenCode: 'Update OpenCode';

--- a/src/features/recent-projects/renderer/ui/RecentProjectCard.tsx
+++ b/src/features/recent-projects/renderer/ui/RecentProjectCard.tsx
@@ -1,12 +1,9 @@
-import { useMemo } from 'react';
-
 import { useAppTranslation } from '@features/localization/renderer';
 import { ProviderBrandLogo } from '@renderer/components/common/ProviderBrandLogo';
 import { ActivePulseIndicator } from '@renderer/components/ui/ActivePulseIndicator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/components/ui/tooltip';
 import { cn } from '@renderer/lib/utils';
-import { projectColor } from '@renderer/utils/projectColor';
-import { FolderGit2, FolderOpen, FolderX, GitBranch, Terminal } from 'lucide-react';
+import { FolderOpen, GitBranch, Terminal } from 'lucide-react';
 
 import type { RecentProjectCardModel } from '../view-models/recentProjectsSectionViewModel';
 
@@ -23,9 +20,7 @@ export const RecentProjectCard = ({
 }: Readonly<RecentProjectCardProps>): React.JSX.Element => {
   const { t } = useAppTranslation('dashboard');
   const { t: tCommon } = useAppTranslation('common');
-  const color = useMemo(() => projectColor(card.name), [card.name]);
   const isDeleted = card.filesystemState === 'deleted';
-  const FolderIcon = isDeleted ? FolderX : FolderGit2;
 
   return (
     <button
@@ -40,13 +35,7 @@ export const RecentProjectCard = ({
         <ActivePulseIndicator className="absolute right-3 top-3" />
       )}
 
-      <div className="mb-1 flex items-center gap-2.5">
-        <div className="flex size-8 shrink-0 items-center justify-center rounded-md border border-border bg-surface-overlay transition-colors duration-300 group-hover:border-border-emphasis">
-          <FolderIcon
-            className="size-4 transition-colors group-hover:text-text"
-            style={{ color: isDeleted ? 'var(--field-error-text)' : color.icon }}
-          />
-        </div>
+      <div className="mb-1 flex items-center">
         <div className="min-w-0">
           <div className="flex items-center gap-1.5">
             <h3 className="min-w-0 truncate text-sm font-medium text-text transition-colors duration-200 group-hover:text-text">

--- a/src/main/ipc/teamIpcRequestParsers.ts
+++ b/src/main/ipc/teamIpcRequestParsers.ts
@@ -130,3 +130,26 @@ export function parseOptionalBoolean(value: unknown, fieldName: string): ParseRe
     ? { valid: true, value }
     : { valid: false, error: `${fieldName} must be a boolean` };
 }
+
+const TEAM_PROVISIONING_BOOLEAN_FIELDS = [
+  'allowExperimentalLocalModels',
+  'limitContext',
+  'skipPermissions',
+  'syncModelsWithLead',
+] as const;
+
+type TeamProvisioningBooleanOptions = Partial<
+  Record<(typeof TEAM_PROVISIONING_BOOLEAN_FIELDS)[number], boolean>
+>;
+
+export function parseTeamProvisioningBooleanOptions(
+  value: Partial<Record<keyof TeamProvisioningBooleanOptions, unknown>>
+): { valid: true; value: TeamProvisioningBooleanOptions } | { valid: false; error: string } {
+  const options: TeamProvisioningBooleanOptions = {};
+  for (const fieldName of TEAM_PROVISIONING_BOOLEAN_FIELDS) {
+    const parsed = parseOptionalBoolean(value[fieldName], fieldName);
+    if (!parsed.valid) return parsed;
+    options[fieldName] = parsed.value;
+  }
+  return { valid: true, value: options };
+}

--- a/src/main/ipc/teams.ts
+++ b/src/main/ipc/teams.ts
@@ -167,7 +167,6 @@ import {
   validateTeamName,
 } from './guards';
 import {
-  parseOptionalBoolean,
   parseOptionalLaunchProviderBackendId,
   parseOptionalMemberEffort,
   parseOptionalMemberProviderId,
@@ -175,6 +174,7 @@ import {
   parseOptionalTeamEffort,
   parseOptionalTeamFastMode,
   parseOptionalTeamProviderId,
+  parseTeamProvisioningBooleanOptions,
 } from './teamIpcRequestParsers';
 
 import type {
@@ -2028,16 +2028,11 @@ async function validateProvisioningRequest(
   if (!fastModeValidation.valid) {
     return { valid: false, error: fastModeValidation.error };
   }
-  if (payload.limitContext !== undefined && typeof payload.limitContext !== 'boolean') {
-    return { valid: false, error: 'limitContext must be a boolean' };
+  const booleanOptionsValidation = parseTeamProvisioningBooleanOptions(payload);
+  if (!booleanOptionsValidation.valid) {
+    return { valid: false, error: booleanOptionsValidation.error };
   }
-  const experimentalModelsValidation = parseOptionalBoolean(
-    payload.allowExperimentalLocalModels,
-    'allowExperimentalLocalModels'
-  );
-  if (!experimentalModelsValidation.valid) {
-    return { valid: false, error: experimentalModelsValidation.error };
-  }
+  const booleanOptions = booleanOptionsValidation.value;
 
   try {
     await fs.promises.mkdir(cwd, { recursive: true });
@@ -2094,10 +2089,10 @@ async function validateProvisioningRequest(
       model: typeof payload.model === 'string' ? payload.model.trim() || undefined : undefined,
       effort: effortValidation.value,
       fastMode: fastModeValidation.value,
-      limitContext: typeof payload.limitContext === 'boolean' ? payload.limitContext : undefined,
-      skipPermissions:
-        typeof payload.skipPermissions === 'boolean' ? payload.skipPermissions : undefined,
-      allowExperimentalLocalModels: experimentalModelsValidation.value,
+      syncModelsWithLead: booleanOptions.syncModelsWithLead,
+      limitContext: booleanOptions.limitContext,
+      skipPermissions: booleanOptions.skipPermissions,
+      allowExperimentalLocalModels: booleanOptions.allowExperimentalLocalModels,
       worktree:
         typeof payload.worktree === 'string' && payload.worktree.trim()
           ? payload.worktree.trim()
@@ -2239,16 +2234,11 @@ async function handleLaunchTeam(
   if (payload.model !== undefined && typeof payload.model !== 'string') {
     return { success: false, error: 'model must be a string' };
   }
-  if (payload.limitContext !== undefined && typeof payload.limitContext !== 'boolean') {
-    return { success: false, error: 'limitContext must be a boolean' };
+  const booleanOptionsValidation = parseTeamProvisioningBooleanOptions(payload);
+  if (!booleanOptionsValidation.valid) {
+    return { success: false, error: booleanOptionsValidation.error };
   }
-  const experimentalModelsValidation = parseOptionalBoolean(
-    payload.allowExperimentalLocalModels,
-    'allowExperimentalLocalModels'
-  );
-  if (!experimentalModelsValidation.valid) {
-    return { success: false, error: experimentalModelsValidation.error };
-  }
+  const booleanOptions = booleanOptionsValidation.value;
   const providerValidation = parseOptionalTeamProviderId(payload.providerId);
   if (!providerValidation.valid) {
     return { success: false, error: providerValidation.error };
@@ -2316,11 +2306,8 @@ async function handleLaunchTeam(
         ? undefined
         : savedRequest.model;
     const draftLimitContext =
-      typeof payload.limitContext === 'boolean'
-        ? payload.limitContext
-        : providerChangedFromSaved
-          ? undefined
-          : savedRequest.limitContext;
+      booleanOptions.limitContext ??
+      (providerChangedFromSaved ? undefined : savedRequest.limitContext);
 
     const createRequest: TeamCreateRequest = {
       teamName: tn,
@@ -2340,12 +2327,10 @@ async function handleLaunchTeam(
       model: draftModel,
       effort: effortValidation.value,
       fastMode: fastModeValidation.value,
+      syncModelsWithLead: booleanOptions.syncModelsWithLead ?? savedRequest.syncModelsWithLead,
       limitContext: draftLimitContext,
-      skipPermissions:
-        typeof payload.skipPermissions === 'boolean'
-          ? payload.skipPermissions
-          : savedRequest.skipPermissions,
-      allowExperimentalLocalModels: experimentalModelsValidation.value,
+      skipPermissions: booleanOptions.skipPermissions ?? savedRequest.skipPermissions,
+      allowExperimentalLocalModels: booleanOptions.allowExperimentalLocalModels,
       worktree:
         typeof payload.worktree === 'string'
           ? payload.worktree.trim() || undefined
@@ -2435,11 +2420,8 @@ async function handleLaunchTeam(
       : undefined
     : persistedLaunchModel;
   const launchLimitContext =
-    typeof payload.limitContext === 'boolean'
-      ? payload.limitContext
-      : providerChangedFromPersisted
-        ? undefined
-        : persistedMeta?.limitContext;
+    booleanOptions.limitContext ??
+    (providerChangedFromPersisted ? undefined : persistedMeta?.limitContext);
 
   return wrapTeamHandler('launch', async () => {
     addMainBreadcrumb('team', 'launch', { teamName: validatedTeamName.value! });
@@ -2460,11 +2442,12 @@ async function handleLaunchTeam(
           model: rawLaunchModel,
           effort: effortValidation.value,
           fastMode: fastModeValidation.value,
+          syncModelsWithLead:
+            booleanOptions.syncModelsWithLead ?? persistedMeta?.syncModelsWithLead,
           limitContext: launchLimitContext,
           clearContext: payload.clearContext === true ? true : undefined,
-          skipPermissions:
-            typeof payload.skipPermissions === 'boolean' ? payload.skipPermissions : undefined,
-          allowExperimentalLocalModels: experimentalModelsValidation.value,
+          skipPermissions: booleanOptions.skipPermissions,
+          allowExperimentalLocalModels: booleanOptions.allowExperimentalLocalModels,
           worktree:
             typeof payload.worktree === 'string' ? payload.worktree.trim() || undefined : undefined,
           extraCliArgs:
@@ -3901,12 +3884,11 @@ async function handleCreateConfig(
   if (!fastModeValidation.valid) {
     return { success: false, error: fastModeValidation.error };
   }
-  if (payload.limitContext !== undefined && typeof payload.limitContext !== 'boolean') {
-    return { success: false, error: 'limitContext must be a boolean' };
+  const booleanOptionsValidation = parseTeamProvisioningBooleanOptions(payload);
+  if (!booleanOptionsValidation.valid) {
+    return { success: false, error: booleanOptionsValidation.error };
   }
-  if (payload.skipPermissions !== undefined && typeof payload.skipPermissions !== 'boolean') {
-    return { success: false, error: 'skipPermissions must be a boolean' };
-  }
+  const booleanOptions = booleanOptionsValidation.value;
   if (payload.worktree !== undefined) {
     if (typeof payload.worktree !== 'string') {
       return { success: false, error: 'worktree must be a string' };
@@ -4028,9 +4010,9 @@ async function handleCreateConfig(
         model: typeof payload.model === 'string' ? payload.model.trim() || undefined : undefined,
         effort: effortValidation.value,
         fastMode: fastModeValidation.value,
-        limitContext: typeof payload.limitContext === 'boolean' ? payload.limitContext : undefined,
-        skipPermissions:
-          typeof payload.skipPermissions === 'boolean' ? payload.skipPermissions : undefined,
+        syncModelsWithLead: booleanOptions.syncModelsWithLead,
+        limitContext: booleanOptions.limitContext,
+        skipPermissions: booleanOptions.skipPermissions,
         worktree:
           typeof payload.worktree === 'string' && payload.worktree.trim()
             ? payload.worktree.trim()

--- a/src/main/services/team/TeamDataService.ts
+++ b/src/main/services/team/TeamDataService.ts
@@ -1196,7 +1196,6 @@ export class TeamDataService {
     const membersMeta = await this.membersMetaStore.getMeta(teamName);
     const members = membersMeta?.members ?? [];
     const resolvedProviderId = meta.providerId ?? 'anthropic';
-
     return {
       teamName,
       displayName: meta.displayName,
@@ -1212,6 +1211,7 @@ export class TeamDataService {
       model: meta.model,
       effort: meta.effort as TeamCreateRequest['effort'],
       fastMode: meta.fastMode,
+      syncModelsWithLead: meta.syncModelsWithLead,
       skipPermissions: meta.skipPermissions,
       worktree: meta.worktree,
       extraCliArgs: meta.extraCliArgs,
@@ -3517,7 +3517,6 @@ export class TeamDataService {
       tasksDirectoryCreated = true;
 
       const joinedAt = Date.now();
-
       // Save team-level metadata to team.meta.json (NOT config.json).
       // config.json is CLI territory — created by TeamCreate during provisioning.
       // team.meta.json preserves user's configuration for the Launch flow.
@@ -3532,6 +3531,7 @@ export class TeamDataService {
         model: request.model,
         effort: request.effort,
         fastMode: request.fastMode,
+        syncModelsWithLead: request.syncModelsWithLead,
         skipPermissions: request.skipPermissions,
         worktree: request.worktree,
         extraCliArgs: request.extraCliArgs,

--- a/src/main/services/team/TeamMetaStore.ts
+++ b/src/main/services/team/TeamMetaStore.ts
@@ -27,6 +27,7 @@ export interface TeamMetaFile {
   model?: string;
   effort?: string;
   fastMode?: TeamFastMode;
+  syncModelsWithLead?: boolean;
   skipPermissions?: boolean;
   worktree?: string;
   extraCliArgs?: string;
@@ -205,6 +206,8 @@ export class TeamMetaStore {
       model: typeof file.model === 'string' ? file.model.trim() || undefined : undefined,
       effort: typeof file.effort === 'string' ? file.effort.trim() || undefined : undefined,
       fastMode: normalizeFastMode(file.fastMode) ?? undefined,
+      syncModelsWithLead:
+        typeof file.syncModelsWithLead === 'boolean' ? file.syncModelsWithLead : undefined,
       skipPermissions: typeof file.skipPermissions === 'boolean' ? file.skipPermissions : undefined,
       worktree: typeof file.worktree === 'string' ? file.worktree.trim() || undefined : undefined,
       extraCliArgs:

--- a/src/main/services/team/TeamMetaStore.ts
+++ b/src/main/services/team/TeamMetaStore.ts
@@ -255,6 +255,7 @@ export class TeamMetaStore {
       model: data.model?.trim() || undefined,
       effort: data.effort?.trim() || undefined,
       fastMode: normalizeFastMode(data.fastMode) ?? undefined,
+      syncModelsWithLead: data.syncModelsWithLead,
       skipPermissions: data.skipPermissions,
       worktree: data.worktree?.trim() || undefined,
       extraCliArgs: data.extraCliArgs?.trim() || undefined,

--- a/src/main/services/team/__tests__/TeamMetaStore.test.ts
+++ b/src/main/services/team/__tests__/TeamMetaStore.test.ts
@@ -65,4 +65,16 @@ describe('TeamMetaStore', () => {
       effort: 'medium',
     });
   });
+
+  it('persists an explicit disabled lead-model sync preference', async () => {
+    await new TeamMetaStore().writeMeta('alpha', {
+      cwd: '/sandbox/team',
+      syncModelsWithLead: false,
+      createdAt: 1,
+    });
+
+    expect(JSON.parse(atomicWriteAsync.mock.calls[0]?.[1])).toMatchObject({
+      syncModelsWithLead: false,
+    });
+  });
 });

--- a/src/main/services/team/provisioning/TeamProvisioningConfiguredMemberSpecs.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningConfiguredMemberSpecs.ts
@@ -15,7 +15,7 @@ type ProvisioningMemberSpec = TeamCreateRequest['members'][number];
 
 type PrimaryOwnedRuntimeDefaults = Pick<
   TeamCreateRequest,
-  'providerId' | 'providerBackendId' | 'model' | 'effort' | 'fastMode'
+  'providerId' | 'providerBackendId' | 'model' | 'effort' | 'fastMode' | 'syncModelsWithLead'
 >;
 
 export function buildConfiguredProvisioningMember(
@@ -47,12 +47,12 @@ export function buildPrimaryOwnedMemberSpecForRuntime(input: {
   const configuredSpec = buildConfiguredProvisioningMember(input.configuredMember);
   const defaultProviderId = resolveTeamProviderId(input.request.providerId);
   const memberProviderId = normalizeTeamMemberProviderId(configuredSpec.providerId);
-  const inheritsDefaultRuntime =
-    memberProviderId == null || memberProviderId === defaultProviderId;
+  const inheritsDefaultRuntime = memberProviderId == null || memberProviderId === defaultProviderId;
   const effectiveSpec = buildEffectiveTeamMemberSpec(configuredSpec, {
     providerId: defaultProviderId,
     model: input.request.model,
     effort: input.request.effort,
+    syncModelsWithLead: input.request.syncModelsWithLead,
   });
   const effectiveProviderId = resolveTeamProviderId(effectiveSpec.providerId);
   const providerBackendId =

--- a/src/main/services/team/provisioning/TeamProvisioningCreateDeterministicSetupFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningCreateDeterministicSetupFlow.ts
@@ -70,6 +70,7 @@ export interface DeterministicCreateSetupFlowPorts<TMixedSecondaryLane> {
       providerId?: TeamProviderId;
       model?: string;
       effort?: TeamCreateRequest['effort'];
+      syncModelsWithLead?: boolean;
     };
     primaryProviderId?: TeamProviderId;
     primaryEnv?: ProvisioningEnvResolution;
@@ -250,6 +251,7 @@ async function prepareDeterministicCreateSetupFlowWithLease<TMixedSecondaryLane>
       providerId: request.providerId,
       model: request.model,
       effort: request.effort,
+      syncModelsWithLead: request.syncModelsWithLead,
     },
     primaryProviderId: request.providerId,
     primaryEnv: provisioningEnv,

--- a/src/main/services/team/provisioning/TeamProvisioningCreateTeamFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningCreateTeamFlow.ts
@@ -122,6 +122,7 @@ export function buildCreateTeamMetaPayload(
   model: TeamCreateRequest['model'];
   effort: TeamCreateRequest['effort'];
   fastMode: TeamCreateRequest['fastMode'];
+  syncModelsWithLead: TeamCreateRequest['syncModelsWithLead'];
   skipPermissions: TeamCreateRequest['skipPermissions'];
   worktree: TeamCreateRequest['worktree'];
   extraCliArgs: TeamCreateRequest['extraCliArgs'];
@@ -140,6 +141,7 @@ export function buildCreateTeamMetaPayload(
     model: request.model,
     effort: request.effort,
     fastMode: request.fastMode,
+    syncModelsWithLead: request.syncModelsWithLead,
     skipPermissions: request.skipPermissions,
     worktree: request.worktree,
     extraCliArgs: request.extraCliArgs,

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchDeterministicSetupFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchDeterministicSetupFlow.ts
@@ -104,6 +104,7 @@ export interface DeterministicLaunchSetupPorts<TMixedSecondaryLane> {
       providerId?: TeamProviderId;
       model?: string;
       effort?: TeamCreateRequest['effort'];
+      syncModelsWithLead?: boolean;
     };
     primaryProviderId?: TeamProviderId;
     primaryEnv?: ProvisioningEnvResolution;
@@ -323,6 +324,7 @@ export async function prepareDeterministicLaunchSetup<TMixedSecondaryLane>(
         providerId: request.providerId,
         model: request.model,
         effort: request.effort,
+        syncModelsWithLead: request.syncModelsWithLead,
       },
       primaryProviderId: request.providerId,
       primaryEnv: provisioningEnv,

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchDeterministicSpawnFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchDeterministicSpawnFlow.ts
@@ -200,6 +200,7 @@ export function buildLaunchTeamMetaPayload(input: {
     model: syntheticRequest.model,
     effort: syntheticRequest.effort,
     fastMode: syntheticRequest.fastMode,
+    syncModelsWithLead: syntheticRequest.syncModelsWithLead,
     skipPermissions: syntheticRequest.skipPermissions,
     worktree: syntheticRequest.worktree,
     extraCliArgs: syntheticRequest.extraCliArgs,

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchTeamFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchTeamFlow.ts
@@ -196,6 +196,7 @@ export function buildLaunchSyntheticRequest(input: {
     model: input.request.model,
     effort: input.request.effort,
     fastMode: input.request.fastMode,
+    syncModelsWithLead: input.request.syncModelsWithLead,
     skipPermissions: input.request.skipPermissions,
     worktree: input.request.worktree,
     extraCliArgs: input.request.extraCliArgs,

--- a/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
@@ -649,7 +649,6 @@ export class TeamProvisioningMemberLifecycleController {
       if (provisioningEnv.warning) {
         throw new Error(provisioningEnv.warning);
       }
-
       const [materializedMemberSpec] = await this.materializeEffectiveTeamMemberSpecs({
         claudePath,
         cwd,
@@ -658,6 +657,7 @@ export class TeamProvisioningMemberLifecycleController {
           providerId: resolveTeamProviderId(input.run.request.providerId),
           model: input.run.request.model,
           effort: input.run.request.effort,
+          syncModelsWithLead: input.run.request.syncModelsWithLead,
         },
         primaryProviderId: providerId,
         primaryEnv: provisioningEnv,
@@ -855,7 +855,6 @@ export class TeamProvisioningMemberLifecycleController {
       if (provisioningEnv.warning) {
         throw new Error(provisioningEnv.warning);
       }
-
       const [materializedMemberSpec] = await this.materializeEffectiveTeamMemberSpecs({
         claudePath,
         cwd,
@@ -864,6 +863,7 @@ export class TeamProvisioningMemberLifecycleController {
           providerId: resolveTeamProviderId(input.run.request.providerId),
           model: input.run.request.model,
           effort: input.run.request.effort,
+          syncModelsWithLead: input.run.request.syncModelsWithLead,
         },
         primaryProviderId: providerId,
         primaryEnv: provisioningEnv,

--- a/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
@@ -2077,7 +2077,6 @@ export class TeamProvisioningMemberLifecycleController {
       reason: 'manual_restart',
       assertStillCurrent: assertRuntimeAdapterRunStillCurrent,
     });
-
     assertRuntimeAdapterRunStillCurrent();
     await this.runOpenCodeTeamRuntimeAdapterLaunch({
       request: {
@@ -2092,6 +2091,7 @@ export class TeamProvisioningMemberLifecycleController {
           targetRuntimeMember.effort ??
           (isTeamEffortLevel(teamMeta?.effort) ? teamMeta.effort : undefined),
         fastMode: teamMeta?.fastMode,
+        syncModelsWithLead: teamMeta?.syncModelsWithLead,
         limitContext: teamMeta?.limitContext,
         skipPermissions: teamMeta?.skipPermissions,
         worktree: teamMeta?.worktree,

--- a/src/main/services/team/provisioning/TeamProvisioningMemberLifecycleHostPorts.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMemberLifecycleHostPorts.ts
@@ -54,6 +54,7 @@ export interface TeamMetaLike {
   model?: string;
   effort?: EffortLevel;
   fastMode?: TeamFastMode;
+  syncModelsWithLead?: boolean;
   limitContext?: boolean;
   skipPermissions?: boolean;
   worktree?: string;
@@ -111,6 +112,7 @@ export interface TeamProvisioningMemberLifecycleMemberSpecPorts {
       providerId: TeamProviderId;
       model?: string;
       effort?: EffortLevel;
+      syncModelsWithLead?: boolean;
     };
     primaryProviderId: TeamProviderId;
     primaryEnv: ProvisioningEnvResolution;

--- a/src/main/services/team/provisioning/TeamProvisioningMemberSpecs.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMemberSpecs.ts
@@ -43,19 +43,21 @@ export function buildEffectiveTeamMemberSpec(
     providerId?: TeamProviderId;
     model?: string;
     effort?: TeamCreateRequest['effort'];
+    syncModelsWithLead?: boolean;
   }
 ): TeamMemberInput {
   const memberProviderId = normalizeTeamMemberProviderId(member.providerId);
   const defaultProviderId = normalizeTeamMemberProviderId(defaults.providerId);
   const effectiveProviderId = memberProviderId ?? defaultProviderId ?? 'anthropic';
   const explicitMemberModel = getExplicitLaunchModelSelection(member.model);
-  const inheritsDefaultRuntime = memberProviderId == null || memberProviderId === defaultProviderId;
+  const usesDefaultProvider = memberProviderId == null || memberProviderId === defaultProviderId;
+  const inheritsLeadModel = defaults.syncModelsWithLead !== false && usesDefaultProvider;
   const model =
     explicitMemberModel ||
-    (inheritsDefaultRuntime ? getExplicitLaunchModelSelection(defaults.model) : undefined) ||
+    (inheritsLeadModel ? getExplicitLaunchModelSelection(defaults.model) : undefined) ||
     undefined;
   const effort =
-    member.effort ?? (inheritsDefaultRuntime && !explicitMemberModel ? defaults.effort : undefined);
+    member.effort ?? (inheritsLeadModel && !explicitMemberModel ? defaults.effort : undefined);
 
   return {
     ...member,
@@ -71,6 +73,7 @@ export function buildEffectiveTeamMemberSpecs(
     providerId?: TeamProviderId;
     model?: string;
     effort?: TeamCreateRequest['effort'];
+    syncModelsWithLead?: boolean;
   }
 ): TeamCreateRequest['members'] {
   return members.map((member) => buildEffectiveTeamMemberSpec(member, defaults));

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeAdapterTeamFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeAdapterTeamFlow.ts
@@ -106,6 +106,7 @@ export async function createOpenCodeTeamThroughRuntimeAdapterFlow(
     providerBackendId: launchRequest.providerBackendId,
     model: launchRequest.model,
     effort: launchRequest.effort,
+    syncModelsWithLead: launchRequest.syncModelsWithLead,
     skipPermissions: launchRequest.skipPermissions,
     worktree: launchRequest.worktree,
     extraCliArgs: launchRequest.extraCliArgs,

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeDefaults.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeDefaults.ts
@@ -45,7 +45,9 @@ export async function materializeOpenCodeRuntimeAdapterDefaults<
     providerId: params.request.providerId,
     model: params.request.model,
     effort: params.request.effort,
+    syncModelsWithLead: params.request.syncModelsWithLead,
   });
+  const syncModelsWithLead = params.request.syncModelsWithLead !== false;
   const explicitRootModel = getExplicitLaunchModelSelection(params.request.model);
   const effectiveOpenCodeMembers = effectiveMembers.filter((member) => {
     const providerId = normalizeTeamMemberProviderId(member.providerId) ?? 'opencode';
@@ -58,7 +60,7 @@ export async function materializeOpenCodeRuntimeAdapterDefaults<
         .filter((model): model is string => Boolean(model))
     ),
   ];
-  const inheritedRootModel = explicitRootModel ? undefined : memberModels[0];
+  const inheritedRootModel = explicitRootModel || !syncModelsWithLead ? undefined : memberModels[0];
   const rootModel = explicitRootModel ?? inheritedRootModel;
   const needsMemberModel = effectiveOpenCodeMembers.some((member) => !member.model?.trim());
   if (rootModel && !needsMemberModel) {
@@ -70,7 +72,7 @@ export async function materializeOpenCodeRuntimeAdapterDefaults<
       members: effectiveMembers,
     };
   }
-  if (rootModel) {
+  if (rootModel && syncModelsWithLead) {
     return {
       request: {
         ...params.request,
@@ -118,7 +120,7 @@ export async function materializeOpenCodeRuntimeAdapterDefaults<
   return {
     request: {
       ...params.request,
-      model: normalizedDefaultModel,
+      model: explicitRootModel ?? normalizedDefaultModel,
     } as TRequest,
     members: effectiveMembers.map((member) => {
       const providerId = normalizeTeamMemberProviderId(member.providerId) ?? 'opencode';

--- a/src/main/services/team/provisioning/TeamProvisioningPrepareCoordinator.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningPrepareCoordinator.ts
@@ -648,7 +648,6 @@ export class TeamProvisioningPrepareCoordinator {
         defaultLaunchModel,
       });
     }
-
     return defaultLaunchModel;
   }
 
@@ -660,6 +659,7 @@ export class TeamProvisioningPrepareCoordinator {
       providerId?: TeamProviderId;
       model?: string;
       effort?: TeamCreateRequest['effort'];
+      syncModelsWithLead?: boolean;
     };
     primaryProviderId?: TeamProviderId;
     primaryEnv?: ProvisioningEnvResolution;

--- a/src/main/services/team/provisioning/TeamProvisioningPrepareFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningPrepareFacade.ts
@@ -198,6 +198,7 @@ export class TeamProvisioningPrepareFacade {
       providerId?: TeamProviderId;
       model?: string;
       effort?: TeamCreateRequest['effort'];
+      syncModelsWithLead?: boolean;
     };
     primaryProviderId?: TeamProviderId;
     primaryEnv?: ProvisioningEnvResolution;

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningConfiguredMemberSpecs.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningConfiguredMemberSpecs.test.ts
@@ -91,4 +91,31 @@ describe('TeamProvisioningConfiguredMemberSpecs', () => {
       effort: undefined,
     });
   });
+
+  it('does not reapply the lead model during teammate restart when sync is disabled', () => {
+    expect(
+      buildPrimaryOwnedMemberSpecForRuntime({
+        configuredMember: {
+          name: 'Builder',
+          agentType: 'specialist',
+        },
+        request: {
+          providerId: 'codex',
+          providerBackendId: 'codex-native',
+          model: 'gpt-5.6-sol',
+          effort: 'high',
+          fastMode: 'on',
+          syncModelsWithLead: false,
+        },
+      })
+    ).toEqual({
+      name: 'Builder',
+      providerId: 'codex',
+      providerBackendId: 'codex-native',
+      model: undefined,
+      effort: undefined,
+      fastMode: 'on',
+      agentType: 'specialist',
+    });
+  });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningMemberLifecycleStaleRun.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningMemberLifecycleStaleRun.test.ts
@@ -1354,7 +1354,12 @@ describe('TeamProvisioningMemberLifecycle stale run guards', () => {
       },
       teamMetaStore: {
         async getMeta() {
-          return { providerId: 'opencode', cwd: '/safe-test-project', prompt: 'Continue' };
+          return {
+            providerId: 'opencode',
+            cwd: '/safe-test-project',
+            prompt: 'Continue',
+            syncModelsWithLead: false,
+          };
         },
       },
       persistSentMessage(_teamName, message) {
@@ -1384,6 +1389,7 @@ describe('TeamProvisioningMemberLifecycle stale run guards', () => {
       request: expect.objectContaining({
         teamName: 'team-a',
         providerId: 'opencode',
+        syncModelsWithLead: false,
       }),
       members: [expect.objectContaining({ name: 'Worker', providerId: 'opencode' })],
     });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningMemberSpecs.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningMemberSpecs.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildEffectiveTeamMemberSpec } from '../TeamProvisioningMemberSpecs';
+
+describe('TeamProvisioningMemberSpecs', () => {
+  it('keeps legacy lead-model inheritance when the sync preference is absent', () => {
+    expect(
+      buildEffectiveTeamMemberSpec(
+        { name: 'builder' },
+        { providerId: 'codex', model: 'gpt-5.6-sol', effort: 'high' }
+      )
+    ).toEqual({
+      name: 'builder',
+      providerId: 'codex',
+      model: 'gpt-5.6-sol',
+      effort: 'high',
+    });
+  });
+
+  it('uses the teammate provider default when lead-model sync is disabled', () => {
+    expect(
+      buildEffectiveTeamMemberSpec(
+        { name: 'builder' },
+        {
+          providerId: 'codex',
+          model: 'gpt-5.6-sol',
+          effort: 'high',
+          syncModelsWithLead: false,
+        }
+      )
+    ).toEqual({
+      name: 'builder',
+      providerId: 'codex',
+      model: undefined,
+      effort: undefined,
+    });
+  });
+
+  it('preserves an explicit teammate model when lead-model sync is disabled', () => {
+    expect(
+      buildEffectiveTeamMemberSpec(
+        { name: 'builder', model: 'gpt-5.5', effort: 'medium' },
+        {
+          providerId: 'codex',
+          model: 'gpt-5.6-sol',
+          effort: 'high',
+          syncModelsWithLead: false,
+        }
+      )
+    ).toEqual({
+      name: 'builder',
+      providerId: 'codex',
+      model: 'gpt-5.5',
+      effort: 'medium',
+    });
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeDefaults.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeDefaults.test.ts
@@ -57,6 +57,25 @@ describe('OpenCode runtime defaults', () => {
     expect(ports.resolveProviderDefaultModel).not.toHaveBeenCalled();
   });
 
+  it('keeps OpenCode teammates on the provider default when lead-model sync is disabled', async () => {
+    const ports = createPorts();
+
+    const result = await materializeOpenCodeRuntimeAdapterDefaults(
+      {
+        request: createRequest({
+          model: 'opencode/gpt-5',
+          syncModelsWithLead: false,
+        }),
+        members: [{ name: 'dev', role: 'developer', providerId: 'opencode' }],
+      },
+      ports
+    );
+
+    expect(result.request.model).toBe('opencode/gpt-5');
+    expect(result.members[0]?.model).toBe('opencode/default');
+    expect(ports.resolveProviderDefaultModel).toHaveBeenCalledOnce();
+  });
+
   it('uses one inherited member model as the root model when no root model is selected', async () => {
     const ports = createPorts();
 

--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -53,6 +53,7 @@ import {
   shouldShowProviderStatusSkeleton,
 } from '@renderer/components/runtime/providerConnectionUi';
 import { ProviderModelBadges } from '@renderer/components/runtime/ProviderModelBadges';
+import { shouldShowLoadedProviderModels } from '@renderer/components/runtime/providerModelVisibility';
 import {
   buildProviderRuntimeBackendSummaryText,
   getProviderRuntimeBackendSummary,
@@ -98,6 +99,7 @@ import {
   SlidersHorizontal,
 } from 'lucide-react';
 
+import { DashboardRateLimitChips } from './DashboardRateLimitChips';
 import {
   getDashboardRateLimitsForProvider,
   isDashboardRateLimitSubscriptionMode,
@@ -151,67 +153,6 @@ const TerminalModal = lazy(() =>
     default: module.TerminalModal,
   }))
 );
-
-const DashboardRateLimitChips = ({
-  providerId,
-  items,
-  refreshCycle,
-  refreshing,
-}: {
-  providerId: CliProviderId;
-  items: DashboardRateLimitItem[];
-  refreshCycle: number;
-  refreshing: boolean;
-}): React.JSX.Element => {
-  const { t } = useAppTranslation('dashboard');
-
-  return (
-    <div
-      className="flex flex-wrap items-center gap-2"
-      aria-busy={refreshing}
-      aria-label={refreshing ? t('cliStatus.labels.loadingRateLimits') : undefined}
-    >
-      {items.map((item) => (
-        <div
-          key={`${providerId}-${item.label}-${refreshCycle}`}
-          className={`w-fit max-w-full rounded-md border px-2 py-1.5 ${
-            refreshing
-              ? 'skeleton-shimmer'
-              : refreshCycle > 0
-                ? 'dashboard-rate-limit-refreshed'
-                : ''
-          }`}
-          style={{
-            borderColor: 'rgba(74, 222, 128, 0.2)',
-            backgroundColor: 'rgba(74, 222, 128, 0.06)',
-          }}
-        >
-          <div className="flex items-baseline gap-1.5 whitespace-nowrap">
-            <span
-              className="text-[10px] uppercase tracking-[0.06em]"
-              style={{ color: 'var(--color-text-muted)' }}
-            >
-              {item.label}
-            </span>
-            <span
-              className="text-xs font-medium"
-              style={{ color: item.isDepleted ? '#f87171' : '#86efac' }}
-            >
-              {item.remaining}
-            </span>
-            <span
-              className="min-w-0 truncate text-[10px]"
-              style={{ color: 'var(--color-text-secondary)' }}
-              title={item.resetsAt}
-            >
-              • {t('cliStatus.labels.resets', { time: item.resetsAt })}
-            </span>
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-};
 
 const RATE_LIMIT_SKELETON_LABELS = ['5h left', 'Weekly left'] as const;
 
@@ -1204,9 +1145,15 @@ const InstalledBanner = ({
               hasRateLimits: hasDashboardRateLimits,
               loading: rateLimitsLoading,
             });
+            const openCodeRuntimeContradictsMissingMetadata =
+              provider.providerId === 'opencode' &&
+              provider.statusCheckErrorCode === 'runtime_missing' &&
+              isOpenCodeRuntimeUsable(openCodeRuntimeStatus);
             const statusText = showSkeleton
               ? t('cliStatus.actions.checking')
-              : formatProviderStatusText(provider, settingsT);
+              : openCodeRuntimeContradictsMissingMetadata
+                ? t('cliStatus.quickConnect.connected')
+                : formatProviderStatusText(provider, settingsT);
             const modelCatalogLoading =
               provider.modelCatalogRefreshState === 'loading' ||
               isOpenCodeCatalogHydrating(provider);
@@ -1215,6 +1162,7 @@ const InstalledBanner = ({
                 ? getVisibleTeamProviderModels(provider.providerId, provider.models, provider)
                     .length > 0
                 : provider.models.length > 0;
+            const showProviderModels = shouldShowLoadedProviderModels(provider, hasProviderModels);
             const openCodeDashboardChips = getOpenCodeDashboardChips(provider, t);
             const hasDetailContent = Boolean(
               (provider.backend?.label && !runtimeSummary) ||
@@ -1476,7 +1424,7 @@ const InstalledBanner = ({
                     </button>
                   </div>
                 </div>
-                {!showSkeleton && !modelCatalogLoading && hasProviderModels && (
+                {!showSkeleton && showProviderModels && (
                   <div className="col-span-2">
                     <ProviderModelBadges
                       providerId={provider.providerId}

--- a/src/renderer/components/dashboard/DashboardRateLimitChips.tsx
+++ b/src/renderer/components/dashboard/DashboardRateLimitChips.tsx
@@ -1,0 +1,75 @@
+import { useAppTranslation } from '@features/localization/renderer';
+
+import type { DashboardRateLimitItem } from './providerDashboardRateLimits';
+import type { CliProviderId } from '@shared/types';
+
+interface DashboardRateLimitChipsProps {
+  providerId: CliProviderId;
+  items: DashboardRateLimitItem[];
+  refreshCycle: number;
+  refreshing: boolean;
+}
+
+export const DashboardRateLimitChips = ({
+  providerId,
+  items,
+  refreshCycle,
+  refreshing,
+}: DashboardRateLimitChipsProps): React.JSX.Element => {
+  const { t } = useAppTranslation('dashboard');
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2"
+      aria-busy={refreshing}
+      aria-label={refreshing ? t('cliStatus.labels.loadingRateLimits') : undefined}
+    >
+      {items.map((item) => (
+        <div
+          key={`${providerId}-${item.label}-${refreshCycle}`}
+          className={`relative w-fit max-w-full overflow-hidden rounded-md border px-2 py-1.5 ${
+            refreshing
+              ? 'skeleton-shimmer'
+              : refreshCycle > 0
+                ? 'dashboard-rate-limit-refreshed'
+                : ''
+          }`}
+          style={{
+            borderColor: 'rgba(74, 222, 128, 0.2)',
+            backgroundColor: 'rgba(74, 222, 128, 0.035)',
+          }}
+        >
+          <div
+            className="dashboard-rate-limit-progress pointer-events-none absolute inset-y-0 left-0 transition-[width] duration-500 ease-out"
+            style={{
+              width: `${item.remainingPercent}%`,
+              backgroundColor: 'rgba(74, 222, 128, 0.1)',
+            }}
+            aria-hidden="true"
+          />
+          <div className="relative z-10 flex items-baseline gap-1.5 whitespace-nowrap">
+            <span
+              className="text-[10px] uppercase tracking-[0.06em]"
+              style={{ color: 'var(--color-text-muted)' }}
+            >
+              {item.label}
+            </span>
+            <span
+              className="text-xs font-medium"
+              style={{ color: item.isDepleted ? '#f87171' : '#86efac' }}
+            >
+              {item.remaining}
+            </span>
+            <span
+              className="min-w-0 truncate text-[10px]"
+              style={{ color: 'var(--color-text-secondary)' }}
+              title={item.resetsAt}
+            >
+              • {t('cliStatus.labels.resets', { time: item.resetsAt })}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/renderer/components/dashboard/providerDashboardRateLimits.test.ts
+++ b/src/renderer/components/dashboard/providerDashboardRateLimits.test.ts
@@ -121,12 +121,14 @@ describe('providerDashboardRateLimits', () => {
       {
         label: '5h left',
         remaining: '75%',
+        remainingPercent: 75,
         resetsAt: 'reset unknown',
         isDepleted: false,
       },
       {
         label: 'Weekly left',
         remaining: '50%',
+        remainingPercent: 50,
         resetsAt: 'reset unknown',
         isDepleted: false,
       },
@@ -190,6 +192,7 @@ describe('providerDashboardRateLimits', () => {
       {
         label: '5h left',
         remaining: '80%',
+        remainingPercent: 80,
         resetsAt: 'reset unknown',
         isDepleted: false,
       },
@@ -215,6 +218,7 @@ describe('providerDashboardRateLimits', () => {
       {
         label: '5h left',
         remaining: '75%',
+        remainingPercent: 75,
         resetsAt: 'reset unknown',
         isDepleted: false,
       },
@@ -248,6 +252,7 @@ describe('providerDashboardRateLimits', () => {
 
     expect(items?.[0]).toMatchObject({
       remaining: '0%',
+      remainingPercent: 0,
       isDepleted: true,
     });
   });

--- a/src/renderer/components/dashboard/providerDashboardRateLimits.ts
+++ b/src/renderer/components/dashboard/providerDashboardRateLimits.ts
@@ -13,6 +13,7 @@ import type { CliProviderAuthMode, CliProviderStatus } from '@shared/types';
 export interface DashboardRateLimitItem {
   label: string;
   remaining: string;
+  remainingPercent: number;
   resetsAt: string;
   isDepleted: boolean;
 }
@@ -194,6 +195,10 @@ function isRateLimitDepleted(usedPercent: number | null | undefined): boolean {
   return typeof usedPercent === 'number' && Number.isFinite(usedPercent) && usedPercent >= 100;
 }
 
+function getRemainingPercent(usedPercent: number): number {
+  return Math.max(0, Math.min(100, 100 - usedPercent));
+}
+
 function buildRateLimitItem(
   label: string,
   usedPercent: number,
@@ -202,6 +207,7 @@ function buildRateLimitItem(
   return {
     label,
     remaining: formatCodexRemainingPercent(usedPercent) ?? 'Unknown',
+    remainingPercent: getRemainingPercent(usedPercent),
     resetsAt: formatDashboardResetTime(resetsAt),
     isDepleted: isRateLimitDepleted(usedPercent),
   };

--- a/src/renderer/components/runtime/ProviderModelBadges.tsx
+++ b/src/renderer/components/runtime/ProviderModelBadges.tsx
@@ -51,19 +51,16 @@ function getAvailabilityChip(
   }
 }
 
-function getCatalogBadgeLabel(
+function isCatalogModelFree(
   model: string,
   providerStatus: Pick<CliProviderStatus, 'modelCatalog' | 'providerId'> | null | undefined
-): string | null {
+): boolean {
   const catalogItem = providerStatus?.modelCatalog?.models.find(
     (item) => item.launchModel === model || item.id === model
   );
   const badgeLabel = catalogItem?.badgeLabel?.trim();
   if (providerStatus?.providerId !== 'opencode') {
-    return badgeLabel || (catalogItem?.metadata?.free === true ? 'Free' : null);
-  }
-  if (badgeLabel && badgeLabel.toLowerCase() !== 'free') {
-    return badgeLabel;
+    return catalogItem?.metadata?.free === true || badgeLabel?.toLowerCase() === 'free';
   }
   const route = catalogItem?.metadata?.opencode;
   return isOpenCodeModelExplicitlyFree({
@@ -74,20 +71,7 @@ function getCatalogBadgeLabel(
     accessKind: route?.accessKind,
     free: catalogItem?.metadata?.free,
     badgeLabel,
-  })
-    ? (badgeLabel ?? 'Free')
-    : null;
-}
-
-function normalizeBadgeText(value: string): string {
-  return value.trim().replace(/\s+/g, ' ').toLowerCase();
-}
-
-function shouldRenderCatalogBadge(modelLabel: string, catalogBadgeLabel: string | null): boolean {
-  if (!catalogBadgeLabel) {
-    return false;
-  }
-  return normalizeBadgeText(modelLabel) !== normalizeBadgeText(catalogBadgeLabel);
+  });
 }
 
 function hasChildAfterRowLimit(container: HTMLElement, rowLimit: number): boolean {
@@ -194,52 +178,38 @@ export const ProviderModelBadges = ({
     return () => observer.disconnect();
   }, [expanded, maxCollapsedRows, shouldCollapse]);
 
-  const badgeClassName =
-    'inline-flex items-center gap-1 rounded-md border px-1.5 py-px font-mono text-[10px] leading-4';
-  const badgeStyle = {
-    borderColor: 'var(--color-border-subtle)',
-    backgroundColor: 'rgba(255, 255, 255, 0.03)',
-    color: 'var(--color-text-secondary)',
-  };
+  const modelClassName =
+    'inline-flex items-center font-mono text-[11px] leading-5 text-[var(--color-text-secondary)]';
   const buttonClassName =
     'inline-flex items-center gap-1 rounded-full border border-[rgba(59,130,246,0.35)] bg-[rgba(59,130,246,0.12)] px-2 py-px text-[10px] font-medium leading-4 text-[rgb(147,197,253)] transition-colors hover:border-[rgba(59,130,246,0.55)] hover:bg-[rgba(59,130,246,0.18)] hover:text-[rgb(191,219,254)]';
-  const listClassName = cn('flex flex-wrap gap-1.5');
+  const listClassName = cn('flex flex-wrap items-center gap-x-[2ch] gap-y-0.5');
 
-  const renderModelBadge = (model: string, index: number): React.JSX.Element => {
+  const renderModelText = (model: string, index: number): React.JSX.Element => {
     const availabilityStatus = getAvailabilityStatus(model, displayModelAvailability);
     const availabilityReason = getAvailabilityReason(model, displayModelAvailability);
     const availabilityChip = getAvailabilityChip(availabilityStatus, t);
     const modelLabel = formatModelBadgeLabel(providerId, model);
-    const catalogBadgeLabel = getCatalogBadgeLabel(model, providerStatus);
-    const catalogBadgeIsFree = catalogBadgeLabel === 'Free';
-    const localizedCatalogBadgeLabel = catalogBadgeIsFree
-      ? t('providerModelBadges.free')
-      : catalogBadgeLabel;
-    const showCatalogBadge = shouldRenderCatalogBadge(modelLabel, catalogBadgeLabel);
+    const catalogModelIsFree = isCatalogModelFree(model, providerStatus);
+    const hasFollowingModel = index < displayedModels.length - 1;
     const title = [
       availabilityReason ?? availabilityChip,
-      showCatalogBadge && catalogBadgeIsFree ? t('providerModelBadges.freeTooltip') : null,
+      catalogModelIsFree ? t('providerModelBadges.freeTooltip') : null,
     ]
       .filter(Boolean)
       .join(' - ');
 
     return (
-      <span
-        key={`${model}-${index}`}
-        className={badgeClassName}
-        style={badgeStyle}
-        title={title || undefined}
-      >
+      <span key={`${model}-${index}`} className={modelClassName} title={title || undefined}>
         <span>{modelLabel}</span>
-        {showCatalogBadge ? (
-          <span className="rounded bg-[rgba(34,197,94,0.14)] px-1 py-0 text-[9px] font-medium uppercase tracking-[0.06em] text-[rgb(74,222,128)]">
-            {localizedCatalogBadgeLabel}
+        {catalogModelIsFree ? (
+          <span className="ml-1 rounded bg-[rgba(34,197,94,0.14)] px-1 py-0 text-[9px] font-medium uppercase tracking-[0.06em] text-[rgb(74,222,128)]">
+            {t('providerModelBadges.free')}
           </span>
         ) : null}
         {availabilityChip ? (
           <span
             className={cn(
-              'rounded px-1 py-0 text-[9px] font-medium uppercase tracking-[0.06em]',
+              'ml-1 rounded px-1 py-0 text-[9px] font-medium uppercase tracking-[0.06em]',
               availabilityStatus === 'checking'
                 ? 'bg-[rgba(59,130,246,0.12)] text-[var(--color-text-secondary)]'
                 : availabilityStatus === 'unavailable'
@@ -250,18 +220,19 @@ export const ProviderModelBadges = ({
             {availabilityChip}
           </span>
         ) : null}
+        {hasFollowingModel ? <span>,</span> : null}
       </span>
     );
   };
 
   if (!shouldCollapse) {
-    return <div className="flex flex-wrap gap-1.5">{displayedModels.map(renderModelBadge)}</div>;
+    return <div className={listClassName}>{displayedModels.map(renderModelText)}</div>;
   }
 
   return (
     <div className="flex flex-col items-start gap-1.5">
       <div ref={listRef} className={listClassName}>
-        {displayedModels.map(renderModelBadge)}
+        {displayedModels.map(renderModelText)}
         {shouldCollapse && !expanded ? (
           <button type="button" className={buttonClassName} onClick={() => setExpanded(true)}>
             <ChevronDown className="size-3" />

--- a/src/renderer/components/runtime/providerModelVisibility.ts
+++ b/src/renderer/components/runtime/providerModelVisibility.ts
@@ -1,0 +1,24 @@
+import { isOpenCodeCatalogHydrating } from './providerConnectionUi';
+
+import type { CliProviderStatus } from '@shared/types';
+
+export function shouldShowLoadedProviderModels(
+  provider:
+    | Pick<
+        CliProviderStatus,
+        | 'providerId'
+        | 'models'
+        | 'modelCatalog'
+        | 'modelCatalogRefreshState'
+        | 'runtimeCapabilities'
+      >
+    | null
+    | undefined,
+  hasVisibleModels: boolean
+): boolean {
+  if (!provider || !hasVisibleModels) return false;
+  if (!isOpenCodeCatalogHydrating(provider)) return true;
+
+  const reportedModels = provider.models.map((model) => model.trim()).filter(Boolean);
+  return reportedModels.length !== 1 || reportedModels[0]?.toLowerCase() !== 'opencode/big-pickle';
+}

--- a/src/renderer/components/settings/sections/CliStatusSection.tsx
+++ b/src/renderer/components/settings/sections/CliStatusSection.tsx
@@ -31,6 +31,7 @@ import {
   shouldShowProviderStatusSkeleton,
 } from '@renderer/components/runtime/providerConnectionUi';
 import { ProviderModelBadges } from '@renderer/components/runtime/ProviderModelBadges';
+import { shouldShowLoadedProviderModels } from '@renderer/components/runtime/providerModelVisibility';
 import {
   buildProviderRuntimeBackendSummaryText,
   getProviderRuntimeBackendSummary,
@@ -654,8 +655,7 @@ export const CliStatusSection = (): React.JSX.Element | null => {
                                 </div>
                               </div>
                               {!effectiveShowSkeleton &&
-                                !modelCatalogLoading &&
-                                hasProviderModels && (
+                                shouldShowLoadedProviderModels(provider, hasProviderModels) && (
                                   <div className="col-span-2">
                                     <ProviderModelBadges
                                       providerId={provider.providerId}

--- a/src/renderer/components/team/TeamListView.tsx
+++ b/src/renderer/components/team/TeamListView.tsx
@@ -904,7 +904,6 @@ export const TeamListView = memo(function TeamListView(): React.JSX.Element {
         try {
           const existingNames = teams.map((t) => t.teamName);
           const uniqueName = generateUniqueName(teamName, existingNames);
-
           const savedRequest = await api.teams.getSavedRequest(teamName).catch(() => null);
           if (savedRequest) {
             setCopyData({
@@ -917,6 +916,7 @@ export const TeamListView = memo(function TeamListView(): React.JSX.Element {
               model: savedRequest.model,
               effort: savedRequest.effort,
               fastMode: savedRequest.fastMode,
+              syncModelsWithLead: savedRequest.syncModelsWithLead,
               limitContext: savedRequest.limitContext,
               skipPermissions: savedRequest.skipPermissions,
               members: buildCopiedTeamMembers(savedRequest.members),

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -231,6 +231,7 @@ export interface TeamCopyData extends Pick<
   | 'model'
   | 'effort'
   | 'fastMode'
+  | 'syncModelsWithLead'
   | 'limitContext'
   | 'skipPermissions'
   | 'members'
@@ -1527,14 +1528,16 @@ export const CreateTeamDialog = ({
     }
 
     if (initialData) {
-      const nextSyncModelsWithLead = !initialData.members.some(
-        (member) =>
-          member.providerId ||
-          member.providerBackendId ||
-          member.model ||
-          member.effort ||
-          member.fastMode
-      );
+      const nextSyncModelsWithLead =
+        initialData.syncModelsWithLead ??
+        !initialData.members.some(
+          (member) =>
+            member.providerId ||
+            member.providerBackendId ||
+            member.model ||
+            member.effort ||
+            member.fastMode
+        );
       const copiedProviderId =
         initialData.providerId == null
           ? selectedProviderId
@@ -1986,6 +1989,7 @@ export const CreateTeamDialog = ({
         selectedProviderId === 'anthropic' || selectedProviderId === 'codex'
           ? selectedFastMode
           : undefined,
+      syncModelsWithLead,
       limitContext: effectiveAnthropicRuntimeLimitContext,
       skipPermissions,
       allowExperimentalLocalModels: experimentalLocalModelOverrideEnabled || undefined,
@@ -2005,6 +2009,7 @@ export const CreateTeamDialog = ({
       effectiveModel,
       selectedEffortForCurrentSelection,
       selectedFastMode,
+      syncModelsWithLead,
       effectiveAnthropicRuntimeLimitContext,
       skipPermissions,
       experimentalLocalModelOverrideEnabled,
@@ -2239,7 +2244,6 @@ export const CreateTeamDialog = ({
         activePlacementParent ? getOrganizationUnitLabel(activePlacementParent) : '',
       ].filter(Boolean)
     : [];
-
   const conflictingTeam = useMemo(() => {
     if (!launchTeam) return null;
     if (!activeTeams?.length || !effectiveCwd) return null;
@@ -2309,6 +2313,7 @@ export const CreateTeamDialog = ({
             model: request.model,
             effort: request.effort,
             fastMode: request.fastMode,
+            syncModelsWithLead: request.syncModelsWithLead,
             limitContext: request.limitContext,
             skipPermissions: request.skipPermissions,
             worktree: request.worktree,
@@ -2751,129 +2756,130 @@ export const CreateTeamDialog = ({
 
           <div className="md:col-span-2">
             <OptionalSettingsSection
-              title={t('create.organizationPlacement.title')}
-              description={t('create.organizationPlacement.description')}
-              summary={organizationPlacementSummary}
-            >
-              <div className="space-y-3">
-                <div className="flex items-start gap-3">
-                  <Checkbox
-                    id="organization-placement-enabled"
-                    className="mt-1 shrink-0"
-                    checked={organizationPlacementEnabled}
-                    disabled={
-                      organizationStructureLoading ||
-                      organizationPlacementOrganizations.length === 0
-                    }
-                    onCheckedChange={(checked) => setOrganizationPlacementEnabled(checked === true)}
-                  />
-                  <div className="min-w-0 space-y-1">
-                    <Label
-                      htmlFor="organization-placement-enabled"
-                      className="cursor-pointer text-sm font-semibold"
-                    >
-                      {t('create.organizationPlacement.addToOrganization')}
-                    </Label>
-                    {organizationPlacementError ? (
-                      <p className="text-[11px]" style={{ color: 'var(--field-error-text)' }}>
-                        {organizationPlacementError}
-                      </p>
-                    ) : null}
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                  <div className="space-y-1.5">
-                    <div className="space-y-0.5">
-                      <Label className="text-xs">
-                        {t('create.organizationPlacement.organizationLabel')}
-                      </Label>
-                      <p className="text-[11px] text-[var(--color-text-muted)]">
-                        {t('create.organizationPlacement.organizationHelp')}
-                      </p>
-                    </div>
-                    <Select
-                      value={activePlacementOrganization?.id ?? ''}
-                      disabled={
-                        !organizationPlacementEnabled ||
-                        organizationPlacementOrganizations.length === 0
-                      }
-                      onValueChange={(value) => {
-                        setOrganizationPlacementOrganizationId(value);
-                        const organization = organizationPlacementOrganizations.find(
-                          (candidate) => candidate.id === value
-                        );
-                        setOrganizationPlacementParentId(organization?.rootNodeId ?? '');
-                      }}
-                    >
-                      <SelectTrigger className="h-8 text-xs">
-                        <SelectValue
-                          placeholder={t('create.organizationPlacement.organizationPlaceholder')}
-                        />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {organizationPlacementOrganizations.map((organization) => (
-                          <SelectItem key={organization.id} value={organization.id}>
-                            {organization.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="space-y-1.5">
-                    <div className="space-y-0.5">
-                      <Label className="text-xs">
-                        {t('create.organizationPlacement.groupOrRootLabel')}
-                      </Label>
-                      <p className="text-[11px] text-[var(--color-text-muted)]">
-                        {t('create.organizationPlacement.groupOrRootHelp')}
-                      </p>
-                    </div>
-                    <Select
-                      value={activePlacementParent?.id ?? ''}
-                      disabled={
-                        !organizationPlacementEnabled ||
-                        organizationPlacementParentOptions.length === 0
-                      }
-                      onValueChange={setOrganizationPlacementParentId}
-                    >
-                      <SelectTrigger className="h-8 text-xs">
-                        <SelectValue
-                          placeholder={t('create.organizationPlacement.groupOrRootPlaceholder')}
-                        />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {organizationPlacementParentOptions.map((option) => (
-                          <SelectItem key={option.unit.id} value={option.unit.id}>
-                            <span
-                              className="flex min-w-0 items-center gap-2"
-                              style={{ paddingLeft: `${Math.min(option.depth, 6) * 12}px` }}
-                            >
-                              <span className="truncate">
-                                {getOrganizationUnitLabel(option.unit)}
-                              </span>
-                              <span className="shrink-0 text-[10px] uppercase tracking-wide text-[var(--color-text-muted)]">
-                                {t(getOrganizationPlacementUnitKindKey(option.unit))}
-                              </span>
-                            </span>
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-              </div>
-            </OptionalSettingsSection>
-          </div>
-
-          <div className="md:col-span-2">
-            <OptionalSettingsSection
               title={t('create.optional.teamDetailsTitle')}
               description={t('create.optional.teamDetailsDescription')}
-              summary={teamDetailsSummary}
+              summary={[...teamDetailsSummary, ...organizationPlacementSummary]}
             >
               <div className="space-y-4">
+                <div className="space-y-3 border-b border-[var(--color-border)] pb-4">
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold">
+                      {t('create.organizationPlacement.title')}
+                    </p>
+                    <p className="text-xs text-[var(--color-text-muted)]">
+                      {t('create.organizationPlacement.description')}
+                    </p>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <Checkbox
+                      id="organization-placement-enabled"
+                      className="mt-1 shrink-0"
+                      checked={organizationPlacementEnabled}
+                      disabled={
+                        organizationStructureLoading ||
+                        organizationPlacementOrganizations.length === 0
+                      }
+                      onCheckedChange={(checked) =>
+                        setOrganizationPlacementEnabled(checked === true)
+                      }
+                    />
+                    <div className="min-w-0 space-y-1">
+                      <Label
+                        htmlFor="organization-placement-enabled"
+                        className="cursor-pointer text-sm font-semibold"
+                      >
+                        {t('create.organizationPlacement.addToOrganization')}
+                      </Label>
+                      {organizationPlacementError ? (
+                        <p className="text-[11px]" style={{ color: 'var(--field-error-text)' }}>
+                          {organizationPlacementError}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                    <div className="space-y-1.5">
+                      <div className="space-y-0.5">
+                        <Label className="text-xs">
+                          {t('create.organizationPlacement.organizationLabel')}
+                        </Label>
+                        <p className="text-[11px] text-[var(--color-text-muted)]">
+                          {t('create.organizationPlacement.organizationHelp')}
+                        </p>
+                      </div>
+                      <Select
+                        value={activePlacementOrganization?.id ?? ''}
+                        disabled={
+                          !organizationPlacementEnabled ||
+                          organizationPlacementOrganizations.length === 0
+                        }
+                        onValueChange={(value) => {
+                          setOrganizationPlacementOrganizationId(value);
+                          const organization = organizationPlacementOrganizations.find(
+                            (candidate) => candidate.id === value
+                          );
+                          setOrganizationPlacementParentId(organization?.rootNodeId ?? '');
+                        }}
+                      >
+                        <SelectTrigger className="h-8 text-xs">
+                          <SelectValue
+                            placeholder={t('create.organizationPlacement.organizationPlaceholder')}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {organizationPlacementOrganizations.map((organization) => (
+                            <SelectItem key={organization.id} value={organization.id}>
+                              {organization.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div className="space-y-1.5">
+                      <div className="space-y-0.5">
+                        <Label className="text-xs">
+                          {t('create.organizationPlacement.groupOrRootLabel')}
+                        </Label>
+                        <p className="text-[11px] text-[var(--color-text-muted)]">
+                          {t('create.organizationPlacement.groupOrRootHelp')}
+                        </p>
+                      </div>
+                      <Select
+                        value={activePlacementParent?.id ?? ''}
+                        disabled={
+                          !organizationPlacementEnabled ||
+                          organizationPlacementParentOptions.length === 0
+                        }
+                        onValueChange={setOrganizationPlacementParentId}
+                      >
+                        <SelectTrigger className="h-8 text-xs">
+                          <SelectValue
+                            placeholder={t('create.organizationPlacement.groupOrRootPlaceholder')}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {organizationPlacementParentOptions.map((option) => (
+                            <SelectItem key={option.unit.id} value={option.unit.id}>
+                              <span
+                                className="flex min-w-0 items-center gap-2"
+                                style={{ paddingLeft: `${Math.min(option.depth, 6) * 12}px` }}
+                              >
+                                <span className="truncate">
+                                  {getOrganizationUnitLabel(option.unit)}
+                                </span>
+                                <span className="shrink-0 text-[10px] uppercase tracking-wide text-[var(--color-text-muted)]">
+                                  {t(getOrganizationPlacementUnitKindKey(option.unit))}
+                                </span>
+                              </span>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                </div>
                 <div className="space-y-1.5">
                   <Label htmlFor="team-description" className="label-optional">
                     {t('create.fields.description')}

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -935,11 +935,17 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
         setTeammateWorktreeDefault(deriveTeammateWorktreeDefault(inputs));
         setSyncModelsWithLead(
           savedSyncModelsWithLead ??
-            !inputs.some((member) => member.providerId || member.model || member.effort)
+            !inputs.some(
+              (member) =>
+                member.providerId ||
+                member.providerBackendId ||
+                member.model ||
+                member.effort ||
+                ('fastMode' in member && member.fastMode)
+            )
         );
       }
     };
-
     if (filterEditableMemberInputs(members).length > 0) applyEditableRoster();
 
     let cancelled = false;

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -915,7 +915,10 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     // Hydrate at most once per open dialog, and never on top of user edits.
     if (hydrationRef.current.dirty || hydrationRef.current.key === effectiveTeamName) return;
 
-    const applyEditableRoster = (savedMembers?: TeamCreateRequest['members']): void => {
+    const applyEditableRoster = (
+      savedMembers?: TeamCreateRequest['members'],
+      savedSyncModelsWithLead?: boolean
+    ): void => {
       const inputs =
         members.length > 0
           ? filterEditableMemberInputs(members)
@@ -931,7 +934,8 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       if (!hydrationRef.current.dirty) {
         setTeammateWorktreeDefault(deriveTeammateWorktreeDefault(inputs));
         setSyncModelsWithLead(
-          !inputs.some((member) => member.providerId || member.model || member.effort)
+          savedSyncModelsWithLead ??
+            !inputs.some((member) => member.providerId || member.model || member.effort)
         );
       }
     };
@@ -951,7 +955,9 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       // Edits made while the request was in flight win over it, but an unrelated control is
       // not a roster edit — and with no live members the saved request is its only source.
       if (cancelled) return;
-      if (!hydrationRef.current.rosterDirty) applyEditableRoster(savedRequest?.members);
+      if (!hydrationRef.current.rosterDirty) {
+        applyEditableRoster(savedRequest?.members, savedRequest?.syncModelsWithLead);
+      }
       if (hydrationRef.current.dirty) return;
 
       const storedEffort = localStorage.getItem('team:lastSelectedEffort');
@@ -2334,6 +2340,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
               selectedProviderId === 'anthropic' || selectedProviderId === 'codex'
                 ? selectedFastMode
                 : undefined,
+            syncModelsWithLead,
             limitContext: effectiveAnthropicRuntimeLimitContext,
             skipPermissions,
             allowExperimentalLocalModels: experimentalLocalModelOverrideEnabled || undefined,

--- a/src/renderer/components/team/dialogs/TeamModelSelector.tsx
+++ b/src/renderer/components/team/dialogs/TeamModelSelector.tsx
@@ -3086,9 +3086,6 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
   return (
     <TooltipProvider delayDuration={150} skipDelayDuration={1500}>
       <div className="mb-5">
-        <Label htmlFor={id} className="label-optional mb-1.5 block">
-          {t('modelSelector.label')}
-        </Label>
         <Tabs
           orientation="vertical"
           value={activeProviderTabId}

--- a/src/renderer/components/team/members/MemberDraftRow.test.tsx
+++ b/src/renderer/components/team/members/MemberDraftRow.test.tsx
@@ -185,6 +185,14 @@ describe('MemberDraftRow', () => {
     expect(nameInput.className).not.toContain('shadow-none');
     expect(nameInput.className).not.toContain('font-semibold');
 
+    const removeButton = host.querySelector<HTMLButtonElement>(
+      'button[aria-label="Remove alice"]'
+    )!;
+    const actionRow = removeButton.parentElement!;
+    expect(actionRow.className).toContain('sm:flex-nowrap');
+    expect(actionRow.className).not.toContain('sm:flex-wrap');
+    expect(actionRow.firstElementChild?.className).toContain('sm:min-w-[140px]');
+
     act(() => {
       root.unmount();
     });

--- a/src/renderer/components/team/members/MemberDraftRow.tsx
+++ b/src/renderer/components/team/members/MemberDraftRow.tsx
@@ -561,13 +561,13 @@ export const MemberDraftRow = ({
         <div
           className={cn(
             'flex flex-col gap-2 sm:flex-row sm:items-start',
-            isFlatRoster && 'sm:flex-wrap sm:gap-1.5'
+            isFlatRoster && 'sm:flex-nowrap sm:gap-1.5'
           )}
         >
           <div
             className={cn(
               'w-full min-w-0 space-y-1',
-              isFlatRoster ? 'sm:w-[170px] sm:min-w-[170px]' : 'sm:w-[150px] sm:min-w-[150px]'
+              isFlatRoster ? 'sm:w-[170px] sm:min-w-[140px]' : 'sm:w-[150px] sm:min-w-[150px]'
             )}
           >
             <HoverTooltip

--- a/src/renderer/components/team/members/MembersEditorSection.test.tsx
+++ b/src/renderer/components/team/members/MembersEditorSection.test.tsx
@@ -376,6 +376,19 @@ describe('MembersEditorSection runtime model selection', () => {
 });
 
 describe('MembersEditorSection worktree master checkbox', () => {
+  it('shows the bulk worktree control when at least one member is active', () => {
+    const alice = createMemberDraft({ id: 'alice', name: 'alice' });
+    const removedAlice = { ...alice, removedAt: Date.now() };
+    const { host, rerender } = renderMembersEditor({ members: [removedAlice] });
+
+    expect(host.querySelector('#teammate-worktree-default-worktree-test')).toBeNull();
+    expect(host.querySelector('#teammate-agent-teams-mcp-default-worktree-test')).toBeTruthy();
+
+    rerender([alice]);
+
+    expect(masterWorktreeCheckbox(host)).toBeTruthy();
+  });
+
   it('renders indeterminate when only some active members use worktrees', () => {
     const { host } = renderMembersEditor({
       members: [

--- a/src/renderer/components/team/members/MembersEditorSection.tsx
+++ b/src/renderer/components/team/members/MembersEditorSection.tsx
@@ -525,32 +525,36 @@ export const MembersEditorSection = ({
   const masterRosterControls =
     showWorktreeIsolationControls && !singleMemberMode ? (
       <>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex min-w-0 items-center gap-2">
-              <Checkbox
-                id={worktreeDefaultControlId}
-                checked={teammateWorktreeDefaultChecked}
-                disabled={worktreeDefaultDisabled}
-                aria-describedby={`${worktreeDefaultControlId}-description`}
-                onCheckedChange={(checked) => updateTeammateWorktreeDefault(checked === true)}
-              />
-              <Label
-                htmlFor={worktreeDefaultControlId}
-                className="flex min-w-0 cursor-pointer items-center gap-1.5 text-xs font-normal text-[var(--color-text-secondary)]"
-              >
-                {!isFlatRoster ? <GitBranch className="size-3.5 shrink-0" /> : null}
-                <span className="truncate">{t('members.editor.runInSeparateWorktrees')}</span>
-              </Label>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent className="max-w-sm text-xs">
-            {worktreeIsolationDisabledReason ?? t('members.editor.worktreeDescription')}
-          </TooltipContent>
-        </Tooltip>
-        <span id={`${worktreeDefaultControlId}-description`} className="sr-only">
-          {worktreeIsolationDisabledReason ?? t('members.editor.worktreeDescription')}
-        </span>
+        {activeMembers.length > 0 ? (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="flex min-w-0 items-center gap-2">
+                  <Checkbox
+                    id={worktreeDefaultControlId}
+                    checked={teammateWorktreeDefaultChecked}
+                    disabled={worktreeDefaultDisabled}
+                    aria-describedby={`${worktreeDefaultControlId}-description`}
+                    onCheckedChange={(checked) => updateTeammateWorktreeDefault(checked === true)}
+                  />
+                  <Label
+                    htmlFor={worktreeDefaultControlId}
+                    className="flex min-w-0 cursor-pointer items-center gap-1.5 text-xs font-normal text-[var(--color-text-secondary)]"
+                  >
+                    {!isFlatRoster ? <GitBranch className="size-3.5 shrink-0" /> : null}
+                    <span className="truncate">{t('members.editor.runInSeparateWorktrees')}</span>
+                  </Label>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-sm text-xs">
+                {worktreeIsolationDisabledReason ?? t('members.editor.worktreeDescription')}
+              </TooltipContent>
+            </Tooltip>
+            <span id={`${worktreeDefaultControlId}-description`} className="sr-only">
+              {worktreeIsolationDisabledReason ?? t('members.editor.worktreeDescription')}
+            </span>
+          </>
+        ) : null}
         <div className="flex shrink-0 items-center gap-2">
           <Checkbox
             id={agentTeamsMcpDefaultControlId}

--- a/src/renderer/hooks/useOpenCodeCatalogPrefetch.ts
+++ b/src/renderer/hooks/useOpenCodeCatalogPrefetch.ts
@@ -164,6 +164,9 @@ export function useOpenCodeCatalogPrefetch({
     if (priority === 'background' && deferBackground) {
       return;
     }
+    if (retryExhaustedRevisionByScopeRef.current.get(normalizedProjectPath) === scopeRevision) {
+      return;
+    }
     if (requestRevisionByScopeRef.current.get(normalizedProjectPath) === scopeRevision) {
       return;
     }

--- a/src/shared/types/team.ts
+++ b/src/shared/types/team.ts
@@ -1068,8 +1068,8 @@ export interface TeamLaunchRequest extends TeamProvisioningTypes.LocalModelLaunc
   model?: string;
   effort?: EffortLevel;
   fastMode?: TeamFastMode;
-  /** When true, context window is limited to 200K tokens instead of the default. */
-  limitContext?: boolean;
+  /** When false, teammates use their provider default. */ syncModelsWithLead?: boolean;
+  /** When true, context is limited to 200K tokens. */ limitContext?: boolean;
   /** Legacy flag retained for compatibility. Deterministic bootstrap launches fresh today. */
   clearContext?: boolean;
   /** When false, run WITHOUT --dangerously-skip-permissions (manual tool approval). Default: true. */
@@ -1515,8 +1515,8 @@ export interface TeamCreateRequest extends TeamProvisioningTypes.LocalModelLaunc
   model?: string;
   effort?: EffortLevel;
   fastMode?: TeamFastMode;
-  /** When true, context window is limited to 200K tokens instead of the default. */
-  limitContext?: boolean;
+  /** When false, teammates use their provider default. */ syncModelsWithLead?: boolean;
+  /** When true, context is limited to 200K tokens. */ limitContext?: boolean;
   /** When false, run WITHOUT --dangerously-skip-permissions (manual tool approval). Default: true. */
   skipPermissions?: boolean;
   /** Worktree name — CLI: --worktree <name>. */
@@ -1538,8 +1538,8 @@ export interface TeamCreateConfigRequest {
   model?: string;
   effort?: EffortLevel;
   fastMode?: TeamFastMode;
-  /** When true, context window is limited to 200K tokens instead of the default. */
-  limitContext?: boolean;
+  /** When false, teammates use their provider default. */ syncModelsWithLead?: boolean;
+  /** When true, context is limited to 200K tokens. */ limitContext?: boolean;
   /** When false, run WITHOUT --dangerously-skip-permissions (manual tool approval). Default: true. */
   skipPermissions?: boolean;
   /** Worktree name — CLI: --worktree <name>. */

--- a/test/features/recent-projects/renderer/ui/RecentProjectCard.test.tsx
+++ b/test/features/recent-projects/renderer/ui/RecentProjectCard.test.tsx
@@ -1,0 +1,58 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { RecentProjectCard } from '@features/recent-projects/renderer/ui/RecentProjectCard';
+import { TooltipProvider } from '@renderer/components/ui/tooltip';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RecentProjectCardModel } from '@features/recent-projects/renderer/view-models/recentProjectsSectionViewModel';
+
+const card: RecentProjectCardModel = {
+  id: 'repo:alpha',
+  project: {
+    id: 'repo:alpha',
+    name: 'alpha',
+    primaryPath: '/Users/test/alpha',
+    associatedPaths: ['/Users/test/alpha'],
+    mostRecentActivity: Date.parse('2026-09-01T12:00:00Z'),
+    providerIds: [],
+    source: 'codex',
+    openTarget: { type: 'synthetic-path', path: '/Users/test/alpha' },
+  },
+  name: 'alpha',
+  formattedPath: '~/alpha',
+  lastActivityLabel: 'a minute ago',
+  providerIds: [],
+  tasksLoading: false,
+  additionalPathCount: 0,
+};
+
+describe('RecentProjectCard', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('does not render a decorative project icon beside the project title', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <RecentProjectCard card={card} onClick={vi.fn()} onOpenPath={vi.fn()} />
+        </TooltipProvider>
+      );
+    });
+
+    const heading = host.querySelector('h3');
+    const headerRow = heading?.parentElement?.parentElement?.parentElement;
+
+    expect(heading?.textContent).toBe('alpha');
+    expect(headerRow?.querySelector('svg')).toBeNull();
+  });
+});

--- a/test/main/ipc/teamIpcRequestParsers.test.ts
+++ b/test/main/ipc/teamIpcRequestParsers.test.ts
@@ -1,0 +1,42 @@
+import { parseTeamProvisioningBooleanOptions } from '@main/ipc/teamIpcRequestParsers';
+import { describe, expect, it } from 'vitest';
+
+describe('parseTeamProvisioningBooleanOptions', () => {
+  it('preserves supported boolean values', () => {
+    expect(
+      parseTeamProvisioningBooleanOptions({
+        allowExperimentalLocalModels: true,
+        limitContext: false,
+        skipPermissions: true,
+        syncModelsWithLead: false,
+      })
+    ).toEqual({
+      valid: true,
+      value: {
+        allowExperimentalLocalModels: true,
+        limitContext: false,
+        skipPermissions: true,
+        syncModelsWithLead: false,
+      },
+    });
+  });
+
+  it('keeps omitted options undefined', () => {
+    expect(parseTeamProvisioningBooleanOptions({})).toEqual({
+      valid: true,
+      value: {
+        allowExperimentalLocalModels: undefined,
+        limitContext: undefined,
+        skipPermissions: undefined,
+        syncModelsWithLead: undefined,
+      },
+    });
+  });
+
+  it('rejects a non-boolean sync preference', () => {
+    expect(parseTeamProvisioningBooleanOptions({ syncModelsWithLead: 'false' })).toEqual({
+      valid: false,
+      error: 'syncModelsWithLead must be a boolean',
+    });
+  });
+});

--- a/test/renderer/components/cli/CliStatusVisibility.test.ts
+++ b/test/renderer/components/cli/CliStatusVisibility.test.ts
@@ -1711,6 +1711,129 @@ describe('CLI status visibility during completed install state', () => {
     });
   });
 
+  it('does not report a missing OpenCode CLI when the app-managed runtime is ready', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    storeState.cliInstallerState = 'idle';
+    storeState.openCodeRuntimeStatus = {
+      installed: true,
+      binaryPath: '/app-data/runtimes/opencode/opencode',
+      version: '1.17.18',
+      source: 'app-managed',
+      state: 'ready',
+    };
+    storeState.cliStatus = createInstalledCliStatus({
+      flavor: 'agent_teams_orchestrator',
+      displayName: 'Multimodel runtime',
+      supportsSelfUpdate: false,
+      showVersionDetails: false,
+      showBinaryPath: false,
+      authLoggedIn: false,
+      providers: [
+        {
+          providerId: 'opencode',
+          displayName: 'OpenCode (200+ models)',
+          supported: false,
+          authenticated: false,
+          authMethod: null,
+          verificationState: 'error',
+          statusCheckOutcome: 'transient_error',
+          statusCheckErrorCode: 'runtime_missing',
+          statusMessage: 'OpenCode CLI not found in known metadata',
+          detailMessage: 'Passive summary does not verify authentication or launch readiness.',
+          models: [],
+          canLoginFromUi: false,
+          capabilities: {
+            teamLaunch: false,
+            oneShot: false,
+          },
+          backend: null,
+          modelCatalog: null,
+          modelCatalogRefreshState: 'loading',
+          runtimeCapabilities: null,
+        },
+      ],
+    });
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(React.createElement(CliStatusBanner));
+      await Promise.resolve();
+    });
+
+    expect(host.textContent).toContain('Connected');
+    expect(host.textContent).toContain('Loading models...');
+    expect(host.textContent).not.toContain('OpenCode CLI not found in known metadata');
+
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+  });
+
+  it('keeps loaded models visible while refreshing and replaces them with the refreshed list', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const createStatus = (models: string[], refreshState: 'loading' | 'ready') =>
+      createInstalledCliStatus({
+        flavor: 'agent_teams_orchestrator',
+        displayName: 'Multimodel runtime',
+        supportsSelfUpdate: false,
+        showVersionDetails: false,
+        showBinaryPath: false,
+        authLoggedIn: true,
+        providers: [
+          createCodexNativeRolloutProvider({
+            state: 'ready',
+            models,
+            modelCatalogRefreshState: refreshState,
+            runtimeCapabilities: {
+              modelCatalog: {
+                dynamic: true,
+                source: 'app-server',
+              },
+            },
+          }),
+        ],
+      });
+    storeState.cliInstallerState = 'idle';
+    storeState.cliStatus = createStatus(['gpt-5.4'], 'loading');
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(React.createElement(CliStatusBanner));
+      await Promise.resolve();
+    });
+
+    expect(host.textContent).toContain('Loading models...');
+    expect(
+      Array.from(host.querySelectorAll('span')).some((span) => span.textContent === '5.4')
+    ).toBe(true);
+
+    storeState.cliStatus = createStatus(['gpt-5.5'], 'ready');
+    await act(async () => {
+      root.render(React.createElement(CliStatusBanner));
+      await Promise.resolve();
+    });
+
+    expect(host.textContent).not.toContain('Loading models...');
+    expect(
+      Array.from(host.querySelectorAll('span')).some((span) => span.textContent === '5.5')
+    ).toBe(true);
+    expect(
+      Array.from(host.querySelectorAll('span')).some((span) => span.textContent === '5.4')
+    ).toBe(false);
+
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+  });
+
   it('shows OpenCode catalog models on the dashboard when provider models are empty', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     storeState.cliInstallerState = 'idle';
@@ -2289,6 +2412,11 @@ describe('CLI status visibility during completed install state', () => {
       });
       expect(host.textContent).toContain('88%');
       expect(host.textContent).toContain('63%');
+      expect(
+        Array.from(host.querySelectorAll<HTMLElement>('.dashboard-rate-limit-progress')).map(
+          (progress) => progress.style.width
+        )
+      ).toEqual(['88%', '63%']);
       expect(host.querySelectorAll('.skeleton-shimmer')).toHaveLength(2);
 
       await act(async () => {
@@ -3223,6 +3351,11 @@ describe('CLI status visibility during completed install state', () => {
     expect(host.textContent).toContain('Weekly left');
     expect(host.textContent).toContain('59%');
     expect(host.textContent).toContain('resets');
+    expect(
+      Array.from(host.querySelectorAll<HTMLElement>('.dashboard-rate-limit-progress')).map(
+        (progress) => progress.style.width
+      )
+    ).toEqual(['95%', '59%']);
 
     const previousSnapshot = codexAccountHookState.snapshot;
     const previousRateLimits = previousSnapshot?.rateLimits;

--- a/test/renderer/components/runtime/ProviderModelBadges.test.tsx
+++ b/test/renderer/components/runtime/ProviderModelBadges.test.tsx
@@ -23,6 +23,18 @@ describe('ProviderModelBadges', () => {
     document.body.innerHTML = '';
   });
 
+  it('renders model names as comma-separated secondary text instead of badges', () => {
+    const host = render(<ProviderModelBadges providerId="codex" models={['gpt-5.4', 'gpt-5.5']} />);
+    const modelItems = Array.from(host.firstElementChild?.children ?? []) as HTMLElement[];
+
+    expect(host.textContent).toBe('5.5,5.4');
+    expect(modelItems).toHaveLength(2);
+    expect(host.firstElementChild?.className).toContain('gap-x-[2ch]');
+    expect(modelItems[0]?.className).toContain('text-[var(--color-text-secondary)]');
+    expect(modelItems[0]?.className).not.toContain('rounded');
+    expect(modelItems[0]?.className).not.toContain('border');
+  });
+
   it('does not render stale availability chips for OpenCode models', () => {
     const host = render(
       <ProviderModelBadges
@@ -169,6 +181,10 @@ describe('ProviderModelBadges', () => {
     expect(host.textContent).toContain('big-pickle');
     expect(host.textContent).toContain('GPT-5.4');
     expect(host.textContent?.match(/Free/g)).toHaveLength(1);
+    const freeBadge = Array.from(host.querySelectorAll('span')).find(
+      (element) => element.textContent === 'Free'
+    );
+    expect(freeBadge?.className).toContain('rounded');
   });
 
   it('ignores a stale Free badge on a connected OpenCode provider route', () => {
@@ -355,7 +371,7 @@ describe('ProviderModelBadges', () => {
     expect(host.textContent).toContain('Free');
   });
 
-  it('does not duplicate a catalog badge that matches the displayed model label', () => {
+  it('does not render non-Free catalog labels as badges', () => {
     const host = render(
       <ProviderModelBadges
         providerId="anthropic"
@@ -386,7 +402,7 @@ describe('ProviderModelBadges', () => {
                 isDefault: true,
                 upgrade: false,
                 source: 'anthropic-models-api',
-                badgeLabel: 'Opus 4.6',
+                badgeLabel: 'Recommended',
               },
             ],
             diagnostics: {
@@ -399,6 +415,7 @@ describe('ProviderModelBadges', () => {
     );
 
     expect(host.textContent?.match(/Opus 4\.6/g)).toHaveLength(1);
+    expect(host.textContent).not.toContain('Recommended');
   });
 
   it('does not render duplicate Anthropic Opus 4.8 model badges when the runtime reports the opus alias', () => {

--- a/test/renderer/components/runtime/providerConnectionUi.test.ts
+++ b/test/renderer/components/runtime/providerConnectionUi.test.ts
@@ -9,6 +9,7 @@ import {
   shouldMaskCodexNegativeBootstrapState,
   shouldShowProviderConnectAction,
 } from '@renderer/components/runtime/providerConnectionUi';
+import { shouldShowLoadedProviderModels } from '@renderer/components/runtime/providerModelVisibility';
 import { createDefaultCliExtensionCapabilities } from '@shared/utils/providerExtensionCapabilities';
 import { describe, expect, it } from 'vitest';
 
@@ -293,6 +294,26 @@ describe('providerConnectionUi', () => {
         },
       })
     ).toBe(false);
+    expect(shouldShowLoadedProviderModels(provider, true)).toBe(false);
+    expect(
+      shouldShowLoadedProviderModels(
+        {
+          ...provider,
+          models: ['opencode/big-pickle', 'openrouter/qwen/qwen3-coder-plus'],
+        },
+        true
+      )
+    ).toBe(true);
+  });
+
+  it('keeps loaded provider models visible while their catalog refreshes', () => {
+    const provider = createCodexProvider({
+      models: ['gpt-5.4'],
+      modelCatalogRefreshState: 'loading',
+    });
+
+    expect(shouldShowLoadedProviderModels(provider, true)).toBe(true);
+    expect(shouldShowLoadedProviderModels(provider, false)).toBe(false);
   });
 
   it('does not describe Anthropic API key mode as subscription connected when the key is missing', () => {

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -1461,6 +1461,54 @@ describe('LaunchTeamDialog', () => {
     });
   });
 
+  it('infers legacy sync-off from teammate backend and fast-mode overrides', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.mocked(api.teams.getSavedRequest).mockResolvedValueOnce({
+      teamName: 'team-alpha',
+      cwd: '/tmp/project',
+      providerId: 'codex',
+      model: 'gpt-5.5',
+      members: [
+        {
+          name: 'jack',
+          role: 'developer',
+          providerBackendId: 'codex-native',
+          fastMode: 'on',
+        },
+      ],
+    } as any);
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        React.createElement(LaunchTeamDialog, {
+          mode: 'launch',
+          open: true,
+          teamName: 'team-alpha',
+          members: [],
+          defaultProjectPath: '/tmp/project',
+          provisioningError: null,
+          clearProvisioningError: vi.fn(),
+          activeTeams: [],
+          onClose: vi.fn(),
+          onLaunch: vi.fn(async () => {}),
+        })
+      );
+      await flush();
+      await flush();
+    });
+
+    expect(teamRosterEditorSectionMock.lastProps?.syncModelsWithTeammates).toBe(false);
+
+    await act(async () => {
+      root.unmount();
+      await flush();
+    });
+  });
+
   it('keeps a teammate worktree toggle made during hydration from being overwritten', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     let resolveSavedRequest: (value: unknown) => void = () => {};

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -1416,6 +1416,51 @@ describe('LaunchTeamDialog', () => {
     });
   });
 
+  it('restores an explicit sync-off preference for teammates using provider defaults', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.mocked(api.teams.getSavedRequest).mockResolvedValueOnce({
+      teamName: 'team-alpha',
+      cwd: '/tmp/project',
+      providerId: 'codex',
+      model: 'gpt-5.5',
+      syncModelsWithLead: false,
+      members: [{ name: 'jack', role: 'developer' }],
+    } as any);
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        React.createElement(LaunchTeamDialog, {
+          mode: 'launch',
+          open: true,
+          teamName: 'team-alpha',
+          members: [],
+          defaultProjectPath: '/tmp/project',
+          provisioningError: null,
+          clearProvisioningError: vi.fn(),
+          activeTeams: [],
+          onClose: vi.fn(),
+          onLaunch: vi.fn(async () => {}),
+        })
+      );
+      await flush();
+      await flush();
+    });
+
+    expect(teamRosterEditorSectionMock.lastProps?.syncModelsWithTeammates).toBe(false);
+    expect(teamRosterEditorSectionMock.lastProps?.members).toEqual([
+      expect.objectContaining({ name: 'jack' }),
+    ]);
+
+    await act(async () => {
+      root.unmount();
+      await flush();
+    });
+  });
+
   it('keeps a teammate worktree toggle made during hydration from being overwritten', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     let resolveSavedRequest: (value: unknown) => void = () => {};
@@ -2406,7 +2451,13 @@ describe('LaunchTeamDialog', () => {
     expect(vi.mocked(api.teams.replaceMembers)).not.toHaveBeenCalled();
 
     const [request, members] = onRelaunch.mock.calls[0] as unknown as [
-      { teamName: string; cwd: string; providerId?: string; model?: string },
+      {
+        teamName: string;
+        cwd: string;
+        providerId?: string;
+        model?: string;
+        syncModelsWithLead?: boolean;
+      },
       Array<{ name: string; providerId?: string; model?: string }>,
     ];
 
@@ -2414,6 +2465,7 @@ describe('LaunchTeamDialog', () => {
     expect(request.cwd).toBe('/tmp/project');
     expect(request.providerId).toBe('anthropic');
     expect(request.model).toBe('opus');
+    expect(request.syncModelsWithLead).toBe(false);
     expect(members).toEqual([
       {
         name: 'alice',

--- a/test/renderer/hooks/useOpenCodeCatalogPrefetch.test.tsx
+++ b/test/renderer/hooks/useOpenCodeCatalogPrefetch.test.tsx
@@ -309,6 +309,11 @@ describe('useOpenCodeCatalogPrefetch', () => {
     expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(4);
     expect(host.firstElementChild?.getAttribute('data-required-catalog-pending')).toBe('false');
 
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(4);
+
     storeState.cliProviderStatusScopeRevision += 1;
     await act(async () => {
       root.render(<PrefetchHarness />);


### PR DESCRIPTION
## Summary

- persist and honor the Sync model with teammates preference across create, launch, relaunch, restart, and provisioning flows
- keep loaded provider models visible while catalogs refresh; render models as secondary comma-separated text and retain only Free as a badge
- polish provider limits, recent project cards, optional team details, and member-row controls
- stop exhausted OpenCode catalog retries from causing repeated loading flashes
- keep legacy source-size baselines intact by extracting reusable IPC, visibility, and rate-limit helpers
- address review findings for metadata serialization, pure OpenCode restarts, and legacy launch inference

## Verification

- pnpm typecheck
- 233 focused Vitest tests across IPC parsing, persistence, provisioning, restarts, dialogs, provider status, model catalogs, limits, and recent projects
- source-file-size, Team Provisioning architecture, and runtime-artifact guards
- pnpm lint:fast:files on changed TypeScript files
- Prettier check on all changed files
- git diff --check

No live agent, provisioning, terminal-runtime, or real-project smoke flow was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a team preference to control whether teammate models sync with the lead model, preserved across creation, copying, launching, and restarts.
  - Dashboard rate-limit indicators now show remaining percentages and progress bars.
  - Provider model displays now use clearer formatting and identify free models.

- **Bug Fixes**
  - Improved provider connection status and model visibility during refreshes.
  - Prevented redundant catalog retries after limits are exhausted.
  - Refined team editor controls and recent-project card presentation.

- **Localization**
  - Updated dashboard translations to refer simply to “Providers and plans” across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->