### PR TITLE
fix(providers): the coordination probe runs a local model in the mode the runtime will use

### DIFF
--- a/src/features/runtime-provider-management/contracts/types.ts
+++ b/src/features/runtime-provider-management/contracts/types.ts
@@ -681,6 +681,12 @@ export interface RuntimeLocalProviderListEntryDto {
   baseUrl: string;
   hasConfiguredApiKey?: boolean;
   configuredModelIds: readonly string[];
+  /**
+   * `options.reasoningEffort` per configured model id, when set in the config.
+   * The coordination probe mirrors it so it exercises the mode OpenCode runs
+   * the model in (a thinking model behaves differently with thinking off).
+   */
+  configuredModelReasoningEffort?: Readonly<Record<string, string>>;
   defaultModelId: string | null;
   /** Selected lightweight-task model when small_model points at this provider. */
   smallModelId?: string | null;

--- a/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalModelCoordinationProbe.test.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalModelCoordinationProbe.test.ts
@@ -96,7 +96,9 @@ describe('probeOpenCodeLocalModelCoordination', () => {
 
     const result = await probeOpenCodeLocalModelCoordination(
       {
-        provider: localProvider('ollama', 'http://127.0.0.1:11434/v1'),
+        // Registered by the connector, which configures the models it registers
+        // to run with a reasoning effort of none.
+        provider: localProvider('ollama', 'http://127.0.0.1:11434/v1', { 'qwen3:8b': 'none' }),
         modelId: 'qwen3:8b',
       },
       { fetchImpl, createNonce: () => 'fixed-nonce' }
@@ -613,14 +615,144 @@ describe('probeOpenCodeLocalModelCoordination', () => {
       message: expect.stringContaining('HTTP 400: tools are not supported by this model'),
     });
   });
+
+  describe('configured reasoning effort', () => {
+    const streamingProvider = (
+      configuredModelReasoningEffort?: Readonly<Record<string, string>>
+    ): RuntimeLocalProviderListEntryDto =>
+      localProvider('ollama', 'http://127.0.0.1:11434/v1', configuredModelReasoningEffort);
+
+    it('mirrors a configured effort and leaves room for the reasoning tokens', async () => {
+      for (const body of await probeRequestBodies(
+        streamingProvider({ 'model-a': 'high' }),
+        'model-a'
+      )) {
+        expect(body.reasoning_effort).toBe('high');
+        expect(body.max_tokens).toBe(4_096);
+      }
+    });
+
+    it('turns thinking off, and keeps the tight budget, only for an effort of none', async () => {
+      for (const body of await probeRequestBodies(
+        streamingProvider({ 'model-a': 'none' }),
+        'model-a'
+      )) {
+        expect(body.reasoning_effort).toBe('none');
+        expect(body.max_tokens).toBe(1_024);
+      }
+    });
+
+    it('sends no effort for a model that has none configured', async () => {
+      // OpenCode sends no reasoning_effort for such a model either, so the
+      // server default is the mode the lane will run in. Probing it with
+      // thinking forced off measured a mode the runtime never uses.
+      for (const body of await probeRequestBodies(streamingProvider(), 'model-a')) {
+        expect(body).not.toHaveProperty('reasoning_effort');
+        expect(body.max_tokens).toBe(4_096);
+        expect(body.stream).toBe(true);
+      }
+    });
+
+    it('treats a blank configured effort as no effort rather than as none', async () => {
+      for (const body of await probeRequestBodies(
+        streamingProvider({ 'model-a': '   ' }),
+        'model-a'
+      )) {
+        expect(body).not.toHaveProperty('reasoning_effort');
+        expect(body.max_tokens).toBe(4_096);
+      }
+    });
+
+    it('reads the effort of the probed model, not of a sibling in the same provider', async () => {
+      for (const body of await probeRequestBodies(
+        streamingProvider({ 'model-b': 'none' }),
+        'model-a'
+      )) {
+        expect(body).not.toHaveProperty('reasoning_effort');
+        expect(body.max_tokens).toBe(4_096);
+      }
+    });
+
+    it('sends no effort to a non-streaming provider, even with one configured', async () => {
+      const provider = localProvider('lm-studio', 'http://127.0.0.1:1234/v1', {
+        'model-a': 'high',
+      });
+
+      for (const body of await probeRequestBodies(provider, 'model-a')) {
+        expect(body).not.toHaveProperty('reasoning_effort');
+        expect(body.max_tokens).toBe(1_024);
+        expect(body.stream).toBe(false);
+      }
+    });
+  });
 });
