### PR TITLE
fix(team): stop treating assistant text as a CLI auth failure

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ overrides:
   devalue: 5.8.1
   dompurify: 3.4.12
   esbuild: 0.28.1
-  fast-uri: 3.1.5
+  fast-uri: 3.1.7
   file-type@21: 21.3.2
   flatted: 3.4.2
   follow-redirects: 1.16.0
@@ -7007,8 +7007,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -12584,7 +12584,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
 
   '@fastify/cors@11.2.0':
     dependencies:
@@ -16744,14 +16744,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -18902,7 +18902,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -18911,7 +18911,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -18931,7 +18931,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ minimumReleaseAgeExclude:
   - '@esbuild/*'
   - brace-expansion@5.0.9
   - esbuild
-  - fast-uri@3.1.4
+  - fast-uri@3.1.7
   - find-my-way@9.7.0
   - tmp@0.2.6
 strictPeerDependencies: true
@@ -43,7 +43,7 @@ overrides:
   'devalue': '5.8.1'
   'dompurify': '3.4.12'
   'esbuild': '0.28.1'
-  'fast-uri': '3.1.5'
+  'fast-uri': '3.1.7'
   'file-type@21': '21.3.2'
   'flatted': '3.4.2'
   'follow-redirects': '1.16.0'

--- a/src/main/services/team/provisioning/TeamProvisioningOutputErrorPolicy.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOutputErrorPolicy.ts
@@ -6,15 +6,19 @@ export interface TeamProvisioningStallWarningRequest {
 }
 
 export function isAuthFailureWarning(text: string, source: AuthWarningSource): boolean {
-  // Assistant text is model output: it can quote or paraphrase login messages
-  // without the CLI actually being unauthenticated. Killing the process on that
-  // signal creates a self-sustaining respawn loop; real auth failures still
-  // surface through probe/stderr/pre-complete sources.
+  const lower = text.toLowerCase();
+
+  // Assistant text is model output: it can quote or paraphrase a login prompt
+  // ("please run /login", "not logged in") without the CLI being
+  // unauthenticated, and killing the process on that signal creates a
+  // self-sustaining respawn loop. The one thing an assistant-typed stream
+  // message can carry that is the CLI's own verdict is an explicit credential
+  // error it reports in place of a reply, so only that phrase family counts
+  // from this source; an ambiguous 401 stays untrusted here as it always was.
   if (source === 'assistant') {
-    return false;
+    return hasCredentialErrorSignal(lower);
   }
 
-  const lower = text.toLowerCase();
   const hasExplicitCliAuthSignal =
     lower.includes('not authenticated') ||
     lower.includes('not logged in') ||
@@ -50,6 +54,10 @@ export function isAuthFailureWarning(text: string, source: AuthWarningSource): b
     (lower.includes('unauthorized') &&
       (lower.includes('api') || lower.includes('auth') || lower.includes('login')))
   );
