### PR TITLE
fix(controller): the post-completion guard and the board-completion notice share one definition of an open task

### DIFF
--- a/agent-teams-controller/src/internal/messageStore.js
+++ b/agent-teams-controller/src/internal/messageStore.js
@@ -6,6 +6,7 @@ const { withFileLockSync } = require('./fileLock.js');
 const { looksLikeIdleAckOnlyText } = require('./idleAckText.js');
 const runtimeHelpers = require('./runtimeHelpers.js');
 const taskStore = require('./taskStore.js');
+const { isTaskOpen } = require('./taskLifecycle.js');
 const {
   RUNTIME_DELIVERY_DUPLICATE_NOTICE,
   REPEATED_MESSAGE_WINDOW_MS,
@@ -234,11 +235,16 @@ const POST_COMPLETION_MESSAGE_NOTICE_SUFFIX =
 
 /**
  * Structural board-completion epoch: the newest task_created / status_changed /
- * owner_changed event across a board whose every live task is completed.
+ * owner_changed event across a board that has no open task left.
  * Comments and attachments bump `updatedAt` but are not board events, so they
  * must not move the epoch (a memoryless lead would otherwise talk its way
  * around the guard by commenting first). Returns null unless the board is
  * complete and non-empty.
+ *
+ * "Open" is `isTaskOpen`, the predicate `notifyLeadWhenBoardCompleted` in
+ * tasks.js also uses, so a task that is completed but still in review or
+ * waiting for a fix keeps the board open here too and the team may still
+ * message the user.
  */
 function readBoardCompletionEpoch(paths) {
   let tasks;
@@ -248,7 +254,7 @@ function readBoardCompletionEpoch(paths) {
     return null;
   }
   if (!Array.isArray(tasks) || tasks.length === 0) return null;
-  if (!tasks.every((task) => task && task.status === 'completed')) return null;
+  if (!tasks.every((task) => task && !isTaskOpen(task))) return null;
   let lastBoardEventMs = 0;
   for (const task of tasks) {
     const events = Array.isArray(task.historyEvents) ? task.historyEvents : [];

--- a/agent-teams-controller/src/internal/messageStore.js
+++ b/agent-teams-controller/src/internal/messageStore.js
@@ -227,15 +227,22 @@ function appendRow(filePath, row) {
   });
 }
 
-const BOARD_EPOCH_EVENT_TYPES = new Set(['task_created', 'status_changed', 'owner_changed']);
+const BOARD_EPOCH_EVENT_TYPES = new Set([
+  'task_created',
+  'status_changed',
+  'owner_changed',
+  'review_approved',
+]);
 const POST_COMPLETION_MESSAGE_NOTICE_PREFIX =
   'Duplicate message ignored. Final message already delivered: the board was already complete when you messaged the user at ';
 const POST_COMPLETION_MESSAGE_NOTICE_SUFFIX =
-  ', and no task has been created, started, completed, reopened, or reassigned since. This restatement was not delivered. Send the user another message only after a task changes state or after the user writes to you again.';
+  ', and no task has been created, started, completed, reopened, reassigned, or approved since. This restatement was not delivered. Send the user another message only after a task changes state or after the user writes to you again.';
 
 /**
  * Structural board-completion epoch: the newest task_created / status_changed /
- * owner_changed event across a board that has no open task left.
+ * owner_changed / review_approved event across a board with no open task left.
+ * Approval closes review without changing task status. Other review transitions
+ * keep the board open, so they do not need a separate completion epoch.
  * Comments and attachments bump `updatedAt` but are not board events, so they
  * must not move the epoch (a memoryless lead would otherwise talk its way
  * around the guard by commenting first). Returns null unless the board is

--- a/agent-teams-controller/src/internal/taskLifecycle.js
+++ b/agent-teams-controller/src/internal/taskLifecycle.js
@@ -1,0 +1,29 @@
+/**
+ * The board's single definition of "this task is still open work".
+ *
+ * Two independent places decide whether a board is finished: the board's own
+ * completion notice to the lead (`notifyLeadWhenBoardCompleted` in `tasks.js`)
+ * and the post-completion guard that stops a memoryless turn from restating its
+ * final message to the user (`readBoardCompletionEpoch` in `messageStore.js`).
+ * They must agree, or the same board is "done" for one of them and "open" for
+ * the other, which either lets a restated final message through or suppresses a
+ * message while review work is still on the board.
+ *
+ * A completed task that is in review or waiting for a fix is NOT finished: the
+ * reviewer can still send it back, so work remains. A deleted task is not live
+ * work and is therefore never open; `taskStore.listTasks` already drops deleted
+ * rows unless the caller asks for them, so that arm only matters to a caller
+ * that passes `includeDeleted`.
+ *
+ * Callers keep their own guard against a malformed row; this predicate answers
+ * only for the task object it was given.
+ */
+function isTaskOpen(task) {
+  if (task.status === 'deleted') return false;
+  if (task.status !== 'completed') return true;
+  return task.reviewState === 'review' || task.reviewState === 'needsFix';
+}
+
+module.exports = {
+  isTaskOpen,
+};

--- a/agent-teams-controller/src/internal/tasks.js
+++ b/agent-teams-controller/src/internal/tasks.js
@@ -9,6 +9,7 @@ const { withTeamBoardLock } = require('./boardLock.js');
 const { wrapAgentBlock } = require('./agentBlocks.js');
 const { buildCommentNotificationMessage } = require('./taskCommentNotification.js');
 const { findRecentDuplicateTask } = require('./taskCreationDeduplication.js');
+const { isTaskOpen } = require('./taskLifecycle.js');
 const {
     createMemberMessagingProtocol,
     isCodexMember,
@@ -534,17 +535,11 @@ function notifyLeadWhenBoardCompleted(context, completedTask) {
         return;
     }
     if (!Array.isArray(tasks) || tasks.length === 0) return;
-    // Work in review or waiting for a fix is not finished, even though the task
+    // isTaskOpen is shared with the post-completion message guard in
+    // messageStore.js, so the two cannot disagree about a finished board: work
+    // in review or waiting for a fix is not finished, even though the task
     // itself already carries the completed status.
-    const open = tasks.filter(
-        (task) =>
-            task &&
-            task.status !== 'deleted' &&
-            (task.status !== 'completed' ||
-                task.reviewState === 'review' ||
-                task.reviewState === 'needsFix')
-    );
-    if (open.length > 0) return;
+    if (tasks.some((task) => task && isTaskOpen(task))) return;
 
     const leadName = runtimeHelpers.inferLeadName(context.paths);
     if (!leadName) return;

--- a/agent-teams-controller/test/boardCompletionOpenTask.test.js
+++ b/agent-teams-controller/test/boardCompletionOpenTask.test.js
@@ -195,6 +195,75 @@ describe('board completion is one question with one answer', () => {
     });
   });
 