+
+/** Drives one passing probe and returns the JSON request body of every call. */
+async function probeRequestBodies(
+  provider: RuntimeLocalProviderListEntryDto,
+  modelId: string
+): Promise<Record<string, unknown>[]> {
+  const streaming = provider.preset.id === 'ollama';
+  const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+    const request = readRequestBody(init?.body) as { messages: unknown[] };
+    const toolCall =
+      request.messages.length === 2
+        ? {
+            id: 'call-1',
+            type: 'function',
+            function: {
+              name: 'agent-teams_task_briefing',
+              arguments: JSON.stringify({
+                teamName: 'agent-teams-local-probe',
+                memberName: 'probe-member',
+              }),
+            },
+          }
+        : {
+            id: 'call-2',
+            type: 'function',
+            function: {
+              name: 'agent-teams_message_send',
+              arguments: JSON.stringify({
+                teamName: 'agent-teams-local-probe',
+                to: 'probe-lead',
+                from: 'probe-member',
+                text: 'fixed-nonce',
+              }),
+            },
+          };
+    return streaming
+      ? sseResponse([{ choices: [{ delta: { tool_calls: [{ index: 0, ...toolCall }] } }] }])
+      : jsonResponse({
+          choices: [{ message: { role: 'assistant', content: null, tool_calls: [toolCall] } }],
+        });
+  });
+
+  const result = await probeOpenCodeLocalModelCoordination(
+    { provider, modelId },
+    { fetchImpl, createNonce: () => 'fixed-nonce' }
+  );
+
+  expect(result.status).toBe('passed');
+  return fetchImpl.mock.calls.map((call) => readRequestBody(call[1]?.body));
+}
+
+/** Reads a request body the probe sent; every probe request carries a JSON string. */
+function readRequestBody(body: BodyInit | null | undefined): Record<string, unknown> {
+  if (typeof body !== 'string') {
+    throw new TypeError('probe request body was not a JSON string');
+  }
+  return JSON.parse(body) as Record<string, unknown>;
+}
 
 function localProvider(
   presetId: RuntimeLocalProviderListEntryDto['preset']['id'],
-  baseUrl: string
+  baseUrl: string,
+  configuredModelReasoningEffort?: Readonly<Record<string, string>>
 ): RuntimeLocalProviderListEntryDto {
   const providerId = presetId === 'lm-studio' ? 'lmstudio' : presetId;
   return {
+    ...(configuredModelReasoningEffort ? { configuredModelReasoningEffort } : {}),
     preset: {
       id: presetId,
       providerId,

--- a/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalModelCoordinationProbe.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalModelCoordinationProbe.ts
@@ -6,6 +6,9 @@ import type { RuntimeLocalProviderListEntryDto } from '../../contracts';
 
 const COORDINATION_PROBE_TIMEOUT_MS = 90_000;
 const MAX_RESPONSE_BYTES = 1_048_576;
+const MAX_TOKENS = 1_024;
+/** Reasoning tokens count against the limit; a thinking model needs headroom. */
+const THINKING_MAX_TOKENS = 4_096;
 const PROBE_TEAM_NAME = 'agent-teams-local-probe';
 const PROBE_MEMBER_NAME = 'probe-member';
 const PROBE_RECIPIENT = 'probe-lead';
@@ -264,14 +267,23 @@ async function requestProbeCompletion(input: {
 > {
   const url = buildOpenAiChatCompletionsUrl(input.provider.baseUrl);
   const useOllamaStreaming = input.provider.preset.id === 'ollama';
+  // Probe the mode OpenCode will run the model in by mirroring the configured
+  // `options.reasoningEffort` (the connector writes `none` for the models it
+  // registers itself). A model left thinking at runtime has to be probed
+  // thinking - its tool-argument fidelity differs between the two modes - and
+  // needs room for the reasoning tokens that come before the tool call.
+  const reasoningEffort = useOllamaStreaming
+    ? resolveConfiguredReasoningEffort(input.provider, input.modelId)
+    : null;
+  const thinking = useOllamaStreaming && reasoningEffort !== 'none';
   const body = {
     model: input.modelId,
     messages: input.messages,
     tools: input.tools,
     stream: useOllamaStreaming,
     temperature: 0,
-    max_tokens: 1_024,
-    ...(useOllamaStreaming ? { reasoning_effort: 'none' } : {}),
+    max_tokens: thinking ? THINKING_MAX_TOKENS : MAX_TOKENS,
+    ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
   };
   const response = await input.fetchImpl(url, {
     method: 'POST',
@@ -589,6 +601,15 @@ function buildToolResultMessage(call: ToolCall, nonce: string): Record<string, u
     tool_call_id: call.id ?? 'agent-teams-probe-call-1',
     content,
   };
+}
+
+/** The model's configured `options.reasoningEffort`, or null when the runtime leaves it to the server default. */
+function resolveConfiguredReasoningEffort(
+  provider: RuntimeLocalProviderListEntryDto,
+  modelId: string
+): string | null {
+  const configured = provider.configuredModelReasoningEffort?.[modelId]?.trim();
+  return configured ? configured : null;
 }
 
 function buildOpenAiChatCompletionsUrl(baseUrl: string): string {

--- a/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderConnector.list.test.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderConnector.list.test.ts
@@ -41,7 +41,7 @@ describe('OpenCodeLocalProviderConnector local provider list', () => {
         '    "ollama": {',
         '      "npm": "@ai-sdk/openai-compatible",',
         '      "options": { "baseURL": "http://127.0.0.1:11434/v1" },',
-        '      "models": { "qwen3:8b": {}, "phi-4": {} }',
+        '      "models": { "qwen3:8b": {}, "phi-4": { "options": { "reasoningEffort": "none" } } }',
         '    },',
         '    "local-lab": {',
         '      "npm": "@ai-sdk/openai-compatible",',
@@ -110,6 +110,53 @@ describe('OpenCodeLocalProviderConnector local provider list', () => {
       message: expect.stringContaining('OpenCode verifies'),
     });
     expect(requests).not.toContain('https://example.com/v1/models');
+    // Only models with an explicit options.reasoningEffort get an entry; the
+    // coordination probe mirrors this so it runs in the model's runtime mode.
+    expect(response.providers?.[0]?.configuredModelReasoningEffort).toEqual({ 'phi-4': 'none' });
+  });
+
+  it('records a configured reasoning effort only for a string value on an accepted model id', async () => {
+    const projectPath = path.join(tempDir, 'reasoning-effort-project');
+    await writeOpenCodeConfig(projectPath, {
+      provider: {
+        ollama: {
+          npm: '@ai-sdk/openai-compatible',
+          options: { baseURL: 'http://127.0.0.1:11434/v1' },
+          models: {
+            'string-effort': { options: { reasoningEffort: '  high  ' } },
+            'number-effort': { options: { reasoningEffort: 3 } },
+            'object-effort': { options: { reasoningEffort: { level: 'high' } } },
+            'null-effort': { options: { reasoningEffort: null } },
+            'blank-effort': { options: { reasoningEffort: '   ' } },
+            '\u0001rejected-id': { options: { reasoningEffort: 'high' } },
+          },
+        },
+      },
+    });
+    const fetchImpl = (async () => {
+      throw new TypeError('connection refused');
+    }) as typeof fetch;
+    const connector = new OpenCodeLocalProviderConnector({ fetchImpl });
+
+    const response = await connector.listLocalProviders({
+      runtimeId: 'opencode',
+      scope: 'project',
+      projectPath,
+    });
+
+    // A non-string value and a whitespace-only value are not a reasoning
+    // effort, and a model id the normalizer rejects is not a model id here
+    // either - the same gate that keeps it out of configuredModelIds.
+    expect(response.providers?.[0]?.configuredModelReasoningEffort).toEqual({
+      'string-effort': 'high',
+    });
+    expect(response.providers?.[0]?.configuredModelIds).toEqual([
+      'string-effort',
+      'number-effort',
+      'object-effort',
+      'null-effort',
+      'blank-effort',
+    ]);
   });
 
   it('returns an empty list when the project has no OpenCode config yet', async () => {

--- a/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderConnector.list.test.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderConnector.list.test.ts
@@ -159,6 +159,67 @@ describe('OpenCodeLocalProviderConnector local provider list', () => {
     ]);
   });
 
+  it('keeps a configured effort under a model id that names an inherited object member', async () => {
+    const projectPath = path.join(tempDir, 'inherited-key-project');
+    // Written as raw JSON: an object literal would make "__proto__" set the
+    // prototype of the fixture instead of a model entry.
+    await writeOpenCodeConfig(
+      projectPath,
+      [
+        '{',
+        '  "provider": {',
+        '    "ollama": {',
+        '      "npm": "@ai-sdk/openai-compatible",',
+        '      "options": { "baseURL": "http://127.0.0.1:11434/v1" },',
+        '      "models": {',
+        '        "qwen3:8b": { "options": { "reasoningEffort": "high" } },',
+        '        "__proto__": { "options": { "reasoningEffort": "low" } },',
+        '        "toString": { "options": { "reasoningEffort": "none" } },',
+        '        "constructor": {}',
+        '      }',
+        '    }',
+        '  }',
+        '}',
+      ].join('\n')
+    );
+    const fetchImpl = (async () => {
+      throw new TypeError('connection refused');
+    }) as typeof fetch;
+    const connector = new OpenCodeLocalProviderConnector({ fetchImpl });
+
+    const response = await connector.listLocalProviders({
+      runtimeId: 'opencode',
+      scope: 'project',
+      projectPath,
+    });
+
+    // A model id is a config key, so it can name a member every plain object
+    // inherits. The configured effort of such a model still has to be stored and
+    // read back as its own entry, or the probe runs the model in another mode.
+    const configuredModelReasoningEffort = response.providers?.[0]?.configuredModelReasoningEffort;
+    // Looked up by a model id held in a variable, the way the coordination probe
+    // reads this record.
+    const effortOf = (modelId: string): string | undefined =>
+      configuredModelReasoningEffort?.[modelId];
+    expect(effortOf('qwen3:8b')).toBe('high');
+    expect(effortOf('__proto__')).toBe('low');
+    expect(effortOf('toString')).toBe('none');
+    expect(Object.keys(configuredModelReasoningEffort ?? {})).toEqual([
+      'qwen3:8b',
+      '__proto__',
+      'toString',
+    ]);
+    // Negative control: a model that configures no effort has no entry, and must
+    // not answer a lookup with an inherited value either.
+    expect(effortOf('constructor')).toBeUndefined();
+    expect(response.providers?.[0]?.configuredModelIds).toEqual([
+      'qwen3:8b',
+      '__proto__',
+      'toString',
+      'constructor',
+    ]);
+  });
+
   it('returns an empty list when the project has no OpenCode config yet', async () => {
     const projectPath = path.join(tempDir, 'empty-project');
     await fs.mkdir(projectPath, { recursive: true });

--- a/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderConnector.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderConnector.ts
@@ -826,7 +826,10 @@ function readConfiguredModelReasoningEffort(input: {
   providerId: string;
   modelsNode: JsoncNode | undefined;
 }): Record<string, string> {
-  const configuredModelReasoningEffort: Record<string, string> = {};
+  // A model id is a config key, so it can be the name of an inherited member.
+  // In a null-prototype record `__proto__` is a stored entry instead of a setter
+  // call, and a lookup for an unconfigured `constructor` stays undefined.
+  const configuredModelReasoningEffort = Object.create(null) as Record<string, string>;
   if (input.modelsNode?.type !== 'object') return configuredModelReasoningEffort;
   for (const { key } of readObjectEntries(input.modelsNode)) {
     const modelId = normalizeRuntimeLocalProviderModelId(key);

--- a/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderConnector.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderConnector.ts
@@ -195,6 +195,11 @@ export class OpenCodeLocalProviderConnector implements RuntimeLocalProviderConne
                       .map(({ key }) => normalizeRuntimeLocalProviderModelId(key))
                       .filter((modelId): modelId is string => Boolean(modelId))
                   : [];
+              const configuredModelReasoningEffort = readConfiguredModelReasoningEffort({
+                configTree,
+                providerId,
+                modelsNode,
+              });
               const routePrefix = `${providerId}/`;
               const isDefault = configuredDefaultModel?.startsWith(routePrefix) ?? false;
               const smallModelId = configuredSmallModel?.startsWith(routePrefix)
@@ -209,6 +214,7 @@ export class OpenCodeLocalProviderConnector implements RuntimeLocalProviderConne
                 baseUrl: target.baseUrl,
                 hasConfiguredApiKey,
                 configuredModelIds,
+                configuredModelReasoningEffort,
                 configuredDefaultModelId,
                 isDefault,
                 smallModelId,
@@ -243,6 +249,7 @@ export class OpenCodeLocalProviderConnector implements RuntimeLocalProviderConne
                 baseUrl: configured.baseUrl,
                 hasConfiguredApiKey: configured.hasConfiguredApiKey,
                 configuredModelIds: configured.configuredModelIds,
+                configuredModelReasoningEffort: configured.configuredModelReasoningEffort,
                 defaultModelId: configured.configuredDefaultModelId,
                 smallModelId: configured.smallModelId,
                 isDefault: configured.isDefault,
@@ -273,6 +280,7 @@ export class OpenCodeLocalProviderConnector implements RuntimeLocalProviderConne
               baseUrl: configured.baseUrl,
               hasConfiguredApiKey: false,
               configuredModelIds: configured.configuredModelIds,
+              configuredModelReasoningEffort: configured.configuredModelReasoningEffort,
               defaultModelId: liveDefaultStillAvailable
                 ? configured.configuredDefaultModelId
                 : (configured.configuredDefaultModelId ?? probe.models[0]?.id ?? null),
@@ -806,6 +814,36 @@ export class OpenCodeLocalProviderConnector implements RuntimeLocalProviderConne
   ): RuntimeLocalProviderScanResponse {
     return { schemaVersion: 1, runtimeId: 'opencode', error: { code, message, recoverable: true } };
   }
+}
+
+/**
+ * Reads `options.reasoningEffort` for every configured model of one provider.
+ * Only models that set it explicitly get an entry; the rest are left to the
+ * server default, which is what OpenCode itself sends them with.
+ */
+function readConfiguredModelReasoningEffort(input: {
+  configTree: JsoncNode;
+  providerId: string;
+  modelsNode: JsoncNode | undefined;
+}): Record<string, string> {
+  const configuredModelReasoningEffort: Record<string, string> = {};
+  if (input.modelsNode?.type !== 'object') return configuredModelReasoningEffort;
+  for (const { key } of readObjectEntries(input.modelsNode)) {
+    const modelId = normalizeRuntimeLocalProviderModelId(key);
+    if (!modelId) continue;
+    const reasoningEffort = readStringNode(
+      findNodeAtLocation(input.configTree, [
+        'provider',
+        input.providerId,
+        'models',
+        key,
+        'options',
+        'reasoningEffort',
+      ])
+    )?.trim();
+    if (reasoningEffort) configuredModelReasoningEffort[modelId] = reasoningEffort;
+  }
+  return configuredModelReasoningEffort;
 }
 
 function parseConfigTree(raw: string): JsoncNode {

--- a/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderSupport.test.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderSupport.test.ts
@@ -53,6 +53,35 @@ describe('OpenCodeLocalProviderSupport', () => {
     });
   });
 
+  it('carries a configured reasoning effort through and stays complete without one', () => {
+    const preset = RUNTIME_LOCAL_PROVIDER_PRESETS.find((candidate) => candidate.id === 'custom');
+    if (!preset) throw new Error('Expected the custom provider preset');
+    const configured = {
+      preset,
+      providerId: 'remote-compatible',
+      baseUrl: 'https://example.com/v1',
+      hasConfiguredApiKey: true,
+      configuredModelIds: ['large-model'],
+      configuredDefaultModelId: 'large-model',
+      isDefault: true,
+    };
+
+    expect(
+      buildDeferredProviderListEntry({
+        ...configured,
+        configuredModelReasoningEffort: { 'large-model': 'high' },
+      })?.configuredModelReasoningEffort
+    ).toEqual({ 'large-model': 'high' });
+    // The field is optional: a snapshot without one still yields a full entry.
+    const withoutReasoningEffort = buildDeferredProviderListEntry(configured);
+    expect(withoutReasoningEffort?.configuredModelReasoningEffort).toBeUndefined();
+    expect(withoutReasoningEffort).toMatchObject({
+      defaultModelId: 'large-model',
+      state: 'available',
+      liveModels: [{ id: 'large-model', displayName: 'large-model' }],
+    });
+  });
+
   it('removes a rotated credential only when its filename proves provider and config ownership', async () => {
     const previousReference = createProviderApiKeyReference({
       configPath,

--- a/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderSupport.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderSupport.ts
@@ -34,6 +34,7 @@ interface ConfiguredProviderSnapshot {
   readonly baseUrl: string;
   readonly hasConfiguredApiKey: boolean;
   readonly configuredModelIds: readonly string[];
+  readonly configuredModelReasoningEffort?: Readonly<Record<string, string>>;
   readonly configuredDefaultModelId: string | null;
   readonly smallModelId?: string | null;
   readonly isDefault: boolean;
@@ -93,6 +94,7 @@ export function buildDeferredProviderListEntry(
     baseUrl: configured.baseUrl,
     hasConfiguredApiKey: configured.hasConfiguredApiKey,
     configuredModelIds: configured.configuredModelIds,
+    configuredModelReasoningEffort: configured.configuredModelReasoningEffort,
     defaultModelId: configured.configuredDefaultModelId ?? configured.configuredModelIds[0] ?? null,
     smallModelId: configured.smallModelId,
     isDefault: configured.isDefault,


### PR DESCRIPTION
Independent of every other open PR.

## Problem

The coordination probe sent `reasoning_effort: 'none'` with every request to a streaming local provider, whatever the model was configured to do. That was right for a model the connector itself registered (it writes `options.reasoningEffort: 'none'` for those) and wrong for every other model, because OpenCode sends no effort at all for a model with none configured, so the lane runs it in whatever mode the server defaults to. A thinking model was therefore measured with thinking off and graded on a mode it would never run in; its tool-argument fidelity differs between the two modes, so the verdict did not describe the lane. On the earlier campaign this was the difference between a local model passing the probe and being refused as unable to coordinate.

Nothing in the list entry said how a model was configured to run, so the probe could not know.

## Fix

Three commits.

1. `feat(providers): expose the configured reasoning effort of each local provider model`: the connector reads `provider.<id>.models.<model>.options.reasoningEffort` from the config tree it already walks for the model ids and carries it to `RuntimeLocalProviderListEntryDto.configuredModelReasoningEffort` along all three list paths (unapproved private-network entry, deferred entry, live-probe entry). Only an explicit string value is recorded, and only under a model id the domain normaliser accepts, the same gate the id list goes through. The field is optional on the DTO, so no existing producer or consumer changes. The connector always emits the map, an empty one when nothing is configured; omitting it entirely is a payload-shape choice I will make if you prefer.
2. `fix(providers): the coordination probe mirrors the model's configured reasoning effort`: `none` is sent as `none`, another value as that value, a model with nothing configured gets no `reasoning_effort` key, exactly the request OpenCode itself makes. A request that leaves the model thinking raises `max_tokens` from 1024 to 4096, because reasoning tokens count against the same budget as the tool call the probe waits for, and a probe that runs out of budget mid-thought reads as a coordination failure. The mirroring stays behind the existing streaming-provider check, so a non-streaming provider still gets a body with no effort and the tight budget. A blank value is treated as nothing configured. Every string other than `none` is passed through unvalidated on purpose: the probe mirrors what OpenCode would send rather than second-guessing the config.

Two scoping notes for your judgement: the gate is the pre-existing `ollama` preset check, so other OpenAI-compatible local servers that accept `reasoning_effort` are still probed without it; a per-preset capability flag is the natural next step if you want it. And the thinking budget is a constant rather than derived from the model's configured output limit, which `fetchModelConfigMetadata` already computes.

Sizes: `contracts/types.ts` 782/800 (default cap, 18 lines left, and you have been adding to it; if you would rather pay first, the `RuntimeLocalProvider*Dto` block moves to a sibling module in one commit), `OpenCodeLocalProviderConnector.ts` 871/1018, `OpenCodeLocalModelCoordinationProbe.ts` 675/800, `OpenCodeLocalProviderSupport.ts` 297. `scripts/ci/source-file-size-baseline.json` untouched.

## Tests

Negative controls, each its own test and each mutation-checked (the rule was broken, the named tests went red, the rule restored):

- A non-streaming provider never gets `reasoning_effort` even with an effort configured: field absent, `max_tokens` 1024; the paired streaming case mirrors it at 4096. Dropping the streaming guard fails it.
- A model without a configured effort yields no `reasoning_effort` key, not `none`; restoring the old constant fails four tests.
- `none` → 1024 and any other value → 4096, with a whitespace-only value trimming to nothing configured; a sibling model's effort is never read.
- The connector writes no entry for a number, an object, `null`, a blank string, or a model id the normaliser rejects; reading the raw node instead of the string reader, or skipping the normaliser, fails it.
- The DTO field is optional: a snapshot without it builds a complete deferred entry unchanged.

Per commit: `pnpm typecheck`, size guard, provisioning guard, `eslint` (0 errors) and `prettier --check` on every changed `src/` file, targeted vitest (14 and 15 tests). Full suite on the tip: zero failures in the provider feature, and the only failures left are the five an unmodified `origin/main` produces on this machine.

## Review follow-ups

- *Use a null-prototype record for model IDs* (review comment on `OpenCodeLocalProviderConnector.ts`): valid, in both directions. Model ids are config keys, so a model named `__proto__` lost its configured effort to the inherited setter and was probed in the server default mode, and a lookup for a model named `constructor` or `toString` that configures no effort answered with an inherited function, which the probe then calls `.trim()` on. Third commit, `fix(providers): a model id that names an inherited member keeps its configured effort`: the record is built with `Object.create(null)`, the way `createModelRecord` already builds the model map in the same feature. Nothing serializes between the two ends - the readiness inspector calls the connector in process and hands the entry straight to the probe - so fixing the record where it is built fixes both directions. The new connector list test round-trips an effort configured under `__proto__` and `toString` and asserts that an unconfigured `constructor` reads as undefined; restoring the plain object literal fails it.

## Tested on

Windows 11 Pro, from source, against `origin/main @ 07be9b5fa`, with local models served through an OpenAI-compatible endpoint registered as an `ollama` preset. A thinking model configured with an effort now passes the probe in the mode the lane runs it, where it previously failed with thinking forced off. Not tested on macOS or Linux; nothing here is platform-specific.

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured per-model reasoning effort is now preserved in local provider metadata.
  * Ollama model checks now honor each model’s configured reasoning effort and allocate tokens accordingly.
  * Reasoning settings are excluded for unsupported non-streaming providers.
* **Bug Fixes**
  * Improved handling of blank, invalid, or unconfigured reasoning-effort values.
  * Model-specific settings are now applied only to the model being checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->