### PR TITLE
fix(opencode): stop passive status from loading forever

### DIFF
--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -1156,9 +1156,12 @@ const InstalledBanner = ({
               : openCodeRuntimeContradictsMissingMetadata
                 ? t('cliStatus.quickConnect.connected')
                 : formatProviderStatusText(provider, settingsT);
+            const isPassiveOpenCodeModelSummary =
+              provider.providerId === 'opencode' && provider.statusCheckOutcome === 'model_only';
             const modelCatalogLoading =
-              provider.modelCatalogRefreshState === 'loading' ||
-              isOpenCodeCatalogHydrating(provider);
+              !isPassiveOpenCodeModelSummary &&
+              (provider.modelCatalogRefreshState === 'loading' ||
+                isOpenCodeCatalogHydrating(provider));
             const hasProviderModels =
               provider.providerId === 'opencode'
                 ? getVisibleTeamProviderModels(provider.providerId, provider.models, provider)
@@ -1240,9 +1243,11 @@ const InstalledBanner = ({
                         {modelCatalogLoading ? (
                           <span>{t('cliStatus.provider.loadingModels')}</span>
                         ) : null}
-                        {!hasProviderModels && !modelCatalogLoading && (
-                          <span>{t('cliStatus.provider.modelsUnavailable')}</span>
-                        )}
+                        {!hasProviderModels &&
+                          !modelCatalogLoading &&
+                          !isPassiveOpenCodeModelSummary && (
+                            <span>{t('cliStatus.provider.modelsUnavailable')}</span>
+                          )}
                       </div>
                     ) : null}
                     {!showSkeleton && codexDashboardHint ? (

--- a/src/renderer/store/slices/cliInstallerSlice.ts
+++ b/src/renderer/store/slices/cliInstallerSlice.ts
@@ -1282,12 +1282,8 @@ export const createCliInstallerSlice: StateCreator<AppState, [], [], CliInstalle
               ? api.cliInstaller.getProviderStatus(providerId, { projectPath })
               : api.cliInstaller.getProviderStatus(providerId);
         let responseProviderStatus = await requestProviderStatus();
-        // OpenCode's app-server can return a structurally valid but partial
-        // status while its catalog is settling. Recheck once in the same
-        // request. Native status probes can also miss their bounded deadline
-        // while the desktop startup scan is busy, so retry that exact transient
-        // timeout once as well. Never retry intentional model-only fallbacks or
-        // any other provider/error indefinitely.
+        // Retry only bounded partial/timeout startup probes; intentional
+        // model-only fallbacks and other provider errors remain settled.
         const shouldRetryOpenCodePartial =
           providerId === 'opencode' &&
           !verifyModels &&

--- a/test/renderer/components/cli/CliStatusVisibility.test.ts
+++ b/test/renderer/components/cli/CliStatusVisibility.test.ts
@@ -1659,7 +1659,7 @@ describe('CLI status visibility during completed install state', () => {
     });
   });
 
-  it('shows OpenCode model loading instead of the summary-only big-pickle badge', async () => {
+  it('does not show endless model loading for a completed OpenCode passive summary', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     storeState.cliInstallerState = 'idle';
     storeState.cliStatus = createInstalledCliStatus({
@@ -1673,15 +1673,17 @@ describe('CLI status visibility during completed install state', () => {
         {
           providerId: 'opencode',
           displayName: 'OpenCode (200+ models)',
-          supported: true,
-          authenticated: true,
-          authMethod: 'opencode_managed',
-          verificationState: 'verified',
-          statusMessage: null,
+          supported: false,
+          authenticated: false,
+          authMethod: null,
+          verificationState: 'unknown',
+          statusCheckOutcome: 'model_only',
+          statusCheckErrorCode: 'partial_response',
+          statusMessage: 'OpenCode detected (passive)',
           models: ['opencode/big-pickle'],
           canLoginFromUi: false,
           capabilities: {
-            teamLaunch: true,
+            teamLaunch: false,
             oneShot: false,
           },
           backend: { kind: 'opencode-cli', label: 'OpenCode CLI' },
@@ -1706,7 +1708,10 @@ describe('CLI status visibility during completed install state', () => {
       await Promise.resolve();
     });
 
-    expect(host.textContent).toContain('Loading models...');
+    expect(host.textContent).toContain('OpenCode detected (passive)');
+    expect(host.textContent).toContain('Runtime: OpenCode CLI');
+    expect(host.textContent).not.toContain('Loading models...');
+    expect(host.textContent).not.toContain('Models unavailable for this runtime build');
     expect(host.textContent).not.toContain('big-pickle');
 
     await act(async () => {


### PR DESCRIPTION
## Summary

- treat a completed OpenCode model-only passive snapshot as settled dashboard presentation
- keep real catalog hydration states and project-scoped launch authority unchanged
- avoid replacing the spinner with a false models-unavailable message

## Verification

- 61 focused dashboard tests
- pnpm typecheck
- focused fast lint
- production build and codesign
- live Electron E2E: backend returned model_only/loading while the card showed passive status without Loading models or Models unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenCode status displays for passive detections.
  * Prevented misleading model-loading indicators and “models unavailable” messages when only runtime information is available.
  * Continued showing the detected runtime and passive status message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->