### PR TITLE
fix(opencode): show dashboard models from scoped catalog

### DIFF
--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -1161,14 +1161,14 @@ const InstalledBanner = ({
                 : provider.models.length > 0;
             const statusText = showSkeleton
               ? t('cliStatus.actions.checking')
-              : openCodeRuntimeContradictsMissingMetadata
-                ? t('cliStatus.quickConnect.connected')
-                : isPassiveOpenCodeModelSummary
-                  ? hasProviderModels
-                    ? settingsT('providerRuntime.connectionUi.status.modelsAvailable')
-                    : provider.modelCatalogRefreshState === 'error'
-                      ? t('cliStatus.provider.modelsUnavailable')
-                      : t('cliStatus.actions.checking')
+              : isPassiveOpenCodeModelSummary
+                ? hasProviderModels
+                  ? settingsT('providerRuntime.connectionUi.status.modelsAvailable')
+                  : provider.modelCatalogRefreshState === 'error'
+                    ? t('cliStatus.provider.modelsUnavailable')
+                    : t('cliStatus.actions.checking')
+                : openCodeRuntimeContradictsMissingMetadata
+                  ? t('cliStatus.quickConnect.connected')
                   : formatProviderStatusText(provider, settingsT);
             const modelCatalogLoading =
               !isPassiveOpenCodeModelSummary &&

--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -24,6 +24,7 @@ import {
   resolveOpenCodeQuickConnectGate,
   RuntimeProviderOnboardingDialog,
   RuntimeProviderQuickConnect,
+  useOpenCodeProviderModelCatalog,
 } from '@features/runtime-provider-management/renderer';
 import { api, isElectronMode } from '@renderer/api';
 import atlasCloudLogo from '@renderer/assets/atlascloud-logo.svg';
@@ -1151,22 +1152,28 @@ const InstalledBanner = ({
               provider.providerId === 'opencode' &&
               provider.statusCheckErrorCode === 'runtime_missing' &&
               isOpenCodeRuntimeUsable(openCodeRuntimeStatus);
-            const statusText = showSkeleton
-              ? t('cliStatus.actions.checking')
-              : openCodeRuntimeContradictsMissingMetadata
-                ? t('cliStatus.quickConnect.connected')
-                : formatProviderStatusText(provider, settingsT);
             const isPassiveOpenCodeModelSummary =
               provider.providerId === 'opencode' && provider.statusCheckOutcome === 'model_only';
-            const modelCatalogLoading =
-              !isPassiveOpenCodeModelSummary &&
-              (provider.modelCatalogRefreshState === 'loading' ||
-                isOpenCodeCatalogHydrating(provider));
             const hasProviderModels =
               provider.providerId === 'opencode'
                 ? getVisibleTeamProviderModels(provider.providerId, provider.models, provider)
                     .length > 0
                 : provider.models.length > 0;
+            const statusText = showSkeleton
+              ? t('cliStatus.actions.checking')
+              : openCodeRuntimeContradictsMissingMetadata
+                ? t('cliStatus.quickConnect.connected')
+                : isPassiveOpenCodeModelSummary
+                  ? hasProviderModels
+                    ? settingsT('providerRuntime.connectionUi.status.modelsAvailable')
+                    : provider.modelCatalogRefreshState === 'error'
+                      ? t('cliStatus.provider.modelsUnavailable')
+                      : t('cliStatus.actions.checking')
+                  : formatProviderStatusText(provider, settingsT);
+            const modelCatalogLoading =
+              !isPassiveOpenCodeModelSummary &&
+              (provider.modelCatalogRefreshState === 'loading' ||
+                isOpenCodeCatalogHydrating(provider));
             const showProviderModels = shouldShowLoadedProviderModels(provider, hasProviderModels);
             const openCodeDashboardChips = getOpenCodeDashboardChips(provider, t);
             const hasDetailContent = Boolean(
@@ -1599,14 +1606,35 @@ export const CliStatusBanner = ({
     initialRefreshDelayMs: CODEX_ACCOUNT_STARTUP_IDLE_MIN_DELAY_MS,
     initialRefreshMaxDelayMs: CODEX_ACCOUNT_STARTUP_IDLE_MAX_DELAY_MS,
   });
+  const passiveOpenCodeProvider = useMemo(
+    () =>
+      loadingCliStatus?.providers.find(
+        (provider) =>
+          provider.providerId === 'opencode' && provider.statusCheckOutcome === 'model_only'
+      ) ?? null,
+    [loadingCliStatus?.providers]
+  );
+  const openCodeDashboardCatalog = useOpenCodeProviderModelCatalog({
+    enabled:
+      isElectron &&
+      multimodelEnabled &&
+      loadingCliStatus?.flavor === 'agent_teams_orchestrator' &&
+      Boolean(passiveOpenCodeProvider),
+    sourceProviderId: 'opencode',
+    projectPath: selectedProjectPath,
+    refreshRevision: providerQuickConnectRefreshKey,
+    passiveProviderStatus: passiveOpenCodeProvider,
+  });
   const visibleCliProviders = useMemo(
     () =>
       filterMainScreenCliProviders(loadingCliStatus?.providers ?? []).map((provider) =>
-        provider.providerId === 'codex'
-          ? mergeCodexProviderStatusWithSnapshot(provider, codexAccount.snapshot)
-          : provider
+        provider.providerId === 'opencode' && openCodeDashboardCatalog.providerStatus
+          ? openCodeDashboardCatalog.providerStatus
+          : provider.providerId === 'codex'
+            ? mergeCodexProviderStatusWithSnapshot(provider, codexAccount.snapshot)
+            : provider
       ),
-    [loadingCliStatus?.providers, codexAccount.snapshot]
+    [loadingCliStatus?.providers, codexAccount.snapshot, openCodeDashboardCatalog.providerStatus]
   );
   const loadingCliProviderMap = useMemo(
     () =>

--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -1622,7 +1622,6 @@ export const CliStatusBanner = ({
       Boolean(passiveOpenCodeProvider),
     sourceProviderId: 'opencode',
     projectPath: selectedProjectPath,
-    refreshRevision: providerQuickConnectRefreshKey,
     passiveProviderStatus: passiveOpenCodeProvider,
   });
   const visibleCliProviders = useMemo(

--- a/src/renderer/components/runtime/providerModelVisibility.ts
+++ b/src/renderer/components/runtime/providerModelVisibility.ts
@@ -11,12 +11,16 @@ export function shouldShowLoadedProviderModels(
         | 'modelCatalog'
         | 'modelCatalogRefreshState'
         | 'runtimeCapabilities'
+        | 'statusCheckOutcome'
       >
     | null
     | undefined,
   hasVisibleModels: boolean
 ): boolean {
   if (!provider || !hasVisibleModels) return false;
+  if (provider.providerId === 'opencode' && provider.statusCheckOutcome === 'model_only') {
+    return true;
+  }
   if (!isOpenCodeCatalogHydrating(provider)) return true;
 
   const reportedModels = provider.models.map((model) => model.trim()).filter(Boolean);

--- a/test/renderer/components/cli/CliStatusVisibility.test.ts
+++ b/test/renderer/components/cli/CliStatusVisibility.test.ts
@@ -1659,7 +1659,7 @@ describe('CLI status visibility during completed install state', () => {
     });
   });
 
-  it('does not show endless model loading for a completed OpenCode passive summary', async () => {
+  it('shows available models without endless loading for a completed OpenCode passive summary', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     storeState.cliInstallerState = 'idle';
     storeState.cliStatus = createInstalledCliStatus({
@@ -1708,11 +1708,11 @@ describe('CLI status visibility during completed install state', () => {
       await Promise.resolve();
     });
 
-    expect(host.textContent).toContain('OpenCode detected (passive)');
+    expect(host.textContent).toContain('Models available');
     expect(host.textContent).toContain('Runtime: OpenCode CLI');
     expect(host.textContent).not.toContain('Loading models...');
     expect(host.textContent).not.toContain('Models unavailable for this runtime build');
-    expect(host.textContent).not.toContain('big-pickle');
+    expect(host.textContent).toContain('big-pickle');
 
     await act(async () => {
       root.unmount();

--- a/test/renderer/components/cli/CliStatusVisibility.test.ts
+++ b/test/renderer/components/cli/CliStatusVisibility.test.ts
@@ -84,6 +84,9 @@ let terminalModalProps: {
   onExit?: (exitCode: number) => void;
 } | null = null;
 let quickConnectConnectedCount = 0;
+let openCodeCatalogHookInputs: Array<{
+  refreshRevision?: number;
+}> = [];
 const codexAccountHookState = {
   snapshot: null as CodexAccountSnapshotDto | null,
   loading: false,
@@ -116,6 +119,12 @@ vi.mock('@features/runtime-provider-management/renderer', async (importOriginal)
     await importOriginal<typeof import('@features/runtime-provider-management/renderer')>();
   return {
     ...actual,
+    useOpenCodeProviderModelCatalog: (
+      input: Parameters<typeof actual.useOpenCodeProviderModelCatalog>[0]
+    ) => {
+      openCodeCatalogHookInputs.push(input);
+      return actual.useOpenCodeProviderModelCatalog(input);
+    },
     RuntimeProviderQuickConnect: (props: {
       onOpenCodeProviderAction?: (providerId: string, action: 'connect' | 'select') => void;
       onConnectedCountChange?: (count: number) => void;
@@ -432,6 +441,7 @@ describe('CLI status visibility during completed install state', () => {
     runtimeProviderOnboardingDialogProps = null;
     terminalModalProps = null;
     quickConnectConnectedCount = 0;
+    openCodeCatalogHookInputs = [];
     codexAccountHookState.snapshot = null;
     codexAccountHookState.loading = false;
     codexAccountHookState.rateLimitsLoading = false;
@@ -1713,6 +1723,7 @@ describe('CLI status visibility during completed install state', () => {
     expect(host.textContent).not.toContain('Loading models...');
     expect(host.textContent).not.toContain('Models unavailable for this runtime build');
     expect(host.textContent).toContain('big-pickle');
+    expect(openCodeCatalogHookInputs.at(-1)?.refreshRevision).toBeUndefined();
 
     await act(async () => {
       root.unmount();

--- a/test/renderer/components/cli/CliStatusVisibility.test.ts
+++ b/test/renderer/components/cli/CliStatusVisibility.test.ts
@@ -1672,6 +1672,13 @@ describe('CLI status visibility during completed install state', () => {
   it('shows available models without endless loading for a completed OpenCode passive summary', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     storeState.cliInstallerState = 'idle';
+    storeState.openCodeRuntimeStatus = {
+      installed: true,
+      binaryPath: '/app-data/runtimes/opencode/opencode',
+      version: '1.17.18',
+      source: 'app-managed',
+      state: 'ready',
+    };
     storeState.cliStatus = createInstalledCliStatus({
       flavor: 'agent_teams_orchestrator',
       displayName: 'Multimodel runtime',
@@ -1688,7 +1695,7 @@ describe('CLI status visibility during completed install state', () => {
           authMethod: null,
           verificationState: 'unknown',
           statusCheckOutcome: 'model_only',
-          statusCheckErrorCode: 'partial_response',
+          statusCheckErrorCode: 'runtime_missing',
           statusMessage: 'OpenCode detected (passive)',
           models: ['opencode/big-pickle'],
           canLoginFromUi: false,
@@ -1722,6 +1729,7 @@ describe('CLI status visibility during completed install state', () => {
     expect(host.textContent).toContain('Runtime: OpenCode CLI');
     expect(host.textContent).not.toContain('Loading models...');
     expect(host.textContent).not.toContain('Models unavailable for this runtime build');
+    expect(host.textContent).not.toContain('OpenCode detected (passive)');
     expect(host.textContent).toContain('big-pickle');
     expect(openCodeCatalogHookInputs.at(-1)?.refreshRevision).toBeUndefined();
 

--- a/test/renderer/components/cli/CliStatusVisibility.test.ts
+++ b/test/renderer/components/cli/CliStatusVisibility.test.ts
@@ -84,9 +84,9 @@ let terminalModalProps: {
   onExit?: (exitCode: number) => void;
 } | null = null;
 let quickConnectConnectedCount = 0;
-let openCodeCatalogHookInputs: Array<{
+let openCodeCatalogHookInputs: {
   refreshRevision?: number;
-}> = [];
+}[] = [];
 const codexAccountHookState = {
   snapshot: null as CodexAccountSnapshotDto | null,
   loading: false,
@@ -1731,6 +1731,7 @@ describe('CLI status visibility during completed install state', () => {
     expect(host.textContent).not.toContain('Models unavailable for this runtime build');
     expect(host.textContent).not.toContain('OpenCode detected (passive)');
     expect(host.textContent).toContain('big-pickle');
+    expect(openCodeCatalogHookInputs).not.toHaveLength(0);
     expect(openCodeCatalogHookInputs.at(-1)?.refreshRevision).toBeUndefined();
 
     await act(async () => {

--- a/test/renderer/components/runtime/providerConnectionUi.test.ts
+++ b/test/renderer/components/runtime/providerConnectionUi.test.ts
@@ -295,6 +295,18 @@ describe('providerConnectionUi', () => {
       })
     ).toBe(false);
     expect(shouldShowLoadedProviderModels(provider, true)).toBe(false);
+    const passiveProvider: CliProviderStatus = {
+      ...provider,
+      supported: false,
+      authenticated: false,
+      authMethod: null,
+      verificationState: 'unknown',
+      statusCheckOutcome: 'model_only',
+      statusCheckErrorCode: 'partial_response',
+      statusMessage: 'OpenCode detected (passive)',
+      capabilities: { ...provider.capabilities, teamLaunch: false },
+    };
+    expect(shouldShowLoadedProviderModels(passiveProvider, true)).toBe(true);
     expect(
       shouldShowLoadedProviderModels(
         {


### PR DESCRIPTION
Summary
- hydrate passive OpenCode dashboard status through the existing project-scoped model catalog
- render the verified model list while keeping passive global status non-authoritative for launch
- replace the internal passive message with user-facing checking, available, or unavailable state

Verification
- pnpm typecheck
- pnpm lint:fast:files -- src/renderer/components/dashboard/CliStatusBanner.tsx src/renderer/components/runtime/providerModelVisibility.ts test/renderer/components/cli/CliStatusVisibility.test.ts test/renderer/components/runtime/providerConnectionUi.test.ts
- pnpm exec vitest run test/renderer/components/runtime/providerConnectionUi.test.ts test/renderer/components/cli/CliStatusVisibility.test.ts test/renderer/features/runtime-provider-management/useOpenCodeProviderModelCatalog.test.tsx
- pnpm guard:source-file-size
- pnpm build
- signed production app codesign verification
- live CDP check against orchestrator 0.0.76: all 7 OpenCode free models visible, no passive label, no endless loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved passive OpenCode provider status reporting in the dashboard.
  - Displays “Models available” when visible models are found, “Models unavailable” when loading fails, and “Checking” while results are pending.
  - Passive providers now display available models without remaining stuck in a loading state, including when runtime status information is incomplete.
  - Provider model visibility now remains accurate when status checks return partial results.

- **Tests**
  - Added coverage for passive provider model visibility and updated dashboard status expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->