### PR TITLE
fix: a probe that costs a process spawn, and a stall that logs nothing

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -135,7 +135,7 @@ import { ChangeExtractorService } from '@main/services/team/ChangeExtractorServi
 import { CrossTeamService } from '@main/services/team/CrossTeamService';
 import { FileContentResolver } from '@main/services/team/FileContentResolver';
 import { GitDiffFallback } from '@main/services/team/GitDiffFallback';
-import { isInformationalOpenCodeRuntimeDeliveryDiagnostic } from '@main/services/team/opencode/delivery/OpenCodeRuntimeDeliveryDiagnostics';
+import { openCodeRelayDiagnosticsLogGate } from '@main/services/team/opencode/delivery/OpenCodeRelayDiagnosticsLogGate';
 import {
   buildOpenCodeAppScopedMcpOwnershipMarker,
   buildOpenCodeAppScopedMcpUrl,
@@ -356,41 +356,6 @@ if (
 }
 for (const warning of earlyElectronDevPathOverrideResult.warnings) {
   logger.warn(warning);
-}
-
-function hasWarningRelayDiagnostics(diagnostics: readonly string[]): boolean {
-  return diagnostics.some(
-    (diagnostic) => !isInformationalOpenCodeRuntimeDeliveryDiagnostic(diagnostic)
-  );
-}
-
-/**
- * A busy inbox re-reports the same relay diagnostics (e.g. a terminal ledger
- * reason) on every file change, flooding the dev console with identical lines.
- * Log a given team/inbox diagnostics message at most once per window; a
- * CHANGED message always logs immediately so real transitions stay visible.
- */
-const RELAY_DIAGNOSTICS_LOG_DEDUP_MS = 60_000;
-const RELAY_DIAGNOSTICS_LOG_DEDUP_MAX_ENTRIES = 512;
-const relayDiagnosticsLogDedup = new Map<string, { message: string; loggedAt: number }>();
-
-function shouldLogRelayDiagnostics(dedupKey: string, message: string, nowMs: number): boolean {
-  const previous = relayDiagnosticsLogDedup.get(dedupKey);
-  if (
-    previous &&
-    previous.message === message &&
-    nowMs - previous.loggedAt < RELAY_DIAGNOSTICS_LOG_DEDUP_MS
-  ) {
-    return false;
-  }
-  if (!previous && relayDiagnosticsLogDedup.size >= RELAY_DIAGNOSTICS_LOG_DEDUP_MAX_ENTRIES) {
-    const oldestKey = relayDiagnosticsLogDedup.keys().next();
-    if (!oldestKey.done) {
-      relayDiagnosticsLogDedup.delete(oldestKey.value);
-    }
-  }
-  relayDiagnosticsLogDedup.set(dedupKey, { message, loggedAt: nowMs });
-  return true;
 }
 
 function readOptionalEnv(name: string): string | undefined {
@@ -1792,17 +1757,12 @@ function wireFileWatcherEvents(context: ServiceContext): void {
             void teamProvisioningService
               .relayInboxFileToLiveRecipient(teamName, inboxName)
               .then((relay) => {
-                if (relay.diagnostics?.length) {
-                  const message = `[FileWatcher] relay diagnostics for ${teamName}/${inboxName}: ${relay.diagnostics.join('; ')}`;
-                  if (!shouldLogRelayDiagnostics(`${teamName}/${inboxName}`, message, Date.now())) {
-                    return;
-                  }
-                  if (hasWarningRelayDiagnostics(relay.diagnostics)) {
-                    logger.warn(message);
-                  } else {
-                    logger.info(message);
-                  }
-                }
+                openCodeRelayDiagnosticsLogGate.log(logger, {
+                  dedupKey: `${teamName}/${inboxName}`,
+                  prefix: `[FileWatcher] relay diagnostics for ${teamName}/${inboxName}`,
+                  diagnostics: relay.diagnostics,
+                  nowMs: Date.now(),
+                });
               })
               .catch((e: unknown) =>
                 logger.warn(`[FileWatcher] relay failed for ${teamName}: ${String(e)}`)

--- a/src/main/services/team/ReviewPersistenceScopeLock.ts
+++ b/src/main/services/team/ReviewPersistenceScopeLock.ts
@@ -1,7 +1,7 @@
-import { spawnSync } from 'node:child_process';
 import { DatabaseSync } from 'node:sqlite';
 
 import { getTeamsBasePath } from '@main/utils/pathDecoder';
+import { readProcessStartTimeMs } from '@main/utils/processStartTime';
 import { createHash, randomUUID } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -15,6 +15,22 @@ const DEFAULT_RETRY_INTERVAL_MS = 25;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 5_000;
 const SQLITE_BUSY_TIMEOUT_MS = 2_000;
 const PROCESS_START_CACHE_TTL_MS = 5_000;
+// A probe that could not observe the owner must expire, or one slow probe becomes a
+// permanent "owner is alive" verdict, but it must not expire per retry: at the 25ms
+// retry cadence a miss shorter than the loop keeps a powershell.exe spawn running for
+// the whole acquire window. A miss therefore covers a stretch of retries, with a floor
+// so a fast loop cannot drive the spawn rate on its own.
+const PROCESS_START_MISS_CACHE_RETRY_INTERVALS = 20;
+const MIN_PROCESS_START_MISS_CACHE_TTL_MS = 1_000;
+// Reading a start time shells out to powershell.exe on Windows, whose startup alone
+// costs the better part of a second on a loaded machine; the margin has to cover
+// that, not the query itself. What is left of the acquire budget caps it, so a probe
+// cannot keep an acquire running seconds past the deadline it promised.
+const PROCESS_START_PROBE_TIMEOUT_MS = 5_000;
+// The cap still has to leave a probe room to answer at all: a short acquire budget
+// that starves every probe could never reclaim a crash-left lease from a recycled pid,
+// and the answer outlives this acquire in the cache anyway.
+const MIN_PROCESS_START_PROBE_TIMEOUT_MS = 1_000;
 const PROCESS_STARTED_AT = Math.floor(Date.now() - process.uptime() * 1_000);
 const LOGICAL_SCOPE_LOCK_TOKEN = 'review-persistence-logical-scope:v1';
 
@@ -36,9 +52,16 @@ interface ReviewScopeLockLease {
   ownerToken: string;
 }
 
+/** What one acquire attempt may still spend on observing the current owner. */
+interface OwnerProbeBudget {
+  deadline: number;
+  retryIntervalMs: number;
+}
+
 const lockDatabases = new Map<string, DatabaseSync>();
 const activeOwnerTokens = new Set<string>();
 const observedProcessStarts = new Map<number, { startedAt: number | null; expiresAt: number }>();
+const pendingProcessStartProbes = new Map<number, Promise<number | null>>();
 
 function getLockDatabasePath(): string {
   return path.join(getTeamsBasePath(), '.review-persistence-locks.sqlite3');
@@ -117,54 +140,51 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-function getProcessStartedAt(pid: number): number | null {
-  if (pid === process.pid) return PROCESS_STARTED_AT;
+function getProcessStartedAt(pid: number, budget: OwnerProbeBudget): Promise<number | null> {
+  if (pid === process.pid) return Promise.resolve(PROCESS_STARTED_AT);
   const cached = observedProcessStarts.get(pid);
-  if (cached && cached.expiresAt > Date.now()) return cached.startedAt;
-  let startedAt: number | null = null;
-  try {
-    if (process.platform === 'win32') {
-      const result = spawnSync(
-        'powershell.exe',
-        [
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
-          `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().ToString('o')`,
-        ],
-        { encoding: 'utf8', timeout: 1_000, windowsHide: true }
-      );
-      if (result.status === 0) {
-        const parsed = Date.parse(result.stdout.trim());
-        startedAt = Number.isFinite(parsed) ? parsed : null;
-      }
-    } else {
-      const result = spawnSync('ps', ['-o', 'lstart=', '-p', String(pid)], {
-        encoding: 'utf8',
-        timeout: 1_000,
-        windowsHide: true,
-        env: { ...process.env, LC_ALL: 'C' },
-      });
-      if (result.status === 0) {
-        const parsed = Date.parse(result.stdout.trim());
-        startedAt = Number.isFinite(parsed) ? parsed : null;
-      }
-    }
-  } catch {
+  if (cached && cached.expiresAt > Date.now()) return Promise.resolve(cached.startedAt);
+  const remainingBudgetMs = budget.deadline - Date.now();
+  // The acquire is already over: a spawn started now could only outlive it, so answer
+  // the same "unobservable" the caller would have to assume anyway.
+  if (remainingBudgetMs <= 0) return Promise.resolve(null);
+  const inFlight = pendingProcessStartProbes.get(pid);
+  // Concurrent acquires of different scopes routinely inspect the same owner PID;
+  // joining the in-flight probe keeps that to one process spawn.
+  if (inFlight) return inFlight;
+  const missCacheTtlMs = Math.max(
+    MIN_PROCESS_START_MISS_CACHE_TTL_MS,
+    budget.retryIntervalMs * PROCESS_START_MISS_CACHE_RETRY_INTERVALS
+  );
+  const probe = readProcessStartTimeMs(
+    pid,
+    process.platform,
+    Math.min(
+      PROCESS_START_PROBE_TIMEOUT_MS,
+      Math.max(remainingBudgetMs, MIN_PROCESS_START_PROBE_TIMEOUT_MS)
+    )
+  )
     // If process identity cannot be observed, keep the live PID owner conservatively.
-  }
-  observedProcessStarts.set(pid, {
-    startedAt,
-    expiresAt: Date.now() + PROCESS_START_CACHE_TTL_MS,
-  });
-  return startedAt;
+    .catch(() => null)
+    .then((startedAt) => {
+      observedProcessStarts.set(pid, {
+        startedAt,
+        expiresAt: Date.now() + (startedAt === null ? missCacheTtlMs : PROCESS_START_CACHE_TTL_MS),
+      });
+      return startedAt;
+    })
+    .finally(() => {
+      if (pendingProcessStartProbes.get(pid) === probe) pendingProcessStartProbes.delete(pid);
+    });
+  pendingProcessStartProbes.set(pid, probe);
+  return probe;
 }
 
-function isStaleOwner(row: ReviewScopeLockRow): boolean {
+async function isStaleOwner(row: ReviewScopeLockRow, budget: OwnerProbeBudget): Promise<boolean> {
   if (!isProcessAlive(row.owner_pid)) return true;
   // A recycled PID must not keep a crash-left row forever. The same process can
   // import this module more than once, so tolerate small uptime rounding drift.
-  const observedProcessStart = getProcessStartedAt(row.owner_pid);
+  const observedProcessStart = await getProcessStartedAt(row.owner_pid, budget);
   if (
     observedProcessStart !== null &&
     Math.abs(row.owner_started_at - observedProcessStart) > 10_000
@@ -182,14 +202,22 @@ function rollbackBestEffort(database: DatabaseSync): void {
   }
 }
 
-function tryAcquireLease(database: DatabaseSync, scopeId: string, ownerToken: string): boolean {
+async function tryAcquireLease(
+  database: DatabaseSync,
+  scopeId: string,
+  ownerToken: string,
+  budget: OwnerProbeBudget
+): Promise<boolean> {
   const observed = database
     .prepare(
       'SELECT owner_token, owner_pid, owner_started_at FROM review_scope_locks WHERE scope_id = ?'
     )
     .get(scopeId) as unknown as ReviewScopeLockRow | undefined;
+  // The owner probe must settle before BEGIN IMMEDIATE: awaiting inside the
+  // transaction would hold the write lock across a process spawn. The row is
+  // re-read below because this pre-read can go stale while the probe runs.
   const observedIsStale =
-    !observed || observed.owner_token === ownerToken || isStaleOwner(observed);
+    !observed || observed.owner_token === ownerToken || (await isStaleOwner(observed, budget));
 
   database.exec('BEGIN IMMEDIATE');
   try {
@@ -249,10 +277,11 @@ async function acquireLease(
   const scopeId = buildScopeId(teamName, persistenceScope);
   const ownerToken = randomUUID();
   const deadline = Date.now() + options.acquireTimeoutMs;
+  const budget: OwnerProbeBudget = { deadline, retryIntervalMs: options.retryIntervalMs };
 
   while (true) {
     try {
-      if (tryAcquireLease(database, scopeId, ownerToken)) {
+      if (await tryAcquireLease(database, scopeId, ownerToken, budget)) {
         activeOwnerTokens.add(ownerToken);
         return { database, scopeId, ownerToken };
       }
@@ -371,4 +400,5 @@ export function closeReviewPersistenceScopeLockDatabasesForTests(): void {
   lockDatabases.clear();
   activeOwnerTokens.clear();
   observedProcessStarts.clear();
+  pendingProcessStartProbes.clear();
 }

--- a/src/main/services/team/ReviewPersistenceScopeLock.ts
+++ b/src/main/services/team/ReviewPersistenceScopeLock.ts
@@ -29,7 +29,8 @@ const MIN_PROCESS_START_MISS_CACHE_TTL_MS = 1_000;
 const PROCESS_START_PROBE_TIMEOUT_MS = 5_000;
 // The cap still has to leave a probe room to answer at all: a short acquire budget
 // that starves every probe could never reclaim a crash-left lease from a recycled pid,
-// and the answer outlives this acquire in the cache anyway.
+// and the answer outlives this acquire in the cache anyway. What the acquire itself
+// waits for is its own budget, never this floor: see settleOwnerProbeWithinBudget.
 const MIN_PROCESS_START_PROBE_TIMEOUT_MS = 1_000;
 const PROCESS_STARTED_AT = Math.floor(Date.now() - process.uptime() * 1_000);
 const LOGICAL_SCOPE_LOCK_TOKEN = 'review-persistence-logical-scope:v1';
@@ -140,14 +141,11 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-function getProcessStartedAt(pid: number, budget: OwnerProbeBudget): Promise<number | null> {
-  if (pid === process.pid) return Promise.resolve(PROCESS_STARTED_AT);
-  const cached = observedProcessStarts.get(pid);
-  if (cached && cached.expiresAt > Date.now()) return Promise.resolve(cached.startedAt);
-  const remainingBudgetMs = budget.deadline - Date.now();
-  // The acquire is already over: a spawn started now could only outlive it, so answer
-  // the same "unobservable" the caller would have to assume anyway.
-  if (remainingBudgetMs <= 0) return Promise.resolve(null);
+function startOrJoinProcessStartProbe(
+  pid: number,
+  budget: OwnerProbeBudget,
+  remainingBudgetMs: number
+): Promise<number | null> {
   const inFlight = pendingProcessStartProbes.get(pid);
   // Concurrent acquires of different scopes routinely inspect the same owner PID;
   // joining the in-flight probe keeps that to one process spawn.
@@ -178,6 +176,50 @@ function getProcessStartedAt(pid: number, budget: OwnerProbeBudget): Promise<num
     });
   pendingProcessStartProbes.set(pid, probe);
   return probe;
+}
+
+/**
+ * The probe's clock and the acquire's budget are two different clocks, and this is
+ * where they are kept apart.
+ *
+ * A probe this acquire starts keeps a floor of MIN_PROCESS_START_PROBE_TIMEOUT_MS so
+ * the spawn can answer at all, and a probe joined from another acquire answers on the
+ * timeout whoever started it chose. Either can outlive the acquire waiting here, so
+ * what this acquire waits on is its own remaining budget: an acquire that promised
+ * 100ms must not return a second late because a probe was still thinking.
+ *
+ * An expired budget reads exactly like a probe that could not answer - "start time
+ * unobservable", keep the live owner - which is the conservative direction this
+ * module already takes everywhere. Nothing is cancelled: the probe runs on and files
+ * its answer in `observedProcessStarts`, so the next retry of this acquire, or the
+ * next acquire of any scope with the same owner, reads an answer nobody waited for.
+ */
+function settleOwnerProbeWithinBudget(
+  probe: Promise<number | null>,
+  remainingBudgetMs: number
+): Promise<number | null> {
+  return new Promise((resolve) => {
+    const budgetExpiry = setTimeout(() => resolve(null), remainingBudgetMs);
+    const settle = (startedAt: number | null): void => {
+      clearTimeout(budgetExpiry);
+      resolve(startedAt);
+    };
+    void probe.then(settle, () => settle(null));
+  });
+}
+
+function getProcessStartedAt(pid: number, budget: OwnerProbeBudget): Promise<number | null> {
+  if (pid === process.pid) return Promise.resolve(PROCESS_STARTED_AT);
+  const cached = observedProcessStarts.get(pid);
+  if (cached && cached.expiresAt > Date.now()) return Promise.resolve(cached.startedAt);
+  const remainingBudgetMs = budget.deadline - Date.now();
+  // The acquire is already over: a spawn started now could only outlive it, so answer
+  // the same "unobservable" the caller would have to assume anyway.
+  if (remainingBudgetMs <= 0) return Promise.resolve(null);
+  return settleOwnerProbeWithinBudget(
+    startOrJoinProcessStartProbe(pid, budget, remainingBudgetMs),
+    remainingBudgetMs
+  );
 }
 
 async function isStaleOwner(row: ReviewScopeLockRow, budget: OwnerProbeBudget): Promise<boolean> {

--- a/src/main/services/team/opencode/delivery/OpenCodeRelayDiagnosticsLogGate.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeRelayDiagnosticsLogGate.ts
@@ -93,7 +93,14 @@ export class OpenCodeRelayDiagnosticsLogGate {
     if (previous?.signature === signature && input.nowMs - previous.loggedAtMs < this.dedupMs) {
       return null;
     }
-    if (!previous && this.lastLogged.size >= this.maxTrackedKeys) {
+    if (previous) {
+      // Eviction below takes the oldest key by INSERTION, and re-setting an existing
+      // key leaves it at the position it first went in at. Deleting it first is what
+      // makes a refresh count as recent: without it a key logged a moment ago can be
+      // evicted ahead of one last logged a window ago, and the condition the operator
+      // is already reading about writes itself again.
+      this.lastLogged.delete(input.dedupKey);
+    } else if (this.lastLogged.size >= this.maxTrackedKeys) {
       const oldestKey = this.lastLogged.keys().next();
       if (!oldestKey.done) {
         this.lastLogged.delete(oldestKey.value);

--- a/src/main/services/team/opencode/delivery/OpenCodeRelayDiagnosticsLogGate.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeRelayDiagnosticsLogGate.ts
@@ -1,0 +1,130 @@
+import { isInformationalOpenCodeRuntimeDeliveryDiagnostic } from './OpenCodeRuntimeDeliveryDiagnostics';
+
+/**
+ * The one place that decides whether a relay's diagnostics reach the log.
+ *
+ * A relay result is the only account the app gives of why a message did or did
+ * not reach a runtime, and exactly one caller turns it into a log line: the
+ * FileWatcher inbox-change path in `src/main/index.ts`. Every other path that
+ * relays discards the result, the retry/wake sweep included, so a lane that
+ * keeps deferring is invisible: a retry wake that keeps deferring writes
+ * nothing at all, and a ten-minute stall can produce no log line describing
+ * itself. The two lines such a stretch does produce exist only because a new
+ * inbox row happened to arrive and take the watched path.
+ *
+ * Concentrating the decision in a module is what lets the other paths adopt it
+ * without each re-deriving the dedup and severity rules. The FileWatcher path
+ * uses it today; the delivery retry path adopts it next.
+ *
+ * Being visible must not mean flooding. A busy inbox re-reports the same
+ * diagnostics on every pass, so an unchanged condition writes at most once per
+ * window while a CHANGED condition writes immediately: a transition is always
+ * news, a repeat almost never is.
+ */
+
+export const OPENCODE_RELAY_DIAGNOSTICS_LOG_DEDUP_MS = 60_000;
+/** Bounds the window map for a long-lived process with many inboxes. */
+export const OPENCODE_RELAY_DIAGNOSTICS_LOG_MAX_TRACKED_KEYS = 512;
+
+/**
+ * `warn` is the durable channel; `debug` and `info` are explicitly not.
+ *
+ * `Logger.warn` is what feeds `emitToLogSinks` and so the persisted diagnostics
+ * file. Informational relay diagnostics - `opencode session status busy`,
+ * `opencode_delivery_response_pending`, a scheduled session refresh - are
+ * expected control flow and stay off that channel on purpose: a lane that
+ * legitimately defers a wake every few seconds must not manufacture warnings.
+ *
+ * They are emitted at `debug` rather than `info`. Neither is durable and
+ * neither prints at the default console level (WARN in development, ERROR in
+ * production), but `debug` is the level an operator actually raises when
+ * chasing a lane, while `info` is the level whose name suggests the line was
+ * recorded somewhere. It was not. What an operator needs durably out of a
+ * stalled lane is the warning allowlist, and that is unchanged.
+ */
+export interface OpenCodeRelayDiagnosticsLogLine {
+  level: 'warn' | 'debug';
+  message: string;
+}
+
+/** The subset of the app logger this gate writes through. */
+export interface OpenCodeRelayDiagnosticsLogWriter {
+  warn(message: string): void;
+  debug(message: string): void;
+}
+
+export interface OpenCodeRelayDiagnosticsLogInput {
+  dedupKey: string;
+  prefix: string;
+  diagnostics: readonly string[] | undefined;
+  nowMs: number;
+}
+
+export function hasWarningOpenCodeRelayDiagnostics(diagnostics: readonly string[]): boolean {
+  return diagnostics.some(
+    (diagnostic) => !isInformationalOpenCodeRuntimeDeliveryDiagnostic(diagnostic)
+  );
+}
+
+export class OpenCodeRelayDiagnosticsLogGate {
+  private readonly lastLogged = new Map<string, { signature: string; loggedAtMs: number }>();
+
+  constructor(
+    private readonly dedupMs: number = OPENCODE_RELAY_DIAGNOSTICS_LOG_DEDUP_MS,
+    private readonly maxTrackedKeys: number = OPENCODE_RELAY_DIAGNOSTICS_LOG_MAX_TRACKED_KEYS
+  ) {}
+
+  /**
+   * The line to write for `diagnostics`, or null when nothing is worth writing:
+   * no diagnostics at all, or the same condition already written this window.
+   *
+   * The dedup signature is the diagnostics ALONE; `prefix` names the message
+   * that happened to hit the condition and is presentation only. A lane blocked
+   * on one condition reports it identically for every message queued behind it,
+   * so a caller whose prefix carries a message id would otherwise let a queue of
+   * rows walk straight past the window one id at a time.
+   */
+  note(input: OpenCodeRelayDiagnosticsLogInput): OpenCodeRelayDiagnosticsLogLine | null {
+    if (!input.diagnostics?.length) {
+      return null;
+    }
+    const signature = input.diagnostics.join('; ');
+    const previous = this.lastLogged.get(input.dedupKey);
+    if (previous?.signature === signature && input.nowMs - previous.loggedAtMs < this.dedupMs) {
+      return null;
+    }
+    if (!previous && this.lastLogged.size >= this.maxTrackedKeys) {
+      const oldestKey = this.lastLogged.keys().next();
+      if (!oldestKey.done) {
+        this.lastLogged.delete(oldestKey.value);
+      }
+    }
+    this.lastLogged.set(input.dedupKey, { signature, loggedAtMs: input.nowMs });
+    return {
+      level: hasWarningOpenCodeRelayDiagnostics(input.diagnostics) ? 'warn' : 'debug',
+      message: `${input.prefix}: ${signature}`,
+    };
+  }
+
+  /**
+   * Writes what `note` allows, and nothing when it allows nothing. Callers use
+   * this rather than branching on the line themselves so the "does this reach
+   * the log" decision stays in one tested place.
+   */
+  log(writer: OpenCodeRelayDiagnosticsLogWriter, input: OpenCodeRelayDiagnosticsLogInput): void {
+    const line = this.note(input);
+    if (line) {
+      writer[line.level](line.message);
+    }
+  }
+
+  clear(): void {
+    this.lastLogged.clear();
+  }
+}
+
+/**
+ * The dedup window has to outlive a single relay result, so the process shares
+ * one gate. Used by the FileWatcher inbox path today.
+ */
+export const openCodeRelayDiagnosticsLogGate = new OpenCodeRelayDiagnosticsLogGate();

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeRelayDiagnosticsLogGate.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeRelayDiagnosticsLogGate.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  hasWarningOpenCodeRelayDiagnostics,
+  OPENCODE_RELAY_DIAGNOSTICS_LOG_DEDUP_MS,
+  OPENCODE_RELAY_DIAGNOSTICS_LOG_MAX_TRACKED_KEYS,
+  OpenCodeRelayDiagnosticsLogGate,
+} from '../OpenCodeRelayDiagnosticsLogGate';
+
+const BLOCKED = ['opencode runtime delivery did not complete.'];
+const INFORMATIONAL = ['opencode session status busy'];
+
+function note(
+  gate: OpenCodeRelayDiagnosticsLogGate,
+  overrides: {
+    dedupKey?: string;
+    prefix?: string;
+    diagnostics?: readonly string[];
+    nowMs?: number;
+  } = {}
+): ReturnType<OpenCodeRelayDiagnosticsLogGate['note']> {
+  return gate.note({
+    dedupKey: overrides.dedupKey ?? 'demo/researcher',
+    prefix: overrides.prefix ?? '[FileWatcher] relay diagnostics for demo/researcher',
+    diagnostics: 'diagnostics' in overrides ? overrides.diagnostics : BLOCKED,
+    nowMs: overrides.nowMs ?? 0,
+  });
+}
+
+describe('OpenCodeRelayDiagnosticsLogGate', () => {
+  it('writes the first occurrence of a condition and renders the prefix with it', () => {
+    const line = note(new OpenCodeRelayDiagnosticsLogGate());
+
+    expect(line).toMatchObject({ level: 'warn' });
+    expect(line?.message).toBe(
+      `[FileWatcher] relay diagnostics for demo/researcher: ${BLOCKED[0]}`
+    );
+  });
+
+  it('says nothing when a relay reported no diagnostics', () => {
+    const gate = new OpenCodeRelayDiagnosticsLogGate();
+
+    expect(note(gate, { diagnostics: undefined })).toBeNull();
+    expect(note(gate, { diagnostics: [] })).toBeNull();
+  });
+
+  /**
+   * One blocked lane refuses every message queued behind it with the identical
+   * diagnostic. Keying the window on the rendered line would let that queue walk
+   * past it one message id at a time, so the signature is the diagnostics alone
+   * and the prefix is presentation.
+   */
+  it('holds the window against a changing prefix on the same condition', () => {
+    const gate = new OpenCodeRelayDiagnosticsLogGate();
+    note(gate, { prefix: 'wake for demo/researcher/210f0017' });
+
+    expect(note(gate, { prefix: 'wake for demo/researcher/3a396156', nowMs: 15_000 })).toBeNull();
+    expect(note(gate, { prefix: 'wake for demo/researcher/510baaaf', nowMs: 30_000 })).toBeNull();
+  });
+
+  it('writes again once the window has passed', () => {
+    const gate = new OpenCodeRelayDiagnosticsLogGate();
+    note(gate);
+
+    expect(note(gate, { nowMs: OPENCODE_RELAY_DIAGNOSTICS_LOG_DEDUP_MS - 1 })).toBeNull();
+    expect(note(gate, { nowMs: OPENCODE_RELAY_DIAGNOSTICS_LOG_DEDUP_MS })).not.toBeNull();
+  });
+
+  // A transition is always news: the condition the operator is watching changed.
+  it('writes a changed condition immediately', () => {
+    const gate = new OpenCodeRelayDiagnosticsLogGate();
+    note(gate);
+
+    const changed = note(gate, {
+      diagnostics: ['opencode returned an empty assistant turn.'],
+      nowMs: 1_000,
+    });
+
+    expect(changed).toMatchObject({ level: 'warn' });
+  });
+
+  it('keeps separate windows per dedup key', () => {
+    const gate = new OpenCodeRelayDiagnosticsLogGate();
+    note(gate, { dedupKey: 'demo/researcher' });
+
+    expect(note(gate, { dedupKey: 'demo/reviewer', nowMs: 1_000 })).not.toBeNull();
+  });
+
+  it('forgets the oldest window rather than tracking keys without bound', () => {
+    const gate = new OpenCodeRelayDiagnosticsLogGate();
+    for (let index = 0; index < OPENCODE_RELAY_DIAGNOSTICS_LOG_MAX_TRACKED_KEYS; index += 1) {
+      note(gate, { dedupKey: `demo/member-${index}` });
+    }
+
+    note(gate, { dedupKey: 'demo/one-too-many' });
+
+    // Everything still tracked keeps its window.
+    expect(note(gate, { dedupKey: 'demo/member-1', nowMs: 1_000 })).toBeNull();
+    // The oldest key was evicted to make room, so its condition is news again.
+    expect(note(gate, { dedupKey: 'demo/member-0', nowMs: 1_000 })).not.toBeNull();
+  });
+
+  /**
+   * Negative control. Expected control flow must not file itself under the
+   * durable warning channel, no matter how often the lane repeats it.
+   */
+  it('reports an informational-only condition at debug, never at warn', () => {
+    const line = note(new OpenCodeRelayDiagnosticsLogGate(), { diagnostics: INFORMATIONAL });
+
+    expect(line).toMatchObject({ level: 'debug' });
+    expect(hasWarningOpenCodeRelayDiagnostics(INFORMATIONAL)).toBe(false);
+  });
+
+  /**
+   * The inverse control, and the reason severity is decided over the whole list
+   * rather than the first entry: one diagnostic that is not expected control
+   * flow is enough to make the line durable, wherever it sits in the list.
+   */
+  it('raises the whole line to warn for a single non-informational diagnostic', () => {
+    const mixed = [...INFORMATIONAL, 'opencode api error: session not found'];
+
+    expect(note(new OpenCodeRelayDiagnosticsLogGate(), { diagnostics: mixed })).toMatchObject({
+      level: 'warn',
+    });
+    expect(hasWarningOpenCodeRelayDiagnostics(mixed)).toBe(true);
+  });
+
+  it('forgets everything on clear', () => {
+    const gate = new OpenCodeRelayDiagnosticsLogGate();
+    note(gate);
+    gate.clear();
+
+    expect(note(gate, { nowMs: 1_000 })).not.toBeNull();
+  });
+
+  /**
+   * What the caller in `src/main/index.ts` delegates: the line is written when
+   * the gate returns one, at the level it chose, and nothing at all is written
+   * when it returns null. Keeping this in the gate is what makes it assertable;
+   * `src/main/index.ts` is not reachable from a unit test.
+   */
+  describe('log', () => {
+    it('writes the line the gate returned, at the level the gate chose', () => {
+      const gate = new OpenCodeRelayDiagnosticsLogGate();
+      const writer = { warn: vi.fn(), debug: vi.fn() };
+
+      gate.log(writer, {
+        dedupKey: 'demo/researcher',
+        prefix: 'relay diagnostics for demo/researcher',
+        diagnostics: BLOCKED,
+        nowMs: 0,
+      });
+      gate.log(writer, {
+        dedupKey: 'demo/reviewer',
+        prefix: 'relay diagnostics for demo/reviewer',
+        diagnostics: INFORMATIONAL,
+        nowMs: 0,
+      });
+
+      expect(writer.warn).toHaveBeenCalledExactlyOnceWith(
+        `relay diagnostics for demo/researcher: ${BLOCKED[0]}`
+      );
+      expect(writer.debug).toHaveBeenCalledExactlyOnceWith(
+        `relay diagnostics for demo/reviewer: ${INFORMATIONAL[0]}`
+      );
+    });
+
+    it('writes nothing at all when the gate returns no line', () => {
+      const gate = new OpenCodeRelayDiagnosticsLogGate();
+      const writer = { warn: vi.fn(), debug: vi.fn() };
+      const input = {
+        dedupKey: 'demo/researcher',
+        prefix: 'relay diagnostics for demo/researcher',
+        diagnostics: BLOCKED,
+        nowMs: 0,
+      };
+
+      gate.log(writer, { ...input, diagnostics: undefined });
+      gate.log(writer, input);
+      gate.log(writer, { ...input, nowMs: 15_000 });
+
+      expect(writer.warn).toHaveBeenCalledTimes(1);
+      expect(writer.debug).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeRelayDiagnosticsLogGate.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeRelayDiagnosticsLogGate.test.ts
@@ -101,6 +101,31 @@ describe('OpenCodeRelayDiagnosticsLogGate', () => {
   });
 
   /**
+   * Eviction reads insertion order, and a `Map` keeps a re-set key at the position
+   * it first went in at. So the key whose window was refreshed a moment ago is the
+   * one eviction reaches first, and the busiest lane in the process - the one the
+   * window exists to quieten - is the one that loses its window and writes again.
+   */
+  it('evicts the key logged longest ago, not the one refreshed most recently', () => {
+    const gate = new OpenCodeRelayDiagnosticsLogGate(OPENCODE_RELAY_DIAGNOSTICS_LOG_DEDUP_MS, 2);
+    const CHANGED = ['opencode api error: session not found'];
+    note(gate, { dedupKey: 'demo/refreshed' });
+    note(gate, { dedupKey: 'demo/quiet', nowMs: 1_000 });
+    // A changed condition writes immediately and reopens the window for that key,
+    // which makes it the most recently logged key of the two.
+    note(gate, { dedupKey: 'demo/refreshed', diagnostics: CHANGED, nowMs: 2_000 });
+
+    note(gate, { dedupKey: 'demo/newcomer', nowMs: 3_000 });
+
+    // The refreshed key kept its place and its window.
+    expect(
+      note(gate, { dedupKey: 'demo/refreshed', diagnostics: CHANGED, nowMs: 4_000 })
+    ).toBeNull();
+    // The key nobody has logged since is the one that made room.
+    expect(note(gate, { dedupKey: 'demo/quiet', nowMs: 4_000 })).not.toBeNull();
+  });
+
+  /**
    * Negative control. Expected control flow must not file itself under the
    * durable warning channel, no matter how often the lane repeats it.
    */

--- a/src/main/utils/processStartTime.ts
+++ b/src/main/utils/processStartTime.ts
@@ -1,0 +1,99 @@
+import { execFile, type ExecFileException } from 'child_process';
+
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+const PROBE_MAX_BUFFER_BYTES = 64 * 1024;
+
+/**
+ * Process start time is the only ownership signal a pid-based guard can trust:
+ * a pid can be recycled and a command line can be copied, but the instant a
+ * process began cannot be forged by whatever inherits its pid afterwards.
+ *
+ * Reading it costs a child process on every platform, and each spelling has its
+ * own trap - a shell-quoted pid on Windows, a locale-dependent timestamp
+ * everywhere else - so the readers that need the signal share one
+ * implementation here rather than each carrying their own.
+ *
+ * `platform` and `timeoutMs` are parameters rather than ambient reads so both
+ * branches stay reachable from a test on any host, and so a caller working
+ * against a deadline can cap what the probe is allowed to spend. A probe that
+ * cannot answer resolves `null`, which every caller must read as "start time
+ * unobservable" and never as "different process".
+ */
+export async function readProcessStartTimeMs(
+  pid: number,
+  platform: NodeJS.Platform = process.platform,
+  timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS
+): Promise<number | null> {
+  return platform === 'win32'
+    ? readWindowsProcessStartTimeMs(pid, timeoutMs)
+    : readNativeProcessStartTimeMs(pid, timeoutMs);
+}
+
+async function readNativeProcessStartTimeMs(
+  pid: number,
+  timeoutMs: number
+): Promise<number | null> {
+  const output = await execProcessProbeText('ps', ['-p', String(pid), '-o', 'lstart='], timeoutMs);
+  if (!output) {
+    return null;
+  }
+  const parsed = Date.parse(output.trim());
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function readWindowsProcessStartTimeMs(
+  pid: number,
+  timeoutMs: number
+): Promise<number | null> {
+  const normalizedPid = Math.trunc(pid);
+  // The pid is interpolated into a PowerShell script, so anything that is not a
+  // plain positive integer is refused here rather than quoted downstream.
+  if (!Number.isFinite(normalizedPid) || normalizedPid <= 0) {
+    return null;
+  }
+
+  const script = [
+    '$ErrorActionPreference = "Stop"',
+    `$process = Get-Process -Id ${normalizedPid} -ErrorAction Stop`,
+    '$process.StartTime.ToUniversalTime().ToString("o")',
+  ].join('; ');
+  const output = await execProcessProbeText(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
+    timeoutMs
+  );
+  if (!output) {
+    return null;
+  }
+  const parsed = Date.parse(output.trim());
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function execProcessProbeText(
+  command: string,
+  args: string[],
+  timeout: number
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      command,
+      args,
+      {
+        encoding: 'utf8',
+        timeout,
+        maxBuffer: PROBE_MAX_BUFFER_BYTES,
+        windowsHide: true,
+        // POSIX `ps` renders `lstart=` in the caller's LC_TIME, and Date.parse only
+        // understands the C spelling of it. On a non-English desktop the probe would
+        // otherwise parse to NaN, read as "start time unobservable", and leave a
+        // recycled pid owning whatever the caller guards. The probe environment is an
+        // override of the app environment, not a replacement: dropping PATH here would
+        // break the `ps` lookup on some hosts.
+        env: { ...process.env, LC_ALL: 'C' },
+      },
+      (error: ExecFileException | null, stdout: string | Buffer) => {
+        resolve(error ? null : String(stdout));
+      }
+    );
+  });
+}

--- a/test/main/services/team/ReviewPersistenceScopeLock.test.ts
+++ b/test/main/services/team/ReviewPersistenceScopeLock.test.ts
@@ -267,6 +267,131 @@ describe('ReviewPersistenceScopeLock', () => {
   });
 
   /**
+   * The probe's floor is not the acquire's floor. A spawned probe may keep a full
+   * second to answer in - a powershell.exe start costs most of that - but an
+   * acquire that asked for a quarter of a second must answer in a quarter of a
+   * second, and the only conservative reading available by then is "start time
+   * unobservable", which keeps the live owner. The probe is not cancelled for it:
+   * its answer still lands in the cache, and the next acquire spends nothing to
+   * read it.
+   */
+  it('answers a sub-second acquire budget while the probe it started runs on', async () => {
+    const { withReviewPersistenceScopeLock } =
+      await import('@main/services/team/ReviewPersistenceScopeLock');
+    const scope = { scopeKey: 'task-task-1', scopeToken: 'task:task-1:probe-outlives-acquire' };
+    await withReviewPersistenceScopeLock(
+      'demo',
+      { scopeKey: 'task-bootstrap', scopeToken: 'bootstrap' },
+      async () => undefined
+    );
+
+    await withLiveForeignProcess(async (childPid) => {
+      seedCrashLeftLease(scope, childPid);
+      let answerProbe!: (startedAt: number) => void;
+      const probeAnswered = new Promise<number>((resolve) => {
+        answerProbe = resolve;
+      });
+      let probeCount = 0;
+      startTimeProbeOverride.read = async () => {
+        probeCount += 1;
+        return probeAnswered;
+      };
+      // Later than the acquire below, and later than the floor a spawned probe keeps.
+      const answerTimer = setTimeout(() => answerProbe(Date.now()), 1_500);
+
+      try {
+        const startedAtMs = Date.now();
+        await expect(
+          withReviewPersistenceScopeLock('demo', scope, async () => 'stolen', {
+            acquireTimeoutMs: 250,
+            retryIntervalMs: 10,
+          })
+        ).rejects.toThrow('busy in another app process');
+
+        expect(Date.now() - startedAtMs).toBeLessThan(1_000);
+        expect(probeCount).toBe(1);
+
+        // The probe was left to finish, so the answer is there for the next acquire
+        // to reclaim the row on without spawning a probe of its own.
+        await probeAnswered;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await expect(
+          withReviewPersistenceScopeLock('demo', scope, async () => 'recovered', {
+            acquireTimeoutMs: 500,
+            retryIntervalMs: 10,
+          })
+        ).resolves.toBe('recovered');
+        expect(probeCount).toBe(1);
+      } finally {
+        clearTimeout(answerTimer);
+      }
+    });
+  });
+
+  /**
+   * Joining an in-flight probe is what keeps concurrent acquires of different
+   * scopes to one process spawn, but the joiner inherits the timeout whoever
+   * started that probe chose - up to the full probe cap. A short-budget acquire
+   * must not be held to another acquire's clock, while the acquire that started
+   * the probe still gets its real answer.
+   */
+  it('holds a joining acquire to its own budget, not to the probe it joined', async () => {
+    const { withReviewPersistenceScopeLock } =
+      await import('@main/services/team/ReviewPersistenceScopeLock');
+    const probeStarter = { scopeKey: 'task-task-1', scopeToken: 'task:task-1:probe-starter' };
+    const probeJoiner = { scopeKey: 'task-task-2', scopeToken: 'task:task-2:probe-joiner' };
+    await withReviewPersistenceScopeLock(
+      'demo',
+      { scopeKey: 'task-bootstrap', scopeToken: 'bootstrap' },
+      async () => undefined
+    );
+
+    await withLiveForeignProcess(async (childPid) => {
+      seedCrashLeftLease(probeStarter, childPid);
+      seedCrashLeftLease(probeJoiner, childPid);
+      let answerProbe!: (startedAt: number) => void;
+      const probeAnswered = new Promise<number>((resolve) => {
+        answerProbe = resolve;
+      });
+      let probeCount = 0;
+      startTimeProbeOverride.read = async () => {
+        probeCount += 1;
+        return probeAnswered;
+      };
+      const answerTimer = setTimeout(() => answerProbe(Date.now()), 1_500);
+
+      try {
+        const patientAcquire = withReviewPersistenceScopeLock(
+          'demo',
+          probeStarter,
+          async () => 'recovered',
+          { acquireTimeoutMs: 5_000, retryIntervalMs: 10 }
+        );
+        for (let attempt = 0; probeCount === 0 && attempt < 200; attempt += 1) {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+        expect(probeCount).toBe(1);
+
+        const startedAtMs = Date.now();
+        await expect(
+          withReviewPersistenceScopeLock('demo', probeJoiner, async () => 'stolen', {
+            acquireTimeoutMs: 250,
+            retryIntervalMs: 10,
+          })
+        ).rejects.toThrow('busy in another app process');
+
+        expect(Date.now() - startedAtMs).toBeLessThan(1_000);
+        // One spawn for both acquires: the second joined rather than starting its own.
+        expect(probeCount).toBe(1);
+        // And the acquire that started the probe still waits for what it asked for.
+        await expect(patientAcquire).resolves.toBe('recovered');
+      } finally {
+        clearTimeout(answerTimer);
+      }
+    });
+  });
+
+  /**
    * The reason the probe is awaited before the transaction rather than inside it,
    * asserted rather than claimed in a comment. `BEGIN IMMEDIATE` takes the SQLite
    * write lock for the whole database, so awaiting a process spawn after it would

--- a/test/main/services/team/ReviewPersistenceScopeLock.test.ts
+++ b/test/main/services/team/ReviewPersistenceScopeLock.test.ts
@@ -14,8 +14,24 @@ vi.mock('@main/utils/pathDecoder', () => ({
   getTeamsBasePath: () => teamsBasePath,
 }));
 
+const startTimeProbeOverride = vi.hoisted(() => ({
+  read: null as ((pid: number, timeoutMs?: number) => Promise<number | null>) | null,
+}));
+
+vi.mock('@main/utils/processStartTime', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@main/utils/processStartTime')>();
+  return {
+    ...actual,
+    readProcessStartTimeMs: (pid: number, platform?: NodeJS.Platform, timeoutMs?: number) =>
+      startTimeProbeOverride.read
+        ? startTimeProbeOverride.read(pid, timeoutMs)
+        : actual.readProcessStartTimeMs(pid, platform, timeoutMs),
+  };
+});
+
 describe('ReviewPersistenceScopeLock', () => {
   beforeEach(async () => {
+    startTimeProbeOverride.read = null;
     teamsBasePath = await mkdtemp(path.join(tmpdir(), 'review-persistence-lock-'));
   });
 
@@ -25,6 +41,46 @@ describe('ReviewPersistenceScopeLock', () => {
     closeReviewPersistenceScopeLockDatabasesForTests();
     await rm(teamsBasePath, { recursive: true, force: true });
   });
+
+  function seedCrashLeftLease(
+    scope: { scopeKey: string; scopeToken: string },
+    ownerPid: number
+  ): void {
+    const scopeId = createHash('sha256')
+      .update('demo')
+      .update('\0')
+      .update(scope.scopeKey)
+      .update('\0')
+      .update(scope.scopeToken)
+      .digest('hex');
+    const database = new DatabaseSync(
+      path.join(teamsBasePath, '.review-persistence-locks.sqlite3')
+    );
+    const now = Date.now();
+    database
+      .prepare(
+        `INSERT INTO review_scope_locks (
+          scope_id, owner_token, owner_pid, owner_started_at, acquired_at, heartbeat_at
+        ) VALUES (?, ?, ?, ?, ?, ?)`
+      )
+      .run(scopeId, 'crashed-owner', ownerPid, now - 24 * 60 * 60 * 1_000, now, now);
+    database.close();
+  }
+
+  async function withLiveForeignProcess(run: (pid: number) => Promise<void>): Promise<void> {
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], {
+      stdio: 'ignore',
+    });
+    await once(child, 'spawn');
+    const childPid = child.pid;
+    if (!childPid) throw new Error('Unable to start reused-PID lock fixture');
+    try {
+      await run(childPid);
+    } finally {
+      child.kill('SIGKILL');
+      await once(child, 'close');
+    }
+  }
 
   it('serializes async operations for one exact scope', async () => {
     const { withReviewPersistenceScopeLock } =
@@ -104,32 +160,8 @@ describe('ReviewPersistenceScopeLock', () => {
       async () => undefined
     );
 
-    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1_000)'], {
-      stdio: 'ignore',
-    });
-    await once(child, 'spawn');
-    const childPid = child.pid;
-    if (!childPid) throw new Error('Unable to start reused-PID lock fixture');
-    try {
-      const scopeId = createHash('sha256')
-        .update('demo')
-        .update('\0')
-        .update(scope.scopeKey)
-        .update('\0')
-        .update(scope.scopeToken)
-        .digest('hex');
-      const database = new DatabaseSync(
-        path.join(teamsBasePath, '.review-persistence-locks.sqlite3')
-      );
-      const now = Date.now();
-      database
-        .prepare(
-          `INSERT INTO review_scope_locks (
-            scope_id, owner_token, owner_pid, owner_started_at, acquired_at, heartbeat_at
-          ) VALUES (?, ?, ?, ?, ?, ?)`
-        )
-        .run(scopeId, 'crashed-owner', childPid, now - 24 * 60 * 60 * 1_000, now, now);
-      database.close();
+    await withLiveForeignProcess(async (childPid) => {
+      seedCrashLeftLease(scope, childPid);
 
       await expect(
         withReviewPersistenceScopeLock('demo', scope, async () => 'recovered', {
@@ -137,9 +169,183 @@ describe('ReviewPersistenceScopeLock', () => {
           retryIntervalMs: 10,
         })
       ).resolves.toBe('recovered');
-    } finally {
-      child.kill('SIGKILL');
-      await once(child, 'close');
-    }
+    });
+  });
+
+  it('re-probes an owner whose start time was unobservable on the first attempt', async () => {
+    const { withReviewPersistenceScopeLock } =
+      await import('@main/services/team/ReviewPersistenceScopeLock');
+    const scope = { scopeKey: 'task-task-1', scopeToken: 'task:task-1:unobservable-start' };
+    await withReviewPersistenceScopeLock(
+      'demo',
+      { scopeKey: 'task-bootstrap', scopeToken: 'bootstrap' },
+      async () => undefined
+    );
+
+    await withLiveForeignProcess(async (childPid) => {
+      seedCrashLeftLease(scope, childPid);
+      let probeCount = 0;
+      // A probe that times out under load answers null. Caching that miss for the
+      // full success TTL would make every retry in one acquire budget reuse it, so
+      // the crash-left row could never be reclaimed.
+      startTimeProbeOverride.read = async () => (probeCount++ === 0 ? null : Date.now());
+
+      await expect(
+        withReviewPersistenceScopeLock('demo', scope, async () => 'recovered', {
+          acquireTimeoutMs: 2_000,
+          retryIntervalMs: 10,
+        })
+      ).resolves.toBe('recovered');
+      expect(probeCount).toBeGreaterThan(1);
+    });
+  });
+
+  it('rate-limits owner probes and caps them by the remaining acquire budget', async () => {
+    const { withReviewPersistenceScopeLock } =
+      await import('@main/services/team/ReviewPersistenceScopeLock');
+    const scope = { scopeKey: 'task-task-1', scopeToken: 'task:task-1:unreadable-owner' };
+    await withReviewPersistenceScopeLock(
+      'demo',
+      { scopeKey: 'task-bootstrap', scopeToken: 'bootstrap' },
+      async () => undefined
+    );
+
+    await withLiveForeignProcess(async (childPid) => {
+      seedCrashLeftLease(scope, childPid);
+      const acquireTimeoutMs = 1_200;
+      const probeTimeouts: number[] = [];
+      // An owner nobody can read: a miss that expires per retry would let the 10ms loop
+      // below spawn a probe process several times a second for the whole acquire window,
+      // each one free to outlive the acquire that started it.
+      startTimeProbeOverride.read = async (_pid, timeoutMs) => {
+        probeTimeouts.push(timeoutMs ?? Number.POSITIVE_INFINITY);
+        return null;
+      };
+
+      await expect(
+        withReviewPersistenceScopeLock('demo', scope, async () => 'unreachable', {
+          acquireTimeoutMs,
+          retryIntervalMs: 10,
+        })
+      ).rejects.toThrow('busy in another app process');
+      // This budget is above the probe floor, so the remaining budget is what caps each
+      // probe: none of them may run on into the seconds after the acquire gave up.
+      for (const probeTimeout of probeTimeouts) {
+        expect(probeTimeout).toBeGreaterThan(0);
+        expect(probeTimeout).toBeLessThanOrEqual(acquireTimeoutMs);
+      }
+      expect(probeTimeouts.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  it('skips the owner probe once the acquire budget is already spent', async () => {
+    const { withReviewPersistenceScopeLock } =
+      await import('@main/services/team/ReviewPersistenceScopeLock');
+    const scope = { scopeKey: 'task-task-1', scopeToken: 'task:task-1:spent-budget' };
+    await withReviewPersistenceScopeLock(
+      'demo',
+      { scopeKey: 'task-bootstrap', scopeToken: 'bootstrap' },
+      async () => undefined
+    );
+
+    await withLiveForeignProcess(async (childPid) => {
+      seedCrashLeftLease(scope, childPid);
+      let probeCount = 0;
+      startTimeProbeOverride.read = async () => {
+        probeCount += 1;
+        return null;
+      };
+
+      await expect(
+        withReviewPersistenceScopeLock('demo', scope, async () => 'unreachable', {
+          acquireTimeoutMs: 0,
+          retryIntervalMs: 10,
+        })
+      ).rejects.toThrow('busy in another app process');
+      expect(probeCount).toBe(0);
+    });
+  });
+
+  /**
+   * The reason the probe is awaited before the transaction rather than inside it,
+   * asserted rather than claimed in a comment. `BEGIN IMMEDIATE` takes the SQLite
+   * write lock for the whole database, so awaiting a process spawn after it would
+   * block every acquire in every app process for the length of that spawn. A
+   * second connection can only take that lock while the acquire under test is not
+   * holding it, so taking it from inside the probe is the observation.
+   */
+  it('holds no write transaction while the owner probe is in flight', async () => {
+    const { withReviewPersistenceScopeLock } =
+      await import('@main/services/team/ReviewPersistenceScopeLock');
+    const scope = { scopeKey: 'task-task-1', scopeToken: 'task:task-1:probe-before-begin' };
+    await withReviewPersistenceScopeLock(
+      'demo',
+      { scopeKey: 'task-bootstrap', scopeToken: 'bootstrap' },
+      async () => undefined
+    );
+
+    await withLiveForeignProcess(async (childPid) => {
+      seedCrashLeftLease(scope, childPid);
+      let writeLockDuringProbe: 'free' | 'held' | 'not probed' = 'not probed';
+      startTimeProbeOverride.read = async () => {
+        const observer = new DatabaseSync(
+          path.join(teamsBasePath, '.review-persistence-locks.sqlite3')
+        );
+        try {
+          // No busy timeout is configured on this connection, so a write lock held
+          // by the acquire under test fails here immediately instead of waiting.
+          observer.exec('BEGIN IMMEDIATE');
+          observer.exec('ROLLBACK');
+          writeLockDuringProbe = 'free';
+        } catch {
+          writeLockDuringProbe = 'held';
+        } finally {
+          observer.close();
+        }
+        return Date.now();
+      };
+
+      await expect(
+        withReviewPersistenceScopeLock('demo', scope, async () => 'recovered', {
+          acquireTimeoutMs: 2_000,
+          retryIntervalMs: 10,
+        })
+      ).resolves.toBe('recovered');
+      expect(writeLockDuringProbe).toBe('free');
+    });
+  });
+
+  /**
+   * The conservative half of the recycled-pid rule, asserted for the first time:
+   * an unobservable start time is not evidence of a different process. The
+   * seeded row claims a start time a day old, so a probe that answered anything
+   * real would evict this owner - answering null must not.
+   */
+  it('keeps a live-pid owner whose start time cannot be observed at all', async () => {
+    const { withReviewPersistenceScopeLock } =
+      await import('@main/services/team/ReviewPersistenceScopeLock');
+    const scope = { scopeKey: 'task-task-1', scopeToken: 'task:task-1:unobservable-owner-kept' };
+    await withReviewPersistenceScopeLock(
+      'demo',
+      { scopeKey: 'task-bootstrap', scopeToken: 'bootstrap' },
+      async () => undefined
+    );
+
+    await withLiveForeignProcess(async (childPid) => {
+      seedCrashLeftLease(scope, childPid);
+      let probeCount = 0;
+      startTimeProbeOverride.read = async () => {
+        probeCount += 1;
+        return null;
+      };
+
+      await expect(
+        withReviewPersistenceScopeLock('demo', scope, async () => 'stolen', {
+          acquireTimeoutMs: 300,
+          retryIntervalMs: 10,
+        })
+      ).rejects.toThrow('busy in another app process');
+      expect(probeCount).toBeGreaterThan(0);
+    });
   });
 });

--- a/test/main/utils/processStartTime.test.ts
+++ b/test/main/utils/processStartTime.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { readProcessStartTimeMs } from '@main/utils/processStartTime';
+import * as childProcess from 'child_process';
+import { afterEach, describe, expect, it, type Mock, vi } from 'vitest';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFile: vi.fn(),
+  };
+});
+
+interface RecordedProbe {
+  command: string;
+  args: string[];
+  options: { env?: NodeJS.ProcessEnv; timeout?: number; maxBuffer?: number };
+}
+
+function recordProbes(result: { stdout?: string; error?: Error }): RecordedProbe[] {
+  const probes: RecordedProbe[] = [];
+  (childProcess.execFile as unknown as Mock).mockImplementation(
+    (
+      command: string,
+      args: string[],
+      options: RecordedProbe['options'],
+      callback: (error: Error | null, stdout: string) => void
+    ) => {
+      probes.push({ command, args, options });
+      callback(result.error ?? null, result.stdout ?? '');
+      return {};
+    }
+  );
+  return probes;
+}
+
+describe('processStartTime', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('forces the C locale so POSIX lstart= stays parseable on a non-English desktop', async () => {
+    vi.stubEnv('LC_ALL', 'de_DE.UTF-8');
+    vi.stubEnv('LC_TIME', 'de_DE.UTF-8');
+    vi.stubEnv('AGENT_TEAMS_PROBE_MARKER', 'kept');
+    const probes = recordProbes({ stdout: 'Wed Aug 27 10:12:33 2025\n' });
+
+    const startedAt = await readProcessStartTimeMs(4321, 'linux', 2_000);
+
+    expect(startedAt).toBe(Date.parse('Wed Aug 27 10:12:33 2025'));
+    expect(probes).toHaveLength(1);
+    expect(probes[0].command).toBe('ps');
+    expect(probes[0].args).toEqual(['-p', '4321', '-o', 'lstart=']);
+    expect(probes[0].options.env?.LC_ALL).toBe('C');
+    // The probe environment is an override of the app environment, not a replacement:
+    // dropping PATH here would break `ps` lookup on some hosts.
+    expect(probes[0].options.env?.AGENT_TEAMS_PROBE_MARKER).toBe('kept');
+  });
+
+  it('still reads the Windows round-trip start time through the forced locale', async () => {
+    const probes = recordProbes({ stdout: '2025-08-27T08:12:33.1234567Z\n' });
+
+    const startedAt = await readProcessStartTimeMs(4321, 'win32', 2_000);
+
+    expect(startedAt).toBe(Date.parse('2025-08-27T08:12:33.123Z'));
+    expect(probes[0].command).toBe('powershell.exe');
+    expect(probes[0].args.at(-1)).toContain('Get-Process -Id 4321');
+    expect(probes[0].options.env?.LC_ALL).toBe('C');
+  });
+
+  it('spends the timeout the caller asked for, and a bounded default when asked for none', async () => {
+    const probes = recordProbes({ stdout: 'Wed Aug 27 10:12:33 2025\n' });
+
+    await readProcessStartTimeMs(4321, 'linux', 250);
+    await readProcessStartTimeMs(4321, 'linux');
+
+    expect(probes[0].options.timeout).toBe(250);
+    expect(probes[1].options.timeout).toBe(2_000);
+    // A probe reads one short line; the buffer only has to stop a runaway child.
+    expect(probes[0].options.maxBuffer).toBe(64 * 1024);
+  });
+
+  /**
+   * The negative control that every caller depends on: a probe that could not
+   * answer must read as "start time unobservable", never as "a different
+   * process". A caller that treated a failed probe as a mismatch would evict a
+   * live owner the moment the host got slow enough to time the probe out.
+   */
+  it('answers null when the probe fails instead of inventing a start time', async () => {
+    recordProbes({ error: new Error('spawn ps ETIMEDOUT') });
+
+    await expect(readProcessStartTimeMs(4321, 'linux', 2_000)).resolves.toBeNull();
+  });
+
+  it('refuses to build a Windows probe script from a pid that is not a positive integer', async () => {
+    const probes = recordProbes({ stdout: '2025-08-27T08:12:33.1234567Z\n' });
+
+    await expect(readProcessStartTimeMs(0, 'win32', 2_000)).resolves.toBeNull();
+    await expect(readProcessStartTimeMs(Number.NaN, 'win32', 2_000)).resolves.toBeNull();
+    expect(probes).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Base: `origin/main`. Independent of every other open PR.

## Problem

Two main-process defects with the same shape: an expensive or invisible operation sitting inside a loop.

**1. The review scope lock spawns a process per acquire attempt, and the attempt does not budget for it.** `ReviewPersistenceScopeLock.tryAcquireLease()` decides whether a lease owner is stale by reading the owner's process start time, which on Windows means spawning PowerShell (`Get-Process`) and on POSIX means `ps -o lstart=`. The probe ran on every attempt of the acquire loop, outside the loop's own retry budget, with the write transaction already open on the sqlite file. Under contention that is a process spawn per retry with the lock held, and the "busy in another app process" error the user sees arrives late and for the wrong reason. The POSIX probe also parsed `lstart=` in whatever locale the shell had, so a non-English locale could make every owner look fresh forever.

**2. A relay stall produces no log line.** A relay result is the only account the app gives of why a message did or did not reach an OpenCode runtime, and exactly one caller turned it into a log line: the FileWatcher inbox-change path. The dedup map, the two window constants and the severity predicate that decide whether a diagnostic is worth a `warn` lived as module state in `src/main/index.ts`, so no other path could log the same way. The retry/wake sweep, which is the path a stalled lane actually takes, threw the result away. A ten-minute stall could produce no log line describing itself; the few lines such a stretch did produce existed only because a new inbox row happened to arrive and take the watched path.

## Fix

Three commits.

1. `refactor(main): extract the process start time probe into a shared util`: `src/main/utils/processStartTime.ts` exposes one function, `readProcessStartTimeMs(pid, { timeoutMs })`. It forces `LC_ALL=C` on POSIX so `lstart=` parses the same everywhere, answers `null` on any failure, and refuses non-positive or non-numeric pids before touching the shell. Two private copies of the same probe remain on main (`OpenCodeManagedHostProcessCleanup.ts`, `AgentTeamsMcpHttpServer.ts`, the latter with no Windows branch at all); migrating them is a follow-up, left out to keep this PR small.
2. `fix(team): the review scope lock probes an owner within its own acquire budget`: the probe moves out of the transaction and into the acquire loop's budget, is rate-limited, and is skipped once the budget is spent. Because the pre-read can now go stale while the probe runs, the row is re-read inside the transaction and the acquire is refused unless the owner it observed is byte for byte the owner still there. `acquireLease` was already `async`, so no new async boundary reaches any caller. Two negative controls were mutation-tested: a second `DatabaseSync` on the same file can take `BEGIN IMMEDIATE` while the probe is pending (moving the `await` after the transaction turns it red), and an owner whose start time cannot be observed is kept, never reclaimed.
3. `refactor(opencode): extract the relay diagnostics log gate from the main entrypoint`: `OpenCodeRelayDiagnosticsLogGate` answers one question, the line to write or `null`, and writes it through a caller-supplied writer. The FileWatcher path uses it today; the delivery retry path adopts it in a follow-up PR, and the doc comment says exactly that rather than claiming a consumer that does not exist yet. `src/main/index.ts` loses 40 lines and keeps no branch of its own. Two things in this commit are not pure motion and the commit body says so: the dedup signature is the diagnostics alone rather than the rendered line (a no-op for the current caller, whose prefix is constant within a window; it matters for the retry path, where a signature that included the message id would let a blocked queue walk past the window one row at a time), and informational diagnostics go out at `debug` rather than `info` (neither level is durable and neither prints at the default console level; `debug` is the level an operator raises when chasing a lane, and I can split this into its own commit if you prefer the extraction strictly mechanical).

Sizes: `src/main/index.ts` 3709 → 3669 (cap 3719, left in place per the `2834fdf90` precedent; happy to ratchet if you prefer); new modules 99 and 137 lines; `ReviewPersistenceScopeLock.ts` 446/800. Two review findings were folded in as follow-up commits: a refreshed dedup key now keeps its place in the eviction order, and what an acquire awaits is a race between the owner probe and the acquire's own remaining budget, so a short acquire never waits out a probe it started or joined; both carry regression tests. `scripts/ci/source-file-size-baseline.json` untouched.

## Tests

- `test/main/utils/processStartTime.test.ts`: the POSIX probe pins `LC_ALL=C`, the timeout is passed through with its default, a failed probe answers `null`, and a non-positive or `NaN` pid never reaches the shell (negative controls).
- `test/main/services/team/ReviewPersistenceScopeLock.test.ts`: re-probe after an unobserved owner start, the rate limit and the budget cap, the skip once the budget is spent, plus the two controls above. 10/10.
- `src/main/services/team/opencode/delivery/__tests__/OpenCodeRelayDiagnosticsLogGate.test.ts`: informational-only diagnostics never raise a `warn`; one non-informational diagnostic in the set raises the whole line; a repeat inside the window is suppressed and a changed set is not; the tracked-key eviction bound; and the writer is called with the line at the level the gate chose and not at all when the gate returns `null`. 12 cases. Fixtures use real diagnostics from `OpenCodeRuntimeDeliveryDiagnostics.ts`.

`pnpm typecheck`, both guards, `eslint` (0 errors) and `prettier --check` on every changed `src/` file, per commit. The broader team/utils/opencode suites fail only the Windows-only cases an unmodified `origin/main` fails on this machine (those come in a separate test-only PR); nothing new.

## Tested on

Windows 11 Pro, from source. The scope-lock contention was reproduced with the review persistence e2e harness during the earlier test campaign; the silent stall is from live mixed-provider runs where a lane deferred for ten minutes with no line in the log. The POSIX locale branch is covered by test only; not run on macOS or Linux here.

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.
