### PR TITLE
fix(providers): clarify connectable and transient states

### DIFF
--- a/src/features/runtime-provider-management/renderer/RuntimeProviderQuickConnect.tsx
+++ b/src/features/runtime-provider-management/renderer/RuntimeProviderQuickConnect.tsx
@@ -350,8 +350,8 @@ export const RuntimeProviderQuickConnect = ({
           providerId: gateway.providerId,
           displayName: gateway.displayName,
           description,
-          state: 'unavailable',
-          stateLabel: t('cliStatus.quickConnect.statusUnavailable'),
+          state: 'connectable',
+          stateLabel: t('cliStatus.quickConnect.readyToConnect'),
           actionLabel: t('cliStatus.quickConnect.checkAndConnect'),
           onAction: () => onOpenCodeProviderAction(gateway.providerId, 'settings-connect'),
         };
@@ -376,8 +376,8 @@ export const RuntimeProviderQuickConnect = ({
           providerId: gateway.providerId,
           displayName: gateway.displayName,
           description,
-          state: 'unavailable',
-          stateLabel: t('cliStatus.quickConnect.statusUnavailable'),
+          state: 'connectable',
+          stateLabel: t('cliStatus.quickConnect.readyToConnect'),
           actionLabel: t('cliStatus.quickConnect.checkAndConnect'),
           onAction: () => onOpenCodeProviderAction(gateway.providerId, 'settings-connect'),
         };

--- a/src/renderer/store/slices/cliInstallerSlice.ts
+++ b/src/renderer/store/slices/cliInstallerSlice.ts
@@ -1275,24 +1275,34 @@ export const createCliInstallerSlice: StateCreator<AppState, [], [], CliInstalle
       }
 
       try {
-        let responseProviderStatus = verifyModels
-          ? await api.cliInstaller.verifyProviderModels(providerId)
-          : projectPath
-            ? await api.cliInstaller.getProviderStatus(providerId, { projectPath })
-            : await api.cliInstaller.getProviderStatus(providerId);
+        const requestProviderStatus = async (): Promise<CliProviderStatus | null> =>
+          verifyModels
+            ? api.cliInstaller.verifyProviderModels(providerId)
+            : projectPath
+              ? api.cliInstaller.getProviderStatus(providerId, { projectPath })
+              : api.cliInstaller.getProviderStatus(providerId);
+        let responseProviderStatus = await requestProviderStatus();
         // OpenCode's app-server can return a structurally valid but partial
         // status while its catalog is settling. Recheck once in the same
-        // request, but do not retry the intentional model-only fallback or
+        // request. Native status probes can also miss their bounded deadline
+        // while the desktop startup scan is busy, so retry that exact transient
+        // timeout once as well. Never retry intentional model-only fallbacks or
         // any other provider/error indefinitely.
-        if (
+        const shouldRetryOpenCodePartial =
           providerId === 'opencode' &&
           !verifyModels &&
           responseProviderStatus?.statusCheckErrorCode === 'partial_response' &&
-          responseProviderStatus.statusCheckOutcome !== 'model_only'
-        ) {
-          responseProviderStatus = projectPath
-            ? await api.cliInstaller.getProviderStatus(providerId, { projectPath })
-            : await api.cliInstaller.getProviderStatus(providerId);
+          responseProviderStatus.statusCheckOutcome !== 'model_only';
+        const shouldRetryTransientTimeout =
+          !verifyModels &&
+          responseProviderStatus?.statusCheckOutcome === 'transient_error' &&
+          responseProviderStatus.statusCheckErrorCode === 'timeout';
+        const requestIsStillCurrent =
+          requestEpoch === cliStatusEpoch &&
+          requestGeneration === cliProviderStatusGeneration &&
+          cliProviderStatusActiveRequestIds.get(scopeKey) === requestId;
+        if (requestIsStillCurrent && (shouldRetryOpenCodePartial || shouldRetryTransientTimeout)) {
+          responseProviderStatus = await requestProviderStatus();
         }
         const responseMatchesProvider = responseProviderStatus?.providerId === providerId;
         const providerStatus =

--- a/test/renderer/features/runtime-provider-management/RuntimeProviderQuickConnectView.test.ts
+++ b/test/renderer/features/runtime-provider-management/RuntimeProviderQuickConnectView.test.ts
@@ -403,7 +403,7 @@ describe('RuntimeProviderQuickConnectView', () => {
     expect(onRetryDirectory).toHaveBeenCalledTimes(1);
   });
 
-  it('shows an explicit connect action when a gateway catalog entry is unavailable', async () => {
+  it('shows an available-to-connect label when a gateway catalog entry is unavailable', async () => {
     const onConnect = vi.fn();
     await act(async () => {
       root.render(
@@ -411,7 +411,8 @@ describe('RuntimeProviderQuickConnectView', () => {
           cards: [
             card('openrouter', {
               displayName: 'OpenRouter',
-              stateLabel: 'Status unavailable',
+              state: 'connectable',
+              stateLabel: 'Available to connect',
               actionLabel: 'Check & connect',
               onAction: onConnect,
             }),
@@ -431,6 +432,14 @@ describe('RuntimeProviderQuickConnectView', () => {
     const connect = host.querySelector<HTMLButtonElement>(
       '[data-testid="provider-quick-action-openrouter"]'
     );
+    expect(connect?.closest('[data-testid="provider-quick-card-openrouter"]')?.textContent).toContain(
+      'Available to connect'
+    );
+    expect(
+      connect
+        ?.closest('[data-testid="provider-quick-card-openrouter"]')
+        ?.querySelector('[title="Available to connect"]')?.className
+    ).toContain('text-sky-300');
     expect(connect?.textContent).toContain('Check & connect');
     expect(connect?.disabled).toBe(false);
     act(() => connect?.click());

--- a/test/renderer/features/runtime-provider-management/runtimeProviderQuickConnect.test.ts
+++ b/test/renderer/features/runtime-provider-management/runtimeProviderQuickConnect.test.ts
@@ -383,6 +383,8 @@ describe('RuntimeProviderQuickConnect', () => {
         authoritativeLoaded: false,
         authoritativePending: false,
         error: 'directory unavailable',
+        expectedState: 'connectable',
+        expectedLabel: 'cliStatus.quickConnect.readyToConnect',
       },
       {
         entries: [],
@@ -391,6 +393,8 @@ describe('RuntimeProviderQuickConnect', () => {
         authoritativeLoaded: false,
         authoritativePending: false,
         error: null,
+        expectedState: 'connectable',
+        expectedLabel: 'cliStatus.quickConnect.readyToConnect',
       },
       {
         entries: [entry('openrouter', { state: 'error', setupKind: 'unsupported' })],
@@ -399,6 +403,8 @@ describe('RuntimeProviderQuickConnect', () => {
         authoritativeLoaded: true,
         authoritativePending: false,
         error: null,
+        expectedState: 'unavailable',
+        expectedLabel: 'cliStatus.quickConnect.notInCatalog',
       },
     ] as const;
 
@@ -411,6 +417,12 @@ describe('RuntimeProviderQuickConnect', () => {
       const action = host.querySelector<HTMLButtonElement>(
         '[data-testid="provider-quick-action-openrouter"]'
       );
+      expect(card?.querySelector(`[title="${directory.expectedLabel}"]`)?.className).toContain(
+        directory.expectedState === 'connectable'
+          ? 'text-sky-300'
+          : 'text-[var(--color-text-muted)]'
+      );
+      expect(card?.textContent).toContain(directory.expectedLabel);
       expect(card?.textContent).toContain('cliStatus.quickConnect.checkAndConnect');
       expect(action).not.toBeNull();
 

--- a/test/renderer/store/cliInstallerSlice.test.ts
+++ b/test/renderer/store/cliInstallerSlice.test.ts
@@ -1353,7 +1353,9 @@ describe('cliInstallerSlice', () => {
             .getState()
             .cliStatus?.providers.every((provider) => !provider.capabilities.teamLaunch)
         ).toBe(true);
-        expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(1);
+        expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(
+          outcome === 'timeout' ? 2 : 1
+        );
       }
     );
 
@@ -1921,6 +1923,57 @@ describe('cliInstallerSlice', () => {
         statusCheckOutcome: 'authoritative',
         modelCatalogRefreshState: 'ready',
       });
+    });
+
+    it('rechecks one transient provider timeout before replacing connected status', async () => {
+      const connectedProvider = createMultimodelProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        authenticated: true,
+        authMethod: 'claude.ai',
+        statusMessage: null,
+        models: ['haiku'],
+        backend: { kind: 'anthropic-api', label: 'Anthropic API' },
+      });
+      const timedOutProvider = createMultimodelProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        supported: false,
+        authenticated: false,
+        authMethod: null,
+        verificationState: 'error',
+        statusCheckOutcome: 'transient_error',
+        statusCheckErrorCode: 'timeout',
+        statusMessage: CLI_PROVIDER_STATUS_UNAVAILABLE_MESSAGE,
+        capabilities: {
+          teamLaunch: false,
+          oneShot: false,
+          extensions: createDefaultCliExtensionCapabilities(),
+        },
+      });
+      useStore.setState({ cliStatus: createMultimodelStatus([connectedProvider]) });
+      vi.mocked(api.cliInstaller.getProviderStatus)
+        .mockResolvedValueOnce(timedOutProvider)
+        .mockResolvedValueOnce(connectedProvider);
+
+      await expect(
+        useStore
+          .getState()
+          .fetchCliProviderStatus('anthropic', { checkReason: 'manual_refresh' })
+      ).resolves.toBe(true);
+
+      expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(2);
+      expect(
+        useStore
+          .getState()
+          .cliStatus?.providers.find((provider) => provider.providerId === 'anthropic')
+      ).toMatchObject({
+        authenticated: true,
+        authMethod: 'claude.ai',
+        verificationState: 'verified',
+        statusCheckOutcome: 'authoritative',
+      });
+      expect(useStore.getState().cliStatusError).toBeNull();
     });
 
     it('reports a scoped OpenCode catalog loaded only after an authoritative ready response', async () => {


### PR DESCRIPTION
## Summary

- show non-authoritative OpenRouter and Vercel gateway fallbacks as blue Available to connect cards using the shared connectable state
- retry one current transient provider timeout before publishing an unavailable snapshot
- keep launch authority fail-closed and skip retries for invalidated requests

## Verification

- 96 focused Vitest tests
- pnpm typecheck
- focused fast lint
- production package and live CDP verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OpenCode gateway cards remain available to connect when the provider directory is unavailable or missing the gateway entry.
  - Provider connection checks now retry once after transient timeout errors, helping preserve valid connected-provider status.
  - OpenRouter cards now clearly distinguish gateways that are ready to connect from providers unavailable in the catalog.
  - Connection status labels and visual indicators now accurately reflect gateway availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->