### PR TITLE
chore(team): remove the dead passive reply linking copy from TeamDataService

### DIFF
--- a/src/main/services/team/TeamDataService.ts
+++ b/src/main/services/team/TeamDataService.ts
@@ -7,7 +7,6 @@ import { killProcessByPid } from '@main/utils/processKill';
 import { stripAgentBlocks, wrapAgentBlock } from '@shared/constants/agentBlocks';
 import { getMemberColorByName } from '@shared/constants/memberColors';
 import { isTeamEffortLevel } from '@shared/utils/effortLevels';
-import { classifyIdleNotificationText } from '@shared/utils/idleNotificationSemantics';
 import { isLeadMember } from '@shared/utils/leadDetection';
 import { createLogger } from '@shared/utils/logger';
 import { migrateProviderBackendId } from '@shared/utils/providerBackend';
@@ -128,7 +127,6 @@ const LEAD_SESSION_PARSE_CACHE_SCHEMA_VERSION = 'combined-v2';
 const PROCESS_HEALTH_INTERVAL_MS = 2_000;
 const TASK_MAP_YIELD_EVERY = 250;
 const TASK_COMMENT_NOTIFICATION_SOURCE = 'system_notification';
-const PASSIVE_USER_REPLY_LINK_WINDOW_MS = 15_000;
 const MEMBER_RUNTIME_ADVISORY_SNAPSHOT_BUDGET_MS = 250;
 const GLOBAL_TASK_TEAM_CONFIG_CONCURRENCY = 12;
 
@@ -325,31 +323,6 @@ function applyDistinctRosterColors<T extends { name: string; color?: string; rem
     ...member,
     color: colorMap.get(member.name) ?? member.color ?? getMemberColorByName(member.name),
   }));
-}
-
-function normalizePassiveUserReplyLinkText(value: string | undefined): string {
-  if (typeof value !== 'string') return '';
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/\s+/g, ' ')
-    .replace(/[.!?…]+$/g, '')
-    .trim();
-}
-
-function extractPassiveUserPeerSummaryBody(text: string): string | null {
-  const classified = classifyIdleNotificationText(text);
-  if (classified?.primaryKind !== 'heartbeat' || !classified.peerSummary) {
-    return null;
-  }
-
-  const match = /^\[to\s+user\]\s*(.*)$/i.exec(classified.peerSummary);
-  if (!match) {
-    return null;
-  }
-
-  const body = match[1]?.trim() ?? '';
-  return body.length > 0 ? body : null;
 }
 
 function readConfigForUiSnapshot(
@@ -1056,88 +1029,6 @@ export class TeamDataService {
 
       pendingSlash = null;
     }
-  }
-
-  private linkPassiveUserReplySummaries(messages: InboxMessage[]): InboxMessage[] {
-    const canonicalReplies = messages
-      .map((message) => {
-        const messageId = typeof message.messageId === 'string' ? message.messageId.trim() : '';
-        if (!messageId || message.to !== 'user') {
-          return null;
-        }
-        if (classifyIdleNotificationText(message.text)) {
-          return null;
-        }
-
-        const time = Date.parse(message.timestamp);
-        if (!Number.isFinite(time)) {
-          return null;
-        }
-
-        return {
-          messageId,
-          from: message.from,
-          time,
-          normalizedSummary: normalizePassiveUserReplyLinkText(message.summary),
-          normalizedText: normalizePassiveUserReplyLinkText(message.text),
-        };
-      })
-      .filter((value): value is NonNullable<typeof value> => value !== null);
-
-    if (canonicalReplies.length === 0) {
-      return messages;
-    }
-
-    let didLink = false;
-    const linkedMessages = messages.map((message) => {
-      if (
-        typeof message.relayOfMessageId === 'string' &&
-        message.relayOfMessageId.trim().length > 0
-      ) {
-        return message;
-      }
-
-      const body = extractPassiveUserPeerSummaryBody(message.text);
-      if (!body) {
-        return message;
-      }
-
-      const passiveTime = Date.parse(message.timestamp);
-      if (!Number.isFinite(passiveTime)) {
-        return message;
-      }
-
-      const normalizedBody = normalizePassiveUserReplyLinkText(body);
-      if (!normalizedBody) {
-        return message;
-      }
-
-      const matches = canonicalReplies.filter((candidate) => {
-        if (candidate.from !== message.from) {
-          return false;
-        }
-        const deltaMs = passiveTime - candidate.time;
-        if (deltaMs < 0 || deltaMs > PASSIVE_USER_REPLY_LINK_WINDOW_MS) {
-          return false;
-        }
-        if (candidate.normalizedSummary === normalizedBody) {
-          return true;
-        }
-        return normalizedBody.length >= 6 && candidate.normalizedText.includes(normalizedBody);
-      });
-
-      if (matches.length !== 1) {
-        return message;
-      }
-
-      didLink = true;
-      return {
-        ...message,
-        relayOfMessageId: matches[0].messageId,
-      };
-    });
-
-    return didLink ? linkedMessages : messages;
   }
 
   async getTaskChangePresence(teamName: string): Promise<Record<string, TaskChangePresenceState>> {


### PR DESCRIPTION
## Problem

`src/main/services/team/TeamDataService.ts` carries a private
`linkPassiveUserReplySummaries()` plus its two helpers
(`normalizePassiveUserReplyLinkText`, `extractPassiveUserPeerSummaryBody`) and
the `PASSIVE_USER_REPLY_LINK_WINDOW_MS` constant. Nothing calls the method:

```
git grep -n "linkPassiveUserReplySummaries" -- src test
```

finds only the definition in `TeamDataService.ts` and the live copy in
`TeamMessageFeedService.ts` (called from `getPage` and `buildFeed`, the only
places the message feed is assembled). The `TeamDataService` copy was left
behind when feed building moved into `TeamMessageFeedService`.

## Fix

Delete the method, the two helpers, the constant and the
`classifyIdleNotificationText` import that only they used (109 lines). No
behaviour change; the feed keeps linking passive replies through
`TeamMessageFeedService` exactly as before. `TeamDataService.ts` goes from
4102 to 3993 lines, below its frozen cap; the cap in
`scripts/ci/source-file-size-baseline.json` is left where it is.

## Tests

No test references the removed code. `TeamMessageFeedService.test.ts` (the
live linking) and `TeamDataService.test.ts` pass unchanged.

One pre-existing, unrelated failure on Windows in `TeamDataService.test.ts`
(`persists a migrated removal tombstone and makes repeated removal
restart-safe`) writes a fixture named `cross_team::other-team.json`; `::` is not
a legal Windows file name, so the test fails on every Windows checkout of
`main` (verified on an unmodified `origin/main`). It is untouched here and will
come with the Windows test-portability series.

## Tested on

Windows 11, from source: typecheck, eslint, prettier, size guard, the two test
files above.

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal code related to passive user reply summaries.
  * No user-facing functionality or public behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->