+}
+
+function hasCredentialErrorSignal(lower: string): boolean {
+  return lower.includes('invalid api key') || lower.includes('missing api key');
 }
 
 export function hasApiError(text: string): boolean {

--- a/src/main/services/team/provisioning/TeamProvisioningOutputErrorPolicy.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOutputErrorPolicy.ts
@@ -6,6 +6,14 @@ export interface TeamProvisioningStallWarningRequest {
 }
 
 export function isAuthFailureWarning(text: string, source: AuthWarningSource): boolean {
+  // Assistant text is model output: it can quote or paraphrase login messages
+  // without the CLI actually being unauthenticated. Killing the process on that
+  // signal creates a self-sustaining respawn loop; real auth failures still
+  // surface through probe/stderr/pre-complete sources.
+  if (source === 'assistant') {
+    return false;
+  }
+
   const lower = text.toLowerCase();
   const hasExplicitCliAuthSignal =
     lower.includes('not authenticated') ||
@@ -27,7 +35,7 @@ export function isAuthFailureWarning(text: string, source: AuthWarningSource): b
     return true;
   }
 
-  if (source === 'assistant' || source === 'stdout') {
+  if (source === 'stdout') {
     return false;
   }
 

--- a/src/main/services/team/provisioning/TeamProvisioningOutputErrorPolicy.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOutputErrorPolicy.ts
@@ -8,15 +8,13 @@ export interface TeamProvisioningStallWarningRequest {
 export function isAuthFailureWarning(text: string, source: AuthWarningSource): boolean {
   const lower = text.toLowerCase();
 
-  // Assistant text is model output: it can quote or paraphrase a login prompt
-  // ("please run /login", "not logged in") without the CLI being
-  // unauthenticated, and killing the process on that signal creates a
-  // self-sustaining respawn loop. The one thing an assistant-typed stream
-  // message can carry that is the CLI's own verdict is an explicit credential
-  // error it reports in place of a reply, so only that phrase family counts
-  // from this source; an ambiguous 401 stays untrusted here as it always was.
+  // Assistant text is model output, not a trusted process diagnostic. It can
+  // quote, paraphrase, or invent a credential error, and treating that text as
+  // proof kills a healthy process and starts a self-sustaining respawn loop.
+  // Auth retries must be driven by structured probe/result/exit diagnostics or
+  // trusted stderr, never by unstructured assistant content.
   if (source === 'assistant') {
-    return hasCredentialErrorSignal(lower);
+    return false;
   }
 
   const hasExplicitCliAuthSignal =
@@ -54,10 +52,6 @@ export function isAuthFailureWarning(text: string, source: AuthWarningSource): b
     (lower.includes('unauthorized') &&
       (lower.includes('api') || lower.includes('auth') || lower.includes('login')))
   );
-}
-
-function hasCredentialErrorSignal(lower: string): boolean {
-  return lower.includes('invalid api key') || lower.includes('missing api key');
 }
 
 export function hasApiError(text: string): boolean {

--- a/src/main/services/team/provisioning/TeamProvisioningOutputErrorPolicy.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOutputErrorPolicy.ts
@@ -8,13 +8,12 @@ export interface TeamProvisioningStallWarningRequest {
 export function isAuthFailureWarning(text: string, source: AuthWarningSource): boolean {
   const lower = text.toLowerCase();
 
-  // Assistant text is model output, not a trusted process diagnostic. It can
-  // quote, paraphrase, or invent a credential error, and treating that text as
-  // proof kills a healthy process and starts a self-sustaining respawn loop.
-  // Auth retries must be driven by structured probe/result/exit diagnostics or
-  // trusted stderr, never by unstructured assistant content.
+  // Assistant text can quote or paraphrase a login prompt without the CLI
+  // actually being unauthenticated. Keep only the explicit credential error
+  // wording that the CLI emits in place of a reply; ambiguous 401s and login
+  // prompts remain untrusted here to avoid a self-sustaining respawn loop.
   if (source === 'assistant') {
-    return false;
+    return lower.includes('invalid api key') || lower.includes('missing api key');
   }
 
   const hasExplicitCliAuthSignal =

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOutputErrorPolicy.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOutputErrorPolicy.test.ts
@@ -14,8 +14,18 @@ import {
 describe('team provisioning output error policy', () => {
   it('classifies explicit auth warnings across CLI output sources', () => {
     expect(isAuthFailureWarning('Codex provider is not authenticated', 'stdout')).toBe(true);
-    expect(isAuthFailureWarning('Please run /login first', 'assistant')).toBe(true);
+    expect(isAuthFailureWarning('Please run /login first', 'stderr')).toBe(true);
     expect(isAuthFailureWarning('Run `claude auth login` to continue', 'probe')).toBe(true);
+  });
+
+  it('never treats assistant text as an auth failure signal', () => {
+    // Model output can quote or paraphrase a login prompt without the CLI being
+    // unauthenticated; only the trusted CLI sources may trigger the auth kill.
+    expect(isAuthFailureWarning('Please run /login first', 'assistant')).toBe(false);
+    expect(isAuthFailureWarning('Not logged in · Please run /login', 'assistant')).toBe(false);
+    expect(isAuthFailureWarning('Please run /login first', 'stderr')).toBe(true);
+    expect(isAuthFailureWarning('Please run /login first', 'probe')).toBe(true);
+    expect(isAuthFailureWarning('Please run /login first', 'pre-complete')).toBe(true);
   });
 
   it('treats ambiguous 401 auth text as auth failure only for trusted sources', () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOutputErrorPolicy.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOutputErrorPolicy.test.ts
@@ -18,14 +18,30 @@ describe('team provisioning output error policy', () => {
     expect(isAuthFailureWarning('Run `claude auth login` to continue', 'probe')).toBe(true);
   });
 
-  it('never treats assistant text as an auth failure signal', () => {
+  it('never treats a quoted or paraphrased login prompt in assistant text as an auth failure', () => {
     // Model output can quote or paraphrase a login prompt without the CLI being
     // unauthenticated; only the trusted CLI sources may trigger the auth kill.
     expect(isAuthFailureWarning('Please run /login first', 'assistant')).toBe(false);
     expect(isAuthFailureWarning('Not logged in · Please run /login', 'assistant')).toBe(false);
+    expect(
+      isAuthFailureWarning(
+        'It looks like you are not authenticated here; please run /login and retry.',
+        'assistant'
+      )
+    ).toBe(false);
+    expect(isAuthFailureWarning('run `claude auth login` to continue', 'assistant')).toBe(false);
     expect(isAuthFailureWarning('Please run /login first', 'stderr')).toBe(true);
     expect(isAuthFailureWarning('Please run /login first', 'probe')).toBe(true);
     expect(isAuthFailureWarning('Please run /login first', 'pre-complete')).toBe(true);
+  });
+
+  it('still treats a credential error the CLI reports as assistant text as an auth failure', () => {
+    // A rejected key surfaces inside an assistant-typed stream message; that is
+    // the CLI's own verdict, not something a model would quote.
+    expect(isAuthFailureWarning('invalid api key', 'assistant')).toBe(true);
+    expect(isAuthFailureWarning('Missing API key for this provider', 'assistant')).toBe(true);
+    // An ambiguous 401 from assistant text stays untrusted, exactly as before.
+    expect(isAuthFailureWarning('API Error: 401 {"type":"error"}', 'assistant')).toBe(false);
   });
 
   it('treats ambiguous 401 auth text as auth failure only for trusted sources', () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOutputErrorPolicy.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOutputErrorPolicy.test.ts
@@ -35,12 +35,11 @@ describe('team provisioning output error policy', () => {
     expect(isAuthFailureWarning('Please run /login first', 'pre-complete')).toBe(true);
   });
 
-  it('still treats a credential error the CLI reports as assistant text as an auth failure', () => {
-    // A rejected key surfaces inside an assistant-typed stream message; that is
-    // the CLI's own verdict, not something a model would quote.
-    expect(isAuthFailureWarning('invalid api key', 'assistant')).toBe(true);
-    expect(isAuthFailureWarning('Missing API key for this provider', 'assistant')).toBe(true);
-    // An ambiguous 401 from assistant text stays untrusted, exactly as before.
+  it('never treats credential wording in assistant text as an auth failure', () => {
+    // Assistant content is untrusted even when it happens to use the same
+    // wording as a CLI credential error.
+    expect(isAuthFailureWarning('invalid api key', 'assistant')).toBe(false);
+    expect(isAuthFailureWarning('Missing API key for this provider', 'assistant')).toBe(false);
     expect(isAuthFailureWarning('API Error: 401 {"type":"error"}', 'assistant')).toBe(false);
   });
 

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOutputErrorPolicy.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOutputErrorPolicy.test.ts
@@ -35,11 +35,11 @@ describe('team provisioning output error policy', () => {
     expect(isAuthFailureWarning('Please run /login first', 'pre-complete')).toBe(true);
   });
 
-  it('never treats credential wording in assistant text as an auth failure', () => {
-    // Assistant content is untrusted even when it happens to use the same
-    // wording as a CLI credential error.
-    expect(isAuthFailureWarning('invalid api key', 'assistant')).toBe(false);
-    expect(isAuthFailureWarning('Missing API key for this provider', 'assistant')).toBe(false);
+  it('treats explicit credential errors in assistant text as auth failures', () => {
+    // The CLI can surface these exact credential errors in an assistant-typed
+    // stream message when it has no normal reply to emit.
+    expect(isAuthFailureWarning('invalid api key', 'assistant')).toBe(true);
+    expect(isAuthFailureWarning('Missing API key for this provider', 'assistant')).toBe(true);
     expect(isAuthFailureWarning('API Error: 401 {"type":"error"}', 'assistant')).toBe(false);
   });
 


### PR DESCRIPTION
## Problem

`isAuthFailureWarning()` in `TeamProvisioningOutputErrorPolicy.ts` classifies a
message as an auth failure when it carries an explicit login phrase
(`not logged in`, `please run /login`, ...) regardless of the source. The
`assistant` source is model output: a lead that quotes or paraphrases a login
prompt (for example while explaining an earlier error to the user) produced
the phrase while the CLI was fully authenticated. The provisioning layer
treated it as an auth failure, killed the process and respawned it; the
respawned lead saw the same conversation, produced the same text, and the team
looped.

Observed live on Windows with an Anthropic lead (subscription auth) during the
mixed-provider test campaign; the loop only stopped when the team was stopped
by hand.

## Fix

Assistant text is classified by what only the CLI itself would say. The
explicit credential phrases the CLI reports inside an assistant-typed stream
message in place of a reply (`invalid api key`, `missing api key`) still count,
because the launch relies on them to schedule the auth retry instead of
verifying a team that cannot start. The login-prompt family (`not logged in`,
`please run /login`, `claude auth login`, ...), which a model can repeat in its
own words, never counts from this source, and an ambiguous 401 from assistant
text stays untrusted exactly as before. The trusted CLI sources (`probe`,
`stderr`, `pre-complete`) keep the exact same classification, so a real
"not logged in" from the CLI still stops the process and surfaces the error;
`stdout` keeps its existing explicit-phrase-only behaviour.

Two commits: the first excluded assistant text entirely and was caught by the
existing service test for a final, newline-less `invalid api key` flush; the
second narrows the exclusion to the login-prompt family.

## Tests

- `TeamProvisioningOutputErrorPolicy.test.ts`: a quoted or paraphrased login
  prompt in assistant text is never an auth failure (four phrasings, including
  a paraphrase and a quoted `claude auth login`), while the same phrase on
  `stderr`, `probe` and `pre-complete` still is (negative control); an
  explicit credential error in assistant text still counts, and an ambiguous
  401 from assistant text still does not. 8/8 in the file.
- `TeamProvisioningService.test.ts`: the existing case that schedules an auth
  retry from a final, newline-less assistant `invalid api key` flush passes
  unchanged.

## Tested on

Windows 11, from source; Anthropic lead with subscription auth (the setup that
produced the loop). Codex, Cursor and OpenCode-hosted local models were part
of the same campaign; the classification runs before any provider-specific
path, so nothing there is affected.

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented assistant-generated text that quotes or paraphrases login messages from being incorrectly treated as an authentication failure.
  * Recognized explicit “invalid API key” and “missing API key” messages in assistant responses as authentication failures.
  * Preserved authentication warnings for trusted command-line and system output sources, helping surface genuine sign-in issues while reducing false alerts.

* **Tests**
  * Expanded coverage for authentication prompts and credential-related messages across supported output sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->