### PR TITLE
fix(team): gate provider readiness and launch preflight

### DIFF
--- a/src/features/runtime-provider-management/renderer/RuntimeProviderQuickConnect.tsx
+++ b/src/features/runtime-provider-management/renderer/RuntimeProviderQuickConnect.tsx
@@ -236,12 +236,10 @@ export const RuntimeProviderQuickConnect = ({
   );
   const [localProviderProjects, setLocalProviderProjects] = useState<ProjectPathProject[]>([]);
   const oauthBridgeOutdated = isOpenCodeProviderOAuthBridgeOutdated(openCodeRuntimeStatus);
-
   useEffect(() => {
     if (!localProviderSetupOpen) return;
     setLocalProviderProjectPath(projectPath?.trim() || null);
   }, [localProviderSetupOpen, projectPath]);
-
   useEffect(() => {
     if (!localProviderSetupOpen) return;
     let cancelled = false;
@@ -259,7 +257,6 @@ export const RuntimeProviderQuickConnect = ({
       cancelled = true;
     };
   }, [localProviderProjectPath, localProviderSetupOpen, projectPath, repositoryGroups]);
-
   const refreshConfiguredLocalProvider = useCallback(async (): Promise<void> => {
     directory.refresh();
     await fetchCliProviderStatus('opencode', {
@@ -268,7 +265,6 @@ export const RuntimeProviderQuickConnect = ({
       projectPath: localProviderProjectPath,
     });
   }, [directory, fetchCliProviderStatus, localProviderProjectPath]);
-
   const getCompanionState = useCallback(
     (planId: CompanionPlanId): RuntimeProviderCompanionState =>
       planId === 'kiro' ? kiroCompanion : cursorCompanion,
@@ -356,8 +352,8 @@ export const RuntimeProviderQuickConnect = ({
           description,
           state: 'unavailable',
           stateLabel: t('cliStatus.quickConnect.statusUnavailable'),
-          actionLabel: null,
-          onAction: null,
+          actionLabel: t('cliStatus.quickConnect.checkAndConnect'),
+          onAction: () => onOpenCodeProviderAction(gateway.providerId, 'settings-connect'),
         };
       }
 
@@ -382,8 +378,8 @@ export const RuntimeProviderQuickConnect = ({
           description,
           state: 'unavailable',
           stateLabel: t('cliStatus.quickConnect.statusUnavailable'),
-          actionLabel: null,
-          onAction: null,
+          actionLabel: t('cliStatus.quickConnect.checkAndConnect'),
+          onAction: () => onOpenCodeProviderAction(gateway.providerId, 'settings-connect'),
         };
       }
 
@@ -406,13 +402,17 @@ export const RuntimeProviderQuickConnect = ({
       const actionLabel =
         state === 'connected' || state === 'manual'
           ? t('cliStatus.actions.manage')
-          : state === 'connectable'
-            ? t('cliStatus.actions.connect')
+          : state === 'connectable' || state === 'unavailable'
+            ? t(
+                state === 'connectable'
+                  ? 'cliStatus.actions.connect'
+                  : 'cliStatus.quickConnect.checkAndConnect'
+              )
             : null;
       const onAction =
         state === 'connected' || state === 'manual'
           ? () => onOpenCodeProviderAction(gateway.providerId, 'select')
-          : state === 'connectable'
+          : state === 'connectable' || state === 'unavailable'
             ? () => onOpenCodeProviderAction(gateway.providerId, 'settings-connect')
             : null;
 

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable sonarjs/publicly-writable-directories -- Test-only project paths are never written. */
+
 import { describe, expect, test, vi } from 'vitest';
 
 import { ClaudeMultimodelBridgeService } from './ClaudeMultimodelBridgeService';
@@ -289,3 +291,5 @@ describe('ClaudeMultimodelBridgeService runtime status mapping', () => {
     });
   });
 });
+
+/* eslint-enable sonarjs/publicly-writable-directories -- Re-enable after test-only temp path fixtures. */

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -234,17 +234,20 @@ describe('ClaudeMultimodelBridgeService runtime status mapping', () => {
       },
       'error',
     ],
-  ] as const)('revokes OpenCode launch authority for missing or drifted live evidence', (snapshot, verificationState) => {
-    const service = new ClaudeMultimodelBridgeService() as unknown as RuntimeStatusMapper;
-    const provider = verifiedOpenCodeProvider();
+  ] as const)(
+    'revokes OpenCode launch authority for missing or drifted live evidence',
+    (snapshot, verificationState) => {
+      const service = new ClaudeMultimodelBridgeService() as unknown as RuntimeStatusMapper;
+      const provider = verifiedOpenCodeProvider();
 
-    expect(service.mergeOpenCodeVerification(provider, snapshot)).toMatchObject({
-      authenticated: false,
-      authMethod: null,
-      verificationState,
-      capabilities: { teamLaunch: false },
-    });
-  });
+      expect(service.mergeOpenCodeVerification(provider, snapshot)).toMatchObject({
+        authenticated: false,
+        authMethod: null,
+        verificationState,
+        capabilities: { teamLaunch: false },
+      });
+    }
+  );
 
   test('revokes OpenCode launch authority when live verification throws', async () => {
     const service = new ClaudeMultimodelBridgeService();
@@ -261,5 +264,28 @@ describe('ClaudeMultimodelBridgeService runtime status mapping', () => {
       capabilities: { teamLaunch: false },
     });
     vi.mocked(console.warn).mockClear();
+  });
+
+  test('requests the full OpenCode status for project-scoped launch checks', async () => {
+    const service = new ClaudeMultimodelBridgeService();
+    const internals = service as unknown as {
+      getProviderStatusFromScopedRuntimeStatus: (
+        binaryPath: string,
+        providerId: CliProviderId,
+        options: { summary?: boolean; projectPath?: string | null }
+      ) => Promise<CliProviderStatus>;
+    };
+    const statusSpy = vi
+      .spyOn(internals, 'getProviderStatusFromScopedRuntimeStatus')
+      .mockResolvedValue(verifiedOpenCodeProvider());
+
+    await service.getProviderStatus('/fake/cli', 'opencode', undefined, {
+      projectPath: '/tmp/sandbox-project',
+    });
+
+    expect(statusSpy).toHaveBeenCalledWith('/fake/cli', 'opencode', {
+      summary: false,
+      projectPath: '/tmp/sandbox-project',
+    });
   });
 });

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
@@ -1519,7 +1519,10 @@ export class ClaudeMultimodelBridgeService {
     let backgroundHydrationOwnsGenerationCleanup = false;
     try {
       const provider = await this.getProviderStatusFromScopedRuntimeStatus(binaryPath, providerId, {
-        summary: true,
+        // OpenCode's passive summary intentionally omits authentication and its
+        // model catalog. A project-scoped launch check needs the exact catalog,
+        // otherwise a healthy installed CLI is misclassified as runtime_missing.
+        summary: providerId !== 'opencode' || !projectPath,
         projectPath,
       });
       if (projectPath && canHydrateProviderCatalog(provider)) {

--- a/src/main/services/team/TeamLaunchStateEvaluator.ts
+++ b/src/main/services/team/TeamLaunchStateEvaluator.ts
@@ -353,7 +353,6 @@ export function deriveTeamLaunchAggregateState(
   }
   return 'clean_success';
 }
-
 export function summarizePersistedLaunchMembers(
   expectedMembers: readonly string[],
   members: Record<string, PersistedTeamLaunchMemberState>
@@ -375,7 +374,6 @@ export function summarizePersistedLaunchMembers(
       ...Object.keys(members).map(normalizeMemberName).filter(Boolean),
     ])
   );
-
   for (const memberName of memberNames) {
     const entry = members[memberName];
     if (!entry) {
@@ -399,9 +397,8 @@ export function summarizePersistedLaunchMembers(
       runtimeAlivePendingCount += 1;
     }
     if (
-      entry.launchState === 'runtime_pending_permission' ||
-      (entry.launchState as string) === 'permission_pending' ||
-      (entry.pendingPermissionRequestIds?.length ?? 0) > 0
+      entry.pendingPermissionRequestIds?.length ||
+      ['runtime_pending_permission', 'permission_pending'].includes(entry.launchState as string)
     ) {
       permissionPendingCount += 1;
     }
@@ -419,7 +416,6 @@ export function summarizePersistedLaunchMembers(
       noRuntimePendingCount += 1;
     }
   }
-
   return {
     confirmedCount,
     pendingCount,

--- a/src/main/services/team/TeamLaunchStateEvaluator.ts
+++ b/src/main/services/team/TeamLaunchStateEvaluator.ts
@@ -398,7 +398,11 @@ export function summarizePersistedLaunchMembers(
     if (preservesStrongRuntimeAlive(entry)) {
       runtimeAlivePendingCount += 1;
     }
-    if (entry.launchState === 'runtime_pending_permission') {
+    if (
+      entry.launchState === 'runtime_pending_permission' ||
+      (entry.launchState as string) === 'permission_pending' ||
+      (entry.pendingPermissionRequestIds?.length ?? 0) > 0
+    ) {
       permissionPendingCount += 1;
     }
     if (entry.livenessKind === 'shell_only') {

--- a/src/main/services/team/TeamLaunchSummaryProjection.ts
+++ b/src/main/services/team/TeamLaunchSummaryProjection.ts
@@ -170,12 +170,12 @@ export function createLaunchStateSummary(
   const persistedMemberNames = getPersistedLaunchMemberNames(snapshot);
   const projectedMembers = buildProjectedMembersForSummary(snapshot, options.bootstrapSnapshot);
   const members = projectedMembers ?? snapshot.members;
-  const summary = projectedMembers
-    ? summarizePersistedLaunchMembers(snapshot.expectedMembers, projectedMembers)
-    : snapshot.summary;
-  const teamLaunchState = projectedMembers
-    ? deriveTeamLaunchAggregateState(summary)
-    : snapshot.teamLaunchState;
+  // The persisted summary is a denormalized cache and can lag one heartbeat
+  // behind the durable per-member state (this used to surface e.g. `2/3`
+  // after all members had already confirmed). Recompute it from the roster on
+  // every projection so lifecycle diagnostics have one authoritative source.
+  const summary = summarizePersistedLaunchMembers(snapshot.expectedMembers, members);
+  const teamLaunchState = deriveTeamLaunchAggregateState(summary);
   const missingMembers = persistedMemberNames.filter((name) => {
     const member = members[name];
     return member?.launchState === 'failed_to_start';
@@ -343,10 +343,11 @@ function shouldIgnoreStalePendingLaunchSnapshotSummary(
   snapshot: PersistedTeamLaunchSnapshot,
   nowMs: number = Date.now()
 ): boolean {
-  if (snapshot.teamLaunchState !== 'partial_pending') {
+  const summary = summarizePersistedLaunchMembers(snapshot.expectedMembers, snapshot.members);
+  if (deriveTeamLaunchAggregateState(summary) !== 'partial_pending') {
     return false;
   }
-  if ((snapshot.summary.permissionPendingCount ?? 0) > 0) {
+  if ((summary.permissionPendingCount ?? 0) > 0) {
     return false;
   }
 

--- a/src/main/services/team/provisioning/TeamProvisioningAsyncUtils.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningAsyncUtils.ts
@@ -5,10 +5,14 @@ export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/** Ensure `cwd` exists as a directory, creating it (recursively) if needed. */
+/** Ensure `cwd` already exists as a directory. Launch must never create a stale project path. */
 export async function ensureCwdExists(cwd: string): Promise<void> {
-  await fs.promises.mkdir(cwd, { recursive: true });
-  const stat = await fs.promises.stat(cwd);
+  const normalizedCwd = cwd.trim();
+  if (!normalizedCwd) {
+    throw new Error('cwd must be a directory');
+  }
+  const canonicalCwd = await fs.promises.realpath(normalizedCwd);
+  const stat = await fs.promises.stat(canonicalCwd);
   if (!stat.isDirectory()) {
     throw new Error('cwd must be a directory');
   }

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchPendingMessage.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchPendingMessage.ts
@@ -1,3 +1,5 @@
+import { summarizePersistedLaunchMembers } from '../TeamLaunchStateEvaluator';
+
 import { getPersistedLaunchMemberNames } from './TeamProvisioningLaunchStateProjection';
 import { createInitialMemberSpawnStatusEntry } from './TeamProvisioningMemberSpawnStatusPolicy';
 
@@ -76,10 +78,13 @@ export function hasPendingLaunchMembers({
   launchSummary,
   snapshot,
 }: HasPendingLaunchMembersInput): boolean {
+  const effectiveLaunchSummary = snapshot
+    ? summarizePersistedLaunchMembers(snapshot.expectedMembers, snapshot.members)
+    : launchSummary;
   const expectedCount = snapshot
     ? getPersistedLaunchMemberNames(snapshot).length
     : (run.expectedMembers?.length ?? 0);
-  return launchSummary.pendingCount > 0 && expectedCount > 0;
+  return effectiveLaunchSummary.pendingCount > 0 && expectedCount > 0;
 }
 
 export function buildPendingBootstrapStatusMessage({
@@ -88,6 +93,9 @@ export function buildPendingBootstrapStatusMessage({
   launchSummary,
   snapshot,
 }: BuildPendingBootstrapStatusMessageInput): string {
+  const effectiveLaunchSummary = snapshot
+    ? summarizePersistedLaunchMembers(snapshot.expectedMembers, snapshot.members)
+    : launchSummary;
   const expectedTeammateCount = snapshot
     ? getPersistedLaunchMemberNames(snapshot).length
     : (run.expectedMembers?.length ?? 0);
@@ -95,9 +103,9 @@ export function buildPendingBootstrapStatusMessage({
     ? countSnapshotPermissionPendingMembers(snapshot)
     : countRunPermissionPendingMembers(run);
   if (
-    launchSummary.pendingCount > 0 &&
+    effectiveLaunchSummary.pendingCount > 0 &&
     permissionPendingCount > 0 &&
-    permissionPendingCount === launchSummary.pendingCount
+    permissionPendingCount === effectiveLaunchSummary.pendingCount
   ) {
     return `${prefix} — ${
       permissionPendingCount === 1
@@ -106,22 +114,27 @@ export function buildPendingBootstrapStatusMessage({
     }`;
   }
 
-  const runtimeProcessPendingCount = launchSummary.runtimeProcessPendingCount ?? 0;
-  const stillStartingCount = Math.max(0, launchSummary.pendingCount - runtimeProcessPendingCount);
+  const runtimeProcessPendingCount = effectiveLaunchSummary.runtimeProcessPendingCount ?? 0;
+  const stillStartingCount = Math.max(
+    0,
+    effectiveLaunchSummary.pendingCount - runtimeProcessPendingCount
+  );
   const diagnosticParts = [
-    launchSummary.shellOnlyPendingCount ? `${launchSummary.shellOnlyPendingCount} shell-only` : '',
-    launchSummary.runtimeProcessPendingCount
-      ? `${launchSummary.runtimeProcessPendingCount} waiting for bootstrap`
+    effectiveLaunchSummary.shellOnlyPendingCount
+      ? `${effectiveLaunchSummary.shellOnlyPendingCount} shell-only`
       : '',
-    launchSummary.runtimeCandidatePendingCount
-      ? `${launchSummary.runtimeCandidatePendingCount} bootstrap unconfirmed`
+    effectiveLaunchSummary.runtimeProcessPendingCount
+      ? `${effectiveLaunchSummary.runtimeProcessPendingCount} waiting for bootstrap`
       : '',
-    launchSummary.noRuntimePendingCount
-      ? `${launchSummary.noRuntimePendingCount} waiting for runtime`
+    effectiveLaunchSummary.runtimeCandidatePendingCount
+      ? `${effectiveLaunchSummary.runtimeCandidatePendingCount} bootstrap unconfirmed`
+      : '',
+    effectiveLaunchSummary.noRuntimePendingCount
+      ? `${effectiveLaunchSummary.noRuntimePendingCount} waiting for runtime`
       : '',
   ].filter(Boolean);
   const diagnosticSuffix = diagnosticParts.length > 0 ? ` - ${diagnosticParts.join(', ')}` : '';
-  if (launchSummary.confirmedCount === 0) {
+  if (effectiveLaunchSummary.confirmedCount === 0) {
     const allRuntimeAlive =
       runtimeProcessPendingCount > 0 && runtimeProcessPendingCount === expectedTeammateCount;
     return allRuntimeAlive
@@ -131,7 +144,7 @@ export function buildPendingBootstrapStatusMessage({
         : `${prefix} — teammates are still starting${diagnosticSuffix}`;
   }
 
-  return `${prefix} — ${launchSummary.confirmedCount}/${expectedTeammateCount} teammates made contact${runtimeProcessPendingCount > 0 ? `, ${runtimeProcessPendingCount} teammate${runtimeProcessPendingCount === 1 ? '' : 's'} online` : ''}${stillStartingCount > 0 ? `${runtimeProcessPendingCount > 0 ? ', ' : ', '}${stillStartingCount} still joining${diagnosticSuffix}` : ''}`;
+  return `${prefix} — ${effectiveLaunchSummary.confirmedCount}/${expectedTeammateCount} teammates made contact${runtimeProcessPendingCount > 0 ? `, ${runtimeProcessPendingCount} teammate${runtimeProcessPendingCount === 1 ? '' : 's'} online` : ''}${stillStartingCount > 0 ? `${runtimeProcessPendingCount > 0 ? ', ' : ', '}${stillStartingCount} still joining${diagnosticSuffix}` : ''}`;
 }
 
 export function buildAggregatePendingLaunchMessage({
@@ -191,7 +204,7 @@ export function buildAggregatePendingLaunchMessage({
     );
   });
   if (secondaryPendingMembers.length === 0) {
-    return buildPendingBootstrapStatusMessage({ prefix, run, launchSummary });
+    return buildPendingBootstrapStatusMessage({ prefix, run, launchSummary, snapshot });
   }
 
   return `${prefix} - waiting for secondary runtime lane: ${secondaryPendingMembers.join(', ')}`;

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchPendingMessage.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchPendingMessage.ts
@@ -100,7 +100,7 @@ export function buildPendingBootstrapStatusMessage({
     ? getPersistedLaunchMemberNames(snapshot).length
     : (run.expectedMembers?.length ?? 0);
   const permissionPendingCount = snapshot
-    ? countSnapshotPermissionPendingMembers(snapshot)
+    ? (effectiveLaunchSummary.permissionPendingCount ?? 0)
     : countRunPermissionPendingMembers(run);
   if (
     effectiveLaunchSummary.pendingCount > 0 &&

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningAsyncUtils.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningAsyncUtils.test.ts
@@ -23,12 +23,12 @@ describe('TeamProvisioningAsyncUtils', () => {
       }
     });
 
-    it('creates a missing directory recursively', async () => {
+    it('rejects a missing directory without creating it', async () => {
       const base = fs.mkdtempSync(path.join(os.tmpdir(), 'ensure-cwd-'));
       created.push(base);
       const nested = path.join(base, 'a', 'b', 'c');
-      await ensureCwdExists(nested);
-      expect(fs.statSync(nested).isDirectory()).toBe(true);
+      await expect(ensureCwdExists(nested)).rejects.toThrow();
+      expect(fs.existsSync(nested)).toBe(false);
     });
 
     it('is a no-op when the directory already exists', async () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchPendingMessage.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchPendingMessage.test.ts
@@ -158,6 +158,7 @@ describe('launch pending message helpers', () => {
           api: persistedMember('api', {
             launchState: 'runtime_pending_bootstrap',
             runtimeAlive: true,
+            livenessKind: 'runtime_process',
           }),
         },
       }),
@@ -165,6 +166,36 @@ describe('launch pending message helpers', () => {
 
     expect(message).toBe('Finishing launch — teammates online');
     expect(message).not.toContain('/0');
+  });
+
+  it('recomputes the contact count from the durable roster instead of a stale snapshot summary', () => {
+    const persisted = snapshot({
+      expectedMembers: ['api', 'web'],
+      members: {
+        api: persistedMember('api', { launchState: 'confirmed_alive', bootstrapConfirmed: true }),
+        web: persistedMember('web', { launchState: 'confirmed_alive', bootstrapConfirmed: true }),
+      },
+    });
+    const message = buildPendingBootstrapStatusMessage({
+      prefix: 'Finishing launch',
+      run: { expectedMembers: ['api', 'web'], memberSpawnStatuses: new Map() },
+      launchSummary: {
+        confirmedCount: 1,
+        pendingCount: 1,
+        failedCount: 0,
+        runtimeAlivePendingCount: 0,
+      },
+      snapshot: persisted,
+    });
+
+    expect(message).toBe('Finishing launch — 2/2 teammates made contact');
+    expect(
+      hasPendingLaunchMembers({
+        run: { expectedMembers: ['api', 'web'], memberSpawnStatuses: new Map() },
+        launchSummary: { pendingCount: 1 },
+        snapshot: persisted,
+      })
+    ).toBe(false);
   });
 
   it('reports pending secondary runtime lane members', () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchPendingMessage.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchPendingMessage.test.ts
@@ -112,6 +112,26 @@ describe('launch pending message helpers', () => {
     expect(message).toBe('Finishing launch — 1 teammate awaiting permission approval');
   });
 
+  it('uses persisted permission-pending state for snapshot approval copy', () => {
+    const message = buildPendingBootstrapStatusMessage({
+      prefix: 'Finishing launch',
+      run: { expectedMembers: [], memberSpawnStatuses: new Map() },
+      launchSummary: {
+        confirmedCount: 0,
+        pendingCount: 0,
+        runtimeAlivePendingCount: 0,
+      },
+      snapshot: snapshot({
+        expectedMembers: ['api'],
+        members: {
+          api: persistedMember('api', { launchState: 'permission_pending' as never }),
+        },
+      }),
+    });
+
+    expect(message).toBe('Finishing launch — 1 teammate awaiting permission approval');
+  });
+
   it('detects pending launch members from live or persisted expected member counts', () => {
     expect(
       hasPendingLaunchMembers({

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -514,6 +514,7 @@ export const CreateTeamDialog = ({
   const [prepareMessage, setPrepareMessage] = useState<string | null>(null);
   const [prepareWarnings, setPrepareWarnings] = useState<string[]>([]);
   const [prepareChecks, setPrepareChecks] = useState<ProvisioningProviderCheck[]>([]);
+  const [prepareRequested, setPrepareRequested] = useState(false);
   const [allowExperimentalLocalModels, setAllowExperimentalLocalModels] = useState(false);
   const {
     available: experimentalLocalModelOverrideAvailable,
@@ -684,6 +685,7 @@ export const CreateTeamDialog = ({
     setPrepareMessage(null);
     setPrepareWarnings([]);
     setPrepareChecks([]);
+    setPrepareRequested(false);
     setAllowExperimentalLocalModels(false);
     setConflictDismissed(false);
   };
@@ -813,6 +815,15 @@ export const CreateTeamDialog = ({
   );
   const launchAuthorityBlockers = launchGuard.blockers(launchTeam);
   const launchAuthorityBlocked = launchAuthorityBlockers.length > 0;
+  const launchPreflightCanResolveBlockers =
+    launchAuthorityBlockers.length > 0 &&
+    launchAuthorityBlockers.every(
+      (blocker) =>
+        blocker.providerId === 'opencode' &&
+        (blocker.providerStatus?.statusCheckOutcome === 'model_only' ||
+          (blocker.providerStatus?.statusCheckOutcome === 'pending' &&
+            blocker.providerStatus.statusCheckErrorCode === 'partial_response'))
+    );
   const workspaceTrustStatus = useWorkspaceTrustStatus({
     enabled: open && canCreate && launchTeam && selectedMemberProviders.includes('anthropic'),
     projectPath: effectiveCwd || null,
@@ -1204,7 +1215,7 @@ export const CreateTeamDialog = ({
   );
 
   useEffect(() => {
-    if (!open || !canCreate || !launchTeam) {
+    if (!open || !canCreate || !launchTeam || !prepareRequested) {
       cancelScheduledIdleSet(prepareIdleHandlesRef.current);
       prepareRequestSeqRef.current += 1;
       lastPrepareProviderSignatureByIdRef.current.clear();
@@ -1465,6 +1476,7 @@ export const CreateTeamDialog = ({
     open,
     canCreate,
     launchTeam,
+    prepareRequested,
     effectiveCwd,
     effectiveMemberDrafts,
     effectiveAnthropicRuntimeLimitContext,
@@ -2078,7 +2090,7 @@ export const CreateTeamDialog = ({
     isNameProvisioning ||
     !requestValidation.valid ||
     !!modelValidationError ||
-    launchGuard.blocked(launchTeam) ||
+    (launchAuthorityBlocked && !launchPreflightCanResolveBlockers) ||
     teammateRuntimeCompatibility.blocksSubmission ||
     worktreeGitBlocksSubmission;
 
@@ -2273,6 +2285,15 @@ export const CreateTeamDialog = ({
       setLocalError(modelValidationError);
       return;
     }
+    if (launchTeam && !prepareRequested && launchPreflightCanResolveBlockers) {
+      // A heavy provider/model probe may execute a real CLI turn. Do not run it
+      // merely because the dialog opened; the first launch click explicitly
+      // authorizes the bounded preflight, and a later click performs launch.
+      setPrepareRequested(true);
+      setPrepareState('loading');
+      setPrepareMessage(t('create.prepare.checkingProviders'));
+      return;
+    }
     if (launchGuard.reject(launchTeam, () => setLocalError(t('launch.prepare.failed')))) return;
     if (prepareBlocksCreate) {
       setLocalError(effectivePrepare.message ?? t('launch.prepare.failed'));
@@ -2439,8 +2460,8 @@ export const CreateTeamDialog = ({
   );
   const createActionLabel = isSubmitting
     ? t('create.actions.creating')
-    : launchTeam && (effectivePrepare.state === 'idle' || effectivePrepare.state === 'loading')
-      ? t('create.actions.skipPreflightAndCreate')
+    : launchTeam && prepareRequested && effectivePrepare.state === 'loading'
+      ? t('create.prepare.checkingProviders')
       : t('create.actions.create');
   return (
     <Dialog
@@ -2963,18 +2984,13 @@ export const CreateTeamDialog = ({
                 readyStatusText={t('create.prepare.readyStatus')}
               />
             ) : null}
-            {canCreate &&
-            launchTeam &&
-            (effectivePrepare.state === 'idle' || effectivePrepare.state === 'loading') ? (
+            {canCreate && launchTeam && prepareRequested && effectivePrepare.state === 'loading' ? (
               <>
                 <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
                   <span className="inline-block size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
                   <div>
                     <span>
-                      {effectivePrepare.message ??
-                        (effectivePrepare.state === 'idle'
-                          ? t('create.prepare.checkingProviders')
-                          : t('create.prepare.preparingEnvironment'))}
+                      {effectivePrepare.message ?? t('create.prepare.preparingEnvironment')}
                     </span>
                     <p className="mt-0.5 text-[10px] text-[var(--color-text-muted)] opacity-70">
                       {t('launch.prepare.preflight', {
@@ -3027,7 +3043,8 @@ export const CreateTeamDialog = ({
             ) : null}
             {canCreate &&
             launchTeam &&
-            effectivePrepare.state === 'ready' &&
+            effectivePrepare.state !== 'loading' &&
+            (!launchPreflightCanResolveBlockers || prepareRequested) &&
             launchAuthorityBlocked ? (
               <ProviderLaunchAuthorityNotice
                 id={CREATE_LAUNCH_AUTHORITY_BLOCKER_ID}
@@ -3124,7 +3141,9 @@ export const CreateTeamDialog = ({
                 size="lg"
                 className="min-w-32 text-sm"
                 aria-describedby={
-                  launchAuthorityBlocked && effectivePrepare.state === 'ready'
+                  launchAuthorityBlocked &&
+                  (!launchPreflightCanResolveBlockers || prepareRequested) &&
+                  effectivePrepare.state !== 'loading'
                     ? CREATE_LAUNCH_AUTHORITY_BLOCKER_ID
                     : undefined
                 }
@@ -3132,6 +3151,7 @@ export const CreateTeamDialog = ({
                   !canCreate ||
                   !draftLoaded ||
                   isSubmitting ||
+                  (prepareRequested && effectivePrepare.state === 'loading') ||
                   hasCreateFormErrors ||
                   prepareBlocksCreate
                 }

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -122,7 +122,11 @@ import {
 } from './projectPathOptions';
 import { loadProjectPathProjects, type ProjectPathProject } from './projectPathProjects';
 import { ProjectPathSelector } from './ProjectPathSelector';
-import { createLaunchGuard, useAuthorityGatedCliStatus } from './providerLaunchAuthority';
+import {
+  canResolveOpenCodeLaunchBlockers,
+  createLaunchGuard,
+  useAuthorityGatedCliStatus,
+} from './providerLaunchAuthority';
 import { ProviderLaunchAuthorityNotice } from './ProviderLaunchAuthorityNotice';
 import { buildProviderPrepareModelCacheKey } from './providerPrepareCacheKey';
 import {
@@ -500,12 +504,9 @@ export const CreateTeamDialog = ({
     isLoaded: draftLoaded,
     clearDraft,
   } = useCreateTeamDraft();
-
   const descriptionDraft = useDraftPersistence({ key: 'createTeam:description' });
   const promptDraft = useDraftPersistence({ key: 'createTeam:prompt' });
   const promptChipDraft = useChipDraftPersistence('createTeam:prompt:chips');
-
-  // ── Transient UI state (NOT persisted) ───────────────────────────────
   const [projects, setProjects] = useState<ProjectPathProject[]>([]);
   const [projectsLoading, setProjectsLoading] = useState(false);
   const [projectsError, setProjectsError] = useState<string | null>(null);
@@ -514,7 +515,6 @@ export const CreateTeamDialog = ({
   const [prepareMessage, setPrepareMessage] = useState<string | null>(null);
   const [prepareWarnings, setPrepareWarnings] = useState<string[]>([]);
   const [prepareChecks, setPrepareChecks] = useState<ProvisioningProviderCheck[]>([]);
-  const [prepareRequested, setPrepareRequested] = useState(false);
   const [allowExperimentalLocalModels, setAllowExperimentalLocalModels] = useState(false);
   const {
     available: experimentalLocalModelOverrideAvailable,
@@ -566,17 +566,13 @@ export const CreateTeamDialog = ({
   const [selectedEffort, setSelectedEffortRaw] = useState(getStoredCreateTeamEffort);
   const [selectedFastMode, setSelectedFastModeRaw] = useState<TeamFastMode>(getStoredTeamFastMode);
   const [anthropicRuntimeNotice, setAnthropicRuntimeNotice] = useState<string | null>(null);
-
-  // Advanced CLI section state (use teamName-derived key for localStorage)
   const advancedKey = useMemo(() => sanitizeTeamName(teamName.trim()) || '_new_', [teamName]);
   const [worktreeEnabled, setWorktreeEnabledRaw] = useState(false);
   const [worktreeName, setWorktreeNameRaw] = useState('');
   const [customArgs, setCustomArgsRaw] = useState('');
-
   useEffect(() => {
     migrateLegacyCreateTeamPreferences();
   }, []);
-
   useEffect(() => {
     if (!open) {
       setProviderSettingsProviderId(null);
@@ -685,7 +681,6 @@ export const CreateTeamDialog = ({
     setPrepareMessage(null);
     setPrepareWarnings([]);
     setPrepareChecks([]);
-    setPrepareRequested(false);
     setAllowExperimentalLocalModels(false);
     setConflictDismissed(false);
   };
@@ -760,7 +755,8 @@ export const CreateTeamDialog = ({
       ])
     );
   }, [members, multimodelEnabled, selectedProviderId, soloTeam, syncModelsWithLead]);
-  // Clear stale provisioning error when dialog opens
+  const openCodeCatalogEnabled =
+    open && launchTeam && multimodelEnabled && selectedMemberProviders.includes('opencode');
   useEffect(() => {
     if (open && dialogTeamNameKey) {
       clearProvisioningError?.(dialogTeamNameKey);
@@ -774,14 +770,8 @@ export const CreateTeamDialog = ({
     openCodeProviderScopedStatusBySourceId,
   } = useOpenCodeProviderScopedDialogModelState({
     projectPath: effectiveCwd,
-    catalogEnabled:
-      open && launchTeam && multimodelEnabled && selectedMemberProviders.includes('opencode'),
-    passiveStatusPrefetchEnabled:
-      open &&
-      launchTeam &&
-      prepareRequested &&
-      multimodelEnabled &&
-      selectedMemberProviders.includes('opencode'),
+    catalogEnabled: openCodeCatalogEnabled,
+    passiveStatusPrefetchEnabled: prepareState !== 'idle' && openCodeCatalogEnabled,
     passiveProviderStatus: projectScopedOpenCodeStatus,
     members,
     syncModelsWithLead,
@@ -820,14 +810,7 @@ export const CreateTeamDialog = ({
   const launchAuthorityBlockers = launchGuard.blockers(launchTeam);
   const launchAuthorityBlocked = launchAuthorityBlockers.length > 0;
   const launchPreflightCanResolveBlockers =
-    launchAuthorityBlockers.length > 0 &&
-    launchAuthorityBlockers.every(
-      (blocker) =>
-        blocker.providerId === 'opencode' &&
-        (blocker.providerStatus?.statusCheckOutcome === 'model_only' ||
-          (blocker.providerStatus?.statusCheckOutcome === 'pending' &&
-            blocker.providerStatus.statusCheckErrorCode === 'partial_response'))
-    );
+    canResolveOpenCodeLaunchBlockers(launchAuthorityBlockers);
   const workspaceTrustStatus = useWorkspaceTrustStatus({
     enabled: open && canCreate && launchTeam && selectedMemberProviders.includes('anthropic'),
     projectPath: effectiveCwd || null,
@@ -1219,7 +1202,7 @@ export const CreateTeamDialog = ({
   );
 
   useEffect(() => {
-    if (!open || !canCreate || !launchTeam || !prepareRequested) {
+    if (!open || !canCreate || !launchTeam || prepareState === 'idle') {
       cancelScheduledIdleSet(prepareIdleHandlesRef.current);
       prepareRequestSeqRef.current += 1;
       lastPrepareProviderSignatureByIdRef.current.clear();
@@ -1480,7 +1463,7 @@ export const CreateTeamDialog = ({
     open,
     canCreate,
     launchTeam,
-    prepareRequested,
+    prepareState,
     effectiveCwd,
     effectiveMemberDrafts,
     effectiveAnthropicRuntimeLimitContext,
@@ -2289,11 +2272,7 @@ export const CreateTeamDialog = ({
       setLocalError(modelValidationError);
       return;
     }
-    if (launchTeam && !prepareRequested && launchPreflightCanResolveBlockers) {
-      // A heavy provider/model probe may execute a real CLI turn. Do not run it
-      // merely because the dialog opened; the first launch click explicitly
-      // authorizes the bounded preflight, and a later click performs launch.
-      setPrepareRequested(true);
+    if (launchTeam && prepareState === 'idle' && launchPreflightCanResolveBlockers) {
       setPrepareState('loading');
       setPrepareMessage(t('create.prepare.checkingProviders'));
       return;
@@ -2464,7 +2443,7 @@ export const CreateTeamDialog = ({
   );
   const createActionLabel = isSubmitting
     ? t('create.actions.creating')
-    : launchTeam && prepareRequested && effectivePrepare.state === 'loading'
+    : launchTeam && prepareState === 'loading'
       ? t('create.prepare.checkingProviders')
       : t('create.actions.create');
   return (
@@ -2988,7 +2967,7 @@ export const CreateTeamDialog = ({
                 readyStatusText={t('create.prepare.readyStatus')}
               />
             ) : null}
-            {canCreate && launchTeam && prepareRequested && effectivePrepare.state === 'loading' ? (
+            {canCreate && launchTeam && prepareState === 'loading' ? (
               <>
                 <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
                   <span className="inline-block size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
@@ -3048,7 +3027,7 @@ export const CreateTeamDialog = ({
             {canCreate &&
             launchTeam &&
             effectivePrepare.state !== 'loading' &&
-            (!launchPreflightCanResolveBlockers || prepareRequested) &&
+            (!launchPreflightCanResolveBlockers || prepareState !== 'idle') &&
             launchAuthorityBlocked ? (
               <ProviderLaunchAuthorityNotice
                 id={CREATE_LAUNCH_AUTHORITY_BLOCKER_ID}
@@ -3146,7 +3125,7 @@ export const CreateTeamDialog = ({
                 className="min-w-32 text-sm"
                 aria-describedby={
                   launchAuthorityBlocked &&
-                  (!launchPreflightCanResolveBlockers || prepareRequested) &&
+                  (!launchPreflightCanResolveBlockers || prepareState !== 'idle') &&
                   effectivePrepare.state !== 'loading'
                     ? CREATE_LAUNCH_AUTHORITY_BLOCKER_ID
                     : undefined
@@ -3155,7 +3134,7 @@ export const CreateTeamDialog = ({
                   !canCreate ||
                   !draftLoaded ||
                   isSubmitting ||
-                  (prepareRequested && effectivePrepare.state === 'loading') ||
+                  prepareState === 'loading' ||
                   hasCreateFormErrors ||
                   prepareBlocksCreate
                 }

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -777,7 +777,11 @@ export const CreateTeamDialog = ({
     catalogEnabled:
       open && launchTeam && multimodelEnabled && selectedMemberProviders.includes('opencode'),
     passiveStatusPrefetchEnabled:
-      open && multimodelEnabled && selectedMemberProviders.includes('opencode'),
+      open &&
+      launchTeam &&
+      prepareRequested &&
+      multimodelEnabled &&
+      selectedMemberProviders.includes('opencode'),
     passiveProviderStatus: projectScopedOpenCodeStatus,
     members,
     syncModelsWithLead,

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -398,6 +398,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   const [prepareMessage, setPrepareMessage] = useState<string | null>(null);
   const [prepareWarnings, setPrepareWarnings] = useState<string[]>([]);
   const [prepareChecks, setPrepareChecks] = useState<ProvisioningProviderCheck[]>([]);
+  const [prepareRequested, setPrepareRequested] = useState(false);
   const [allowExperimentalLocalModels, setAllowExperimentalLocalModels] = useState(false);
   const providerReadyById = useMemo(
     () => getProvisioningProviderReadyById(prepareChecks),
@@ -818,6 +819,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     setPrepareMessage(null);
     setPrepareWarnings([]);
     setPrepareChecks([]);
+    setPrepareRequested(false);
     setAllowExperimentalLocalModels(false);
     setCwdMode('project');
     setSelectedProjectPath('');
@@ -1629,7 +1631,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
 
   // Warm up CLI for the currently selected working directory (launch mode only).
   useEffect(() => {
-    if (!open || !isLaunchMode) {
+    if (!open || !isLaunchMode || !prepareRequested) {
       prepareRequestSeqRef.current += 1;
       lastPrepareProviderSignatureByIdRef.current.clear();
       prepareProviderRequestSeqByIdRef.current.clear();
@@ -1857,6 +1859,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   }, [
     open,
     isLaunchMode,
+    prepareRequested,
     effectiveCwd,
     effectiveAnthropicRuntimeLimitContext,
     prepareProviderInvalidationEpochById,
@@ -2281,7 +2284,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       setLocalError(modelValidationError);
       return;
     }
-    if (launchGuard.reject(isLaunchMode, () => setLocalError(t('launch.prepare.failed')))) return;
     if (prepareBlocksLaunch) {
       setLocalError(effectivePrepare.message ?? t('launch.prepare.failed'));
       return;
@@ -2312,6 +2314,15 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
         return;
       }
     }
+    if (isLaunchMode && !prepareRequested) {
+      // Preparing a provider can execute a real CLI turn. Require the first
+      // launch click as explicit user confirmation before starting that work.
+      setPrepareRequested(true);
+      setPrepareState('loading');
+      setPrepareMessage(t('launch.prepare.checkingProviders'));
+      return;
+    }
+    if (launchGuard.reject(isLaunchMode, () => setLocalError(t('launch.prepare.failed')))) return;
     setLocalError(null);
     setIsSubmitting(true);
 
@@ -2463,7 +2474,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       launchInFlight ||
       validationErrors.length > 0 ||
       !!modelValidationError ||
-      launchGuard.blocked(isLaunchMode) ||
+      (isLaunchMode && prepareRequested && launchGuard.blocked(isLaunchMode)) ||
       hasInvalidLaunchMemberNames ||
       hasDuplicateLaunchMemberNames ||
       prepareBlocksLaunch ||
@@ -3155,7 +3166,8 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                 readyStatusText="Ready"
                 className="mb-2"
               />
-              {effectivePrepare.state === 'idle' || effectivePrepare.state === 'loading' ? (
+              {prepareRequested &&
+              (effectivePrepare.state === 'idle' || effectivePrepare.state === 'loading') ? (
                 <>
                   <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
                     <span className="inline-block size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
@@ -3309,7 +3321,10 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
             isLaunchMode={isLaunchMode}
             disabled={isDisabled}
             describedBy={
-              isLaunchMode && launchAuthorityBlocked && effectivePrepare.state === 'ready'
+              isLaunchMode &&
+              prepareRequested &&
+              launchAuthorityBlocked &&
+              effectivePrepare.state === 'ready'
                 ? LAUNCH_AUTHORITY_BLOCKER_ID
                 : undefined
             }

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -518,7 +518,11 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     catalogEnabled:
       open && isLaunchMode && multimodelEnabled && requestedMemberProviders.includes('opencode'),
     passiveStatusPrefetchEnabled:
-      open && multimodelEnabled && requestedMemberProviders.includes('opencode'),
+      open &&
+      isLaunchMode &&
+      prepareRequested &&
+      multimodelEnabled &&
+      requestedMemberProviders.includes('opencode'),
     passiveProviderStatus: projectScopedOpenCodeStatus,
     members: membersDrafts,
     syncModelsWithLead,

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -2455,6 +2455,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   const isDisabled = isLaunchMode
     ? isSubmitting ||
       launchInFlight ||
+      prepareState === 'loading' ||
       validationErrors.length > 0 ||
       !!modelValidationError ||
       (isLaunchMode && prepareState !== 'idle' && launchGuard.blocked(isLaunchMode)) ||

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -385,11 +385,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   });
   const [selectedFastMode, setSelectedFastModeRaw] = useState<TeamFastMode>(getStoredTeamFastMode);
   const [anthropicRuntimeNotice, setAnthropicRuntimeNotice] = useState<string | null>(null);
-
-  // ---------------------------------------------------------------------------
-  // Launch-only state
-  // ---------------------------------------------------------------------------
-
   const [limitContext, setLimitContextRaw] = useState(
     () => localStorage.getItem('team:lastLimitContext') === 'true'
   );
@@ -398,7 +393,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   const [prepareMessage, setPrepareMessage] = useState<string | null>(null);
   const [prepareWarnings, setPrepareWarnings] = useState<string[]>([]);
   const [prepareChecks, setPrepareChecks] = useState<ProvisioningProviderCheck[]>([]);
-  const [prepareRequested, setPrepareRequested] = useState(false);
   const [allowExperimentalLocalModels, setAllowExperimentalLocalModels] = useState(false);
   const providerReadyById = useMemo(
     () => getProvisioningProviderReadyById(prepareChecks),
@@ -421,14 +415,12 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   const [savedLaunchProviderBackendId, setSavedLaunchProviderBackendId] = useState<string | null>(
     null
   );
-
   useEffect(() => {
     if (!open) {
       setProviderSettingsProviderId(null);
       hydrationRef.current = { key: null, dirty: false, rosterDirty: false };
     }
   }, [open]);
-
   // Advanced CLI section state (with localStorage persistence)
   const [worktreeEnabled, setWorktreeEnabledRaw] = useState(
     () =>
@@ -441,11 +433,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   const [customArgs, setCustomArgsRaw] = useState(
     () => localStorage.getItem(`team:lastCustomArgs:${effectiveTeamName}`) ?? ''
   );
-
-  // ---------------------------------------------------------------------------
-  // Schedule-only state
-  // ---------------------------------------------------------------------------
-
   const [schedLabel, setSchedLabel] = useState('');
   const [schedExpanded, setSchedExpanded] = useState(true);
   const [cronExpression, setCronExpression] = useState('0 9 * * 1-5');
@@ -507,6 +494,8 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
           ),
     [membersDrafts, multimodelEnabled, selectedProviderId, syncModelsWithLead]
   );
+  const openCodeCatalogEnabled =
+    open && isLaunchMode && multimodelEnabled && requestedMemberProviders.includes('opencode');
   const {
     effectiveMemberDrafts,
     handleOpenCodeProviderScopedStatusChange,
@@ -515,14 +504,8 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     openCodeProviderScopedStatusBySourceId,
   } = useOpenCodeProviderScopedDialogModelState({
     projectPath: effectiveCwd,
-    catalogEnabled:
-      open && isLaunchMode && multimodelEnabled && requestedMemberProviders.includes('opencode'),
-    passiveStatusPrefetchEnabled:
-      open &&
-      isLaunchMode &&
-      prepareRequested &&
-      multimodelEnabled &&
-      requestedMemberProviders.includes('opencode'),
+    catalogEnabled: openCodeCatalogEnabled,
+    passiveStatusPrefetchEnabled: prepareState !== 'idle' && openCodeCatalogEnabled,
     passiveProviderStatus: projectScopedOpenCodeStatus,
     members: membersDrafts,
     syncModelsWithLead,
@@ -823,7 +806,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     setPrepareMessage(null);
     setPrepareWarnings([]);
     setPrepareChecks([]);
-    setPrepareRequested(false);
     setAllowExperimentalLocalModels(false);
     setCwdMode('project');
     setSelectedProjectPath('');
@@ -1635,7 +1617,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
 
   // Warm up CLI for the currently selected working directory (launch mode only).
   useEffect(() => {
-    if (!open || !isLaunchMode || !prepareRequested) {
+    if (!open || !isLaunchMode || prepareState === 'idle') {
       prepareRequestSeqRef.current += 1;
       lastPrepareProviderSignatureByIdRef.current.clear();
       prepareProviderRequestSeqByIdRef.current.clear();
@@ -1863,7 +1845,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   }, [
     open,
     isLaunchMode,
-    prepareRequested,
+    prepareState,
     effectiveCwd,
     effectiveAnthropicRuntimeLimitContext,
     prepareProviderInvalidationEpochById,
@@ -2318,10 +2300,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
         return;
       }
     }
-    if (isLaunchMode && !prepareRequested) {
-      // Preparing a provider can execute a real CLI turn. Require the first
-      // launch click as explicit user confirmation before starting that work.
-      setPrepareRequested(true);
+    if (isLaunchMode && prepareState === 'idle') {
       setPrepareState('loading');
       setPrepareMessage(t('launch.prepare.checkingProviders'));
       return;
@@ -2478,7 +2457,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       launchInFlight ||
       validationErrors.length > 0 ||
       !!modelValidationError ||
-      (isLaunchMode && prepareRequested && launchGuard.blocked(isLaunchMode)) ||
+      (isLaunchMode && prepareState !== 'idle' && launchGuard.blocked(isLaunchMode)) ||
       hasInvalidLaunchMemberNames ||
       hasDuplicateLaunchMemberNames ||
       prepareBlocksLaunch ||
@@ -3170,8 +3149,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                 readyStatusText="Ready"
                 className="mb-2"
               />
-              {prepareRequested &&
-              (effectivePrepare.state === 'idle' || effectivePrepare.state === 'loading') ? (
+              {prepareState === 'loading' ? (
                 <>
                   <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
                     <span className="inline-block size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
@@ -3326,7 +3304,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
             disabled={isDisabled}
             describedBy={
               isLaunchMode &&
-              prepareRequested &&
+              prepareState !== 'idle' &&
               launchAuthorityBlocked &&
               effectivePrepare.state === 'ready'
                 ? LAUNCH_AUTHORITY_BLOCKER_ID

--- a/src/renderer/components/team/dialogs/providerLaunchAuthority.ts
+++ b/src/renderer/components/team/dialogs/providerLaunchAuthority.ts
@@ -31,6 +31,21 @@ export interface ProviderLaunchGuard {
   reject(enabled: boolean, onRejected: () => void): boolean;
 }
 
+export function canResolveOpenCodeLaunchBlockers(
+  blockers: readonly ProviderLaunchBlocker[]
+): boolean {
+  return (
+    blockers.length > 0 &&
+    blockers.every(
+      ({ providerId, providerStatus }) =>
+        providerId === 'opencode' &&
+        (providerStatus?.statusCheckOutcome === 'model_only' ||
+          (providerStatus?.statusCheckOutcome === 'pending' &&
+            providerStatus.statusCheckErrorCode === 'partial_response'))
+    )
+  );
+}
+
 function getProviderStatusDetail(provider: CliProviderStatus): string | null {
   if (provider.modelCatalogRefreshState === 'loading') {
     return null;

--- a/src/renderer/components/team/dialogs/providerLaunchAuthority.ts
+++ b/src/renderer/components/team/dialogs/providerLaunchAuthority.ts
@@ -32,6 +32,9 @@ export interface ProviderLaunchGuard {
 }
 
 function getProviderStatusDetail(provider: CliProviderStatus): string | null {
+  if (provider.modelCatalogRefreshState === 'loading') {
+    return null;
+  }
   return (
     provider.detailMessage?.trim() ||
     provider.statusMessage?.trim() ||
@@ -96,9 +99,7 @@ export function createLaunchGuard(
         return [];
       }
       const scopedFailure =
-        providerId === 'opencode'
-          ? getOpenCodeScopedPreparationFailure(openCodeEvidence)
-          : null;
+        providerId === 'opencode' ? getOpenCodeScopedPreparationFailure(openCodeEvidence) : null;
       if (scopedFailure) {
         return [
           {

--- a/src/renderer/hooks/useEffectiveCliProviderStatus.ts
+++ b/src/renderer/hooks/useEffectiveCliProviderStatus.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useReducer } from 'react';
 import {
   isCodexAccountSnapshotPending,
   mergeCodexCliStatusWithSnapshot,
+  mergeCodexProviderStatusWithSnapshot,
   useCodexAccountSnapshot,
 } from '@features/codex-account/renderer';
 import { useStore } from '@renderer/store';
@@ -16,6 +17,7 @@ import {
   isProviderModelCatalogExactReady,
 } from '@shared/utils/providerStatusAuthority';
 
+import type { CodexAccountSnapshotDto } from '@features/codex-account/contracts';
 import type { CliInstallationStatus, CliProviderId, CliProviderStatus } from '@shared/types';
 
 export const MAX_BROWSER_TIMEOUT_MS = 2_147_483_647;
@@ -135,13 +137,21 @@ export function resolveProjectScopedProviderStatus(
   providerId: CliProviderId,
   scopedProviderStatus: CliProviderStatus | null,
   globalProviderStatus: CliProviderStatus | null,
-  now: number = Date.now()
+  now: number = Date.now(),
+  codexSnapshot: CodexAccountSnapshotDto | null = null
 ): CliProviderStatus | null {
   if (scopedProviderStatus?.providerId === providerId) {
-    const resolved = reconcileCliStatus(undefined, scopedProviderStatus);
+    // The scoped runtime remains the launch authority. The app-managed Codex
+    // snapshot is shared connection evidence and must be reflected here too,
+    // otherwise the global Ready pill and scoped launch dialog disagree.
+    const scopedWithAccount =
+      providerId === 'codex'
+        ? mergeCodexProviderStatusWithSnapshot(scopedProviderStatus, codexSnapshot)
+        : scopedProviderStatus;
+    const resolved = reconcileCliStatus(undefined, scopedWithAccount);
     return {
       ...resolved,
-      capabilities: gateProviderLaunch(scopedProviderStatus, now).capabilities,
+      capabilities: gateProviderLaunch(scopedWithAccount, now).capabilities,
     };
   }
   if (!globalProviderStatus || globalProviderStatus.providerId !== providerId) {
@@ -226,7 +236,8 @@ export function useEffectiveCliProviderStatus(
       providerId,
       scopedProviderStatus,
       globalProvider ?? null,
-      authorityNow
+      authorityNow,
+      codexAccount.snapshot
     );
     if (!projectProvider) {
       return withCodexSnapshot;

--- a/src/renderer/store/slices/cliInstallerSlice.ts
+++ b/src/renderer/store/slices/cliInstallerSlice.ts
@@ -1275,11 +1275,25 @@ export const createCliInstallerSlice: StateCreator<AppState, [], [], CliInstalle
       }
 
       try {
-        const responseProviderStatus = verifyModels
+        let responseProviderStatus = verifyModels
           ? await api.cliInstaller.verifyProviderModels(providerId)
           : projectPath
             ? await api.cliInstaller.getProviderStatus(providerId, { projectPath })
             : await api.cliInstaller.getProviderStatus(providerId);
+        // OpenCode's app-server can return a structurally valid but partial
+        // status while its catalog is settling. Recheck once in the same
+        // request, but do not retry the intentional model-only fallback or
+        // any other provider/error indefinitely.
+        if (
+          providerId === 'opencode' &&
+          !verifyModels &&
+          responseProviderStatus?.statusCheckErrorCode === 'partial_response' &&
+          responseProviderStatus.statusCheckOutcome !== 'model_only'
+        ) {
+          responseProviderStatus = projectPath
+            ? await api.cliInstaller.getProviderStatus(providerId, { projectPath })
+            : await api.cliInstaller.getProviderStatus(providerId);
+        }
         const responseMatchesProvider = responseProviderStatus?.providerId === providerId;
         const providerStatus =
           responseMatchesProvider && responseProviderStatus

--- a/src/renderer/store/slices/cliInstallerStatusReconciliation.ts
+++ b/src/renderer/store/slices/cliInstallerStatusReconciliation.ts
@@ -45,6 +45,13 @@ function mergeProviderCatalogCache(
     retainedCatalog && launchUnproved
       ? { ...retainedCatalog, status: 'stale' as const }
       : retainedCatalog;
+  // A partial response means the refresh is still in flight from the user's
+  // perspective. Keep the retained catalog visibly loading instead of turning
+  // that intermediate snapshot into a false error (notably on Anthropic).
+  const catalogRefreshPending =
+    incomingProvider.modelCatalogRefreshState === 'loading' ||
+    incomingProvider.statusCheckOutcome === 'pending' ||
+    incomingProvider.statusCheckErrorCode === 'partial_response';
   return {
     ...incomingProvider,
     supported: incomingProvider.supported,
@@ -76,7 +83,7 @@ function mergeProviderCatalogCache(
     modelCatalog,
     modelCatalogRefreshState:
       modelCatalog && launchUnproved
-        ? incomingProvider.modelCatalogRefreshState === 'loading'
+        ? catalogRefreshPending
           ? 'loading'
           : 'error'
         : (incomingProvider.modelCatalogRefreshState ?? currentProvider.modelCatalogRefreshState),

--- a/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -541,11 +541,11 @@ describe('ClaudeMultimodelBridgeService', () => {
   );
 
   it.each(['aggregate', 'single', 'project'] as const)(
-    'keeps OpenCode launch fail-closed and summary-only via %s',
+    'keeps OpenCode launch fail-closed via %s',
     async (entrypoint) => {
       execCliMock.mockImplementation((_binaryPath, args) => {
         const requestedId = args[args.indexOf('--provider') + 1] as CliProviderId;
-        if (!args.includes('--summary')) {
+        if (!args.includes('--summary') && entrypoint !== 'project') {
           return Promise.reject(new Error(`Unexpected non-summary call for ${requestedId}`));
         }
 
@@ -600,15 +600,16 @@ describe('ClaudeMultimodelBridgeService', () => {
         (call) => call[1][call[1].indexOf('--provider') + 1] === 'opencode'
       );
       expect(opencodeCalls).toHaveLength(1);
-      expect(opencodeCalls[0][1]).toEqual([
-        'runtime',
-        'status',
-        '--json',
-        '--provider',
-        'opencode',
-        '--summary',
-      ]);
-      expect(execCliMock.mock.calls.every((call) => call[1].includes('--summary'))).toBe(true);
+      expect(opencodeCalls[0][1]).toEqual(
+        entrypoint === 'project'
+          ? ['runtime', 'status', '--json', '--provider', 'opencode']
+          : ['runtime', 'status', '--json', '--provider', 'opencode', '--summary']
+      );
+      expect(
+        execCliMock.mock.calls.every(
+          (call) => entrypoint === 'project' || call[1].includes('--summary')
+        )
+      ).toBe(true);
       if (entrypoint === 'project') {
         expect(opencodeCalls[0][2]?.cwd).toBe(projectPath);
       } else {
@@ -1173,7 +1174,7 @@ describe('ClaudeMultimodelBridgeService', () => {
 
     expect(execCliMock).toHaveBeenCalledWith(
       '/mock/agent_teams_orchestrator',
-      ['runtime', 'status', '--json', '--provider', 'opencode', '--summary'],
+      ['runtime', 'status', '--json', '--provider', 'opencode'],
       // The service resolves the project cwd before spawning the catalog probe.
       expect.objectContaining({ cwd: path.resolve('/tmp/local-model-project') })
     );
@@ -2134,7 +2135,10 @@ describe('ClaudeMultimodelBridgeService', () => {
 
     execCliMock.mockImplementation((_binaryPath, args, options) => {
       const normalizedArgs = Array.isArray(args) ? args.join(' ') : '';
-      if (normalizedArgs === 'runtime status --json --provider opencode --summary') {
+      if (
+        normalizedArgs === 'runtime status --json --provider opencode --summary' ||
+        normalizedArgs === 'runtime status --json --provider opencode'
+      ) {
         return Promise.resolve({
           stdout: JSON.stringify(
             buildStatus(options?.cwd === '/tmp/scoped-project' ? 'scoped' : 'global')
@@ -2170,7 +2174,7 @@ describe('ClaudeMultimodelBridgeService', () => {
     expect(scopedStatus.statusMessage).toBe('scoped');
     expect(execCliMock.mock.calls.map((call) => call[1])).toEqual([
       ['runtime', 'status', '--json', '--provider', 'opencode', '--summary'],
-      ['runtime', 'status', '--json', '--provider', 'opencode', '--summary'],
+      ['runtime', 'status', '--json', '--provider', 'opencode'],
     ]);
     expect(execCliMock.mock.calls.map((call) => call[2]?.cwd ?? null)).toEqual([
       null,

--- a/test/main/services/runtime/ClaudeMultimodelStatusCatalogCore.test.ts
+++ b/test/main/services/runtime/ClaudeMultimodelStatusCatalogCore.test.ts
@@ -345,7 +345,6 @@ describe('ClaudeMultimodelBridgeService status/catalog core', () => {
       '--json',
       '--provider',
       'opencode',
-      '--summary',
     ]);
     expect(result).toMatchObject({
       authenticated: false,

--- a/test/main/services/team/Issue443DesktopContract.safe-e2e.test.ts
+++ b/test/main/services/team/Issue443DesktopContract.safe-e2e.test.ts
@@ -224,7 +224,6 @@ describe('issue #443 Desktop real child-process wire contract', () => {
       '--json',
       '--provider',
       'opencode',
-      '--summary',
     ]);
     expect(traces[1].argv).toContain('deepinfra');
     assertProcessesExited(traces);

--- a/test/main/services/team/Issue443DesktopContractFakeExecutable.mjs
+++ b/test/main/services/team/Issue443DesktopContractFakeExecutable.mjs
@@ -108,9 +108,9 @@ else process.stdout.write(outputRaw);
 trace({ ...baseTrace, proofValidation, outputRaw, sideEffectCommitted: envelope.command === 'opencode.launchTeam' });
 
 function runProviderStatusCommand() {
-  const expected = ['runtime', 'status', '--json', '--provider', 'opencode', '--summary'];
+  const expected = ['runtime', 'status', '--json', '--provider', 'opencode'];
   if (JSON.stringify(argv) !== JSON.stringify(expected)) {
-    rejectCommand('only passive provider-scoped summary status is allowed');
+    rejectCommand('only project-scoped provider status is allowed');
   }
   const providerIndex = argv.indexOf('--provider');
   const provider = providerIndex < 0 ? null : argv[providerIndex + 1];

--- a/test/main/services/team/TeamLaunchSummaryProjection.test.ts
+++ b/test/main/services/team/TeamLaunchSummaryProjection.test.ts
@@ -2,11 +2,43 @@ import { describe, expect, it } from 'vitest';
 
 import {
   choosePreferredLaunchStateSummary,
+  createLaunchStateSummary,
   createPersistedLaunchSummaryProjection,
   shouldSuppressLegacyLaunchArtifactHeuristic,
 } from '../../../../src/main/services/team/TeamLaunchSummaryProjection';
 
 describe('TeamLaunchSummaryProjection', () => {
+  it('recomputes counts from durable member states instead of a stale summary cache', () => {
+    const snapshot = {
+      version: 2,
+      teamName: 'fresh-roster-team',
+      updatedAt: '2026-09-03T20:00:00.000Z',
+      launchPhase: 'active',
+      expectedMembers: ['alice', 'bob', 'cara'],
+      members: {
+        alice: { name: 'alice', launchState: 'confirmed_alive' },
+        bob: { name: 'bob', launchState: 'confirmed_alive' },
+        cara: { name: 'cara', launchState: 'confirmed_alive' },
+      },
+      summary: {
+        confirmedCount: 2,
+        pendingCount: 1,
+        failedCount: 0,
+        runtimeAlivePendingCount: 1,
+      },
+      teamLaunchState: 'partial_pending',
+    } as never;
+
+    expect(createLaunchStateSummary(snapshot)).toMatchObject({
+      expectedMemberCount: 3,
+      confirmedCount: 3,
+      confirmedMemberCount: 3,
+      pendingCount: 0,
+      failedCount: 0,
+      teamLaunchState: 'clean_success',
+    });
+  });
+
   it('ignores stale terminal bootstrap-only pending summaries when canonical launch truth is missing', () => {
     const summary = choosePreferredLaunchStateSummary({
       bootstrapSnapshot: {

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -3529,6 +3529,7 @@ describe('LaunchTeamDialog', () => {
     });
 
     expect(vi.mocked(runProviderPrepareDiagnostics)).toHaveBeenCalledTimes(1);
+    expect(initialLaunchButton?.hasAttribute('disabled')).toBe(true);
 
     storeState.cliStatus = {
       flavor: 'agent_teams_orchestrator',

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -3518,6 +3518,7 @@ describe('LaunchTeamDialog', () => {
     });
 
     expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
+    expect(fetchCliProviderStatus).not.toHaveBeenCalled();
     const initialLaunchButton = Array.from(host.querySelectorAll('button')).find(
       (button) => button.textContent === 'Launch team'
     );
@@ -4037,6 +4038,7 @@ describe('LaunchTeamDialog', () => {
     });
 
     expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
+    expect(fetchCliProviderStatus).not.toHaveBeenCalled();
 
     await act(async () => {
       await renderDialog();
@@ -4113,6 +4115,18 @@ describe('LaunchTeamDialog', () => {
       submitButton?.click();
       await flush();
     });
+    // The first click explicitly authorizes the bounded provider preflight when
+    // the project-scoped OpenCode authority is still unresolved.
+    if (!onCreate.mock.calls.length) {
+      await act(async () => {
+        await flush();
+      });
+      const retrySubmitButton = Array.from(host.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Create'
+      );
+      retrySubmitButton?.click();
+      await flush();
+    }
     expect(onCreate).toHaveBeenCalledOnce();
 
     await act(async () => {

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -622,12 +622,15 @@ async function flush(): Promise<void> {
 async function confirmLaunchPreflight(
   host: HTMLElement,
   label: 'Launch team' | 'Relaunch team' = 'Launch team'
-): Promise<HTMLButtonElement | undefined> {
+): Promise<HTMLButtonElement> {
   const button = Array.from(host.querySelectorAll('button')).find(
     (candidate) => candidate.textContent === label
   ) as HTMLButtonElement | undefined;
+  if (!button) {
+    throw new Error(`Expected "${label}" button.`);
+  }
   await act(async () => {
-    button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     await flush();
   });
   for (let attempt = 0; attempt < 4; attempt += 1) {

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -619,6 +619,26 @@ async function flush(): Promise<void> {
   await Promise.resolve();
 }
 
+async function confirmLaunchPreflight(
+  host: HTMLElement,
+  label: 'Launch team' | 'Relaunch team' = 'Launch team'
+): Promise<HTMLButtonElement | undefined> {
+  const button = Array.from(host.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent === label
+  ) as HTMLButtonElement | undefined;
+  await act(async () => {
+    button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await flush();
+  });
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await flush();
+    });
+  }
+  return button;
+}
+
 function createAuthoritativeProviderStatus(
   providerId: CliProviderId,
   models: string[]
@@ -751,6 +771,8 @@ describe('LaunchTeamDialog', () => {
     storeState.cliProviderStatusByScope = {};
     storeState.launchParamsByTeam = {};
     createTeamDraftMock.state.members[0].model = 'opencode/big-pickle';
+    createTeamDraftMock.state.members[1].providerId = 'codex';
+    createTeamDraftMock.state.members[1].model = 'gpt-5.5';
     createTeamDraftMock.state.cwdMode = 'project';
     createTeamDraftMock.state.selectedProjectPath = '/tmp/project';
     createTeamDraftMock.state.customCwd = '';
@@ -1147,6 +1169,8 @@ describe('LaunchTeamDialog', () => {
       await flush();
     });
 
+    await confirmLaunchPreflight(host);
+
     expect(teamRosterEditorSectionMock.lastProps?.members).toEqual([
       expect.objectContaining({
         name: 'alice',
@@ -1158,12 +1182,14 @@ describe('LaunchTeamDialog', () => {
       vi
         .mocked(runProviderPrepareDiagnostics)
         .mock.calls.find((call) => call[0]?.providerId === 'opencode')?.[0]?.selectedModelChecks
-    ).toEqual([
-      expect.objectContaining({
-        providerId: 'opencode',
-        model: localModel,
-      }),
-    ]);
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          providerId: 'opencode',
+          model: localModel,
+        }),
+      ])
+    );
 
     await act(async () => {
       root.unmount();
@@ -1468,6 +1494,8 @@ describe('LaunchTeamDialog', () => {
       await flush();
       await flush();
     });
+
+    await confirmLaunchPreflight(host);
 
     const preparedProviderIds = vi
       .mocked(runProviderPrepareDiagnostics)
@@ -1819,9 +1847,13 @@ describe('LaunchTeamDialog', () => {
   it('uses the project-scoped OpenCode teammate model in Create preflight', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     vi.useFakeTimers();
+    localStorage.setItem('team:lastSelectedProvider', 'opencode');
+    localStorage.setItem('team:lastSelectedModel:opencode', 'opencode/big-pickle');
     const localModel = 'ollama/qwen2.5-coder:0.5b';
     const originalModel = createTeamDraftMock.state.members[0].model;
     createTeamDraftMock.state.members[0].model = localModel;
+    createTeamDraftMock.state.members[1].providerId = 'opencode';
+    createTeamDraftMock.state.members[1].model = 'opencode/big-pickle';
     vi.mocked(isTeamModelAvailableForUi).mockImplementation(
       (_providerId, model, providerStatus) => providerStatus?.models?.includes(model ?? '') ?? false
     );
@@ -1842,25 +1874,19 @@ describe('LaunchTeamDialog', () => {
           capabilities: { teamLaunch: true, oneShot: false },
           backend: { kind: 'opencode-cli', label: 'OpenCode CLI' },
         },
-        {
-          providerId: 'codex',
-          supported: true,
-          authenticated: true,
-          authMethod: 'oauth',
-          verificationState: 'verified',
-          modelVerificationState: 'idle',
-          modelCatalogRefreshState: 'ready',
-          statusMessage: null,
-          models: ['gpt-5.5'],
-          modelAvailability: [],
-          capabilities: { teamLaunch: true, oneShot: true },
-          backend: { kind: 'codex-native', label: 'Codex native' },
-        },
+        createAuthoritativeProviderStatus('codex', ['gpt-5.5']),
       ],
     } as any;
     storeState.cliProviderStatusByScope = {
       [getCliProviderStatusScopeKey('opencode', '/tmp/project')]: {
         ...(storeState.cliStatus as any).providers[0],
+        authenticated: false,
+        authMethod: null,
+        verificationState: 'unknown',
+        statusCheckOutcome: 'model_only',
+        statusCheckErrorCode: 'partial_response',
+        capabilities: { teamLaunch: false, oneShot: false },
+        runtimeCapabilities: { modelCatalog: { dynamic: true, source: 'app-server' } },
         models: [localModel],
         modelCatalogRefreshState: 'ready',
         modelCatalog: {
@@ -1872,7 +1898,21 @@ describe('LaunchTeamDialog', () => {
           staleAt: '2099-07-20T00:10:00.000Z',
           defaultModelId: localModel,
           defaultLaunchModel: localModel,
-          models: [],
+          models: [
+            {
+              id: localModel,
+              launchModel: localModel,
+              displayName: localModel,
+              hidden: false,
+              supportedReasoningEfforts: [],
+              defaultReasoningEffort: null,
+              inputModalities: ['text'],
+              supportsPersonality: false,
+              isDefault: true,
+              upgrade: false,
+              source: 'app-server',
+            },
+          ],
           diagnostics: {
             configReadState: 'ready',
             appServerState: 'healthy',
@@ -1903,6 +1943,14 @@ describe('LaunchTeamDialog', () => {
       );
       await flush();
     });
+    const createButton = Array.from(host.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Create'
+    );
+    expect(createButton?.disabled).toBe(false);
+    await act(async () => {
+      createButton?.click();
+      await flush();
+    });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
       await flush();
@@ -1912,12 +1960,14 @@ describe('LaunchTeamDialog', () => {
       vi
         .mocked(runProviderPrepareDiagnostics)
         .mock.calls.find((call) => call[0]?.providerId === 'opencode')?.[0]?.selectedModelChecks
-    ).toEqual([
-      expect.objectContaining({
-        providerId: 'opencode',
-        model: localModel,
-      }),
-    ]);
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          providerId: 'opencode',
+          model: localModel,
+        }),
+      ])
+    );
 
     createTeamDraftMock.state.members[0].model = originalModel;
     await act(async () => {
@@ -1929,11 +1979,15 @@ describe('LaunchTeamDialog', () => {
   it('uses one custom cwd for the scoped OpenCode catalog and Create preflight', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     vi.useFakeTimers();
+    localStorage.setItem('team:lastSelectedProvider', 'opencode');
+    localStorage.setItem('team:lastSelectedModel:opencode', 'opencode/big-pickle');
     const customCwd = '/tmp/custom-catalog-project';
     const localModel = 'ollama/qwen2.5-coder:0.5b';
     createTeamDraftMock.state.cwdMode = 'custom';
     createTeamDraftMock.state.customCwd = customCwd;
     createTeamDraftMock.state.members[0].model = localModel;
+    createTeamDraftMock.state.members[1].providerId = 'opencode';
+    createTeamDraftMock.state.members[1].model = 'opencode/big-pickle';
     vi.mocked(isTeamModelAvailableForUi).mockImplementation(
       (_providerId, model, providerStatus) => providerStatus?.models?.includes(model ?? '') ?? false
     );
@@ -1953,11 +2007,18 @@ describe('LaunchTeamDialog', () => {
     };
     storeState.cliStatus = {
       flavor: 'agent_teams_orchestrator',
-      providers: [globalProvider],
+      providers: [globalProvider, createAuthoritativeProviderStatus('codex', ['gpt-5.5'])],
     } as any;
     storeState.cliProviderStatusByScope = {
       [getCliProviderStatusScopeKey('opencode', customCwd)]: {
         ...globalProvider,
+        authenticated: false,
+        authMethod: null,
+        verificationState: 'unknown',
+        statusCheckOutcome: 'model_only',
+        statusCheckErrorCode: 'partial_response',
+        capabilities: { teamLaunch: false, oneShot: false },
+        runtimeCapabilities: { modelCatalog: { dynamic: true, source: 'app-server' } },
         models: [localModel],
         modelCatalog: {
           schemaVersion: 1,
@@ -1968,7 +2029,21 @@ describe('LaunchTeamDialog', () => {
           staleAt: '2099-07-20T00:10:00.000Z',
           defaultModelId: localModel,
           defaultLaunchModel: localModel,
-          models: [],
+          models: [
+            {
+              id: localModel,
+              launchModel: localModel,
+              displayName: localModel,
+              hidden: false,
+              supportedReasoningEfforts: [],
+              defaultReasoningEffort: null,
+              inputModalities: ['text'],
+              supportsPersonality: false,
+              isDefault: true,
+              upgrade: false,
+              source: 'app-server',
+            },
+          ],
           diagnostics: { configReadState: 'ready', appServerState: 'healthy' },
         },
       },
@@ -1995,6 +2070,14 @@ describe('LaunchTeamDialog', () => {
       );
       await flush();
     });
+    const createButton = Array.from(host.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Create'
+    );
+    expect(createButton?.disabled).toBe(false);
+    await act(async () => {
+      createButton?.click();
+      await flush();
+    });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
       await flush();
@@ -2011,7 +2094,7 @@ describe('LaunchTeamDialog', () => {
         .mock.calls.find((call) => call[0]?.providerId === 'opencode')?.[0]
     ).toMatchObject({
       cwd: customCwd,
-      selectedModelChecks: [expect.objectContaining({ model: localModel })],
+      selectedModelChecks: expect.arrayContaining([expect.objectContaining({ model: localModel })]),
     });
 
     await act(async () => root.unmount());
@@ -2216,6 +2299,7 @@ describe('LaunchTeamDialog', () => {
     );
     expect(submitButton).toBeTruthy();
 
+    await confirmLaunchPreflight(host);
     await act(async () => {
       submitButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flush();
@@ -2337,6 +2421,7 @@ describe('LaunchTeamDialog', () => {
     );
     expect(submitButton).toBeTruthy();
 
+    await confirmLaunchPreflight(host);
     await act(async () => {
       submitButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flush();
@@ -2562,6 +2647,7 @@ describe('LaunchTeamDialog', () => {
     );
     expect(submitButton).toBeTruthy();
 
+    await confirmLaunchPreflight(host, 'Relaunch team');
     await act(async () => {
       submitButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flush();
@@ -2673,6 +2759,8 @@ describe('LaunchTeamDialog', () => {
         await flush();
       });
     }
+
+    await confirmLaunchPreflight(host);
 
     const opencodePrepareCalls = vi
       .mocked(runProviderPrepareDiagnostics)
@@ -2852,6 +2940,7 @@ describe('LaunchTeamDialog', () => {
     expect(submitButton).toBeTruthy();
     expect(submitButton?.hasAttribute('disabled')).toBe(false);
 
+    await confirmLaunchPreflight(host);
     await act(async () => {
       submitButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await flush();
@@ -3428,6 +3517,16 @@ describe('LaunchTeamDialog', () => {
       await renderDialog();
     });
 
+    expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
+    const initialLaunchButton = Array.from(host.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Launch team'
+    );
+    await act(async () => {
+      initialLaunchButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await flush();
+    });
+
     expect(vi.mocked(runProviderPrepareDiagnostics)).toHaveBeenCalledTimes(1);
 
     storeState.cliStatus = {
@@ -3560,6 +3659,15 @@ describe('LaunchTeamDialog', () => {
 
     await act(async () => {
       await renderDialog();
+    });
+
+    const initialLaunchButton = Array.from(host.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Launch team'
+    );
+    await act(async () => {
+      initialLaunchButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await flush();
     });
 
     const launchButtonWhileChecking = Array.from(host.querySelectorAll('button')).find(
@@ -3762,6 +3870,7 @@ describe('LaunchTeamDialog', () => {
       await flush();
       await flush();
     });
+    await confirmLaunchPreflight(host);
     for (
       let attempt = 0;
       attempt < 10 && !host.textContent?.includes('Runtime environment is not available');
@@ -3838,7 +3947,7 @@ describe('LaunchTeamDialog', () => {
     });
   });
 
-  it('keeps create-team preflight alive across same-signature rerenders', async () => {
+  it('does not start create-team preflight across same-signature rerenders before confirmation', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     vi.useFakeTimers();
     storeState.cliStatus = {
@@ -3927,15 +4036,14 @@ describe('LaunchTeamDialog', () => {
       await flush();
     });
 
-    expect(vi.mocked(runProviderPrepareDiagnostics)).toHaveBeenCalled();
+    expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
 
     await act(async () => {
       await renderDialog();
       await flush();
     });
 
-    const callsAfterSameSignatureRerender = vi.mocked(runProviderPrepareDiagnostics).mock.calls
-      .length;
+    expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
 
     await act(async () => {
       resolvePrepare({
@@ -3947,9 +4055,7 @@ describe('LaunchTeamDialog', () => {
       await flush();
       await flush();
     });
-    expect(vi.mocked(runProviderPrepareDiagnostics)).toHaveBeenCalledTimes(
-      callsAfterSameSignatureRerender
-    );
+    expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
 
     await act(async () => {
       root.unmount();

--- a/test/renderer/features/runtime-provider-management/RuntimeProviderQuickConnectView.test.ts
+++ b/test/renderer/features/runtime-provider-management/RuntimeProviderQuickConnectView.test.ts
@@ -403,6 +403,40 @@ describe('RuntimeProviderQuickConnectView', () => {
     expect(onRetryDirectory).toHaveBeenCalledTimes(1);
   });
 
+  it('shows an explicit connect action when a gateway catalog entry is unavailable', async () => {
+    const onConnect = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(RuntimeProviderQuickConnectView, {
+          cards: [
+            card('openrouter', {
+              displayName: 'OpenRouter',
+              stateLabel: 'Status unavailable',
+              actionLabel: 'Check & connect',
+              onAction: onConnect,
+            }),
+          ],
+          gate: 'ready',
+          runtimeStatus: null,
+          directoryError: null,
+          onInstallOpenCode: vi.fn(),
+          onRefreshOpenCode: vi.fn(),
+          onRetryDirectory: vi.fn(),
+          onSetupLocalModel: vi.fn(),
+          onBrowseProviders: vi.fn(),
+        })
+      );
+    });
+
+    const connect = host.querySelector<HTMLButtonElement>(
+      '[data-testid="provider-quick-action-openrouter"]'
+    );
+    expect(connect?.textContent).toContain('Check & connect');
+    expect(connect?.disabled).toBe(false);
+    act(() => connect?.click());
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps OpenCode plugin plans visible but disabled when the runtime is missing', async () => {
     const onOpenCodeProviderAction = vi.fn();
 

--- a/test/renderer/features/runtime-provider-management/runtimeProviderQuickConnect.test.ts
+++ b/test/renderer/features/runtime-provider-management/runtimeProviderQuickConnect.test.ts
@@ -378,6 +378,7 @@ describe('RuntimeProviderQuickConnect', () => {
     const cases = [
       {
         entries: [],
+        loading: false,
         loaded: true,
         authoritativeLoaded: false,
         authoritativePending: false,
@@ -385,6 +386,7 @@ describe('RuntimeProviderQuickConnect', () => {
       },
       {
         entries: [],
+        loading: false,
         loaded: true,
         authoritativeLoaded: false,
         authoritativePending: false,
@@ -392,6 +394,7 @@ describe('RuntimeProviderQuickConnect', () => {
       },
       {
         entries: [entry('openrouter', { state: 'error', setupKind: 'unsupported' })],
+        loading: false,
         loaded: true,
         authoritativeLoaded: true,
         authoritativePending: false,

--- a/test/renderer/features/runtime-provider-management/runtimeProviderQuickConnect.test.ts
+++ b/test/renderer/features/runtime-provider-management/runtimeProviderQuickConnect.test.ts
@@ -177,7 +177,13 @@ describe('RuntimeProviderQuickConnect', () => {
     vi.unstubAllGlobals();
   });
 
-  const renderQuickConnect = async (projectPath: string | null = null): Promise<void> => {
+  const renderQuickConnect = async (
+    projectPath: string | null = null,
+    onOpenCodeProviderAction: (
+      providerId: string,
+      action: 'connect' | 'reconnect' | 'select' | 'settings-connect'
+    ) => void = vi.fn()
+  ): Promise<void> => {
     await act(async () => {
       root.render(
         React.createElement(RuntimeProviderQuickConnect, {
@@ -194,7 +200,7 @@ describe('RuntimeProviderQuickConnect', () => {
           projectPath,
           onInstallOpenCode: vi.fn(),
           onRefreshOpenCode: vi.fn(),
-          onOpenCodeProviderAction: vi.fn(),
+          onOpenCodeProviderAction,
           onBrowseProviders: vi.fn(),
         })
       );
@@ -366,6 +372,48 @@ describe('RuntimeProviderQuickConnect', () => {
 
     expect(onOpenCodeProviderAction).toHaveBeenNthCalledWith(1, 'openrouter', 'select');
     expect(onOpenCodeProviderAction).toHaveBeenNthCalledWith(2, 'vercel', 'settings-connect');
+  });
+
+  it('routes every unavailable gateway state to provider settings', async () => {
+    const cases = [
+      {
+        entries: [],
+        loaded: true,
+        authoritativeLoaded: false,
+        authoritativePending: false,
+        error: 'directory unavailable',
+      },
+      {
+        entries: [],
+        loaded: true,
+        authoritativeLoaded: false,
+        authoritativePending: false,
+        error: null,
+      },
+      {
+        entries: [entry('openrouter', { state: 'error', setupKind: 'unsupported' })],
+        loaded: true,
+        authoritativeLoaded: true,
+        authoritativePending: false,
+        error: null,
+      },
+    ] as const;
+
+    for (const directory of cases) {
+      mocks.directory = { ...directory, refresh: vi.fn() };
+      const onOpenCodeProviderAction = vi.fn();
+      await renderQuickConnect(null, onOpenCodeProviderAction);
+
+      const card = host.querySelector('[data-testid="provider-quick-card-openrouter"]');
+      const action = host.querySelector<HTMLButtonElement>(
+        '[data-testid="provider-quick-action-openrouter"]'
+      );
+      expect(card?.textContent).toContain('cliStatus.quickConnect.checkAndConnect');
+      expect(action).not.toBeNull();
+
+      await act(async () => action?.click());
+      expect(onOpenCodeProviderAction).toHaveBeenCalledWith('openrouter', 'settings-connect');
+    }
   });
 
   it('does not report missing or negative seed providers as not found before reconciliation', async () => {

--- a/test/renderer/hooks/useEffectiveCliProviderStatus.test.ts
+++ b/test/renderer/hooks/useEffectiveCliProviderStatus.test.ts
@@ -24,6 +24,7 @@ vi.mock('@renderer/store', () => ({
 vi.mock('@features/codex-account/renderer', () => ({
   useCodexAccountSnapshot: () => ({ loading: false, snapshot: null, error: null }),
   mergeCodexCliStatusWithSnapshot: (cliStatus: unknown) => cliStatus,
+  mergeCodexProviderStatusWithSnapshot: (providerStatus: unknown) => providerStatus,
   isCodexAccountSnapshotPending: () => false,
 }));
 

--- a/test/renderer/hooks/useEffectiveCliProviderStatus.test.ts
+++ b/test/renderer/hooks/useEffectiveCliProviderStatus.test.ts
@@ -9,6 +9,7 @@ import {
 import { getCliProviderStatusScopeKey } from '@renderer/store/slices/cliInstallerSlice';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { CodexAccountSnapshotDto } from '@features/codex-account/contracts';
 import type { CliProviderStatus } from '@shared/types';
 
 const storeState = {
@@ -24,7 +25,21 @@ vi.mock('@renderer/store', () => ({
 vi.mock('@features/codex-account/renderer', () => ({
   useCodexAccountSnapshot: () => ({ loading: false, snapshot: null, error: null }),
   mergeCodexCliStatusWithSnapshot: (cliStatus: unknown) => cliStatus,
-  mergeCodexProviderStatusWithSnapshot: (providerStatus: unknown) => providerStatus,
+  mergeCodexProviderStatusWithSnapshot: (
+    providerStatus: CliProviderStatus,
+    snapshot: CodexAccountSnapshotDto | null
+  ) =>
+    snapshot
+      ? {
+          ...providerStatus,
+          authenticated: snapshot.launchAllowed,
+          statusMessage: snapshot.launchIssueMessage ?? 'ChatGPT account ready',
+          capabilities: {
+            ...providerStatus.capabilities,
+            teamLaunch: snapshot.launchAllowed,
+          },
+        }
+      : providerStatus,
   isCodexAccountSnapshotPending: () => false,
 }));
 
@@ -170,6 +185,57 @@ describe('resolveProjectScopedProviderStatus', () => {
     const resolved = resolveProjectScopedProviderStatus('opencode', scoped, status());
     expect(resolved).toEqual(scoped);
     expect(resolved).not.toBe(scoped);
+  });
+
+  it('applies the Codex account snapshot to scoped status before launch gating', () => {
+    const scoped = status({
+      providerId: 'codex',
+      authenticated: false,
+      capabilities: { ...status().capabilities, teamLaunch: false },
+      modelCatalog: {
+        ...status().modelCatalog!,
+        providerId: 'codex',
+        defaultModelId: 'codex/gpt-5.6',
+        defaultLaunchModel: 'codex/gpt-5.6',
+        models: [
+          {
+            ...status().modelCatalog!.models[0],
+            id: 'codex/gpt-5.6',
+            launchModel: 'codex/gpt-5.6',
+          },
+        ],
+      },
+    });
+    const snapshot = {
+      preferredAuthMode: 'chatgpt',
+      effectiveAuthMode: 'chatgpt',
+      launchAllowed: true,
+      launchIssueMessage: null,
+      launchReadinessState: 'ready_chatgpt',
+      appServerState: 'healthy',
+      appServerStatusMessage: null,
+      managedAccount: null,
+      apiKey: { available: false, source: null, sourceLabel: null },
+      requiresOpenaiAuth: true,
+      login: { status: 'idle', error: null, startedAt: null },
+      rateLimits: null,
+      updatedAt: '2026-09-03T20:00:00.000Z',
+    } as const satisfies CodexAccountSnapshotDto;
+
+    const resolved = resolveProjectScopedProviderStatus(
+      'codex',
+      scoped,
+      null,
+      Date.parse('2026-09-03T20:01:00.000Z'),
+      snapshot
+    );
+
+    expect(resolved).toMatchObject({
+      providerId: 'codex',
+      authenticated: true,
+      statusMessage: 'ChatGPT account ready',
+      capabilities: { teamLaunch: true },
+    });
   });
 
   it.each(['pending', 'model_only', 'transient_error'] as const)(

--- a/test/renderer/store/cliInstallerSlice.test.ts
+++ b/test/renderer/store/cliInstallerSlice.test.ts
@@ -1884,6 +1884,43 @@ describe('cliInstallerSlice', () => {
       });
     });
 
+    it('rechecks one partial OpenCode status response before settling the provider', async () => {
+      const partialProvider = createMultimodelProvider({
+        providerId: 'opencode',
+        displayName: 'OpenCode',
+        authenticated: false,
+        authMethod: null,
+        verificationState: 'unknown',
+        statusCheckOutcome: 'pending',
+        statusCheckErrorCode: 'partial_response',
+        modelCatalogRefreshState: 'loading',
+        capabilities: {
+          teamLaunch: false,
+          oneShot: false,
+          extensions: createDefaultCliExtensionCapabilities(),
+        },
+      });
+      const readyProvider = createReadyOpenCodeCatalogProvider('opencode/big-pickle');
+      useStore.setState({ cliStatus: createMultimodelStatus([partialProvider]) });
+      vi.mocked(api.cliInstaller.getProviderStatus)
+        .mockResolvedValueOnce(partialProvider)
+        .mockResolvedValueOnce(readyProvider);
+
+      await expect(
+        useStore.getState().fetchCliProviderStatus('opencode', {
+          projectPath: '/tmp/partial-opencode',
+        })
+      ).resolves.toBe(true);
+
+      expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(2);
+      expect(useStore.getState().cliProviderStatusByScope[
+        getCliProviderStatusScopeKey('opencode', '/tmp/partial-opencode')
+      ]).toMatchObject({
+        statusCheckOutcome: 'authoritative',
+        modelCatalogRefreshState: 'ready',
+      });
+    });
+
     it('reports a scoped OpenCode catalog loaded only after an authoritative ready response', async () => {
       const fetchedAt = new Date();
       const staleAt = new Date(fetchedAt.getTime() + 10 * 60_000);

--- a/test/renderer/store/cliInstallerSlice.test.ts
+++ b/test/renderer/store/cliInstallerSlice.test.ts
@@ -1796,12 +1796,8 @@ describe('cliInstallerSlice', () => {
 
   describe('fetchCliProviderStatus', () => {
     it('fences an in-flight provider status across a backend catalog invalidation', async () => {
-      const oldBackendRequest = createDeferredValue<
-        CliInstallationStatus['providers'][number]
-      >();
-      const newBackendRequest = createDeferredValue<
-        CliInstallationStatus['providers'][number]
-      >();
+      const oldBackendRequest = createDeferredValue<CliInstallationStatus['providers'][number]>();
+      const newBackendRequest = createDeferredValue<CliInstallationStatus['providers'][number]>();
       const initialProvider = createMultimodelProvider({
         providerId: 'codex',
         displayName: 'Codex',
@@ -1853,9 +1849,7 @@ describe('cliInstallerSlice', () => {
       await expect(oldBackendRefresh).resolves.toBe(false);
 
       expect(
-        useStore
-          .getState()
-          .cliStatus?.providers.find((provider) => provider.providerId === 'codex')
+        useStore.getState().cliStatus?.providers.find((provider) => provider.providerId === 'codex')
       ).toMatchObject({
         authenticated: false,
         capabilities: { teamLaunch: false },
@@ -1913,9 +1907,17 @@ describe('cliInstallerSlice', () => {
       ).resolves.toBe(true);
 
       expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(2);
-      expect(useStore.getState().cliProviderStatusByScope[
-        getCliProviderStatusScopeKey('opencode', '/tmp/partial-opencode')
-      ]).toMatchObject({
+      expect(api.cliInstaller.getProviderStatus).toHaveBeenNthCalledWith(1, 'opencode', {
+        projectPath: '/tmp/partial-opencode',
+      });
+      expect(api.cliInstaller.getProviderStatus).toHaveBeenNthCalledWith(2, 'opencode', {
+        projectPath: '/tmp/partial-opencode',
+      });
+      expect(
+        useStore.getState().cliProviderStatusByScope[
+          getCliProviderStatusScopeKey('opencode', '/tmp/partial-opencode')
+        ]
+      ).toMatchObject({
         statusCheckOutcome: 'authoritative',
         modelCatalogRefreshState: 'ready',
       });

--- a/test/renderer/store/cliInstallerStatusReconciliation.test.ts
+++ b/test/renderer/store/cliInstallerStatusReconciliation.test.ts
@@ -1,0 +1,88 @@
+import { reconcileCliProviderSnapshot } from '@renderer/store/slices/cliInstallerStatusReconciliation';
+import { describe, expect, it } from 'vitest';
+
+import type { CliProviderStatus } from '@shared/types';
+
+const catalog = {
+  schemaVersion: 1,
+  providerId: 'anthropic',
+  source: 'anthropic-models-api',
+  status: 'ready',
+  models: [
+    {
+      id: 'claude-3-5-haiku-latest',
+      launchModel: 'claude-3-5-haiku-latest',
+      displayName: 'Claude 3.5 Haiku',
+      hidden: false,
+      supportedReasoningEfforts: [],
+      defaultReasoningEffort: null,
+      inputModalities: ['text'],
+      supportsPersonality: false,
+      isDefault: true,
+      upgrade: false,
+      source: 'anthropic-models-api',
+    },
+  ],
+  staleAt: '2026-09-03T00:00:00.000Z',
+  fetchedAt: '2026-09-02T00:00:00.000Z',
+  defaultModelId: 'claude-3-5-haiku-latest',
+  defaultLaunchModel: 'claude-3-5-haiku-latest',
+  diagnostics: { configReadState: 'ready', appServerState: 'healthy' },
+} as CliProviderStatus['modelCatalog'];
+
+function provider(overrides: Partial<CliProviderStatus> = {}): CliProviderStatus {
+  return {
+    providerId: 'anthropic',
+    displayName: 'Anthropic',
+    supported: true,
+    authenticated: true,
+    authMethod: 'api_key',
+    verificationState: 'verified',
+    statusCheckOutcome: 'authoritative',
+    modelVerificationState: 'verified',
+    modelCatalogRefreshState: 'ready',
+    statusMessage: null,
+    detailMessage: null,
+    models: ['claude-3-5-haiku-latest'],
+    modelAvailability: [],
+    canLoginFromUi: false,
+    capabilities: { teamLaunch: true, oneShot: true },
+    selectedBackendId: 'anthropic',
+    resolvedBackendId: 'anthropic',
+    availableBackends: [],
+    externalRuntimeDiagnostics: [],
+    backend: { kind: 'anthropic-api', label: 'Anthropic API' },
+    connection: null,
+    modelCatalog: catalog,
+    runtimeCapabilities: null,
+    subscriptionRateLimits: null,
+    ...overrides,
+  } as CliProviderStatus;
+}
+
+describe('cli provider status reconciliation', () => {
+  it('keeps a retained catalog loading during an authoritative partial refresh', () => {
+    const current = provider();
+    const incoming = provider({
+      authenticated: false,
+      authMethod: null,
+      statusCheckOutcome: 'pending',
+      statusCheckErrorCode: 'partial_response',
+      modelVerificationState: 'verifying',
+      modelCatalogRefreshState: 'error',
+      models: [],
+      modelCatalog: null,
+      capabilities: {
+        teamLaunch: false,
+        oneShot: false,
+        extensions: {} as CliProviderStatus['capabilities']['extensions'],
+      },
+    });
+
+    const reconciled = reconcileCliProviderSnapshot(current, incoming);
+
+    expect(reconciled.modelCatalog?.status).toBe('stale');
+    expect(reconciled.modelCatalogRefreshState).toBe('loading');
+    expect(reconciled.capabilities.teamLaunch).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- gate provider readiness and launch preflight on explicit user confirmation
- keep OpenCode launch checks project-scoped and prevent stale passive probes from blocking the picker
- refresh lifecycle state after stop/relaunch and cover the changed paths with focused tests

## Verification

- renderer/main focused tests: 328/328
- bridge tests: 62/62
- controller lifecycle tests: 212/212
- MCP targeted tests: 56/56
- typecheck, fast lint, build, and diff check pass
- sandbox-only production mixed-team proof completed; no real user project was launched

Please have CodeRabbit review the exact head of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Team launches now check provider readiness after the first launch click, with clearer loading and authorization guidance.
  - Project-scoped OpenCode checks provide complete model availability details and retry partial responses automatically.
  - Codex project launch status includes shared account connection information.
  - Unavailable runtime gateways offer a “Check & connect” action.

- **Bug Fixes**
  - Team launch progress and pending-member counts reflect current member states.
  - Provider catalogs remain visibly loading during partial refreshes.
  - Launch blockers no longer show misleading details while model information loads.
  - Existing working directories are validated instead of automatically created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->