### PR TITLE
fix(codex-account): a legacy auth file written a moment ago is not "from the future"

### DIFF
--- a/src/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.ts
+++ b/src/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.ts
@@ -12,6 +12,7 @@ const LEGACY_AUTH_SYNC_MARKER_FILE = '.agent-teams-legacy-auth-sync.json';
 // revokes the entire token family — so a legacy auth.json only counts as an
 // active account while it is fresh. The stale file is ignored, never deleted.
 const LEGACY_AUTH_STALE_AFTER_MS = 14 * 24 * 60 * 60 * 1000;
+const LEGACY_AUTH_FUTURE_SKEW_TOLERANCE_MS = 5_000;
 
 interface CodexAccountsRegistry {
   active_account_id?: string | null;
@@ -115,9 +116,13 @@ async function isLegacyAuthFileFresh(
   // revocation from a reused refresh_token.
   const lastRefreshMs = getLastRefreshMs(authFile) ?? (await getMtimeMs(filePath));
   const now = Date.now();
+  // A file written a moment ago can carry an mtime a little ahead of Date.now():
+  // filesystem timestamps round up on some hosts and are not read from the same
+  // clock. That is not a future refresh, so a small lead is tolerated; a
+  // timestamp genuinely in the future still counts as unknown, hence stale.
   return (
     lastRefreshMs !== null &&
-    lastRefreshMs <= now &&
+    lastRefreshMs - now <= LEGACY_AUTH_FUTURE_SKEW_TOLERANCE_MS &&
     now - lastRefreshMs <= LEGACY_AUTH_STALE_AFTER_MS
   );
 }

--- a/test/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.test.ts
+++ b/test/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.test.ts
@@ -1,9 +1,9 @@
 // @vitest-environment node
-import { mkdtemp, mkdir, readFile, rm, utimes, writeFile } from 'fs/promises';
+import { mkdtemp, mkdir, readFile, rm, stat, utimes, writeFile } from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   detectCodexLocalAccountArtifacts,
@@ -25,6 +25,27 @@ async function makeCodexHome(): Promise<{ codexHome: string; accountsDir: string
   const accountsDir = path.join(codexHome, 'accounts');
   await mkdir(accountsDir, { recursive: true });
   return { codexHome, accountsDir };
+}
+
+// Mirrors the private LEGACY_AUTH_FUTURE_SKEW_TOLERANCE_MS of
+// src/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.ts.
+const LEGACY_AUTH_FUTURE_SKEW_TOLERANCE_MS = 5_000;
+
+// The legacy auth.json carries no last_refresh, so its own mtime is the freshness
+// timestamp. Returning that mtime lets a test pin the clock relative to the file
+// instead of to wall time, so elapsed test time cannot move the classification.
+async function makeLegacyChatgptAuthHome(): Promise<{ accountsDir: string; mtimeMs: number }> {
+  const { codexHome, accountsDir } = await makeCodexHome();
+  const legacyAuthPath = path.join(codexHome, 'auth.json');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test uses isolated temp dir
+  await writeFile(
+    legacyAuthPath,
+    JSON.stringify({ auth_mode: 'chatgpt', tokens: { refresh_token: 'legacy-refresh-token' } }),
+    'utf8'
+  );
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test uses isolated temp dir
+  const { mtimeMs } = await stat(legacyAuthPath);
+  return { accountsDir, mtimeMs };
 }
 
 afterEach(async () => {
@@ -335,6 +356,42 @@ describe('detectCodexLocalAccountArtifacts', () => {
       hasArtifacts: true,
       hasActiveChatgptAccount: false,
     });
+  });
+
+  it('treats a legacy auth.json whose mtime leads the clock by exactly the tolerated skew as fresh', async () => {
+    const { accountsDir, mtimeMs } = await makeLegacyChatgptAuthHome();
+    // The lead is exactly the tolerance, and the bound is inclusive: `<=` in
+    // isLegacyAuthFileFresh, so this timestamp still counts as fresh.
+    const dateNowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValue(mtimeMs - LEGACY_AUTH_FUTURE_SKEW_TOLERANCE_MS);
+
+    try {
+      await expect(detectCodexLocalAccountState(accountsDir)).resolves.toEqual({
+        hasArtifacts: true,
+        hasActiveChatgptAccount: true,
+      });
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+  });
+
+  it('treats a legacy auth.json whose mtime leads the clock by one millisecond past the tolerated skew as stale', async () => {
+    const { accountsDir, mtimeMs } = await makeLegacyChatgptAuthHome();
+    // One millisecond further ahead is outside the tolerance, so the timestamp is
+    // an unknown future refresh again.
+    const dateNowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValue(mtimeMs - LEGACY_AUTH_FUTURE_SKEW_TOLERANCE_MS - 1);
+
+    try {
+      await expect(detectCodexLocalAccountState(accountsDir)).resolves.toEqual({
+        hasArtifacts: true,
+        hasActiveChatgptAccount: false,
+      });
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 
   it('does not treat a future last_refresh as fresh', async () => {

--- a/test/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.test.ts
+++ b/test/features/codex-account/main/infrastructure/detectCodexLocalAccountArtifacts.test.ts
@@ -302,6 +302,41 @@ describe('detectCodexLocalAccountArtifacts', () => {
     });
   });
 
+  it('treats a legacy auth.json whose mtime is a moment ahead of the clock as fresh', async () => {
+    const { codexHome, accountsDir } = await makeCodexHome();
+    const legacyAuthPath = path.join(codexHome, 'auth.json');
+    await writeFile(
+      legacyAuthPath,
+      JSON.stringify({ auth_mode: 'chatgpt', tokens: { refresh_token: 'legacy-refresh-token' } }),
+      'utf8'
+    );
+    // Filesystem timestamps can round up past Date.now() right after a write.
+    const slightlyAhead = new Date(Date.now() + 1_000);
+    await utimes(legacyAuthPath, slightlyAhead, slightlyAhead);
+
+    await expect(detectCodexLocalAccountState(accountsDir)).resolves.toEqual({
+      hasArtifacts: true,
+      hasActiveChatgptAccount: true,
+    });
+  });
+
+  it('still treats a legacy auth.json whose mtime is well in the future as stale', async () => {
+    const { codexHome, accountsDir } = await makeCodexHome();
+    const legacyAuthPath = path.join(codexHome, 'auth.json');
+    await writeFile(
+      legacyAuthPath,
+      JSON.stringify({ auth_mode: 'chatgpt', tokens: { refresh_token: 'legacy-refresh-token' } }),
+      'utf8'
+    );
+    const farAhead = new Date(Date.now() + 60_000);
+    await utimes(legacyAuthPath, farAhead, farAhead);
+
+    await expect(detectCodexLocalAccountState(accountsDir)).resolves.toEqual({
+      hasArtifacts: true,
+      hasActiveChatgptAccount: false,
+    });
+  });
+
   it('does not treat a future last_refresh as fresh', async () => {
     const { codexHome, accountsDir } = await makeCodexHome();
     const legacyAuthPath = path.join(codexHome, 'auth.json');


### PR DESCRIPTION
Base: `origin/main`. Independent of every other open PR. Two commits.

## Problem

`isLegacyAuthFileFresh` rejects any timestamp later than `Date.now()`. When the in-file `last_refresh` is absent the timestamp is the file's mtime, and a file written a moment ago can carry an mtime a little ahead of `Date.now()`: on some hosts filesystem timestamps round up to their own granularity and are not read from the same clock. The freshly written legacy `auth.json` then counts as stale, the ChatGPT account is reported absent, and the suite's own "falls back to legacy auth.json when the accounts registry is absent" case fails intermittently on CI runners (seen on a Linux `test (1/2)` shard of #542, a PR that does not touch this code).

## Fix

A lead of up to five seconds is tolerated when deciding freshness. A timestamp genuinely in the future is still unknown, hence stale, which keeps the original reason for the rule (never reuse a refresh token whose age cannot be trusted).

## Tests

`detectCodexLocalAccountArtifacts.test.ts`: an `auth.json` whose mtime is one second ahead of the clock is fresh (fails on `main`, passes here); one whose mtime is a minute ahead is still stale (negative control, mirrors the existing case for a `last_refresh` a minute ahead, which keeps passing). 20/20 in the file. `pnpm typecheck`, size guard, `eslint` and `prettier --check` on the changed file.

## Review follow-ups

- *Add tests for the configured skew boundary* (review comment on the test file): valid, the two mtime cases sat at +1s and +60s, a second inside and 55 seconds outside a five-second window, so the window itself was never asserted. `test(codex-account): pin the legacy auth mtime tolerance at its boundary` adds two cases one millisecond apart on the boundary. The clock is stubbed relative to the file's own mtime rather than to wall time, so elapsed test time cannot move the classification: exactly the tolerance is fresh, because the comparison is `<=`, and one millisecond more is stale. Mutation-checked in both directions - tightening the comparison to `<` fails the first case, widening the constant fails the second.

## Tested on

Windows 11 Pro, from source, against `origin/main @ 07be9b5fa`. The intermittent failure itself was observed on the upstream Linux CI runner; locally on Windows the timestamps happened to agree, which is why the flake never reproduced here. Not run on macOS or Linux locally.

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of recently refreshed local authentication files when their timestamps are slightly ahead due to minor system-clock differences.
  - Authentication files up to 5 seconds ahead of the current time are now recognized as fresh, while significantly older or more future-dated files remain stale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->