+  it.each([false, true])('delivers one final after approval (fix cycle: %s)', (needsFix) => {
+    const claudeDir = makeClaudeDir();
+    const controller = createController({ teamName: 'my-team', claudeDir });
+    const send = (text) => controller.messages.sendMessage({ to: 'user', from: 'alice', text });
+    withClock((advance) => {
+      const task = controller.tasks.createTask({ subject: 'Sandbox review', owner: 'bob' });
+      advance(1);
+      controller.tasks.completeTask(task.id, 'bob');
+      controller.review.requestReview(task.id, { from: 'alice', reviewer: 'alice' });
+      controller.review.startReview(task.id, { from: 'alice' });
+      if (needsFix) {
+        advance(1);
+        controller.review.requestChanges(task.id, { from: 'alice', comment: 'Add evidence' });
+        expect(send('The reviewer requested more evidence.').deduplicated).toBeUndefined();
+        advance(1);
+        controller.tasks.completeTask(task.id, 'bob');
+        expect(controller.tasks.getTask(task.id).reviewState).toBe('needsFix');
+        expect(send('The evidence is ready for another pass.').deduplicated).toBeUndefined();
+        advance(1);
+        controller.review.requestReview(task.id, { from: 'alice', reviewer: 'alice' });
+        controller.review.startReview(task.id, { from: 'alice' });
+      }
+      advance(1);
+      expect(send('Review is in progress.').deduplicated).toBeUndefined();
+      advance(1);
+      controller.review.approveReview(task.id, { from: 'alice', note: 'Evidence accepted' });
+      advance(1);
+      const final = send('Review approved. The result is ready.');
+      expect(final.deduplicated).toBeUndefined();
+      advance(1);
+      expect(send('Everything is now finished.').duplicateOfMessageId).toBe(final.messageId);
+      // Approval retries and metadata edits must not reset the guard.
+      advance(1);
+      expect(controller.review.approveReview(task.id, { from: 'alice' }).alreadyApproved).toBe(true);
+      controller.tasks.addTaskComment(task.id, { from: 'alice', text: 'Archival note' });
+      controller.tasks.addTaskAttachmentMeta(task.id, {
+        id: 'sandbox-evidence',
+        filename: 'evidence.txt',
+        mimeType: 'text/plain',
+        size: 0,
+      });
+      advance(1);
+      expect(send('A recap of the approved result.').duplicateOfMessageId).toBe(final.messageId);
+      expect(readInbox(claudeDir, 'user')).toHaveLength(needsFix ? 4 : 2);
+    });
+  });
+
+  it('retains the updatedAt fallback for legacy tasks without history events', () => {
+    const claudeDir = makeClaudeDir();
+    const controller = createController({ teamName: 'my-team', claudeDir });
+    const send = (text) => controller.messages.sendMessage({ to: 'user', from: 'alice', text });
+    withClock((advance) => {
+      const task = controller.tasks.createTask({ subject: 'Legacy sandbox task', owner: 'bob' });
+      advance(1);
+      send('Legacy work in progress.');
+      advance(1);
+      controller.tasks.updateTask(task.id, (persisted) => {
+        persisted.status = 'completed';
+        delete persisted.historyEvents;
+        return persisted;
+      });
+      advance(1);
+      const final = send('Legacy work done.');
+      expect(final.deduplicated).toBeUndefined();
+      advance(1);
+      expect(send('Legacy final recap.').duplicateOfMessageId).toBe(final.messageId);
+    });
+  });
+
   it('routes both sites through the shared predicate instead of restating the rule', () => {
     const internalDir = path.join(__dirname, '..', 'src', 'internal');
     const messageStoreSource = fs.readFileSync(path.join(internalDir, 'messageStore.js'), 'utf8');

--- a/agent-teams-controller/test/boardCompletionOpenTask.test.js
+++ b/agent-teams-controller/test/boardCompletionOpenTask.test.js
@@ -1,0 +1,210 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { createController } = require('../src/index.js');
+
+// The board-completion notice (tasks.js) and the post-completion message guard
+// (messageStore.js) both ask "is any task on this board still open?". These
+// cases put the same board in front of both and assert they answer the same
+// way, on the two fixtures where the two used to disagree.
+describe('board completion is one question with one answer', () => {
+  const tempDirs = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function makeClaudeDir() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-teams-board-completion-'));
+    tempDirs.push(dir);
+    fs.mkdirSync(path.join(dir, 'teams', 'my-team'), { recursive: true });
+    fs.mkdirSync(path.join(dir, 'tasks', 'my-team'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'teams', 'my-team', 'config.json'),
+      JSON.stringify(
+        {
+          name: 'my-team',
+          leadSessionId: 'lead-session-1',
+          members: [
+            { name: 'alice', role: 'team-lead' },
+            { name: 'bob', role: 'developer' },
+          ],
+        },
+        null,
+        2
+      )
+    );
+    return dir;
+  }
+
+  function readInbox(claudeDir, member) {
+    const file = path.join(claudeDir, 'teams', 'my-team', 'inboxes', `${member}.json`);
+    return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : [];
+  }
+
+  function boardNotices(claudeDir) {
+    return readInbox(claudeDir, 'alice').filter((row) =>
+      String(row.messageId || '').startsWith('board-complete:')
+    );
+  }
+
+  function withClock(run) {
+    const clock = { now: Date.parse('2026-09-02T09:00:00.000Z') };
+    vi.useFakeTimers({ now: clock.now, toFake: ['Date'] });
+    const advance = (minutes) => {
+      clock.now += minutes * 60 * 1000;
+      vi.setSystemTime(clock.now);
+    };
+    try {
+      run(advance);
+    } finally {
+      vi.useRealTimers();
+    }
+  }
+
+  it('does not keep the board open for a deleted task at either site', () => {
+    const claudeDir = makeClaudeDir();
+    const controller = createController({ teamName: 'my-team', claudeDir });
+
+    withClock((advance) => {
+      const kept = controller.tasks.createTask({ subject: 'Write the summary', owner: 'bob' });
+      const dropped = controller.tasks.createTask({ subject: 'Print the poster', owner: 'bob' });
+      advance(1);
+      controller.tasks.softDeleteTask(dropped.id, 'alice');
+      advance(1);
+      controller.tasks.completeTask(kept.id, 'bob');
+
+      // The notice fires: a deleted task is not live work.
+      const notices = boardNotices(claudeDir);
+      expect(notices).toHaveLength(1);
+      expect(notices[0].text).toContain('Board complete');
+
+      advance(1);
+      const final = controller.messages.sendMessage({
+        to: 'user',
+        from: 'alice',
+        text: 'The summary is written; the poster task was dropped and the board is finished.',
+      });
+      expect(final.deduplicated).toBeUndefined();
+
+      // Same board, same answer: the guard treats it as complete and holds the
+      // restatement back.
+      advance(2);
+      const restated = controller.messages.sendMessage({
+        to: 'user',
+        from: 'alice',
+        text: 'Everything you asked for is done, nothing else is pending on my side.',
+      });
+      expect(restated.deduplicated).toBe(true);
+      expect(restated.duplicateOfMessageId).toBe(final.messageId);
+      expect(restated.deduplicationNotice).toContain('Final message already delivered');
+    });
+  });
+
+  it('keeps the board open at both sites while a completed task is in review', () => {
+    const claudeDir = makeClaudeDir();
+    const controller = createController({ teamName: 'my-team', claudeDir });
+
+    withClock((advance) => {
+      const written = controller.tasks.createTask({ subject: 'Write the summary', owner: 'bob' });
+      const checked = controller.tasks.createTask({ subject: 'Check the summary', owner: 'bob' });
+      controller.tasks.completeTask(written.id, 'bob');
+      controller.review.requestReview(written.id, { from: 'alice', reviewer: 'alice' });
+      expect(controller.tasks.getTask(written.id)).toMatchObject({
+        status: 'completed',
+        reviewState: 'review',
+      });
+
+      advance(1);
+      controller.tasks.completeTask(checked.id, 'bob');
+
+      // Work in review is still work: no completion notice.
+      expect(boardNotices(claudeDir)).toEqual([]);
+
+      advance(1);
+      const first = controller.messages.sendMessage({
+        to: 'user',
+        from: 'alice',
+        text: 'The summary is written and is with the reviewer right now.',
+      });
+      expect(first.deduplicated).toBeUndefined();
+
+      // And the guard stays out of the way, so the team can still report the
+      // review outcome to the user.
+      advance(2);
+      const second = controller.messages.sendMessage({
+        to: 'user',
+        from: 'alice',
+        text: 'The reviewer is through the first half; I will report again when it is signed off.',
+      });
+      expect(second.deduplicated).toBeUndefined();
+      expect(readInbox(claudeDir, 'user')).toHaveLength(2);
+    });
+  });
+
+  it('keeps the board open at both sites while a completed task waits for another review pass', () => {
+    const claudeDir = makeClaudeDir();
+    const controller = createController({ teamName: 'my-team', claudeDir });
+
+    withClock((advance) => {
+      const written = controller.tasks.createTask({ subject: 'Write the summary', owner: 'bob' });
+      const checked = controller.tasks.createTask({ subject: 'Check the summary', owner: 'bob' });
+      controller.tasks.completeTask(written.id, 'bob');
+      controller.review.requestReview(written.id, { from: 'alice', reviewer: 'alice' });
+      controller.review.requestChanges(written.id, {
+        from: 'alice',
+        comment: 'The second section is missing.',
+      });
+      expect(controller.tasks.getTask(written.id)).toMatchObject({
+        status: 'pending',
+        reviewState: 'needsFix',
+      });
+
+      // The owner fixes it and completes it again: the task is completed but is
+      // owed another review pass.
+      advance(1);
+      controller.tasks.completeTask(written.id, 'bob');
+      expect(controller.tasks.getTask(written.id)).toMatchObject({
+        status: 'completed',
+        reviewState: 'needsFix',
+      });
+
+      advance(1);
+      controller.tasks.completeTask(checked.id, 'bob');
+      expect(boardNotices(claudeDir)).toEqual([]);
+
+      advance(1);
+      const first = controller.messages.sendMessage({
+        to: 'user',
+        from: 'alice',
+        text: 'The missing section is written and the summary is back with the reviewer.',
+      });
+      expect(first.deduplicated).toBeUndefined();
+
+      advance(2);
+      const second = controller.messages.sendMessage({
+        to: 'user',
+        from: 'alice',
+        text: 'The reviewer signed off on the first half, one more pass to go.',
+      });
+      expect(second.deduplicated).toBeUndefined();
+      expect(readInbox(claudeDir, 'user')).toHaveLength(2);
+    });
+  });
+
+  it('routes both sites through the shared predicate instead of restating the rule', () => {
+    const internalDir = path.join(__dirname, '..', 'src', 'internal');
+    const messageStoreSource = fs.readFileSync(path.join(internalDir, 'messageStore.js'), 'utf8');
+    const tasksSource = fs.readFileSync(path.join(internalDir, 'tasks.js'), 'utf8');
+
+    expect(messageStoreSource).toContain("require('./taskLifecycle.js')");
+    expect(tasksSource).toContain("require('./taskLifecycle.js')");
+    // Neither site may re-derive the rule: restating it is how the two drifted
+    // apart in the first place.
+    expect(messageStoreSource).not.toContain("status === 'completed'");
+    expect(tasksSource).not.toContain("reviewState === 'review'");
+  });
+});

--- a/agent-teams-controller/test/taskLifecycle.test.js
+++ b/agent-teams-controller/test/taskLifecycle.test.js
@@ -1,0 +1,48 @@
+const { isTaskOpen } = require('../src/internal/taskLifecycle.js');
+
+// taskStore.js accepts exactly four statuses and reviewState.js exactly four
+// review states, so these two tables are the whole product a board row can
+// hold. Some pairs are unreachable through the store (a deleted or in_progress
+// task has its reviewState reset to 'none'), but the predicate is handed rows
+// straight off disk and must still answer for them.
+describe('isTaskOpen', () => {
+  it.each([
+    ['pending', 'none'],
+    ['pending', 'review'],
+    ['pending', 'needsFix'],
+    ['pending', 'approved'],
+    ['in_progress', 'none'],
+    ['in_progress', 'review'],
+    ['in_progress', 'needsFix'],
+    ['in_progress', 'approved'],
+    // Completed but not finished: the reviewer can still send the work back.
+    ['completed', 'review'],
+    ['completed', 'needsFix'],
+  ])('counts %s / %s as open board work', (status, reviewState) => {
+    expect(isTaskOpen({ status, reviewState })).toBe(true);
+  });
+
+  it.each([
+    ['completed', 'none'],
+    ['completed', 'approved'],
+    // A deleted task is not live work, whatever review state it carries.
+    ['deleted', 'none'],
+    ['deleted', 'review'],
+    ['deleted', 'needsFix'],
+    ['deleted', 'approved'],
+  ])('counts %s / %s as finished board work', (status, reviewState) => {
+    expect(isTaskOpen({ status, reviewState })).toBe(false);
+  });
+
+  it('answers without a reviewState field', () => {
+    expect(isTaskOpen({ status: 'pending' })).toBe(true);
+    expect(isTaskOpen({ status: 'in_progress' })).toBe(true);
+    expect(isTaskOpen({ status: 'completed' })).toBe(false);
+    expect(isTaskOpen({ status: 'deleted' })).toBe(false);
+  });
+
+  it('treats an unknown status as open rather than silently finishing the board', () => {
+    expect(isTaskOpen({ status: 'blocked', reviewState: 'none' })).toBe(true);
+    expect(isTaskOpen({})).toBe(true);
+  });
+});

--- a/test/renderer/features/runtime-provider-management/useRuntimeProviderManagement.test.ts
+++ b/test/renderer/features/runtime-provider-management/useRuntimeProviderManagement.test.ts
@@ -1,5 +1,5 @@
 import React, { act } from 'react';
-import { createRoot } from 'react-dom/client';
+import { createRoot as createReactRoot } from 'react-dom/client';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -126,9 +126,16 @@ function createEmptyDirectoryResponse(
 }
 
 describe('useRuntimeProviderManagement', () => {
+  const roots = new Set<ReturnType<typeof createReactRoot>>();
   let host: HTMLDivElement;
   let state: RuntimeProviderManagementState | null = null;
   let actions: RuntimeProviderManagementActions | null = null;
+
+  function createRoot(container: HTMLDivElement): ReturnType<typeof createReactRoot> {
+    const root = createReactRoot(container);
+    roots.add(root);
+    return root;
+  }
 
   function Harness(): React.ReactElement {
     const hook = useRuntimeProviderManagement({
@@ -199,7 +206,12 @@ describe('useRuntimeProviderManagement', () => {
     actions = null;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Removing DOM alone leaves effects alive and able to overwrite the next test's state.
+    await act(async () => {
+      for (const root of roots) root.unmount();
+    });
+    roots.clear();
     Reflect.deleteProperty(window, 'electronAPI');
     document.body.innerHTML = '';
     vi.unstubAllGlobals();


### PR DESCRIPTION
Follows up the CodeRabbit finding on #546: https://github.com/777genius/agent-teams-ai/pull/546#discussion_r3924705069. Independent of every other open PR; branches from `origin/main @ b80091a22`.

## Problem

Two places in the controller decide whether a board is finished, each from its own inline rule.

`notifyLeadWhenBoardCompleted` (`agent-teams-controller/src/internal/tasks.js`) counted a task as open when it was not deleted and either not completed, or completed with `reviewState` `review` or `needsFix`.

`readBoardCompletionEpoch` (`agent-teams-controller/src/internal/messageStore.js`) required every row on the board to carry `status === 'completed'`.

A completed task in review, or one sent back and completed again while it still carries `needsFix`, is therefore open for the notice and closed for the guard. The guard treats such a board as finished and returns the team's next message to the user as a duplicate of the previous one, while the work the user is waiting on - the review outcome - has not happened yet. The notice has correctly not fired, because the board is not finished, so the guard is the only one of the two acting on that board and what it does is hold back the update.

The second half of the mismatch is defensive rather than live: the guard's `status === 'completed'` test also rejects a deleted row, which the notice skips explicitly. Both sites read the board through `taskStore.listTasks(paths)` without `includeDeleted`, and that call already drops deleted rows, so no board reaches either predicate with a deleted task on it today. It is still one rule written down twice with two different answers, and the next caller that passes `includeDeleted` inherits the difference.

## Fix

`isTaskOpen(task)` in the new `agent-teams-controller/src/internal/taskLifecycle.js`, called by both sites:

- `status === 'deleted'` - not open, whatever review state the row carries;
- `status !== 'completed'` - open;
- completed - open while `reviewState` is `review` or `needsFix`, finished otherwise.

`notifyLeadWhenBoardCompleted` drops its inline copy for `tasks.some((task) => task && isTaskOpen(task))`, which answers the same on every input it could previously receive. `readBoardCompletionEpoch` replaces `task.status === 'completed'` with `!isTaskOpen(task)`; that is where behaviour changes. A board holding a completed task in review or waiting for a fix no longer yields a completion epoch, so the post-completion guard stays out of the way until the review is over, and a board whose only other task was deleted yields one at both sites.

## Why this shape

The predicate is its own module rather than an export of either site: `tasks.js` already requires `messageStore.js`, so exporting it from `tasks.js` would close a require cycle, and a rule owned by one of the two consumers is a rule the other one can quietly stop matching. It has no dependencies and no state; callers keep their own guard against a malformed row, so the predicate answers only for the object it is handed.

The deleted arm is kept even though `listTasks` makes it unreachable from either call site. Dropping it would make the predicate wrong for a row read with `includeDeleted`, which is how most of `taskStore.js` reads tasks, and the comment on the function says exactly that so the arm is not mistaken for a live fix.

Three other lifecycle expressions in `tasks.js` are deliberately left alone, because they ask a different question and routing them through `isTaskOpen` would change behaviour rather than align it: `hasOpenBlockers` and `notifyUnblockedOwners` ask whether a blocker is still in the way (a completed task awaiting review would start blocking its dependents), and `maybeNotifyPreviousOwnerOnReassignment` asks whether the previous owner is still on the hook (a completed task in review would start producing reassignment notices). The finding is about one question asked in two places, and that is the whole of the change.

Sizes: `tasks.js` 1125/1233 (five lines shorter), `messageStore.js` 584/800, `taskLifecycle.js` 29. `scripts/ci/source-file-size-baseline.json` and `test/setup.ts` untouched.

## Tests

Two new files, 22 executed cases.

`agent-teams-controller/test/taskLifecycle.test.js` - the predicate against the whole product `taskStore.js` and `reviewState.js` can hold (four statuses, four review states):

- open: `pending` and `in_progress`, each with `none`, `review`, `needsFix` and `approved`;
- open: `completed` with `review`, and `completed` with `needsFix`;
- finished: `completed` with `none`, `completed` with `approved`, and `deleted` with each of the four review states;
- a row with no `reviewState` field at all, for each of the four statuses;
- an unknown status and an empty object read as open, so a malformed row cannot silently finish a board.

`agent-teams-controller/test/boardCompletionOpenTask.test.js` - the same board put in front of both sites, once per fixture:

- a board whose other task was deleted: the completion notice fires, the first message to the user is delivered, and a restatement two minutes later comes back with `Final message already delivered`;
- a board holding a completed task in review (`completeTask` then `review.requestReview`, on a two-task board): no completion notice, and two consecutive user-directed messages are both delivered;
- a board holding a completed task that was sent back and completed again (`completeTask`, `review.requestReview`, `review.requestChanges`, `completeTask`, asserting `pending` / `needsFix` after the fix request and `completed` / `needsFix` after the second completion): no completion notice, and both user-directed messages delivered;
- a structural case: both modules require `./taskLifecycle.js`, and neither restates the rule inline.

Negative controls, each applied alone and then reverted:

1. `readBoardCompletionEpoch` back to `task.status === 'completed'`: the review board and the needs-fix board fail on the guard assertion (the second message is suppressed), and the structural case fails. The deleted board still passes - `listTasks` filters deleted rows before the predicate sees them - so that arm is proved by the unit matrix alone, which is what the comment on the module says.
2. `notifyLeadWhenBoardCompleted` given that same completed-only rule: the review board and the needs-fix board fail on `boardNotices`, the notice announcing a finished board over open review work. The deleted board and the structural case pass.
3. the notifier's inline copy restored verbatim: only the structural case fails. That is the point of it - the copy is behaviour-identical right up until someone edits one of the two.
4. the `deleted` arm removed from `isTaskOpen`: five unit cases fail, no integration case does.
5. the `review`/`needsFix` arm removed: `completed` / `review` and `completed` / `needsFix` in the matrix fail, and so do both review boards.

Gates on the tip: `agent-teams-controller` suite 11 files / 292 tests, root `pnpm typecheck`, `node ./scripts/ci/check-source-file-size.mjs`, `pnpm guard:team-provisioning-architecture`, and `prettier --check` on the three added files. `prettier --check` on `tasks.js` (4-space indentation throughout) and on `messageStore.js` (five ternary and call-wrapping hunks) fails on `origin/main` as well; the output for `messageStore.js` is hunk-for-hunk the same before and after this branch, and neither file is reformatted here. ESLint does not cover this package: `pnpm lint:ci:files` reports `was not found by the project service` for every file under `agent-teams-controller/src`, including files this branch does not touch.

The root suite runs `test/**/*.test.ts` and `src/**/*.test.ts` only, so it does not execute the controller's `.test.js` files; it is reported here as a regression check. 14989 tests, 6 failed - the same six an unmodified `origin/main @ efb8ddced` produces on this machine (three `TeamProvisioningService` liveness cases and three `ClaudeMultimodelBridgeService` cases), nothing new and nothing newly passing. The branch was then rebased onto `b80091a22`; the three commits in between touch `docs/RELEASE.md`, `runtime.lock.json` and the runtime-provider-management test fixtures (the v0.0.76 runtime bump and the fixture alignment that followed it), none of it controller code. The controller suite, `pnpm typecheck` and the two runtime-provider-management test files that the bump had broken at `417b2e06d` were re-run on the rebased tip.

## Tested on

Windows 11 Pro, from source, against `origin/main @ b80091a22` (root full suite at `efb8ddced`, see Tests).

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Board completion remains open while completed tasks await review or require fixes.
  * Completion notifications now account for review approval and follow-up fix cycles.
  * Prevented premature final notifications and improved duplicate-message handling when task states change.
  * Deleted tasks and tasks with legacy or incomplete status information are handled more consistently when determining board completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->