### PR TITLE
test(team): compare facade guard paths as slash-separated on every host

### DIFF
--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningServiceFacadeGuard.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningServiceFacadeGuard.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { dirname, relative, resolve } from 'node:path';
+import { dirname, relative, resolve, sep } from 'node:path';
 
 import { format, type Options as PrettierOptions } from 'prettier';
 import ts from 'typescript';
@@ -357,7 +357,9 @@ function getEffectivePublicServiceInstanceMemberNames(): string[] {
 }
 
 function projectRelativePath(filePath: string): string {
-  return relative(process.cwd(), filePath);
+  // Guarded paths are compared against slash-separated literals, so they must
+  // not carry the host separator.
+  return relative(process.cwd(), filePath).split(sep).join('/');
 }
 
 function readGuardedFacadeSource(filePath: string): GuardedFacadeSource {


### PR DESCRIPTION
## Problem

`src/main/services/team/provisioning/__tests__/TeamProvisioningServiceFacadeGuard.test.ts`
collects the files it inspects with `path.relative()` and compares them against
slash-separated repo paths (`'src/main/services/team/provisioning/...'`). On
Windows `path.relative()` returns backslash-separated paths, so the coverage
assertion (`includes extracted facade delegates and superclasses in
forbidden-reference coverage`) failed on every Windows checkout of `main`
although the guarded set was complete:

```
FAIL  TeamProvisioningServiceFacadeGuard.test.ts > includes extracted facade delegates and superclasses in forbidden-reference coverage
AssertionError: expected [ …(25) ] to deeply equal ArrayContaining{…}
```

## Fix

Normalize the collected relative paths to forward slashes before comparing
(`relative(...).split(sep).join('/')`). No behaviour change on POSIX hosts; the
guard now runs the same assertion on Windows.

## Tests

- The file itself: 8/8 on Windows (was 7/8), unchanged on POSIX.

## Tested on

Windows 11, from source. Negative control: the unmodified test on a clean
`origin/main` checkout fails on this machine with the assertion above.

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved cross-platform path handling checks to ensure guarded project paths are matched consistently across operating systems.
  - Added coverage for differences in host path separators, reducing the risk of environment-specific test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->