### PR TITLE
fix(team): a runtime check-in heals its own identity

### DIFF
--- a/src/main/services/team/provisioning/TeamProvisioningConfigMaintenance.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningConfigMaintenance.ts
@@ -136,6 +136,7 @@ export class TeamProvisioningConfigMaintenance {
         readConfig: () => this.readTeamConfig(configPath),
         writeConfig: (raw) => this.options.ports.writeFileUtf8(configPath, raw),
         invalidateTeam: (name) => this.options.ports.invalidateTeam(name),
+        readMetaMembers: () => this.options.ports.membersMetaStore.getMembers(teamName),
         scanForNewestSession: (scanProjectPath, knownSessions) =>
           this.options.ports.scanForNewestProjectSession({
             projectPath: scanProjectPath,

--- a/src/main/services/team/provisioning/TeamProvisioningConfigMaterialization.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningConfigMaterialization.ts
@@ -57,6 +57,7 @@ export interface UpdateTeamConfigPostLaunchPorts {
   writeConfig(raw: string): Promise<void>;
   invalidateTeam(teamName: string): void;
   scanForNewestSession(projectPath: string, knownSessions: string[]): Promise<string | null>;
+  readMetaMembers(): Promise<readonly TeamMember[]>;
   getLanguage(): string;
   info(message: string): void;
   warn(message: string): void;
@@ -210,6 +211,90 @@ export function buildOpenCodeConfigMemberFromLaunchMember(
   );
 }
 
+export function buildConfigMemberFromMetaMember(
+  teamName: string,
+  member: TeamMember,
+  clock: TeamProvisioningConfigMaterializationClock = {}
+): Record<string, unknown> {
+  const name = member.name.trim();
+  const configMember: Record<string, unknown> = {
+    name,
+    agentId: `${name}@${teamName}`,
+    agentType: member.agentType?.trim() || 'general-purpose',
+    role: member.role?.trim() || undefined,
+    workflow: member.workflow?.trim() || undefined,
+    isolation: member.isolation === 'worktree' ? 'worktree' : undefined,
+    providerId: normalizeOptionalTeamProviderId(member.providerId),
+    model: member.model?.trim() || undefined,
+    effort: isTeamEffortLevel(member.effort) ? member.effort : undefined,
+    mcpPolicy: normalizeTeamMemberMcpPolicy(member.mcpPolicy),
+    cwd: member.cwd?.trim() || undefined,
+    joinedAt: typeof member.joinedAt === 'number' ? member.joinedAt : (clock.now ?? Date.now)(),
+  };
+
+  return Object.fromEntries(
+    Object.entries(configMember).filter(([, value]) => value !== undefined)
+  );
+}
+
+/**
+ * Self-healing roster sync: appends members that exist in members.meta.json but are
+ * missing from config.json members. Members without an authoritative config identity
+ * break OpenCode runtime recipient resolution ("has no authoritative config identity"),
+ * which permanently fails inbox relay to those teammates.
+ */
+export function appendMissingConfigMembersFromMeta(
+  teamName: string,
+  config: Record<string, unknown>,
+  metaMembers: readonly TeamMember[],
+  clock: TeamProvisioningConfigMaterializationClock = {}
+): boolean {
+  const activeMetaMembers = metaMembers.filter((member) => {
+    const name = member.name?.trim() ?? '';
+    const lower = name.toLowerCase();
+    return (
+      name.length > 0 &&
+      !member.removedAt &&
+      lower !== 'user' &&
+      lower !== 'team-lead' &&
+      !isLeadMember(member)
+    );
+  });
+  if (activeMetaMembers.length === 0) {
+    return false;
+  }
+
+  const existingMembers = Array.isArray(config.members)
+    ? (config.members as Record<string, unknown>[])
+    : [];
+  const existingNames = new Set(
+    existingMembers
+      .map((member) =>
+        member && typeof member === 'object' && typeof member.name === 'string'
+          ? member.name.trim().toLowerCase()
+          : ''
+      )
+      .filter(Boolean)
+  );
+
+  const appendedMembers: Record<string, unknown>[] = [];
+  for (const member of activeMetaMembers) {
+    const nameLower = member.name.trim().toLowerCase();
+    if (existingNames.has(nameLower)) {
+      continue;
+    }
+    appendedMembers.push(buildConfigMemberFromMetaMember(teamName, member, clock));
+    existingNames.add(nameLower);
+  }
+
+  if (appendedMembers.length === 0) {
+    return false;
+  }
+
+  config.members = [...existingMembers, ...appendedMembers];
+  return true;
+}
+
 export function collectPostLaunchSessionHistory(config: Record<string, unknown>): string[] {
   const sessionHistory = Array.isArray(config.sessionHistory)
     ? [...(config.sessionHistory as string[])]
@@ -312,6 +397,21 @@ export async function updateTeamConfigPostLaunch(
       color,
       launchState,
     });
+
+    try {
+      const metaMembers = await ports.readMetaMembers();
+      if (appendMissingConfigMembersFromMeta(teamName, config, metaMembers)) {
+        ports.info(
+          `[${teamName}] Synced missing members.meta.json members into config.json members`
+        );
+      }
+    } catch (error) {
+      ports.warn(
+        `[${teamName}] Failed to sync members.meta.json into config members: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
 
     await ports.writeConfig(JSON.stringify(config, null, 2));
     ports.invalidateTeam(teamName);

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeCheckin.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeCheckin.ts
@@ -20,7 +20,11 @@ import {
 } from './TeamProvisioningOpenCodeBootstrapEvidence';
 import { summarizeRuntimeLaunchResultMembers } from './TeamProvisioningOpenCodeRuntimeEvidencePolicy';
 import { shouldEmitOpenCodeRuntimeLivenessMemberSpawnChange } from './TeamProvisioningOpenCodeRuntimeLivenessPolicy';
-import { assertOpenCodeRuntimeMemberSessionAcceptedFromState } from './TeamProvisioningOpenCodeRuntimeMemberSessionAcceptance';
+import {
+  applyHealedRuntimeMemberLaneIdentity,
+  assertOpenCodeRuntimeMemberSessionAcceptedFromState,
+  shouldSelfHealMissingHeartbeatMemberIdentity,
+} from './TeamProvisioningOpenCodeRuntimeMemberSessionAcceptance';
 import { resolvePersistedRuntimeMemberIdentity } from './TeamProvisioningPersistedRuntimeMemberIdentity';
 import {
   asRuntimeRecord,
@@ -413,20 +417,33 @@ export async function updateOpenCodeRuntimeMemberLiveness<Run extends OpenCodeRu
         },
         ports
       );
+      const sessionIdentity = {
+        teamName: input.teamName,
+        runId: input.runId,
+        laneId: requiredIdentity.laneId,
+        memberName: input.memberName,
+        runtimeSessionId: input.runtimeSessionId,
+        evidenceKind: requiredIdentity.evidenceKind,
+      };
+      const allowMissingPersistedMember = await shouldSelfHealMissingHeartbeatMemberIdentity(
+        sessionIdentity,
+        previous,
+        () => ports.createOpenCodeRuntimeBootstrapEvidencePorts()
+      );
       assertOpenCodeRuntimeMemberSessionAcceptedFromState(
-        {
-          teamName: input.teamName,
-          runId: input.runId,
-          laneId: requiredIdentity.laneId,
-          memberName: input.memberName,
-          runtimeSessionId: input.runtimeSessionId,
-          evidenceKind: requiredIdentity.evidenceKind,
-        },
+        sessionIdentity,
         previous,
         config,
-        metaMembers
+        metaMembers,
+        { allowMissingPersistedMember }
       );
       const built = buildOpenCodeRuntimeMemberLivenessSnapshot(input, previous, ports);
+      if (allowMissingPersistedMember) {
+        applyHealedRuntimeMemberLaneIdentity(
+          built.snapshot.members[input.memberName],
+          requiredIdentity.laneId
+        );
+      }
       shouldEmitMemberSpawnChange = built.shouldEmitMemberSpawnChange;
       return built.snapshot;
     });

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeCheckin.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeCheckin.ts
@@ -20,6 +20,7 @@ import {
 } from './TeamProvisioningOpenCodeBootstrapEvidence';
 import { summarizeRuntimeLaunchResultMembers } from './TeamProvisioningOpenCodeRuntimeEvidencePolicy';
 import { shouldEmitOpenCodeRuntimeLivenessMemberSpawnChange } from './TeamProvisioningOpenCodeRuntimeLivenessPolicy';
+import { assertOpenCodeRuntimeMemberSessionAcceptedFromState } from './TeamProvisioningOpenCodeRuntimeMemberSessionAcceptance';
 import { resolvePersistedRuntimeMemberIdentity } from './TeamProvisioningPersistedRuntimeMemberIdentity';
 import {
   asRuntimeRecord,
@@ -43,12 +44,14 @@ import type {
   MemberSpawnStatusEntry,
   PersistedTeamLaunchMemberState,
   PersistedTeamLaunchSnapshot,
-  TeamConfig,
-  TeamMember,
 } from '@shared/types';
 
 export type { OpenCodeRuntimeControlAck } from '../runtime-control';
 export * from './TeamProvisioningOpenCodeRuntimeCheckinPorts';
+export {
+  assertOpenCodeRuntimeMemberSessionAccepted,
+  type OpenCodeRuntimeMemberSessionAcceptancePorts,
+} from './TeamProvisioningOpenCodeRuntimeMemberSessionAcceptance';
 
 interface OpenCodeRuntimeLivenessInput {
   teamName: string;
@@ -63,12 +66,6 @@ interface OpenCodeRuntimeLivenessInput {
     laneId: string;
     evidenceKind: RuntimeEvidenceKind;
   };
-}
-
-export interface OpenCodeRuntimeMemberSessionAcceptancePorts {
-  readLaunchState(teamName: string): Promise<PersistedTeamLaunchSnapshot | null>;
-  readConfigForStrictDecision(teamName: string): Promise<TeamConfig | null>;
-  readMetaMembers(teamName: string): Promise<readonly TeamMember[]>;
 }
 
 export async function recordOpenCodeRuntimeBootstrapCheckin<Run extends OpenCodeRuntimeCheckinRun>(
@@ -307,104 +304,6 @@ export async function recordOpenCodeRuntimeHeartbeat<Run extends OpenCodeRuntime
       observedAt,
     };
   });
-}
-
-export async function assertOpenCodeRuntimeMemberSessionAccepted(
-  input: {
-    teamName: string;
-    runId: string;
-    laneId: string;
-    memberName: string;
-    runtimeSessionId: string;
-    evidenceKind: RuntimeEvidenceKind;
-  },
-  ports: OpenCodeRuntimeMemberSessionAcceptancePorts
-): Promise<void> {
-  const [snapshot, config, metaMembers] = await Promise.all([
-    ports.readLaunchState(input.teamName),
-    ports.readConfigForStrictDecision(input.teamName),
-    ports.readMetaMembers(input.teamName),
-  ]);
-  assertOpenCodeRuntimeMemberSessionAcceptedFromState(input, snapshot, config, metaMembers);
-}
-
-function assertOpenCodeRuntimeMemberSessionAcceptedFromState(
-  input: {
-    teamName: string;
-    runId: string;
-    laneId: string;
-    memberName: string;
-    runtimeSessionId: string;
-    evidenceKind: RuntimeEvidenceKind;
-  },
-  snapshot: PersistedTeamLaunchSnapshot | null,
-  config: TeamConfig | null,
-  metaMembers: readonly TeamMember[]
-): void {
-  if (!config || config.deletedAt) {
-    throwRuntimeMemberSessionMismatch(input, 'team configuration is unavailable');
-  }
-
-  const configuredMember = resolveEffectiveConfiguredMember(
-    config.members ?? [],
-    metaMembers,
-    input.memberName
-  );
-  if (!configuredMember) {
-    throwRuntimeMemberSessionMismatch(input, 'member is not configured');
-  }
-  if (configuredMember.removedAt != null) {
-    throwRuntimeMemberSessionMismatch(input, 'member has been removed');
-  }
-  if (configuredMember.providerId !== 'opencode')
-    throwRuntimeMemberSessionMismatch(input, 'member is not owned by OpenCode');
-
-  const persistedMember = Object.entries(snapshot?.members ?? {}).find(([memberName]) =>
-    matchesTeamMemberIdentity(memberName, configuredMember.name)
-  )?.[1];
-  const isBootstrapCheckin = input.evidenceKind === 'bootstrap_checkin';
-  if (!persistedMember) {
-    if (isBootstrapCheckin) return;
-    throwRuntimeMemberSessionMismatch(input, 'member runtime identity is unavailable');
-  }
-  const persistedRunId = persistedMember.runtimeRunId?.trim();
-  if (isBootstrapCheckin && persistedRunId !== input.runId) return;
-  const persistedOwnerProviderId =
-    persistedMember.laneOwnerProviderId ?? persistedMember.providerId;
-  if (persistedOwnerProviderId !== 'opencode') {
-    throwRuntimeMemberSessionMismatch(input, 'member is not owned by OpenCode');
-  }
-
-  const persistedLaneId = persistedMember.laneId?.trim();
-  if (persistedLaneId !== input.laneId) {
-    throwRuntimeMemberSessionMismatch(input, 'member lane does not match');
-  }
-  if (persistedRunId !== input.runId) {
-    throwRuntimeMemberSessionMismatch(input, 'member runtime run does not match');
-  }
-  const persistedSessionId = persistedMember.runtimeSessionId?.trim();
-  if (
-    persistedSessionId !== input.runtimeSessionId &&
-    (!isBootstrapCheckin || Boolean(persistedSessionId))
-  ) {
-    throwRuntimeMemberSessionMismatch(input, 'member runtime session does not match');
-  }
-}
-
-function throwRuntimeMemberSessionMismatch(
-  input: {
-    memberName: string;
-    runId: string;
-    evidenceKind: RuntimeEvidenceKind;
-  },
-  reason: string
-): never {
-  throw new RuntimeStaleEvidenceError(
-    `Rejected OpenCode ${input.evidenceKind} for ${input.memberName}: ${reason}`,
-    'run_mismatch',
-    input.evidenceKind,
-    input.runId
-  );
 }
 
 export async function assertOpenCodeRuntimeEvidenceAccepted<Run extends OpenCodeRuntimeCheckinRun>(

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeMemberSessionAcceptance.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeMemberSessionAcceptance.ts
@@ -1,0 +1,113 @@
+import {
+  type RuntimeEvidenceKind,
+  RuntimeStaleEvidenceError,
+} from '../opencode/store/RuntimeRunTombstoneStore';
+
+import { matchesTeamMemberIdentity } from './TeamProvisioningMemberIdentity';
+import { resolveEffectiveConfiguredMember } from './TeamProvisioningMemberStatusProjection';
+
+import type { PersistedTeamLaunchSnapshot, TeamConfig, TeamMember } from '@shared/types';
+
+export interface OpenCodeRuntimeMemberSessionAcceptancePorts {
+  readLaunchState(teamName: string): Promise<PersistedTeamLaunchSnapshot | null>;
+  readConfigForStrictDecision(teamName: string): Promise<TeamConfig | null>;
+  readMetaMembers(teamName: string): Promise<readonly TeamMember[]>;
+}
+
+export async function assertOpenCodeRuntimeMemberSessionAccepted(
+  input: {
+    teamName: string;
+    runId: string;
+    laneId: string;
+    memberName: string;
+    runtimeSessionId: string;
+    evidenceKind: RuntimeEvidenceKind;
+  },
+  ports: OpenCodeRuntimeMemberSessionAcceptancePorts
+): Promise<void> {
+  const [snapshot, config, metaMembers] = await Promise.all([
+    ports.readLaunchState(input.teamName),
+    ports.readConfigForStrictDecision(input.teamName),
+    ports.readMetaMembers(input.teamName),
+  ]);
+  assertOpenCodeRuntimeMemberSessionAcceptedFromState(input, snapshot, config, metaMembers);
+}
+
+export function assertOpenCodeRuntimeMemberSessionAcceptedFromState(
+  input: {
+    teamName: string;
+    runId: string;
+    laneId: string;
+    memberName: string;
+    runtimeSessionId: string;
+    evidenceKind: RuntimeEvidenceKind;
+  },
+  snapshot: PersistedTeamLaunchSnapshot | null,
+  config: TeamConfig | null,
+  metaMembers: readonly TeamMember[]
+): void {
+  if (!config || config.deletedAt) {
+    throwRuntimeMemberSessionMismatch(input, 'team configuration is unavailable');
+  }
+
+  const configuredMember = resolveEffectiveConfiguredMember(
+    config.members ?? [],
+    metaMembers,
+    input.memberName
+  );
+  if (!configuredMember) {
+    throwRuntimeMemberSessionMismatch(input, 'member is not configured');
+  }
+  if (configuredMember.removedAt != null) {
+    throwRuntimeMemberSessionMismatch(input, 'member has been removed');
+  }
+  if (configuredMember.providerId !== 'opencode')
+    throwRuntimeMemberSessionMismatch(input, 'member is not owned by OpenCode');
+
+  const persistedMember = Object.entries(snapshot?.members ?? {}).find(([memberName]) =>
+    matchesTeamMemberIdentity(memberName, configuredMember.name)
+  )?.[1];
+  const isBootstrapCheckin = input.evidenceKind === 'bootstrap_checkin';
+  if (!persistedMember) {
+    if (isBootstrapCheckin) return;
+    throwRuntimeMemberSessionMismatch(input, 'member runtime identity is unavailable');
+  }
+  const persistedRunId = persistedMember.runtimeRunId?.trim();
+  if (isBootstrapCheckin && persistedRunId !== input.runId) return;
+  const persistedOwnerProviderId =
+    persistedMember.laneOwnerProviderId ?? persistedMember.providerId;
+  if (persistedOwnerProviderId !== 'opencode') {
+    throwRuntimeMemberSessionMismatch(input, 'member is not owned by OpenCode');
+  }
+
+  const persistedLaneId = persistedMember.laneId?.trim();
+  if (persistedLaneId !== input.laneId) {
+    throwRuntimeMemberSessionMismatch(input, 'member lane does not match');
+  }
+  if (persistedRunId !== input.runId) {
+    throwRuntimeMemberSessionMismatch(input, 'member runtime run does not match');
+  }
+  const persistedSessionId = persistedMember.runtimeSessionId?.trim();
+  if (
+    persistedSessionId !== input.runtimeSessionId &&
+    (!isBootstrapCheckin || Boolean(persistedSessionId))
+  ) {
+    throwRuntimeMemberSessionMismatch(input, 'member runtime session does not match');
+  }
+}
+
+function throwRuntimeMemberSessionMismatch(
+  input: {
+    memberName: string;
+    runId: string;
+    evidenceKind: RuntimeEvidenceKind;
+  },
+  reason: string
+): never {
+  throw new RuntimeStaleEvidenceError(
+    `Rejected OpenCode ${input.evidenceKind} for ${input.memberName}: ${reason}`,
+    'run_mismatch',
+    input.evidenceKind,
+    input.runId
+  );
+}

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeMemberSessionAcceptance.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeMemberSessionAcceptance.ts
@@ -5,8 +5,26 @@ import {
 
 import { matchesTeamMemberIdentity } from './TeamProvisioningMemberIdentity';
 import { resolveEffectiveConfiguredMember } from './TeamProvisioningMemberStatusProjection';
+import {
+  hasCommittedOpenCodeRuntimeBootstrapSessionEvidence,
+  type OpenCodeRuntimeBootstrapEvidencePorts,
+} from './TeamProvisioningOpenCodeBootstrapEvidence';
 
-import type { PersistedTeamLaunchSnapshot, TeamConfig, TeamMember } from '@shared/types';
+import type {
+  PersistedTeamLaunchMemberState,
+  PersistedTeamLaunchSnapshot,
+  TeamConfig,
+  TeamMember,
+} from '@shared/types';
+
+export interface OpenCodeRuntimeMemberSessionIdentityInput {
+  teamName: string;
+  runId: string;
+  laneId: string;
+  memberName: string;
+  runtimeSessionId: string;
+  evidenceKind: RuntimeEvidenceKind;
+}
 
 export interface OpenCodeRuntimeMemberSessionAcceptancePorts {
   readLaunchState(teamName: string): Promise<PersistedTeamLaunchSnapshot | null>;
@@ -15,14 +33,7 @@ export interface OpenCodeRuntimeMemberSessionAcceptancePorts {
 }
 
 export async function assertOpenCodeRuntimeMemberSessionAccepted(
-  input: {
-    teamName: string;
-    runId: string;
-    laneId: string;
-    memberName: string;
-    runtimeSessionId: string;
-    evidenceKind: RuntimeEvidenceKind;
-  },
+  input: OpenCodeRuntimeMemberSessionIdentityInput,
   ports: OpenCodeRuntimeMemberSessionAcceptancePorts
 ): Promise<void> {
   const [snapshot, config, metaMembers] = await Promise.all([
@@ -34,17 +45,11 @@ export async function assertOpenCodeRuntimeMemberSessionAccepted(
 }
 
 export function assertOpenCodeRuntimeMemberSessionAcceptedFromState(
-  input: {
-    teamName: string;
-    runId: string;
-    laneId: string;
-    memberName: string;
-    runtimeSessionId: string;
-    evidenceKind: RuntimeEvidenceKind;
-  },
+  input: OpenCodeRuntimeMemberSessionIdentityInput,
   snapshot: PersistedTeamLaunchSnapshot | null,
   config: TeamConfig | null,
-  metaMembers: readonly TeamMember[]
+  metaMembers: readonly TeamMember[],
+  options: { allowMissingPersistedMember?: boolean } = {}
 ): void {
   if (!config || config.deletedAt) {
     throwRuntimeMemberSessionMismatch(input, 'team configuration is unavailable');
@@ -64,12 +69,14 @@ export function assertOpenCodeRuntimeMemberSessionAcceptedFromState(
   if (configuredMember.providerId !== 'opencode')
     throwRuntimeMemberSessionMismatch(input, 'member is not owned by OpenCode');
 
-  const persistedMember = Object.entries(snapshot?.members ?? {}).find(([memberName]) =>
-    matchesTeamMemberIdentity(memberName, configuredMember.name)
-  )?.[1];
+  const persistedMember = findPersistedLaunchMemberState(snapshot, configuredMember.name);
   const isBootstrapCheckin = input.evidenceKind === 'bootstrap_checkin';
   if (!persistedMember) {
     if (isBootstrapCheckin) return;
+    // Heartbeat self-heal: the caller has already verified lane-scoped committed
+    // bootstrap session evidence for this exact runId + runtime session, so a
+    // missing launch-state entry is a recoverable snapshot gap, not a stale run.
+    if (input.evidenceKind === 'heartbeat' && options.allowMissingPersistedMember) return;
     throwRuntimeMemberSessionMismatch(input, 'member runtime identity is unavailable');
   }
   const persistedRunId = persistedMember.runtimeRunId?.trim();
@@ -94,6 +101,59 @@ export function assertOpenCodeRuntimeMemberSessionAcceptedFromState(
   ) {
     throwRuntimeMemberSessionMismatch(input, 'member runtime session does not match');
   }
+}
+
+/**
+ * A heartbeat may arrive while the persisted launch snapshot no longer carries the
+ * member (snapshot cleared or rewritten). When the lane-scoped committed bootstrap
+ * evidence already pins this exact runId + runtime session, the heartbeat may
+ * re-materialize the member entry instead of being rejected with
+ * "member runtime identity is unavailable".
+ */
+export async function shouldSelfHealMissingHeartbeatMemberIdentity(
+  input: OpenCodeRuntimeMemberSessionIdentityInput,
+  snapshot: PersistedTeamLaunchSnapshot | null,
+  createEvidencePorts: () => OpenCodeRuntimeBootstrapEvidencePorts
+): Promise<boolean> {
+  if (input.evidenceKind !== 'heartbeat') {
+    return false;
+  }
+  if (findPersistedLaunchMemberState(snapshot, input.memberName)) {
+    return false;
+  }
+  return hasCommittedOpenCodeRuntimeBootstrapSessionEvidence(
+    {
+      teamName: input.teamName,
+      runId: input.runId,
+      laneId: input.laneId,
+      memberName: input.memberName,
+      runtimeSessionId: input.runtimeSessionId,
+    },
+    createEvidencePorts()
+  );
+}
+
+/** Restore lane/provider identity on a member entry re-materialized by a heartbeat. */
+export function applyHealedRuntimeMemberLaneIdentity(
+  member: PersistedTeamLaunchMemberState | undefined,
+  laneId: string
+): void {
+  if (!member) {
+    return;
+  }
+  member.providerId ??= 'opencode';
+  member.laneId ??= laneId;
+  member.laneOwnerProviderId ??= 'opencode';
+  member.laneKind ??= laneId === 'primary' ? 'primary' : 'secondary';
+}
+
+function findPersistedLaunchMemberState(
+  snapshot: PersistedTeamLaunchSnapshot | null,
+  memberName: string
+): PersistedTeamLaunchMemberState | undefined {
+  return Object.entries(snapshot?.members ?? {}).find(([persistedName]) =>
+    matchesTeamMemberIdentity(persistedName, memberName)
+  )?.[1];
 }
 
 function throwRuntimeMemberSessionMismatch(

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningConfigMaterialization.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningConfigMaterialization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  appendMissingConfigMembersFromMeta,
   applyConfigPostLaunchMaterialization,
   applyEffectiveLaunchStateToConfig,
   buildConfigLaunchCompatibilityReport,
@@ -16,6 +17,12 @@ import {
   getMixedLaunchFallbackRecoveryError,
   isPureOpenCodeProvisioningRequest,
 } from '../TeamProvisioningLaunchCompatibility';
+
+import type { TeamMember } from '@shared/types';
+
+function parseConfigMembers(raw: string): unknown {
+  return (JSON.parse(raw) as { members?: unknown }).members;
+}
 
 describe('team provisioning config materialization', () => {
   it('applies effective launch provider, model, and effort to lead and member config entries', () => {
@@ -128,6 +135,241 @@ describe('team provisioning config materialization', () => {
         joinedAt: 12345,
       },
     ]);
+  });
+
+  it('appends missing members.meta members into config members without duplicating entries', () => {
+    const config: Record<string, unknown> = {
+      members: [
+        { name: 'team-lead', agentType: 'team-lead', providerId: 'anthropic' },
+        { name: 'Existing', providerId: 'opencode', model: 'opencode/openai/gpt-5.4' },
+      ],
+    };
+
+    const changed = appendMissingConfigMembersFromMeta(
+      'runtime-team',
+      config,
+      [
+        { name: 'team-lead', agentType: 'team-lead', providerId: 'anthropic' },
+        { name: 'user' },
+        { name: 'Removed', providerId: 'opencode', model: 'opencode/x/y', removedAt: 1 },
+        { name: ' existing ', providerId: 'opencode', model: 'opencode/openai/gpt-5.4' },
+        {
+          name: 'Worker',
+          providerId: 'opencode',
+          model: 'opencode/zai-coding-plan/glm-4.6',
+          role: 'Implementer',
+          agentType: 'general-purpose',
+          joinedAt: 111,
+        },
+        { name: 'Builder', providerId: 'anthropic', model: 'claude-sonnet-4-5' },
+      ],
+      { now: () => 999 }
+    );
+
+    expect(changed).toBe(true);
+    expect(config.members).toEqual([
+      { name: 'team-lead', agentType: 'team-lead', providerId: 'anthropic' },
+      { name: 'Existing', providerId: 'opencode', model: 'opencode/openai/gpt-5.4' },
+      {
+        name: 'Worker',
+        agentId: 'Worker@runtime-team',
+        agentType: 'general-purpose',
+        role: 'Implementer',
+        providerId: 'opencode',
+        model: 'opencode/zai-coding-plan/glm-4.6',
+        joinedAt: 111,
+      },
+      {
+        name: 'Builder',
+        agentId: 'Builder@runtime-team',
+        agentType: 'general-purpose',
+        providerId: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        joinedAt: 999,
+      },
+    ]);
+  });
+
+  it.each([
+    ['the runtime-owned lead by name', { name: 'team-lead', providerId: 'anthropic' }],
+    [
+      'the runtime-owned lead by agent type',
+      { name: 'Captain', agentType: 'orchestrator', providerId: 'anthropic' },
+    ],
+    ['the user pseudo-member', { name: 'user' }],
+    [
+      'a member already removed from the roster',
+      { name: 'Scout', providerId: 'opencode', model: 'opencode/x/y', removedAt: 1 },
+    ],
+    ['a blank member name', { name: '   ', providerId: 'opencode' }],
+  ] satisfies [string, TeamMember][])(
+    'never materializes %s into the config member list',
+    (_label, metaMember) => {
+      const configMembers = [{ name: 'team-lead', agentType: 'team-lead' }];
+      const config: Record<string, unknown> = { members: configMembers };
+
+      expect(appendMissingConfigMembersFromMeta('runtime-team', config, [metaMember])).toBe(false);
+      expect(config.members).toBe(configMembers);
+    }
+  );
+
+  it('reports no config change when every active meta member already has a config identity', () => {
+    const members = [
+      { name: 'team-lead', agentType: 'team-lead' },
+      { name: 'Worker', providerId: 'opencode', model: 'opencode/openai/gpt-5.4' },
+    ];
+    const config: Record<string, unknown> = { members };
+
+    expect(
+      appendMissingConfigMembersFromMeta('runtime-team', config, [
+        { name: 'Worker', providerId: 'opencode', model: 'opencode/openai/gpt-5.4' },
+        { name: 'Gone', providerId: 'opencode', model: 'opencode/x/y', removedAt: 42 },
+      ])
+    ).toBe(false);
+    expect(config.members).toBe(members);
+  });
+
+  it('leaves an already-synced config member list untouched on a second sync', () => {
+    const metaMembers: TeamMember[] = [
+      { name: 'Worker', providerId: 'opencode', model: 'opencode/openai/gpt-5.4', joinedAt: 111 },
+    ];
+    const config: Record<string, unknown> = {
+      members: [{ name: 'team-lead', agentType: 'team-lead' }],
+    };
+
+    expect(
+      appendMissingConfigMembersFromMeta('runtime-team', config, metaMembers, { now: () => 999 })
+    ).toBe(true);
+    const afterFirstSync = config.members;
+
+    expect(
+      appendMissingConfigMembersFromMeta('runtime-team', config, metaMembers, { now: () => 1000 })
+    ).toBe(false);
+    expect(config.members).toBe(afterFirstSync);
+  });
+
+  it('syncs members.meta members into config members during post-launch config update', async () => {
+    let writtenRaw = '';
+    const info = vi.fn();
+
+    await updateTeamConfigPostLaunch(
+      {
+        teamName: 'runtime-team',
+        projectPath: '/repo/app',
+        detectedSessionId: 'session-1',
+      },
+      {
+        readConfig: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            members: [{ name: 'team-lead', agentType: 'team-lead' }],
+          })
+        ),
+        writeConfig: vi.fn(async (raw: string) => {
+          writtenRaw = raw;
+        }),
+        invalidateTeam: vi.fn(),
+        scanForNewestSession: vi.fn(),
+        readMetaMembers: vi.fn(async () => [
+          {
+            name: 'Worker',
+            providerId: 'opencode' as const,
+            model: 'opencode/zai-coding-plan/glm-4.6',
+            role: 'Implementer',
+            agentType: 'general-purpose',
+            joinedAt: 111,
+          },
+        ]),
+        getLanguage: () => 'system',
+        info,
+        warn: vi.fn(),
+      }
+    );
+
+    expect(parseConfigMembers(writtenRaw)).toEqual([
+      { name: 'team-lead', agentType: 'team-lead' },
+      {
+        name: 'Worker',
+        agentId: 'Worker@runtime-team',
+        agentType: 'general-purpose',
+        role: 'Implementer',
+        providerId: 'opencode',
+        model: 'opencode/zai-coding-plan/glm-4.6',
+        joinedAt: 111,
+      },
+    ]);
+    expect(info).toHaveBeenCalledWith(
+      '[runtime-team] Synced missing members.meta.json members into config.json members'
+    );
+  });
+
+  it('writes the same member list on a second post-launch update over a synced config', async () => {
+    const writtenRaws: string[] = [];
+    const info = vi.fn();
+    let storedRaw = JSON.stringify({ members: [{ name: 'team-lead', agentType: 'team-lead' }] });
+    const ports = {
+      readConfig: vi.fn(async () => storedRaw),
+      writeConfig: vi.fn(async (raw: string) => {
+        writtenRaws.push(raw);
+        storedRaw = raw;
+      }),
+      invalidateTeam: vi.fn(),
+      scanForNewestSession: vi.fn(),
+      readMetaMembers: vi.fn(async () => [
+        { name: 'Worker', providerId: 'opencode' as const, model: 'opencode/x/y', joinedAt: 111 },
+      ]),
+      getLanguage: () => 'system',
+      info,
+      warn: vi.fn(),
+    };
+    const input = {
+      teamName: 'runtime-team',
+      projectPath: '/repo/app',
+      detectedSessionId: 'session-1',
+    };
+
+    await updateTeamConfigPostLaunch(input, ports);
+    await updateTeamConfigPostLaunch(input, ports);
+
+    const syncLogs = info.mock.calls
+      .map((call) => String(call[0]))
+      .filter((message) => message.includes('Synced missing members.meta.json members'));
+    expect(syncLogs).toHaveLength(1);
+    expect(writtenRaws).toHaveLength(2);
+    expect(parseConfigMembers(writtenRaws[1])).toEqual(parseConfigMembers(writtenRaws[0]));
+  });
+
+  it('keeps the post-launch config write when the members.meta roster cannot be read', async () => {
+    let writtenRaw = '';
+    const warn = vi.fn();
+
+    await updateTeamConfigPostLaunch(
+      {
+        teamName: 'runtime-team',
+        projectPath: '/repo/app',
+        detectedSessionId: 'session-1',
+      },
+      {
+        readConfig: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            members: [{ name: 'team-lead', agentType: 'team-lead' }],
+          })
+        ),
+        writeConfig: vi.fn(async (raw: string) => {
+          writtenRaw = raw;
+        }),
+        invalidateTeam: vi.fn(),
+        scanForNewestSession: vi.fn(),
+        readMetaMembers: vi.fn().mockRejectedValue(new Error('members.meta.json unreadable')),
+        getLanguage: () => 'system',
+        info: vi.fn(),
+        warn,
+      }
+    );
+
+    expect(parseConfigMembers(writtenRaw)).toEqual([{ name: 'team-lead', agentType: 'team-lead' }]);
+    expect(warn).toHaveBeenCalledWith(
+      '[runtime-team] Failed to sync members.meta.json into config members: members.meta.json unreadable'
+    );
   });
 
   it('extracts teammate specs from config and ignores lead, user, removed, and auto-suffixed entries', () => {
@@ -264,6 +506,7 @@ describe('team provisioning config materialization', () => {
         }),
         invalidateTeam,
         scanForNewestSession,
+        readMetaMembers: vi.fn(async () => []),
         getLanguage: () => 'uk',
         info,
         warn: vi.fn(),
@@ -304,6 +547,7 @@ describe('team provisioning config materialization', () => {
         writeConfig,
         invalidateTeam,
         scanForNewestSession: vi.fn(),
+        readMetaMembers: vi.fn(async () => []),
         getLanguage: () => 'system',
         info: vi.fn(),
         warn,

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeCheckin.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeCheckin.test.ts
@@ -118,6 +118,58 @@ function createPorts(
   return merged;
 }
 
+const aliceOnlyConfig = {
+  name: 'Team',
+  members: [{ name: 'Alice', providerId: 'opencode' }],
+} as TeamConfig;
+
+/**
+ * Committed bootstrap evidence is read per lane, so a lane the heartbeat does not
+ * belong to reads back as "nothing committed here".
+ */
+function createCommittedEvidencePortsFactory(options: {
+  teamsBasePath: string;
+  committedLaneId: string;
+  committedRunId: string;
+  memberName?: string;
+  runtimeSessionId?: string;
+}): OpenCodeRuntimeCheckinPorts<TestRun>['createOpenCodeRuntimeBootstrapEvidencePorts'] {
+  const memberName = options.memberName ?? 'Alice';
+  const runtimeSessionId = options.runtimeSessionId ?? 'session-1';
+  return vi.fn(() => ({
+    ...createDefaultOpenCodeRuntimeBootstrapEvidencePorts({
+      teamsBasePath: options.teamsBasePath,
+    }),
+    readCommittedBootstrapSessionEvidence: vi.fn(async (input: { laneId: string }) =>
+      input.laneId === options.committedLaneId
+        ? {
+            state: 'healthy' as const,
+            committed: true,
+            activeRunId: options.committedRunId,
+            sessions: [
+              {
+                id: runtimeSessionId,
+                teamName: 'Team',
+                memberName,
+                laneId: options.committedLaneId,
+                runId: options.committedRunId,
+                observedAt,
+                source: 'runtime_bootstrap_checkin' as const,
+              },
+            ],
+            diagnostics: [],
+          }
+        : {
+            state: 'healthy' as const,
+            committed: false,
+            activeRunId: null,
+            sessions: [],
+            diagnostics: [],
+          }
+    ),
+  }));
+}
+
 describe('TeamProvisioningOpenCodeRuntimeCheckin', () => {
   it('resolves bootstrap check-in idempotency from the launch state port', async () => {
     const snapshot = createPersistedLaunchSnapshot({
@@ -497,6 +549,233 @@ describe('TeamProvisioningOpenCodeRuntimeCheckin', () => {
       expect(writeLaunchState).not.toHaveBeenCalled();
       expect(ports.emitMemberSpawnChange).not.toHaveBeenCalled();
       expect(ports.emitRuntimeMemberSpawnChange).not.toHaveBeenCalled();
+    } finally {
+      rmSync(teamsBasePath, { recursive: true, force: true });
+    }
+  });
+
+  it('self-heals a heartbeat missing from the launch snapshot when committed bootstrap evidence matches', async () => {
+    const teamsBasePath = createSafeTempDir('opencode-runtime-heartbeat-heal-');
+    // Snapshot was rewritten from a roster that no longer carries Alice at all.
+    const rosterGapSnapshot = createPersistedLaunchSnapshot({
+      teamName: 'Team',
+      expectedMembers: ['Bob'],
+      launchPhase: 'active',
+      members: {
+        Bob: {
+          name: 'Bob',
+          launchState: 'confirmed_alive',
+          agentToolAccepted: true,
+          runtimeAlive: true,
+          bootstrapConfirmed: true,
+          hardFailure: false,
+          runtimeRunId: 'run-1',
+          runtimeSessionId: 'session-bob',
+          lastEvaluatedAt: observedAt,
+        },
+      },
+      updatedAt: observedAt,
+    });
+    const writeLaunchState = vi.fn(
+      async (_teamName: string, _snapshot: PersistedTeamLaunchSnapshot) => undefined
+    );
+    const ports = createPorts({
+      teamsBasePath,
+      readLaunchState: vi.fn(async () => rosterGapSnapshot),
+      readConfigForStrictDecision: vi.fn(async () => aliceOnlyConfig),
+      writeLaunchState,
+      createOpenCodeRuntimeBootstrapEvidencePorts: createCommittedEvidencePortsFactory({
+        teamsBasePath,
+        committedLaneId: 'secondary:opencode:alice',
+        committedRunId: 'run-1',
+      }),
+    });
+
+    try {
+      await expect(
+        recordOpenCodeRuntimeHeartbeat(
+          {
+            teamName: 'Team',
+            runId: 'run-1',
+            memberName: 'Alice',
+            runtimeSessionId: 'session-1',
+            observedAt,
+          },
+          ports
+        )
+      ).resolves.toMatchObject({
+        ok: true,
+        state: 'accepted',
+        memberName: 'Alice',
+        runtimeSessionId: 'session-1',
+      });
+
+      const snapshot = writeLaunchState.mock.calls.at(-1)?.[1];
+      expect(snapshot?.members.Alice).toMatchObject({
+        launchState: 'confirmed_alive',
+        runtimeRunId: 'run-1',
+        runtimeSessionId: 'session-1',
+        providerId: 'opencode',
+        laneId: 'secondary:opencode:alice',
+        laneKind: 'secondary',
+        laneOwnerProviderId: 'opencode',
+      });
+    } finally {
+      rmSync(teamsBasePath, { recursive: true, force: true });
+    }
+  });
+
+  it('still rejects a snapshot-less heartbeat without committed bootstrap evidence', async () => {
+    const teamsBasePath = createSafeTempDir('opencode-runtime-heartbeat-no-evidence-');
+    const writeLaunchState = vi.fn(async () => undefined);
+    const ports = createPorts({
+      teamsBasePath,
+      readLaunchState: vi.fn(async () => null),
+      readConfigForStrictDecision: vi.fn(async () => aliceOnlyConfig),
+      writeLaunchState,
+      createOpenCodeRuntimeBootstrapEvidencePorts: vi.fn(() =>
+        createDefaultOpenCodeRuntimeBootstrapEvidencePorts({ teamsBasePath })
+      ),
+    });
+
+    try {
+      await expect(
+        recordOpenCodeRuntimeHeartbeat(
+          {
+            teamName: 'Team',
+            runId: 'run-1',
+            memberName: 'Alice',
+            runtimeSessionId: 'session-1',
+            observedAt,
+          },
+          ports
+        )
+      ).rejects.toThrow('member runtime identity is unavailable');
+      expect(writeLaunchState).not.toHaveBeenCalled();
+    } finally {
+      rmSync(teamsBasePath, { recursive: true, force: true });
+    }
+  });
+
+  it('still rejects a snapshot-less heartbeat when the committed evidence belongs to another lane', async () => {
+    const teamsBasePath = createSafeTempDir('opencode-runtime-heartbeat-other-lane-');
+    const writeLaunchState = vi.fn(async () => undefined);
+    const ports = createPorts({
+      teamsBasePath,
+      readLaunchState: vi.fn(async () => null),
+      readConfigForStrictDecision: vi.fn(async () => aliceOnlyConfig),
+      writeLaunchState,
+      createOpenCodeRuntimeBootstrapEvidencePorts: createCommittedEvidencePortsFactory({
+        teamsBasePath,
+        committedLaneId: 'secondary:opencode:carol',
+        committedRunId: 'run-1',
+      }),
+    });
+
+    try {
+      await expect(
+        recordOpenCodeRuntimeHeartbeat(
+          {
+            teamName: 'Team',
+            runId: 'run-1',
+            memberName: 'Alice',
+            runtimeSessionId: 'session-1',
+            observedAt,
+          },
+          ports
+        )
+      ).rejects.toThrow('member runtime identity is unavailable');
+      expect(writeLaunchState).not.toHaveBeenCalled();
+    } finally {
+      rmSync(teamsBasePath, { recursive: true, force: true });
+    }
+  });
+
+  it('still rejects a snapshot-less heartbeat when the committed evidence belongs to another run', async () => {
+    const teamsBasePath = createSafeTempDir('opencode-runtime-heartbeat-other-run-');
+    const writeLaunchState = vi.fn(async () => undefined);
+    const ports = createPorts({
+      teamsBasePath,
+      readLaunchState: vi.fn(async () => null),
+      readConfigForStrictDecision: vi.fn(async () => aliceOnlyConfig),
+      writeLaunchState,
+      createOpenCodeRuntimeBootstrapEvidencePorts: createCommittedEvidencePortsFactory({
+        teamsBasePath,
+        committedLaneId: 'secondary:opencode:alice',
+        committedRunId: 'run-0',
+      }),
+    });
+
+    try {
+      await expect(
+        recordOpenCodeRuntimeHeartbeat(
+          {
+            teamName: 'Team',
+            runId: 'run-1',
+            memberName: 'Alice',
+            runtimeSessionId: 'session-1',
+            observedAt,
+          },
+          ports
+        )
+      ).rejects.toThrow('member runtime identity is unavailable');
+      expect(writeLaunchState).not.toHaveBeenCalled();
+    } finally {
+      rmSync(teamsBasePath, { recursive: true, force: true });
+    }
+  });
+
+  it('never reads bootstrap evidence for a heartbeat whose persisted identity already matches', async () => {
+    const teamsBasePath = createSafeTempDir('opencode-runtime-heartbeat-no-heal-');
+    const matchingSnapshot = createPersistedLaunchSnapshot({
+      teamName: 'Team',
+      expectedMembers: ['Alice'],
+      launchPhase: 'active',
+      members: {
+        Alice: {
+          name: 'Alice',
+          launchState: 'confirmed_alive',
+          agentToolAccepted: true,
+          runtimeAlive: true,
+          bootstrapConfirmed: true,
+          hardFailure: false,
+          providerId: 'opencode',
+          laneId: 'secondary:opencode:alice',
+          laneKind: 'secondary',
+          laneOwnerProviderId: 'opencode',
+          runtimeRunId: 'run-1',
+          runtimeSessionId: 'session-1',
+          lastEvaluatedAt: observedAt,
+        },
+      },
+      updatedAt: observedAt,
+    });
+    const createEvidencePorts = createCommittedEvidencePortsFactory({
+      teamsBasePath,
+      committedLaneId: 'secondary:opencode:alice',
+      committedRunId: 'run-1',
+    });
+    const ports = createPorts({
+      teamsBasePath,
+      readLaunchState: vi.fn(async () => matchingSnapshot),
+      readConfigForStrictDecision: vi.fn(async () => aliceOnlyConfig),
+      createOpenCodeRuntimeBootstrapEvidencePorts: createEvidencePorts,
+    });
+
+    try {
+      await expect(
+        recordOpenCodeRuntimeHeartbeat(
+          {
+            teamName: 'Team',
+            runId: 'run-1',
+            memberName: 'Alice',
+            runtimeSessionId: 'session-1',
+            observedAt,
+          },
+          ports
+        )
+      ).resolves.toMatchObject({ ok: true, state: 'accepted' });
+      expect(createEvidencePorts).toHaveBeenCalledTimes(0);
     } finally {
       rmSync(teamsBasePath, { recursive: true, force: true });
     }


### PR DESCRIPTION
Independent of every other open PR.

## Problem

Two ways a teammate that is actually running ends up unreachable, both seen on live runs during the earlier campaign and both in the failure class #137 describes (a launch that "did not complete" although the runtime is up).

**1. `members.meta.json` and the `config.json` member list drift.** The roster the app maintains as members are added and the file the runtimes read can disagree: a member added after the config was last written, or a config rewritten from a stale roster, exists in one and not the other. A member with no `config.json` entry has no authoritative config identity, so OpenCode runtime recipient resolution refuses to deliver to it and every inbox relay to that teammate fails permanently. Nothing repaired that state.

**2. A heartbeat is refused once the persisted launch snapshot forgets the member.** The snapshot is a live document, rewritten from the current roster, cleared and rebuilt, so a member can drop out of it while its lane is still up and still sending heartbeats. From that point every heartbeat is rejected with "member runtime identity is unavailable", the member never returns to `confirmed_alive`, and the run reports a teammate that failed to bootstrap even though its bootstrap completed and was recorded. Restarting the member was the only way out.

## Fix

Three commits; the first is a pure extraction whose order is load-bearing.

1. `refactor(team): extract OpenCode runtime member session acceptance from the check-in flow`: `TeamProvisioningOpenCodeRuntimeCheckin.ts` sits at 799 against the 800 default. The self-contained acceptance rule ("may this runtime check-in claim this member identity", two entry points) moves to `TeamProvisioningOpenCodeRuntimeMemberSessionAcceptance.ts`, bodies byte-identical, with a re-export so `TeamProvisioningOpenCodeRuntimeDelivery.ts` keeps its import path. The extraction comes first so no intermediate tree in this branch crosses the size guard; if you would rather repoint the one consumer and drop the re-export, that adds a fifth file and I will do it.
2. `fix(team): members.meta is materialized into the config.json member list`: the post-launch config update reads the members-meta roster and appends the entries `config.json` is missing, in the single read-mutate-write it already performs. Append is the only operation: an existing config entry is never rewritten. The sync skips the runtime-owned lead, the `user` pseudo-member, blank names and members carrying `removedAt`, because materialising any of those would invent a teammate rather than recover one. It is idempotent (a second run yields the identical list and no second log line) and non-fatal (a roster that cannot be read is warned about and the write proceeds, since it also carries the session history and project path). `readMetaMembers` is a required port rather than the optional one the first version had: the single production caller always has a store, and an optional field would have existed only to let tests omit it. One redundant guard is kept as written (`team-lead` by name, which `isLeadMember` already matches); say the word and I will drop it.
3. `fix(team): a runtime_heartbeat check-in heals its identity from committed bootstrap evidence`: before deciding, the check-in asks whether the missing snapshot entry is a recoverable gap. It is recoverable only when the lane-scoped committed bootstrap evidence pins this exact team, lane, run and runtime session, meaning the runtime already proved this identity at bootstrap and nothing superseded it. In that one case the heartbeat is accepted and re-materialises the member entry (provider, lane, lane kind, lane owner). `allowMissingPersistedMember` is a precondition the caller earns from a single helper, not a bypass flag: the acceptance rule applies it only to the "no persisted member" branch and still enforces lane, run, session and provider agreement on every member it does find. The evidence lookup is skipped entirely when the snapshot carries the member, so an ordinary heartbeat performs no extra reads.

Sizes: `TeamProvisioningOpenCodeRuntimeCheckin.ts` 715/800 (698 after the extraction), `TeamProvisioningConfigMaterialization.ts` 719/800, new acceptance module 173, `TeamProvisioningConfigMaintenance.ts` 370. Both 7xx numbers are worth knowing; nothing later in this series adds to either file. `scripts/ci/source-file-size-baseline.json` untouched.

## Tests

Negative controls, each its own test and each mutation-checked (the rule was broken, the named tests went red, the rule restored):

- Self-heal refuses an identity without committed bootstrap evidence, for each of the three shapes: no evidence, evidence for another lane, evidence for another run. Making the helper return true without checking evidence fails all three; ignoring `runId` fails exactly the "another run" case.
- A heartbeat whose persisted identity already matches never enters the self-heal branch: a zero-call spy on the bootstrap-evidence ports, which in the heartbeat path have exactly one call site.
- Meta sync never adds the lead, never adds `user`, never resurrects a member with `removedAt`, and skips a blank name; dropping each guard fails its named test.
- Meta sync is idempotent: the second `appendMissingConfigMembersFromMeta` returns false with the member array referentially unchanged, and two post-launch updates over the fed-back config log the sync line exactly once and write the same list.
- The post-launch config write still happens when the roster cannot be read.
- The motion commit: 102 removed and 102 added lines detected as moved under `--color-moved`, the remainder being the import header, the `export` keyword and the re-export.

Per commit: `pnpm typecheck`, size guard, provisioning guard, `eslint` (0 errors, no new warnings) and `prettier --check` on every changed `src/` file, targeted vitest (31 and 17 tests). Tip sweep over `src/main/services/team` + `test/main/services/team`: 5790 tests, 3 failed, all 3 among the failures an unmodified `origin/main` produces on this machine; nothing new.

## Tested on

Windows 11 Pro, from source, against `origin/main @ 07be9b5fa`. Both defects were observed on live mixed-provider runs during the earlier campaign (a teammate unreachable by relay after a config rewrite; a running OpenCode lane reported as failed to bootstrap after its snapshot entry was cleared). With the series in place the roster repair runs at the next post-launch write and the heartbeat re-materialises the member instead of being refused. Not tested on macOS or Linux; nothing here is platform-specific.

Refs #137.

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-healing roster synchronization to restore missing team members from metadata.
  * Added runtime heartbeat recovery when valid bootstrap evidence confirms a missing member’s identity.
  * Improved runtime session validation for team member, lane, and run consistency.

* **Bug Fixes**
  * Prevented valid members from remaining absent after configuration materialization.
  * Added safeguards against accepting stale or mismatched runtime sessions.

* **Tests**
  * Expanded coverage for roster synchronization, deduplication, recovery scenarios, and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->