### PR TITLE
fix(dashboard): make card interactions edge-to-edge

### DIFF
--- a/src/features/recent-projects/renderer/ui/RecentProjectCard.tsx
+++ b/src/features/recent-projects/renderer/ui/RecentProjectCard.tsx
@@ -26,9 +26,10 @@ export const RecentProjectCard = ({
     <button
       onClick={isDeleted ? undefined : onClick}
       aria-disabled={isDeleted}
+      data-recent-project-cell="project"
       className={cn(
-        'project-row-zebra-card group relative flex min-h-[120px] flex-col overflow-hidden rounded-lg border border-border p-4 text-left transition-all duration-300 hover:border-border-emphasis',
-        isDeleted && 'cursor-default border-red-500/25 bg-red-500/[0.03] hover:border-red-500/35'
+        'project-row-zebra-card group relative flex min-h-[112px] flex-col overflow-hidden p-3.5 text-left transition-colors duration-200 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-emphasis',
+        isDeleted && 'cursor-default bg-red-500/[0.03]'
       )}
     >
       {card.activeTeams && card.activeTeams.length > 0 && (

--- a/src/features/recent-projects/renderer/ui/RecentProjectsSection.tsx
+++ b/src/features/recent-projects/renderer/ui/RecentProjectsSection.tsx
@@ -13,17 +13,18 @@ interface RecentProjectsSectionProps {
 const titleWidths = [60, 66, 50, 55, 75, 45, 40, 65];
 const pathWidths = [80, 75, 85, 66, 70, 80, 60, 72];
 
-function SelectProjectFolderCard({
+const SelectProjectFolderCard = ({
   onClick,
 }: Readonly<{
   onClick: () => void;
-}>): React.JSX.Element {
+}>): React.JSX.Element => {
   const { t } = useAppTranslation('dashboard');
   return (
     <button
-      className="hover:bg-surface/30 group relative flex min-h-[120px] flex-col items-center justify-center rounded-lg border border-dashed border-border bg-transparent p-4 transition-all duration-300 hover:border-border-emphasis"
+      className="project-row-zebra-card group relative flex min-h-[112px] flex-col items-center justify-center p-3.5 transition-colors duration-200 focus-visible:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border-emphasis"
       onClick={onClick}
-      title={t('recentProjects.selectFolderTitle')}
+      aria-label={t('recentProjects.selectFolderTitle')}
+      data-recent-project-cell="select-folder"
     >
       <div className="mb-2 flex size-8 items-center justify-center rounded-md border border-dashed border-border transition-colors duration-300 group-hover:border-border-emphasis">
         <FolderOpen className="size-4 text-text-muted transition-colors group-hover:text-text-secondary" />
@@ -33,7 +34,7 @@ function SelectProjectFolderCard({
       </span>
     </button>
   );
-}
+};
 
 export const RecentProjectsSection = ({
   searchQuery,
@@ -54,14 +55,16 @@ export const RecentProjectsSection = ({
 
   if (loading) {
     return (
-      <div className="grid grid-cols-2 gap-3 lg:grid-cols-3 xl:grid-cols-4">
+      <div
+        className="project-row-zebra-grid grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-border bg-border lg:grid-cols-3 xl:grid-cols-4"
+        data-recent-projects-grid
+      >
         {Array.from({ length: 8 }).map((_, index) => (
           <div
             key={index}
-            className="skeleton-card flex min-h-[120px] flex-col rounded-sm border border-border p-4"
+            className="project-row-zebra-card skeleton-card flex min-h-[112px] flex-col p-3.5"
             style={{
               animationDelay: `${index * 80}ms`,
-              backgroundColor: 'var(--skeleton-base)',
             }}
           >
             <div
@@ -148,7 +151,10 @@ export const RecentProjectsSection = ({
 
   return (
     <div className="space-y-4">
-      <div className="project-row-zebra-grid grid grid-cols-2 gap-3 lg:grid-cols-3 xl:grid-cols-4">
+      <div
+        className="project-row-zebra-grid grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-border bg-border lg:grid-cols-3 xl:grid-cols-4"
+        data-recent-projects-grid
+      >
         {hasSelectFolderCard && (
           <SelectProjectFolderCard onClick={() => void selectProjectFolder()} />
         )}

--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -928,13 +928,15 @@ const InstalledBanner = ({
 
   return (
     <div
-      className={`mb-6 rounded-lg px-4 ${showExpandedContent ? `py-3 ${BANNER_MIN_H}` : 'py-2.5'}`}
+      className={`mb-6 overflow-hidden rounded-lg px-4 ${showExpandedContent ? `py-3 ${BANNER_MIN_H}` : 'py-2.5'}`}
       style={{ backgroundColor: INSTALLED_BANNER_BACKGROUND }}
     >
       <div
-        className={`flex items-center justify-between rounded-md ${
+        className={`flex items-center justify-between ${
           showCollapseControl
-            ? '-mx-2 cursor-pointer px-2 py-1 transition-colors hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/15'
+            ? `${
+                showExpandedContent ? '-mx-4 -mt-3 px-4 pb-1 pt-4' : '-mx-4 -my-2.5 px-4 py-3.5'
+              } cursor-pointer transition-colors hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-white/15`
             : ''
         }`}
         role="button"

--- a/test/features/recent-projects/renderer/hooks/useRecentProjectsSection.test.tsx
+++ b/test/features/recent-projects/renderer/hooks/useRecentProjectsSection.test.tsx
@@ -310,4 +310,32 @@ describe('useRecentProjectsSection', () => {
     expect(storeState.openTeamsTab).toHaveBeenCalledOnce();
     expect(storeState.openTeamsTab).toHaveBeenCalledWith('/tmp/alpha');
   });
+
+  it('opens a selected folder as a synthetic project without using a real dialog', async () => {
+    const selectedPath = '/tmp/recent-projects-select-folder-fixture';
+    const encodedId = '-tmp-recent-projects-select-folder-fixture';
+    apiMock.getDashboardRecentProjects.mockResolvedValue(payload('alpha'));
+    apiMock.config.selectFolders.mockResolvedValue([selectedPath]);
+    apiMock.config.addCustomProjectPath.mockResolvedValue(undefined);
+    storeState.fetchRepositoryGroups.mockResolvedValue(undefined);
+
+    await renderHarness();
+
+    await act(async () => {
+      await latest?.selectProjectFolder();
+      await flushPromises();
+    });
+
+    expect(apiMock.config.selectFolders).toHaveBeenCalledOnce();
+    expect(storeState.fetchRepositoryGroups).toHaveBeenCalledOnce();
+    expect(apiMock.config.addCustomProjectPath).toHaveBeenCalledWith(selectedPath);
+    expect(storeState.repositoryGroups[0]).toEqual(
+      expect.objectContaining({
+        id: encodedId,
+        name: 'recent-projects-select-folder-fixture',
+      })
+    );
+    expect(storeState.fetchSessionsInitial).toHaveBeenCalledWith(encodedId);
+    expect(storeState.openTeamsTab).toHaveBeenCalledWith(selectedPath);
+  });
 });

--- a/test/features/recent-projects/renderer/ui/RecentProjectCard.test.tsx
+++ b/test/features/recent-projects/renderer/ui/RecentProjectCard.test.tsx
@@ -55,4 +55,29 @@ describe('RecentProjectCard', () => {
     expect(heading?.textContent).toBe('alpha');
     expect(headerRow?.querySelector('svg')).toBeNull();
   });
+
+  it('renders as a flat grid cell without its own border or rounded corners', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <RecentProjectCard card={card} onClick={vi.fn()} onOpenPath={vi.fn()} />
+        </TooltipProvider>
+      );
+    });
+
+    const projectCell = host.querySelector<HTMLButtonElement>(
+      '[data-recent-project-cell="project"]'
+    );
+
+    expect(projectCell).not.toBeNull();
+    expect(projectCell?.classList.contains('project-row-zebra-card')).toBe(true);
+    expect(projectCell?.classList.contains('border')).toBe(false);
+    expect([...projectCell?.classList ?? []].some((name) => name.startsWith('rounded'))).toBe(
+      false
+    );
+  });
 });

--- a/test/features/recent-projects/renderer/ui/RecentProjectsSection.test.tsx
+++ b/test/features/recent-projects/renderer/ui/RecentProjectsSection.test.tsx
@@ -1,0 +1,91 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hookState = vi.hoisted(() => ({
+  cards: [{ id: 'repo:alpha' }],
+  loading: false,
+  error: null,
+  canLoadMore: false,
+  isElectron: true,
+  loadMore: vi.fn(),
+  reload: vi.fn(),
+  openRecentProject: vi.fn(),
+  openProjectPath: vi.fn(),
+  selectProjectFolder: vi.fn(),
+}));
+
+vi.mock('@features/recent-projects/renderer/hooks/useRecentProjectsSection', () => ({
+  useRecentProjectsSection: () => hookState,
+}));
+
+vi.mock('@features/localization/renderer', () => ({
+  useAppTranslation: () => ({
+    t: (key: string) =>
+      key === 'recentProjects.selectFolder'
+        ? 'Select Folder'
+        : key === 'recentProjects.selectFolderTitle'
+          ? 'Select a project folder'
+          : key,
+  }),
+}));
+
+vi.mock('@features/recent-projects/renderer/ui/RecentProjectCard', () => ({
+  RecentProjectCard: () => (
+    <button className="project-row-zebra-card" data-recent-project-cell="project">
+      alpha
+    </button>
+  ),
+}));
+
+import { RecentProjectsSection } from '@features/recent-projects/renderer/ui/RecentProjectsSection';
+
+describe('RecentProjectsSection', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    hookState.selectProjectFolder.mockClear();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('renders Select Folder and projects inside one dense divided grid', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    act(() => {
+      root.render(<RecentProjectsSection searchQuery="" />);
+    });
+
+    const grid = host.querySelector<HTMLElement>('[data-recent-projects-grid]');
+    const selectFolder = host.querySelector<HTMLButtonElement>(
+      '[data-recent-project-cell="select-folder"]'
+    );
+
+    expect(grid).not.toBeNull();
+    expect(grid?.classList.contains('gap-px')).toBe(true);
+    expect(grid?.classList.contains('overflow-hidden')).toBe(true);
+    expect(grid?.classList.contains('rounded-lg')).toBe(true);
+    expect(grid?.classList.contains('border')).toBe(true);
+    expect(grid?.querySelectorAll('[data-recent-project-cell]')).toHaveLength(2);
+
+    expect(selectFolder?.textContent).toContain('Select Folder');
+    expect(selectFolder?.getAttribute('aria-label')).toBe('Select a project folder');
+    expect(selectFolder?.classList.contains('project-row-zebra-card')).toBe(true);
+    expect(selectFolder?.classList.contains('items-center')).toBe(true);
+    expect(selectFolder?.classList.contains('justify-center')).toBe(true);
+    expect(selectFolder?.classList.contains('border')).toBe(false);
+    expect([...selectFolder?.classList ?? []].some((name) => name.startsWith('rounded'))).toBe(
+      false
+    );
+
+    act(() => selectFolder?.click());
+    expect(hookState.selectProjectFolder).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+  });
+});


### PR DESCRIPTION
## Summary

- render recent projects and the Select Folder action as a dense divided grid with one shared outer border
- extend the collapsible provider banner hover/focus surface to the full card bounds while preserving content spacing
- add focused regression coverage for grid structure, project cells, and the synthetic folder-selection flow

## Tests

- `pnpm lint:fast:files -- src/features/recent-projects/renderer/ui/RecentProjectCard.tsx src/features/recent-projects/renderer/ui/RecentProjectsSection.tsx src/renderer/components/dashboard/CliStatusBanner.tsx test/features/recent-projects/renderer/hooks/useRecentProjectsSection.test.tsx test/features/recent-projects/renderer/ui/RecentProjectCard.test.tsx test/features/recent-projects/renderer/ui/RecentProjectsSection.test.tsx`
- `pnpm typecheck`
- `pnpm exec vitest run test/features/recent-projects/renderer/hooks/useRecentProjectsSection.test.tsx test/features/recent-projects/renderer/ui/RecentProjectCard.test.tsx test/features/recent-projects/renderer/ui/RecentProjectsSection.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated recent project cards and folder selection cards with a denser, more consistent grid layout.
  * Improved keyboard focus styling and accessibility labels for project and folder-selection controls.
  * Adjusted loading placeholders and card spacing for a more cohesive appearance.
  * Refined the installed CLI status banner’s spacing and overflow behavior.

* **Bug Fixes**
  * Improved the folder-selection flow so selected folders are registered, initialized, and opened in the Teams view.

* **Tests**
  * Added coverage for recent project rendering, styling, accessibility, and folder-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->