### PR TITLE
fix(opencode): recover idle delivery lanes and track lead activity

### DIFF
--- a/src/main/services/team/opencode/delivery/OpenCodeActiveDeliveryPreemption.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeActiveDeliveryPreemption.ts
@@ -1,12 +1,10 @@
 import { isOpenCodeAcceptedDeliveryMissingPromptProof } from './OpenCodePromptDeliveryReadCommitPolicy';
-import { decideOpenCodeStalePendingUserPreemption } from './OpenCodePromptDeliveryStalePendingPolicy';
 
 import type { OpenCodeMemberMessageDeliveryServiceDependencies } from './OpenCodeMemberMessageDeliveryPorts';
 import type {
   OpenCodePromptDeliveryLedgerRecord,
   OpenCodePromptDeliveryLedgerStore,
 } from './OpenCodePromptDeliveryLedger';
-import type { OpenCodeStalePendingResolution } from './OpenCodePromptDeliveryStalePendingPolicy';
 
 /**
  * Ports needed to decide whether the record currently holding a lane still
@@ -85,61 +83,4 @@ export async function recoverOpenCodeActiveDeliveryBlocker(input: {
     });
   }
   return active;
-}
-
-/**
- * Settles a stale-pending resolution against the ledger. Returns the settled
- * record, or null when the resolution changed nothing.
- */
-export type OpenCodeStalePendingSettler = (input: {
-  ledgerRecord: OpenCodePromptDeliveryLedgerRecord;
-  resolution: OpenCodeStalePendingResolution;
-  eventContext: Record<string, unknown>;
-}) => Promise<OpenCodePromptDeliveryLedgerRecord | null>;
-
-/**
- * A new user message must never wait behind a stale non-user record that the
- * observe loop never settled. Decide whether the blocker can be preempted, and
- * settle it if so.
- *
- * Returns the record that still blocks the lane, or null once it no longer does.
- */
-export async function preemptStaleOpenCodeActiveDelivery(input: {
-  ports: Pick<
-    OpenCodeMemberMessageDeliveryServiceDependencies,
-    'scheduleOpenCodePromptDeliveryWatchdog' | 'openCodeStalePendingPolicyConfig'
-  >;
-  activeRecord: OpenCodePromptDeliveryLedgerRecord;
-  incomingMessageId?: string;
-  incomingReplyRecipient?: string;
-  laneKind: 'primary' | 'secondary';
-  teamName: string;
-  memberName: string;
-  settle: OpenCodeStalePendingSettler;
-}): Promise<OpenCodePromptDeliveryLedgerRecord | null> {
-  const preemption = decideOpenCodeStalePendingUserPreemption({
-    activeRecord: input.activeRecord,
-    incomingReplyRecipient: input.incomingReplyRecipient,
-    laneKind: input.laneKind,
-    nowMs: Date.now(),
-    config: input.ports.openCodeStalePendingPolicyConfig,
-  });
-  const settled = await input.settle({
-    ledgerRecord: input.activeRecord,
-    resolution: preemption,
-    eventContext: { preemptedByUserMessageId: input.incomingMessageId },
-  });
-  if (!settled) {
-    return input.activeRecord;
-  }
-  if (settled.status === 'responded') {
-    // Let the watchdog relay read-commit the settled inbox row.
-    input.ports.scheduleOpenCodePromptDeliveryWatchdog({
-      teamName: input.teamName,
-      memberName: input.memberName,
-      messageId: settled.inboxMessageId,
-      delayMs: 500,
-    });
-  }
-  return null;
 }

--- a/src/main/services/team/opencode/delivery/OpenCodeActiveDeliveryPreemption.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeActiveDeliveryPreemption.ts
@@ -1,10 +1,12 @@
 import { isOpenCodeAcceptedDeliveryMissingPromptProof } from './OpenCodePromptDeliveryReadCommitPolicy';
+import { decideOpenCodeStalePendingUserPreemption } from './OpenCodePromptDeliveryStalePendingPolicy';
 
 import type { OpenCodeMemberMessageDeliveryServiceDependencies } from './OpenCodeMemberMessageDeliveryPorts';
 import type {
   OpenCodePromptDeliveryLedgerRecord,
   OpenCodePromptDeliveryLedgerStore,
 } from './OpenCodePromptDeliveryLedger';
+import type { OpenCodeStalePendingResolution } from './OpenCodePromptDeliveryStalePendingPolicy';
 
 /**
  * Ports needed to decide whether the record currently holding a lane still
@@ -83,4 +85,61 @@ export async function recoverOpenCodeActiveDeliveryBlocker(input: {
     });
   }
   return active;
+}
+
+/**
+ * Settles a stale-pending resolution against the ledger. Returns the settled
+ * record, or null when the resolution changed nothing.
+ */
+export type OpenCodeStalePendingSettler = (input: {
+  ledgerRecord: OpenCodePromptDeliveryLedgerRecord;
+  resolution: OpenCodeStalePendingResolution;
+  eventContext: Record<string, unknown>;
+}) => Promise<OpenCodePromptDeliveryLedgerRecord | null>;
+
+/**
+ * A new user message must never wait behind a stale non-user record that the
+ * observe loop never settled. Decide whether the blocker can be preempted, and
+ * settle it if so.
+ *
+ * Returns the record that still blocks the lane, or null once it no longer does.
+ */
+export async function preemptStaleOpenCodeActiveDelivery(input: {
+  ports: Pick<
+    OpenCodeMemberMessageDeliveryServiceDependencies,
+    'scheduleOpenCodePromptDeliveryWatchdog' | 'openCodeStalePendingPolicyConfig'
+  >;
+  activeRecord: OpenCodePromptDeliveryLedgerRecord;
+  incomingMessageId?: string;
+  incomingReplyRecipient?: string;
+  laneKind: 'primary' | 'secondary';
+  teamName: string;
+  memberName: string;
+  settle: OpenCodeStalePendingSettler;
+}): Promise<OpenCodePromptDeliveryLedgerRecord | null> {
+  const preemption = decideOpenCodeStalePendingUserPreemption({
+    activeRecord: input.activeRecord,
+    incomingReplyRecipient: input.incomingReplyRecipient,
+    laneKind: input.laneKind,
+    nowMs: Date.now(),
+    config: input.ports.openCodeStalePendingPolicyConfig,
+  });
+  const settled = await input.settle({
+    ledgerRecord: input.activeRecord,
+    resolution: preemption,
+    eventContext: { preemptedByUserMessageId: input.incomingMessageId },
+  });
+  if (!settled) {
+    return input.activeRecord;
+  }
+  if (settled.status === 'responded') {
+    // Let the watchdog relay read-commit the settled inbox row.
+    input.ports.scheduleOpenCodePromptDeliveryWatchdog({
+      teamName: input.teamName,
+      memberName: input.memberName,
+      messageId: settled.inboxMessageId,
+      delayMs: 500,
+    });
+  }
+  return null;
 }

--- a/src/main/services/team/opencode/delivery/OpenCodeActiveDeliveryPreemption.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeActiveDeliveryPreemption.ts
@@ -1,0 +1,86 @@
+import { isOpenCodeAcceptedDeliveryMissingPromptProof } from './OpenCodePromptDeliveryReadCommitPolicy';
+
+import type { OpenCodeMemberMessageDeliveryServiceDependencies } from './OpenCodeMemberMessageDeliveryPorts';
+import type {
+  OpenCodePromptDeliveryLedgerRecord,
+  OpenCodePromptDeliveryLedgerStore,
+} from './OpenCodePromptDeliveryLedger';
+
+/**
+ * Ports needed to decide whether the record currently holding a lane still
+ * blocks the next delivery.
+ */
+export type OpenCodeActiveDeliveryPreemptionPorts = Pick<
+  OpenCodeMemberMessageDeliveryServiceDependencies,
+  | 'openCodeVisibleReplyProofService'
+  | 'isOpenCodeDeliveryResponseReadCommitAllowed'
+  | 'markOpenCodeAcceptedDeliveryMissingPromptProofForRetry'
+  | 'scheduleOpenCodePromptDeliveryWatchdog'
+  | 'logOpenCodePromptDeliveryEvent'
+>;
+
+/**
+ * Re-examine the record that is blocking the lane before queueing a new message
+ * behind it. The proof service may have picked up a reply that landed after the
+ * last observation; when it did, the blocker is settled and the lane is free.
+ * An accepted record whose prompt proof went missing is re-armed for a retry
+ * instead.
+ *
+ * Returns the record that still blocks the lane, or null once it no longer does.
+ */
+export async function recoverOpenCodeActiveDeliveryBlocker(input: {
+  ports: OpenCodeActiveDeliveryPreemptionPorts;
+  ledger: OpenCodePromptDeliveryLedgerStore;
+  activeRecord: OpenCodePromptDeliveryLedgerRecord;
+  teamName: string;
+  memberName: string;
+}): Promise<OpenCodePromptDeliveryLedgerRecord | null> {
+  const { ports, ledger, teamName, memberName } = input;
+  let active = input.activeRecord;
+  let proof = await ports.openCodeVisibleReplyProofService.applyDestinationProof({
+    ledger,
+    ledgerRecord: active,
+    teamName,
+    replyRecipient: active.replyRecipient,
+    memberName,
+  });
+  active = proof.ledgerRecord;
+  proof = await ports.openCodeVisibleReplyProofService.materializePlainTextReplyIfNeeded({
+    ledger,
+    ledgerRecord: active,
+    teamName,
+    memberName,
+    visibleReply: proof.visibleReply,
+  });
+  active = proof.ledgerRecord;
+  const activeReadAllowed = await ports.isOpenCodeDeliveryResponseReadCommitAllowed({
+    teamName,
+    memberName,
+    responseState: active.responseState,
+    actionMode: active.actionMode ?? undefined,
+    taskRefs: active.taskRefs,
+    visibleReply: proof.visibleReply,
+    ledgerRecord: active,
+  });
+  if (activeReadAllowed) {
+    ports.logOpenCodePromptDeliveryEvent('opencode_prompt_delivery_response_observed', active, {
+      visibleReplySemanticallySufficient: true,
+      unblockedNextDelivery: true,
+    });
+    return null;
+  }
+  if (isOpenCodeAcceptedDeliveryMissingPromptProof(active)) {
+    active = await ports.markOpenCodeAcceptedDeliveryMissingPromptProofForRetry({
+      ledger,
+      ledgerRecord: active,
+      eventContext: { recoveredActiveBlocker: true },
+    });
+    ports.scheduleOpenCodePromptDeliveryWatchdog({
+      teamName,
+      memberName,
+      messageId: active.inboxMessageId,
+      delayMs: 500,
+    });
+  }
+  return active;
+}

--- a/src/main/services/team/opencode/delivery/OpenCodeLeadTurnActivity.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeLeadTurnActivity.ts
@@ -1,0 +1,21 @@
+import { isLeadMember } from '@shared/utils/leadDetection';
+
+import { resolveOpenCodeSoloMemberIdentityFromDirectory } from '../../provisioning/TeamProvisioningOpenCodeSoloRuntime';
+
+import type { OpenCodeMemberDirectory } from './OpenCodeMemberMessageDeliveryPorts';
+
+/** Lane membership is not lead identity: same-model teammates share primary. */
+export function isOpenCodeLeadRecipient(
+  memberName: string,
+  directory: OpenCodeMemberDirectory
+): boolean {
+  const normalized = memberName.trim().toLowerCase();
+  const members = [...(directory.config?.members ?? []), ...directory.metaMembers];
+  return (
+    isLeadMember({ name: normalized }) ||
+    members.some(
+      (member) => member.name.trim().toLowerCase() === normalized && isLeadMember(member)
+    ) ||
+    resolveOpenCodeSoloMemberIdentityFromDirectory(memberName, directory) !== null
+  );
+}

--- a/src/main/services/team/opencode/delivery/OpenCodeLegacyMemberMessageDelivery.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeLegacyMemberMessageDelivery.ts
@@ -1,0 +1,136 @@
+import { normalizeOpenCodeDeliveryResponseObservation } from './OpenCodePromptDeliveryReadCommitPolicy';
+
+import type { OpenCodeCommittedBootstrapSessionRecord } from '../store/OpenCodeRuntimeManifestEvidenceReader';
+import type {
+  OpenCodeMemberInboxDelivery,
+  OpenCodeMemberMessageDeliveryInput,
+  OpenCodeMemberMessageDeliveryServiceDependencies,
+  OpenCodeRuntimeMessageAdapter,
+} from './OpenCodeMemberMessageDeliveryPorts';
+import type { OpenCodeFilePart } from '@features/agent-attachments/main';
+
+export type OpenCodeLegacyMemberMessageDeliveryPorts = Pick<
+  OpenCodeMemberMessageDeliveryServiceDependencies,
+  | 'resolveControlApiBaseUrl'
+  | 'sendOpenCodeMemberMessageToRuntimeSerialized'
+  | 'rememberOpenCodeRuntimePidFromBridge'
+  | 'stampOpenCodeAppMcpTransportEvidenceIfMissing'
+  | 'maybeSyncOpenCodeRuntimePermissionsAfterDelivery'
+  | 'isLegacyOpenCodeMemberWorkSyncReadCommitAllowed'
+>;
+
+/**
+ * Delivery path used when the prompt-delivery watchdog is disabled: send once
+ * over the runtime bridge and report what came back, with no ledger record and
+ * therefore no retry, no observation loop and no read-commit proof. The only
+ * response that is waited for is a member work-sync report.
+ *
+ * Everything the watchdog path adds - acceptance proof, retries, stale-pending
+ * handling, lead turn activity - is deliberately absent here.
+ */
+export async function deliverOpenCodeMemberMessageWithoutWatchdog(input: {
+  ports: OpenCodeLegacyMemberMessageDeliveryPorts;
+  adapter: OpenCodeRuntimeMessageAdapter;
+  message: OpenCodeMemberMessageDeliveryInput;
+  teamName: string;
+  memberName: string;
+  laneId: string;
+  cwd: string;
+  runtimeRunId: string | null;
+  fileParts: OpenCodeFilePart[];
+  forceSessionRefreshReason?: string;
+  legacyBootstrapSessionToStamp: OpenCodeCommittedBootstrapSessionRecord | null;
+  refreshedBootstrapSessionToStamp: OpenCodeCommittedBootstrapSessionRecord | null;
+  teamColor?: string;
+  teamDisplayName?: string;
+}): Promise<OpenCodeMemberInboxDelivery> {
+  const { ports, message, teamName, memberName, laneId, cwd, runtimeRunId } = input;
+  const controlUrl =
+    message.messageKind === 'member_work_sync_nudge'
+      ? await ports.resolveControlApiBaseUrl()
+      : null;
+  const result = await ports.sendOpenCodeMemberMessageToRuntimeSerialized({
+    teamName,
+    laneId,
+    memberName,
+    send: async () =>
+      await input.adapter.sendMessageToMember({
+        ...(runtimeRunId ? { runId: runtimeRunId } : {}),
+        teamName,
+        laneId,
+        memberName,
+        cwd,
+        text: message.text,
+        messageId: message.messageId,
+        fileParts: input.fileParts,
+        replyRecipient: message.replyRecipient,
+        actionMode: message.actionMode,
+        messageKind: message.messageKind,
+        workSyncIntent: message.workSyncIntent,
+        workSyncReviewRequestEventIds: message.workSyncReviewRequestEventIds,
+        controlUrl: controlUrl ?? undefined,
+        taskRefs: message.taskRefs,
+        forceSessionRefreshReason: input.forceSessionRefreshReason,
+      }),
+  });
+  await ports.rememberOpenCodeRuntimePidFromBridge({
+    teamName,
+    memberName,
+    laneId,
+    runId: runtimeRunId,
+    runtimeSessionId: result.sessionId,
+    runtimePid: result.runtimePid,
+    reason: 'opencode_delivery_runtime_pid_observed',
+  });
+  if (result.ok && input.legacyBootstrapSessionToStamp) {
+    await ports.stampOpenCodeAppMcpTransportEvidenceIfMissing(input.legacyBootstrapSessionToStamp);
+  }
+  if (result.ok && result.sessionId && input.refreshedBootstrapSessionToStamp) {
+    await ports.stampOpenCodeAppMcpTransportEvidenceIfMissing(
+      input.refreshedBootstrapSessionToStamp,
+      {
+        overwriteExistingHash: true,
+        runtimeSessionId: result.sessionId,
+      }
+    );
+  }
+  const responseObservation = normalizeOpenCodeDeliveryResponseObservation(
+    result.responseObservation
+  );
+  await ports.maybeSyncOpenCodeRuntimePermissionsAfterDelivery({
+    teamName,
+    runId: runtimeRunId,
+    laneId,
+    memberName,
+    cwd,
+    sessionId: result.sessionId,
+    responseState: responseObservation?.state,
+    reason: responseObservation?.reason ?? result.diagnostics[0],
+    diagnostics: result.diagnostics,
+    teamColor: input.teamColor,
+    teamDisplayName: input.teamDisplayName,
+  });
+  const legacyWorkSyncReadAllowed =
+    message.messageKind === 'member_work_sync_nudge' && result.ok
+      ? await ports.isLegacyOpenCodeMemberWorkSyncReadCommitAllowed({
+          teamName,
+          memberName,
+          workSyncIntent: message.workSyncIntent,
+          responseObservation,
+        })
+      : true;
+  const legacyWorkSyncResponsePending =
+    result.ok && message.messageKind === 'member_work_sync_nudge' && !legacyWorkSyncReadAllowed;
+  return {
+    delivered: result.ok,
+    accepted: result.ok,
+    responsePending: legacyWorkSyncResponsePending,
+    responseState: responseObservation?.state,
+    ...(legacyWorkSyncResponsePending
+      ? { reason: responseObservation?.reason ?? 'member_work_sync_report_required' }
+      : result.ok
+        ? {}
+        : { reason: result.diagnostics[0] ?? 'opencode_message_delivery_failed' }),
+    diagnostics: result.diagnostics,
+  };
+}

--- a/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryPorts.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryPorts.ts
@@ -128,6 +128,7 @@ export interface OpenCodeLeadTurnActivityNotification {
   teamName: string;
   memberName: string;
   laneId: string;
+  runId: string | null;
   state: 'active' | 'idle';
 }
 

--- a/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryPorts.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryPorts.ts
@@ -123,6 +123,13 @@ interface DeliverableTrackedRun {
   }[];
 }
 
+export interface OpenCodeLeadTurnActivityNotification {
+  teamName: string;
+  memberName: string;
+  laneId: string;
+  state: 'active' | 'idle';
+}
+
 export interface OpenCodeMemberMessageDeliveryServiceDependencies {
   getOpenCodeRuntimeMessageAdapter(): OpenCodeRuntimeMessageAdapter | null;
   readOpenCodeMemberDirectory(teamName: string): Promise<OpenCodeMemberDirectory>;
@@ -253,6 +260,12 @@ export interface OpenCodeMemberMessageDeliveryServiceDependencies {
     record: OpenCodePromptDeliveryLedgerRecord,
     detail: string
   ): void;
+  /**
+   * Lead activity for the OpenCode primary lane. A pure-OpenCode lead has no
+   * stdin stream, so "Working"/"Idle" is derived from prompt-delivery turns:
+   * 'active' once a prompt is accepted, 'idle' once the delivery settles.
+   */
+  notifyOpenCodeLeadTurnActivity?(input: OpenCodeLeadTurnActivityNotification): void;
   observeOpenCodeDirectUserDeliveryInlineIfNeeded(input: {
     adapter: OpenCodeRuntimeMessageAdapter;
     ledger: OpenCodePromptDeliveryLedgerStore;

--- a/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryPorts.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryPorts.ts
@@ -10,6 +10,7 @@ import type {
   OpenCodePromptDeliveryLedgerStore,
   OpenCodePromptDeliveryStatus,
 } from './OpenCodePromptDeliveryLedger';
+import type { OpenCodeStalePendingPolicyConfig } from './OpenCodePromptDeliveryStalePendingPolicy';
 import type { OpenCodeVisibleReplyProof } from './OpenCodePromptDeliveryWatchdog';
 import type { OpenCodePromptDeliveryWatchdogScheduler } from './OpenCodePromptDeliveryWatchdogScheduler';
 import type { OpenCodeVisibleReplyProofService } from './OpenCodeVisibleReplyProofService';
@@ -220,6 +221,11 @@ export interface OpenCodeMemberMessageDeliveryServiceDependencies {
     'isEnabled'
   >;
   openCodePromptDeliveryFollowUpPolicy: Pick<OpenCodePromptDeliveryFollowUpPolicy, 'schedule'>;
+  /**
+   * Windows the stale-pending guard bounds a pending delivery with. Supplied by
+   * whoever composes this service; the policy itself has no defaults.
+   */
+  openCodeStalePendingPolicyConfig: OpenCodeStalePendingPolicyConfig;
   isOpenCodeDeliveryResponseReadCommitAllowed(input: {
     teamName?: string;
     memberName?: string;

--- a/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
@@ -14,6 +14,7 @@ import {
 } from '../store/OpenCodeRuntimeManifestEvidenceReader';
 
 import { recoverOpenCodeActiveDeliveryBlocker } from './OpenCodeActiveDeliveryPreemption';
+import { deliverOpenCodeMemberMessageWithoutWatchdog } from './OpenCodeLegacyMemberMessageDelivery';
 import { isOpenCodeSessionRefreshRetryRecord } from './OpenCodePromptDeliveryFollowUpPolicy';
 import {
   buildOpenCodePromptDeliveryAttemptId,
@@ -341,96 +342,22 @@ export class OpenCodeMemberMessageDeliveryService {
     }
 
     if (!this.deps.openCodePromptDeliveryWatchdogScheduler.isEnabled()) {
-      const controlUrl =
-        input.messageKind === 'member_work_sync_nudge'
-          ? await this.deps.resolveControlApiBaseUrl()
-          : null;
-      const result = await this.deps.sendOpenCodeMemberMessageToRuntimeSerialized({
-        teamName,
-        laneId: laneIdentity.laneId,
-        memberName: canonicalMemberName,
-        send: async () =>
-          await adapter.sendMessageToMember({
-            ...(runtimeRunId ? { runId: runtimeRunId } : {}),
-            teamName,
-            laneId: laneIdentity.laneId,
-            memberName: canonicalMemberName,
-            cwd,
-            text: input.text,
-            messageId: input.messageId,
-            fileParts: openCodeFileParts,
-            replyRecipient: input.replyRecipient,
-            actionMode: input.actionMode,
-            messageKind: input.messageKind,
-            workSyncIntent: input.workSyncIntent,
-            workSyncReviewRequestEventIds: input.workSyncReviewRequestEventIds,
-            controlUrl: controlUrl ?? undefined,
-            taskRefs: input.taskRefs,
-            forceSessionRefreshReason: forceOpenCodeSessionRefreshReason,
-          }),
-      });
-      await this.deps.rememberOpenCodeRuntimePidFromBridge({
+      return await deliverOpenCodeMemberMessageWithoutWatchdog({
+        ports: this.deps,
+        adapter,
+        message: input,
         teamName,
         memberName: canonicalMemberName,
         laneId: laneIdentity.laneId,
-        runId: runtimeRunId,
-        runtimeSessionId: result.sessionId,
-        runtimePid: result.runtimePid,
-        reason: 'opencode_delivery_runtime_pid_observed',
-      });
-      if (result.ok && legacyOpenCodeBootstrapSessionToStamp) {
-        await this.deps.stampOpenCodeAppMcpTransportEvidenceIfMissing(
-          legacyOpenCodeBootstrapSessionToStamp
-        );
-      }
-      if (result.ok && result.sessionId && refreshedOpenCodeBootstrapSessionToStamp) {
-        await this.deps.stampOpenCodeAppMcpTransportEvidenceIfMissing(
-          refreshedOpenCodeBootstrapSessionToStamp,
-          {
-            overwriteExistingHash: true,
-            runtimeSessionId: result.sessionId,
-          }
-        );
-      }
-      const responseObservation = normalizeOpenCodeDeliveryResponseObservation(
-        result.responseObservation
-      );
-      await this.deps.maybeSyncOpenCodeRuntimePermissionsAfterDelivery({
-        teamName,
-        runId: runtimeRunId,
-        laneId: laneIdentity.laneId,
-        memberName: canonicalMemberName,
         cwd,
-        sessionId: result.sessionId,
-        responseState: responseObservation?.state,
-        reason: responseObservation?.reason ?? result.diagnostics[0],
-        diagnostics: result.diagnostics,
+        runtimeRunId,
+        fileParts: openCodeFileParts,
+        forceSessionRefreshReason: forceOpenCodeSessionRefreshReason,
+        legacyBootstrapSessionToStamp: legacyOpenCodeBootstrapSessionToStamp,
+        refreshedBootstrapSessionToStamp: refreshedOpenCodeBootstrapSessionToStamp,
         teamColor: config?.color,
         teamDisplayName: config?.name,
       });
-      const legacyWorkSyncReadAllowed =
-        input.messageKind === 'member_work_sync_nudge' && result.ok
-          ? await this.deps.isLegacyOpenCodeMemberWorkSyncReadCommitAllowed({
-              teamName,
-              memberName: canonicalMemberName,
-              workSyncIntent: input.workSyncIntent,
-              responseObservation,
-            })
-          : true;
-      const legacyWorkSyncResponsePending =
-        result.ok && input.messageKind === 'member_work_sync_nudge' && !legacyWorkSyncReadAllowed;
-      return {
-        delivered: result.ok,
-        accepted: result.ok,
-        responsePending: legacyWorkSyncResponsePending,
-        responseState: responseObservation?.state,
-        ...(legacyWorkSyncResponsePending
-          ? { reason: responseObservation?.reason ?? 'member_work_sync_report_required' }
-          : result.ok
-            ? {}
-            : { reason: result.diagnostics[0] ?? 'opencode_message_delivery_failed' }),
-        diagnostics: result.diagnostics,
-      };
     }
 
     const messageId = input.messageId?.trim();

--- a/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
@@ -13,6 +13,7 @@ import {
   recoverStaleOpenCodeRuntimeLaneIndexEntry,
 } from '../store/OpenCodeRuntimeManifestEvidenceReader';
 
+import { recoverOpenCodeActiveDeliveryBlocker } from './OpenCodeActiveDeliveryPreemption';
 import { isOpenCodeSessionRefreshRetryRecord } from './OpenCodePromptDeliveryFollowUpPolicy';
 import {
   buildOpenCodePromptDeliveryAttemptId,
@@ -445,54 +446,13 @@ export class OpenCodeMemberMessageDeliveryService {
         })
       : null;
     if (active && active.inboxMessageId !== messageId && ledger) {
-      let proof = await this.deps.openCodeVisibleReplyProofService.applyDestinationProof({
+      active = await recoverOpenCodeActiveDeliveryBlocker({
+        ports: this.deps,
         ledger,
-        ledgerRecord: active,
-        teamName,
-        replyRecipient: active.replyRecipient,
-        memberName: canonicalMemberName,
-      });
-      active = proof.ledgerRecord;
-      proof = await this.deps.openCodeVisibleReplyProofService.materializePlainTextReplyIfNeeded({
-        ledger,
-        ledgerRecord: active,
+        activeRecord: active,
         teamName,
         memberName: canonicalMemberName,
-        visibleReply: proof.visibleReply,
       });
-      active = proof.ledgerRecord;
-      const activeReadAllowed = await this.deps.isOpenCodeDeliveryResponseReadCommitAllowed({
-        teamName,
-        memberName: canonicalMemberName,
-        responseState: active.responseState,
-        actionMode: active.actionMode ?? undefined,
-        taskRefs: active.taskRefs,
-        visibleReply: proof.visibleReply,
-        ledgerRecord: active,
-      });
-      if (activeReadAllowed) {
-        this.deps.logOpenCodePromptDeliveryEvent(
-          'opencode_prompt_delivery_response_observed',
-          active,
-          {
-            visibleReplySemanticallySufficient: true,
-            unblockedNextDelivery: true,
-          }
-        );
-        active = null;
-      } else if (isOpenCodeAcceptedDeliveryMissingPromptProof(active)) {
-        active = await this.deps.markOpenCodeAcceptedDeliveryMissingPromptProofForRetry({
-          ledger,
-          ledgerRecord: active,
-          eventContext: { recoveredActiveBlocker: true },
-        });
-        this.deps.scheduleOpenCodePromptDeliveryWatchdog({
-          teamName,
-          memberName: canonicalMemberName,
-          messageId: active.inboxMessageId,
-          delayMs: 500,
-        });
-      }
     }
     if (active && active.inboxMessageId !== messageId) {
       const activeDueMs = active.nextAttemptAt ? Date.parse(active.nextAttemptAt) : NaN;

--- a/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
@@ -13,10 +13,8 @@ import {
   recoverStaleOpenCodeRuntimeLaneIndexEntry,
 } from '../store/OpenCodeRuntimeManifestEvidenceReader';
 
-import {
-  preemptStaleOpenCodeActiveDelivery,
-  recoverOpenCodeActiveDeliveryBlocker,
-} from './OpenCodeActiveDeliveryPreemption';
+import { recoverOpenCodeActiveDeliveryBlocker } from './OpenCodeActiveDeliveryPreemption';
+import { isOpenCodeLeadRecipient } from './OpenCodeLeadTurnActivity';
 import { deliverOpenCodeMemberMessageWithoutWatchdog } from './OpenCodeLegacyMemberMessageDelivery';
 import { isOpenCodeSessionRefreshRetryRecord } from './OpenCodePromptDeliveryFollowUpPolicy';
 import {
@@ -37,6 +35,7 @@ import {
 import {
   buildOpenCodeStalePendingPlainTextObservation,
   decideOpenCodeStalePendingResolution,
+  getOpenCodeObservedSessionActivity,
 } from './OpenCodePromptDeliveryStalePendingPolicy';
 import {
   isOpenCodePromptDeliveryRetryAttemptDue,
@@ -47,7 +46,6 @@ import type { OpenCodeTeamRuntimeMessageResult } from '../../runtime';
 import type {
   OpenCodeLeadTurnActivityNotification,
   OpenCodeMemberInboxDelivery,
-  OpenCodeMemberLaneIdentity,
   OpenCodeMemberMessageDeliveryInput,
   OpenCodeMemberMessageDeliveryServiceDependencies,
 } from './OpenCodeMemberMessageDeliveryPorts';
@@ -66,29 +64,6 @@ function nowIso(): string {
 export class OpenCodeMemberMessageDeliveryService {
   constructor(private readonly deps: OpenCodeMemberMessageDeliveryServiceDependencies) {}
 
-  private notifyLeadTurnActivity(
-    teamName: string,
-    memberName: string,
-    laneIdentity: OpenCodeMemberLaneIdentity,
-    state: OpenCodeLeadTurnActivityNotification['state']
-  ): void {
-    if (laneIdentity.laneKind !== 'primary' || !this.deps.notifyOpenCodeLeadTurnActivity) {
-      return;
-    }
-    try {
-      this.deps.notifyOpenCodeLeadTurnActivity({
-        teamName,
-        memberName,
-        laneId: laneIdentity.laneId,
-        state,
-      });
-    } catch (error) {
-      logger.warn(
-        `[${teamName}] OpenCode lead turn activity (${state}) notification failed: ${getErrorMessage(error)}`
-      );
-    }
-  }
-
   /**
    * Apply a stale-pending resolution to the ledger. `settle_plain_text` marks
    * the record responded (plain-text turn end); `fail_terminal` closes it so it
@@ -100,7 +75,7 @@ export class OpenCodeMemberMessageDeliveryService {
     resolution: OpenCodeStalePendingResolution;
     teamName: string;
     memberName: string;
-    laneIdentity: OpenCodeMemberLaneIdentity;
+    notifyActivity: (state: OpenCodeLeadTurnActivityNotification['state']) => void;
     eventContext: Record<string, unknown>;
   }): Promise<OpenCodePromptDeliveryLedgerRecord | null> {
     const { resolution } = input;
@@ -141,7 +116,7 @@ export class OpenCodeMemberMessageDeliveryService {
           stalePending: true,
         }
       );
-      this.notifyLeadTurnActivity(input.teamName, input.memberName, input.laneIdentity, 'idle');
+      input.notifyActivity('idle');
       return failed;
     }
     // 'none' and 'keep_observing' fall through to the regular follow-up
@@ -432,6 +407,26 @@ export class OpenCodeMemberMessageDeliveryService {
       });
     }
 
+    const isLeadRecipient =
+      laneIdentity.laneKind === 'primary' &&
+      isOpenCodeLeadRecipient(canonicalMemberName, directory);
+    const activityRunId = runtimeRunId;
+    const notifyActivity = (state: OpenCodeLeadTurnActivityNotification['state']): void => {
+      if (!isLeadRecipient || !activityRunId) return;
+      try {
+        this.deps.notifyOpenCodeLeadTurnActivity?.({
+          teamName,
+          memberName: canonicalMemberName,
+          laneId: laneIdentity.laneId,
+          runId: activityRunId,
+          state,
+        });
+      } catch (error) {
+        logger.warn(
+          `[${teamName}] OpenCode lead turn activity (${state}) notification failed: ${getErrorMessage(error)}`
+        );
+      }
+    };
     const messageId = input.messageId?.trim();
     const ledger = messageId
       ? this.deps.createOpenCodePromptDeliveryLedger(teamName, laneIdentity.laneId)
@@ -453,26 +448,7 @@ export class OpenCodeMemberMessageDeliveryService {
         memberName: canonicalMemberName,
       });
     }
-    if (active && active.inboxMessageId !== messageId && ledger) {
-      const blockingLedger = ledger;
-      active = await preemptStaleOpenCodeActiveDelivery({
-        ports: this.deps,
-        activeRecord: active,
-        incomingMessageId: messageId,
-        incomingReplyRecipient: input.replyRecipient,
-        laneKind: laneIdentity.laneKind,
-        teamName,
-        memberName: canonicalMemberName,
-        settle: async (settlement) =>
-          await this.applyStalePendingResolution({
-            ledger: blockingLedger,
-            teamName,
-            memberName: canonicalMemberName,
-            laneIdentity,
-            ...settlement,
-          }),
-      });
-    }
+
     if (active && active.inboxMessageId !== messageId) {
       const activeDueMs = active.nextAttemptAt ? Date.parse(active.nextAttemptAt) : NaN;
       this.deps.scheduleOpenCodePromptDeliveryWatchdog({
@@ -564,7 +540,7 @@ export class OpenCodeMemberMessageDeliveryService {
           ledgerRecord,
           { visibleReplySemanticallySufficient: true }
         );
-        this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
+        notifyActivity('idle');
         return {
           delivered: true,
           accepted: true,
@@ -589,7 +565,7 @@ export class OpenCodeMemberMessageDeliveryService {
           'opencode_prompt_delivery_terminal_failure',
           ledgerRecord
         );
-        this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
+        notifyActivity('idle');
         return {
           delivered: false,
           accepted: false,
@@ -774,7 +750,7 @@ export class OpenCodeMemberMessageDeliveryService {
             ledgerRecord,
             { visibleReplySemanticallySufficient: true }
           );
-          this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
+          notifyActivity('idle');
           return {
             delivered: true,
             accepted: true,
@@ -789,12 +765,21 @@ export class OpenCodeMemberMessageDeliveryService {
           };
         }
 
+        if (
+          hasOpenCodeAcceptedRuntimePrompt(ledgerRecord) &&
+          getOpenCodeObservedSessionActivity(observed.diagnostics) !== 'idle' &&
+          (ledgerRecord.responseState === 'pending' ||
+            ledgerRecord.responseState === 'prompt_not_indexed')
+        ) {
+          notifyActivity('active');
+        }
+
         // Stale-pending guard: an accepted prompt the bridge keeps reporting as
         // `pending` has no attempt budget, so bound it here. A lead plain-text
         // turn end settles non-user messages; stale idle records go terminal.
         const staleResolution = decideOpenCodeStalePendingResolution({
           record: ledgerRecord,
-          laneKind: laneIdentity.laneKind,
+          laneKind: isLeadRecipient ? 'primary' : 'secondary',
           observation: responseObservation,
           observedDiagnostics: observed.diagnostics,
           nowMs: Date.now(),
@@ -806,7 +791,7 @@ export class OpenCodeMemberMessageDeliveryService {
           resolution: staleResolution,
           teamName,
           memberName: canonicalMemberName,
-          laneIdentity,
+          notifyActivity,
           eventContext: { observedAfterAcceptedPrompt: true },
         });
         if (staleSettled) {
@@ -823,7 +808,7 @@ export class OpenCodeMemberMessageDeliveryService {
               ledgerRecord,
             }));
           if (settledReadAllowed || ledgerRecord.status === 'failed_terminal') {
-            this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
+            notifyActivity('idle');
             return {
               delivered: settledReadAllowed,
               accepted: true,
@@ -871,7 +856,7 @@ export class OpenCodeMemberMessageDeliveryService {
             reason: pendingReason,
           });
           if (ledgerRecord.status === 'failed_terminal') {
-            this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
+            notifyActivity('idle');
             return {
               delivered: false,
               accepted: true,
@@ -912,7 +897,7 @@ export class OpenCodeMemberMessageDeliveryService {
             reason: pendingReason,
           });
           if (ledgerRecord.status === 'failed_terminal') {
-            this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
+            notifyActivity('idle');
             return {
               delivered: false,
               accepted: true,
@@ -1021,7 +1006,7 @@ export class OpenCodeMemberMessageDeliveryService {
       });
     } catch (error) {
       const diagnostic = `opencode_message_delivery_exception: ${getErrorMessage(error)}`;
-      this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
+      notifyActivity('idle');
       await this.deps.maybeSyncOpenCodeRuntimePermissionsAfterDelivery({
         teamName,
         runId: runtimeRunId,
@@ -1158,7 +1143,7 @@ export class OpenCodeMemberMessageDeliveryService {
         'opencode-prompt-delivery-session-evidence'
       );
       if (promptAccepted) {
-        this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'active');
+        notifyActivity('active');
       }
       let proof = await this.deps.openCodeVisibleReplyProofService.applyDestinationProof({
         ledger,
@@ -1257,7 +1242,7 @@ export class OpenCodeMemberMessageDeliveryService {
         }),
       });
       if (ledgerRecord.status === 'failed_terminal') {
-        this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
+        notifyActivity('idle');
         return {
           delivered: false,
           accepted: true,
@@ -1345,7 +1330,7 @@ export class OpenCodeMemberMessageDeliveryService {
       // Settled in this frame: response read-committable, or the prompt was not
       // (or not provably) accepted. An accepted-but-pending turn stays 'active'
       // until a later observation/watchdog settles it.
-      this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
+      notifyActivity('idle');
     }
     return {
       delivered: promptAccepted || acceptanceUnknown,

--- a/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
@@ -13,7 +13,10 @@ import {
   recoverStaleOpenCodeRuntimeLaneIndexEntry,
 } from '../store/OpenCodeRuntimeManifestEvidenceReader';
 
-import { recoverOpenCodeActiveDeliveryBlocker } from './OpenCodeActiveDeliveryPreemption';
+import {
+  preemptStaleOpenCodeActiveDelivery,
+  recoverOpenCodeActiveDeliveryBlocker,
+} from './OpenCodeActiveDeliveryPreemption';
 import { deliverOpenCodeMemberMessageWithoutWatchdog } from './OpenCodeLegacyMemberMessageDelivery';
 import { isOpenCodeSessionRefreshRetryRecord } from './OpenCodePromptDeliveryFollowUpPolicy';
 import {
@@ -32,6 +35,10 @@ import {
   normalizeOpenCodeDeliveryResponseObservation,
 } from './OpenCodePromptDeliveryReadCommitPolicy';
 import {
+  buildOpenCodeStalePendingPlainTextObservation,
+  decideOpenCodeStalePendingResolution,
+} from './OpenCodePromptDeliveryStalePendingPolicy';
+import {
   isOpenCodePromptDeliveryRetryAttemptDue,
   OPENCODE_PROMPT_DELIVERY_OBSERVE_DELAY_MS,
 } from './OpenCodePromptDeliveryWatchdog';
@@ -44,6 +51,11 @@ import type {
   OpenCodeMemberMessageDeliveryInput,
   OpenCodeMemberMessageDeliveryServiceDependencies,
 } from './OpenCodeMemberMessageDeliveryPorts';
+import type {
+  OpenCodePromptDeliveryLedgerRecord,
+  OpenCodePromptDeliveryLedgerStore,
+} from './OpenCodePromptDeliveryLedger';
+import type { OpenCodeStalePendingResolution } from './OpenCodePromptDeliveryStalePendingPolicy';
 
 const logger = createLogger('Service:OpenCodeMemberMessageDelivery');
 
@@ -75,6 +87,66 @@ export class OpenCodeMemberMessageDeliveryService {
         `[${teamName}] OpenCode lead turn activity (${state}) notification failed: ${getErrorMessage(error)}`
       );
     }
+  }
+
+  /**
+   * Apply a stale-pending resolution to the ledger. `settle_plain_text` marks
+   * the record responded (plain-text turn end); `fail_terminal` closes it so it
+   * stops blocking the lane. Returns null when nothing was changed.
+   */
+  private async applyStalePendingResolution(input: {
+    ledger: OpenCodePromptDeliveryLedgerStore;
+    ledgerRecord: OpenCodePromptDeliveryLedgerRecord;
+    resolution: OpenCodeStalePendingResolution;
+    teamName: string;
+    memberName: string;
+    laneIdentity: OpenCodeMemberLaneIdentity;
+    eventContext: Record<string, unknown>;
+  }): Promise<OpenCodePromptDeliveryLedgerRecord | null> {
+    const { resolution } = input;
+    if (resolution.action === 'settle_plain_text') {
+      const settled = await input.ledger.applyObservation({
+        id: input.ledgerRecord.id,
+        responseObservation: buildOpenCodeStalePendingPlainTextObservation({
+          record: input.ledgerRecord,
+          reason: resolution.reason,
+        }),
+        diagnostics: [resolution.reason],
+        observedAt: nowIso(),
+      });
+      this.deps.logOpenCodePromptDeliveryEvent(
+        'opencode_prompt_delivery_response_observed',
+        settled,
+        {
+          ...input.eventContext,
+          reason: resolution.reason,
+          stalePendingSettledAsPlainText: true,
+        }
+      );
+      return settled;
+    }
+    if (resolution.action === 'fail_terminal') {
+      const failed = await input.ledger.markFailedTerminal({
+        id: input.ledgerRecord.id,
+        reason: resolution.reason,
+        diagnostics: resolution.diagnostics,
+        failedAt: nowIso(),
+      });
+      this.deps.logOpenCodePromptDeliveryEvent(
+        'opencode_prompt_delivery_terminal_failure',
+        failed,
+        {
+          ...input.eventContext,
+          reason: resolution.reason,
+          stalePending: true,
+        }
+      );
+      this.notifyLeadTurnActivity(input.teamName, input.memberName, input.laneIdentity, 'idle');
+      return failed;
+    }
+    // 'none' and 'keep_observing' fall through to the regular follow-up
+    // scheduling, which already logs each observe cycle.
+    return null;
   }
 
   async deliver(
@@ -379,6 +451,26 @@ export class OpenCodeMemberMessageDeliveryService {
         activeRecord: active,
         teamName,
         memberName: canonicalMemberName,
+      });
+    }
+    if (active && active.inboxMessageId !== messageId && ledger) {
+      const blockingLedger = ledger;
+      active = await preemptStaleOpenCodeActiveDelivery({
+        ports: this.deps,
+        activeRecord: active,
+        incomingMessageId: messageId,
+        incomingReplyRecipient: input.replyRecipient,
+        laneKind: laneIdentity.laneKind,
+        teamName,
+        memberName: canonicalMemberName,
+        settle: async (settlement) =>
+          await this.applyStalePendingResolution({
+            ledger: blockingLedger,
+            teamName,
+            memberName: canonicalMemberName,
+            laneIdentity,
+            ...settlement,
+          }),
       });
     }
     if (active && active.inboxMessageId !== messageId) {
@@ -695,6 +787,61 @@ export class OpenCodeMemberMessageDeliveryService {
             visibleReplyCorrelation: ledgerRecord.visibleReplyCorrelation ?? undefined,
             diagnostics: ledgerRecord.diagnostics,
           };
+        }
+
+        // Stale-pending guard: an accepted prompt the bridge keeps reporting as
+        // `pending` has no attempt budget, so bound it here. A lead plain-text
+        // turn end settles non-user messages; stale idle records go terminal.
+        const staleResolution = decideOpenCodeStalePendingResolution({
+          record: ledgerRecord,
+          laneKind: laneIdentity.laneKind,
+          observation: responseObservation,
+          observedDiagnostics: observed.diagnostics,
+          nowMs: Date.now(),
+          config: this.deps.openCodeStalePendingPolicyConfig,
+        });
+        const staleSettled = await this.applyStalePendingResolution({
+          ledger,
+          ledgerRecord,
+          resolution: staleResolution,
+          teamName,
+          memberName: canonicalMemberName,
+          laneIdentity,
+          eventContext: { observedAfterAcceptedPrompt: true },
+        });
+        if (staleSettled) {
+          ledgerRecord = staleSettled;
+          const settledReadAllowed =
+            ledgerRecord.status === 'responded' &&
+            (await this.deps.isOpenCodeDeliveryResponseReadCommitAllowed({
+              teamName,
+              memberName: canonicalMemberName,
+              responseState: ledgerRecord.responseState,
+              actionMode: ledgerRecord.actionMode ?? undefined,
+              taskRefs: ledgerRecord.taskRefs,
+              visibleReply: proof.visibleReply,
+              ledgerRecord,
+            }));
+          if (settledReadAllowed || ledgerRecord.status === 'failed_terminal') {
+            this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
+            return {
+              delivered: settledReadAllowed,
+              accepted: true,
+              responsePending: false,
+              responseState: ledgerRecord.responseState,
+              ledgerStatus: ledgerRecord.status,
+              ledgerRecordId: ledgerRecord.id,
+              laneId: laneIdentity.laneId,
+              visibleReplyMessageId: ledgerRecord.visibleReplyMessageId ?? undefined,
+              visibleReplyCorrelation: ledgerRecord.visibleReplyCorrelation ?? undefined,
+              ...(settledReadAllowed
+                ? {}
+                : {
+                    reason: ledgerRecord.lastReason ?? 'opencode_prompt_delivery_failed_terminal',
+                  }),
+              diagnostics: ledgerRecord.diagnostics,
+            };
+          }
         }
 
         const pendingReason = this.deps.getOpenCodeDeliveryPendingReason({

--- a/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
@@ -36,7 +36,9 @@ import {
 
 import type { OpenCodeTeamRuntimeMessageResult } from '../../runtime';
 import type {
+  OpenCodeLeadTurnActivityNotification,
   OpenCodeMemberInboxDelivery,
+  OpenCodeMemberLaneIdentity,
   OpenCodeMemberMessageDeliveryInput,
   OpenCodeMemberMessageDeliveryServiceDependencies,
 } from './OpenCodeMemberMessageDeliveryPorts';
@@ -49,6 +51,29 @@ function nowIso(): string {
 
 export class OpenCodeMemberMessageDeliveryService {
   constructor(private readonly deps: OpenCodeMemberMessageDeliveryServiceDependencies) {}
+
+  private notifyLeadTurnActivity(
+    teamName: string,
+    memberName: string,
+    laneIdentity: OpenCodeMemberLaneIdentity,
+    state: OpenCodeLeadTurnActivityNotification['state']
+  ): void {
+    if (laneIdentity.laneKind !== 'primary' || !this.deps.notifyOpenCodeLeadTurnActivity) {
+      return;
+    }
+    try {
+      this.deps.notifyOpenCodeLeadTurnActivity({
+        teamName,
+        memberName,
+        laneId: laneIdentity.laneId,
+        state,
+      });
+    } catch (error) {
+      logger.warn(
+        `[${teamName}] OpenCode lead turn activity (${state}) notification failed: ${getErrorMessage(error)}`
+      );
+    }
+  }
 
   async deliver(
     teamName: string,
@@ -560,6 +585,7 @@ export class OpenCodeMemberMessageDeliveryService {
           ledgerRecord,
           { visibleReplySemanticallySufficient: true }
         );
+        this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
         return {
           delivered: true,
           accepted: true,
@@ -584,6 +610,7 @@ export class OpenCodeMemberMessageDeliveryService {
           'opencode_prompt_delivery_terminal_failure',
           ledgerRecord
         );
+        this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
         return {
           delivered: false,
           accepted: false,
@@ -768,6 +795,7 @@ export class OpenCodeMemberMessageDeliveryService {
             ledgerRecord,
             { visibleReplySemanticallySufficient: true }
           );
+          this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
           return {
             delivered: true,
             accepted: true,
@@ -809,6 +837,7 @@ export class OpenCodeMemberMessageDeliveryService {
             reason: pendingReason,
           });
           if (ledgerRecord.status === 'failed_terminal') {
+            this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
             return {
               delivered: false,
               accepted: true,
@@ -849,6 +878,7 @@ export class OpenCodeMemberMessageDeliveryService {
             reason: pendingReason,
           });
           if (ledgerRecord.status === 'failed_terminal') {
+            this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
             return {
               delivered: false,
               accepted: true,
@@ -957,6 +987,7 @@ export class OpenCodeMemberMessageDeliveryService {
       });
     } catch (error) {
       const diagnostic = `opencode_message_delivery_exception: ${getErrorMessage(error)}`;
+      this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
       await this.deps.maybeSyncOpenCodeRuntimePermissionsAfterDelivery({
         teamName,
         runId: runtimeRunId,
@@ -1092,6 +1123,9 @@ export class OpenCodeMemberMessageDeliveryService {
         ledgerRecord,
         'opencode-prompt-delivery-session-evidence'
       );
+      if (promptAccepted) {
+        this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'active');
+      }
       let proof = await this.deps.openCodeVisibleReplyProofService.applyDestinationProof({
         ledger,
         ledgerRecord,
@@ -1189,6 +1223,7 @@ export class OpenCodeMemberMessageDeliveryService {
         }),
       });
       if (ledgerRecord.status === 'failed_terminal') {
+        this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
         return {
           delivered: false,
           accepted: true,
@@ -1272,6 +1307,12 @@ export class OpenCodeMemberMessageDeliveryService {
     // is allowed, and callers MUST keep the inbox row unread while
     // responsePending is true — reacting to `delivered` only would mark an
     // unconfirmed message as read and silently lose it on a dead lane.
+    if (!promptAccepted || !responsePending) {
+      // Settled in this frame: response read-committable, or the prompt was not
+      // (or not provably) accepted. An accepted-but-pending turn stays 'active'
+      // until a later observation/watchdog settles it.
+      this.notifyLeadTurnActivity(teamName, canonicalMemberName, laneIdentity, 'idle');
+    }
     return {
       delivered: promptAccepted || acceptanceUnknown,
       ...(ledgerRecord || responseObservation ? { accepted: promptAccepted } : {}),

--- a/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy.ts
@@ -21,8 +21,7 @@ import type { OpenCodePromptDeliveryLedgerRecord } from './OpenCodePromptDeliver
 /** An accepted/pending record older than this (since its last send) is stale. */
 export const OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS = 5 * 60_000;
 /**
- * A stale non-user record whose session still reports busy is settled terminal
- * after this long regardless; user-prompt records are never hard-capped.
+ * Legacy configuration window. Age alone never terminates busy or unknown work.
  */
 export const OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS = 30 * 60_000;
 
@@ -35,7 +34,7 @@ export const OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS = 30 * 60_000;
 export interface OpenCodeStalePendingPolicyConfig {
   /** Age since the last send at which an observe-only pending record is stale. */
   staleAfterMs: number;
-  /** Age at which a stale non-user record settles terminal even while busy. */
+  /** Legacy observation window, retained for callers; never a completion deadline. */
   hardCapMs: number;
 }
 
@@ -131,23 +130,10 @@ export function isOpenCodePromptDeliveryStalePending(
 }
 
 /**
- * Decide what to do with an observe-only pending record after a fresh bridge
- * observation that still did not settle it.
- *
- * - Primary (lead) lane, non-user message, turn ended (assistant message seen
- *   and the session observed idle): settle as `responded_plain_text` right
- *   away. Lead replies to teammate reports and system notifications are
- *   optional, so a plain-text turn end is a complete response and read-commit
- *   may proceed. An unknown session is never a turn end - only the stale
- *   window below bounds a record the bridge reports nothing about.
- * - Any lane, reply-optional delivery (informational notice or teammate
- *   report), turn ended: same settlement. The member owed no reply, so a
- *   finished turn is the whole contract; without this the record sat pending
- *   until the stale window expired.
- * - Stale (older than `config.staleAfterMs`) and the session is not busy:
- *   terminal.
- * - Stale and busy: keep observing; non-user records are capped at
- *   `config.hardCapMs` and then settled terminal.
+ * Only a fresh explicit idle observation may settle an accepted prompt.
+ * Reply-optional deliveries settle after turn proof; reply-required deliveries
+ * retain their proof contract and fail visibly after the idle stale window.
+ * Busy or unknown runtime activity is never completion, regardless of age.
  */
 export function decideOpenCodeStalePendingResolution(input: {
   record: OpenCodePromptDeliveryLedgerRecord;
@@ -161,7 +147,7 @@ export function decideOpenCodeStalePendingResolution(input: {
   if (!isOpenCodePromptDeliveryObserveOnlyPendingRecord(record)) {
     return { action: 'none' };
   }
-  const { staleAfterMs, hardCapMs } = input.config;
+  const { staleAfterMs } = input.config;
   const isUserPrompt = isOpenCodeDirectUserPromptDelivery(record);
   const activity = getOpenCodeObservedSessionActivity(input.observedDiagnostics);
   const assistantMessageSeen = Boolean(
@@ -172,7 +158,12 @@ export function decideOpenCodeStalePendingResolution(input: {
   // the observation said nothing about the session.
   const turnEnded = assistantMessageSeen && activity === 'idle';
 
-  if (input.laneKind === 'primary' && !isUserPrompt && turnEnded) {
+  if (
+    input.laneKind === 'primary' &&
+    !isUserPrompt &&
+    turnEnded &&
+    isOpenCodeReplyOptionalDeliveryContract(record.replyRecipient)
+  ) {
     return { action: 'settle_plain_text', reason: OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON };
   }
   if (turnEnded && isOpenCodeReplyOptionalDeliveryContract(record.replyRecipient)) {
@@ -184,63 +175,14 @@ export function decideOpenCodeStalePendingResolution(input: {
     return { action: 'none' };
   }
   const ageDescription = `accepted prompt has been pending for ${Math.round(ageMs / 1000)}s`;
-  if (activity === 'busy') {
-    if (!isUserPrompt && ageMs >= hardCapMs) {
-      return {
-        action: 'fail_terminal',
-        reason: OPENCODE_STALE_PENDING_HARD_CAP_REASON,
-        diagnostics: [
-          `OpenCode session still reported busy after ${Math.round(hardCapMs / 60_000)} minute(s); ${ageDescription}.`,
-        ],
-      };
-    }
-    return { action: 'keep_observing', reason: 'opencode_stale_pending_session_busy' };
+  if (activity !== 'idle') {
+    return { action: 'keep_observing', reason: `opencode_stale_pending_session_${activity}` };
   }
   return {
     action: 'fail_terminal',
     reason: OPENCODE_STALE_PENDING_TERMINAL_REASON,
     diagnostics: [
       `OpenCode observation never settled the accepted prompt (session ${activity}); ${ageDescription}.`,
-    ],
-  };
-}
-
-/**
- * A new user message must never wait behind a stale non-user record (teammate
- * report, task/system notification). Decide how to settle the blocking record
- * so the user delivery can proceed. Non-stale or user-prompt records keep the
- * normal queue-behind semantics.
- */
-export function decideOpenCodeStalePendingUserPreemption(input: {
-  activeRecord: OpenCodePromptDeliveryLedgerRecord;
-  incomingReplyRecipient?: string | null;
-  laneKind: 'primary' | 'secondary';
-  nowMs: number;
-  config: OpenCodeStalePendingPolicyConfig;
-}): OpenCodeStalePendingResolution {
-  if (input.incomingReplyRecipient?.trim().toLowerCase() !== 'user') {
-    return { action: 'none' };
-  }
-  if (isOpenCodeDirectUserPromptDelivery(input.activeRecord)) {
-    return { action: 'none' };
-  }
-  if (
-    !isOpenCodePromptDeliveryStalePending(
-      input.activeRecord,
-      input.nowMs,
-      input.config.staleAfterMs
-    )
-  ) {
-    return { action: 'none' };
-  }
-  if (input.laneKind === 'primary' && input.activeRecord.observedAssistantMessageId?.trim()) {
-    return { action: 'settle_plain_text', reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON };
-  }
-  return {
-    action: 'fail_terminal',
-    reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON,
-    diagnostics: [
-      'A newer user message preempted this stale non-user delivery so the lane can continue.',
     ],
   };
 }

--- a/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy.ts
@@ -1,3 +1,4 @@
+import { isOpenCodeReplyOptionalDeliveryContract } from './OpenCodeDeliveryReplyContract';
 import {
   hasOpenCodeAcceptedRuntimePrompt,
   isOpenCodeDirectUserPromptDelivery,
@@ -46,6 +47,7 @@ export const OPENCODE_STALE_PENDING_POLICY_CONFIG: OpenCodeStalePendingPolicyCon
 
 export const OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON =
   'opencode_lead_plain_text_turn_end_non_user_message';
+export const OPENCODE_REPLY_OPTIONAL_TURN_END_REASON = 'opencode_reply_optional_delivery_turn_end';
 export const OPENCODE_STALE_PENDING_TERMINAL_REASON =
   'opencode_stale_pending_observe_window_exhausted';
 export const OPENCODE_STALE_PENDING_HARD_CAP_REASON =
@@ -136,6 +138,10 @@ export function isOpenCodePromptDeliveryStalePending(
  *   and session not busy): settle as `responded_plain_text` right away. Lead
  *   replies to teammate reports and system notifications are optional, so a
  *   plain-text turn end is a complete response and read-commit may proceed.
+ * - Any lane, reply-optional delivery (informational notice or teammate
+ *   report), turn ended: same settlement. The member owed no reply, so a
+ *   finished turn is the whole contract; without this the record sat pending
+ *   until the stale window expired.
  * - Stale (older than `config.staleAfterMs`) and the session is not busy:
  *   terminal.
  * - Stale and busy: keep observing; non-user records are capped at
@@ -163,6 +169,9 @@ export function decideOpenCodeStalePendingResolution(input: {
 
   if (input.laneKind === 'primary' && !isUserPrompt && turnEnded) {
     return { action: 'settle_plain_text', reason: OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON };
+  }
+  if (turnEnded && isOpenCodeReplyOptionalDeliveryContract(record.replyRecipient)) {
+    return { action: 'settle_plain_text', reason: OPENCODE_REPLY_OPTIONAL_TURN_END_REASON };
   }
 
   const ageMs = getOpenCodePromptDeliveryPendingAgeMs(record, input.nowMs);

--- a/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy.ts
@@ -1,0 +1,250 @@
+import {
+  hasOpenCodeAcceptedRuntimePrompt,
+  isOpenCodeDirectUserPromptDelivery,
+} from './OpenCodePromptDeliveryReadCommitPolicy';
+
+import type { OpenCodeDeliveryResponseObservation } from '../bridge/OpenCodeBridgeCommandContract';
+import type { OpenCodePromptDeliveryLedgerRecord } from './OpenCodePromptDeliveryLedger';
+
+/**
+ * Stale-pending guard for accepted OpenCode prompt deliveries.
+ *
+ * An accepted prompt whose bridge observation keeps answering `pending` is
+ * re-observed every OPENCODE_PROMPT_DELIVERY_OBSERVE_DELAY_MS with no attempt
+ * budget (attempts only count sends). The ledger record then never reaches a
+ * terminal decision, and because the delivery service queues every later
+ * message behind the oldest non-terminal record, one such record blocks the
+ * whole lane forever. This policy bounds that loop.
+ */
+
+/** An accepted/pending record older than this (since its last send) is stale. */
+export const OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS = 5 * 60_000;
+/**
+ * A stale non-user record whose session still reports busy is settled terminal
+ * after this long regardless; user-prompt records are never hard-capped.
+ */
+export const OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS = 30 * 60_000;
+
+/**
+ * The windows this policy bounds a pending delivery with. The policy has no
+ * defaults of its own: whoever composes the delivery pipeline states them, so
+ * the shipped values are read at one place in the composition rather than
+ * hidden as fallbacks behind every call.
+ */
+export interface OpenCodeStalePendingPolicyConfig {
+  /** Age since the last send at which an observe-only pending record is stale. */
+  staleAfterMs: number;
+  /** Age at which a stale non-user record settles terminal even while busy. */
+  hardCapMs: number;
+}
+
+/** The windows the shipped delivery pipeline runs this policy with. */
+export const OPENCODE_STALE_PENDING_POLICY_CONFIG: OpenCodeStalePendingPolicyConfig = {
+  staleAfterMs: OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS,
+  hardCapMs: OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS,
+};
+
+export const OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON =
+  'opencode_lead_plain_text_turn_end_non_user_message';
+export const OPENCODE_STALE_PENDING_TERMINAL_REASON =
+  'opencode_stale_pending_observe_window_exhausted';
+export const OPENCODE_STALE_PENDING_HARD_CAP_REASON =
+  'opencode_stale_pending_busy_hard_cap_exceeded';
+export const OPENCODE_STALE_PENDING_PREEMPTED_REASON =
+  'opencode_stale_pending_preempted_by_user_message';
+
+export type OpenCodeObservedSessionActivity = 'busy' | 'idle' | 'unknown';
+
+export type OpenCodeStalePendingResolution =
+  | { action: 'none' }
+  | { action: 'keep_observing'; reason: string }
+  | { action: 'settle_plain_text'; reason: string }
+  | { action: 'fail_terminal'; reason: string; diagnostics: string[] };
+
+/**
+ * Session activity as reported by the bridge observation diagnostics. The
+ * bridge emits "OpenCode session status busy" while a turn runs and the
+ * "... treating session as idle" heuristic once the transcript shows a
+ * completed assistant response for the latest user message.
+ */
+export function getOpenCodeObservedSessionActivity(
+  diagnostics: readonly string[] | undefined
+): OpenCodeObservedSessionActivity {
+  const normalized = (diagnostics ?? []).map((diagnostic) => diagnostic.trim().toLowerCase());
+  if (
+    normalized.some(
+      (diagnostic) =>
+        diagnostic.includes('treating session as idle') ||
+        diagnostic.startsWith('opencode session status idle')
+    )
+  ) {
+    return 'idle';
+  }
+  if (normalized.some((diagnostic) => diagnostic.startsWith('opencode session status busy'))) {
+    return 'busy';
+  }
+  return 'unknown';
+}
+
+/** Milliseconds since the last send/acceptance of the record, or null when unknown. */
+export function getOpenCodePromptDeliveryPendingAgeMs(
+  record: Pick<OpenCodePromptDeliveryLedgerRecord, 'lastAttemptAt' | 'acceptedAt' | 'createdAt'>,
+  nowMs: number
+): number | null {
+  const anchors = [record.lastAttemptAt, record.acceptedAt, record.createdAt]
+    .map((value) => (value ? Date.parse(value) : NaN))
+    .filter((value) => Number.isFinite(value));
+  if (anchors.length === 0) {
+    return null;
+  }
+  return Math.max(0, nowMs - Math.max(...anchors));
+}
+
+/**
+ * Accepted prompt that is only being observed (no retry budget applies):
+ * the bridge has the prompt, nothing has been read-committed, and the
+ * observation state is still `pending`/`prompt_not_indexed`.
+ */
+export function isOpenCodePromptDeliveryObserveOnlyPendingRecord(
+  record: OpenCodePromptDeliveryLedgerRecord
+): boolean {
+  return (
+    record.status === 'accepted' &&
+    !record.inboxReadCommittedAt &&
+    hasOpenCodeAcceptedRuntimePrompt(record) &&
+    (record.responseState === 'pending' || record.responseState === 'prompt_not_indexed')
+  );
+}
+
+export function isOpenCodePromptDeliveryStalePending(
+  record: OpenCodePromptDeliveryLedgerRecord,
+  nowMs: number,
+  staleAfterMs: number
+): boolean {
+  if (!isOpenCodePromptDeliveryObserveOnlyPendingRecord(record)) {
+    return false;
+  }
+  const ageMs = getOpenCodePromptDeliveryPendingAgeMs(record, nowMs);
+  return ageMs !== null && ageMs >= staleAfterMs;
+}
+
+/**
+ * Decide what to do with an observe-only pending record after a fresh bridge
+ * observation that still did not settle it.
+ *
+ * - Primary (lead) lane, non-user message, turn ended (assistant message seen
+ *   and session not busy): settle as `responded_plain_text` right away. Lead
+ *   replies to teammate reports and system notifications are optional, so a
+ *   plain-text turn end is a complete response and read-commit may proceed.
+ * - Stale (older than `config.staleAfterMs`) and the session is not busy:
+ *   terminal.
+ * - Stale and busy: keep observing; non-user records are capped at
+ *   `config.hardCapMs` and then settled terminal.
+ */
+export function decideOpenCodeStalePendingResolution(input: {
+  record: OpenCodePromptDeliveryLedgerRecord;
+  laneKind: 'primary' | 'secondary';
+  observation?: Pick<OpenCodeDeliveryResponseObservation, 'state' | 'assistantMessageId'> | null;
+  observedDiagnostics?: readonly string[];
+  nowMs: number;
+  config: OpenCodeStalePendingPolicyConfig;
+}): OpenCodeStalePendingResolution {
+  const { record } = input;
+  if (!isOpenCodePromptDeliveryObserveOnlyPendingRecord(record)) {
+    return { action: 'none' };
+  }
+  const { staleAfterMs, hardCapMs } = input.config;
+  const isUserPrompt = isOpenCodeDirectUserPromptDelivery(record);
+  const activity = getOpenCodeObservedSessionActivity(input.observedDiagnostics);
+  const assistantMessageSeen = Boolean(
+    input.observation?.assistantMessageId?.trim() || record.observedAssistantMessageId?.trim()
+  );
+  const turnEnded = assistantMessageSeen && activity !== 'busy';
+
+  if (input.laneKind === 'primary' && !isUserPrompt && turnEnded) {
+    return { action: 'settle_plain_text', reason: OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON };
+  }
+
+  const ageMs = getOpenCodePromptDeliveryPendingAgeMs(record, input.nowMs);
+  if (ageMs === null || ageMs < staleAfterMs) {
+    return { action: 'none' };
+  }
+  const ageDescription = `accepted prompt has been pending for ${Math.round(ageMs / 1000)}s`;
+  if (activity === 'busy') {
+    if (!isUserPrompt && ageMs >= hardCapMs) {
+      return {
+        action: 'fail_terminal',
+        reason: OPENCODE_STALE_PENDING_HARD_CAP_REASON,
+        diagnostics: [
+          `OpenCode session still reported busy after ${Math.round(hardCapMs / 60_000)} minute(s); ${ageDescription}.`,
+        ],
+      };
+    }
+    return { action: 'keep_observing', reason: 'opencode_stale_pending_session_busy' };
+  }
+  return {
+    action: 'fail_terminal',
+    reason: OPENCODE_STALE_PENDING_TERMINAL_REASON,
+    diagnostics: [
+      `OpenCode observation never settled the accepted prompt (session ${activity}); ${ageDescription}.`,
+    ],
+  };
+}
+
+/**
+ * A new user message must never wait behind a stale non-user record (teammate
+ * report, task/system notification). Decide how to settle the blocking record
+ * so the user delivery can proceed. Non-stale or user-prompt records keep the
+ * normal queue-behind semantics.
+ */
+export function decideOpenCodeStalePendingUserPreemption(input: {
+  activeRecord: OpenCodePromptDeliveryLedgerRecord;
+  incomingReplyRecipient?: string | null;
+  laneKind: 'primary' | 'secondary';
+  nowMs: number;
+  config: OpenCodeStalePendingPolicyConfig;
+}): OpenCodeStalePendingResolution {
+  if (input.incomingReplyRecipient?.trim().toLowerCase() !== 'user') {
+    return { action: 'none' };
+  }
+  if (isOpenCodeDirectUserPromptDelivery(input.activeRecord)) {
+    return { action: 'none' };
+  }
+  if (
+    !isOpenCodePromptDeliveryStalePending(
+      input.activeRecord,
+      input.nowMs,
+      input.config.staleAfterMs
+    )
+  ) {
+    return { action: 'none' };
+  }
+  if (input.laneKind === 'primary' && input.activeRecord.observedAssistantMessageId?.trim()) {
+    return { action: 'settle_plain_text', reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON };
+  }
+  return {
+    action: 'fail_terminal',
+    reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON,
+    diagnostics: [
+      'A newer user message preempted this stale non-user delivery so the lane can continue.',
+    ],
+  };
+}
+
+/** Observation payload that settles a record as a plain-text turn end. */
+export function buildOpenCodeStalePendingPlainTextObservation(input: {
+  record: OpenCodePromptDeliveryLedgerRecord;
+  reason: string;
+}): OpenCodeDeliveryResponseObservation {
+  return {
+    state: 'responded_plain_text',
+    deliveredUserMessageId: input.record.deliveredUserMessageId,
+    assistantMessageId: input.record.observedAssistantMessageId,
+    toolCallNames: input.record.observedToolCallNames,
+    visibleMessageToolCallId: input.record.observedVisibleMessageId,
+    visibleReplyMessageId: null,
+    visibleReplyCorrelation: null,
+    latestAssistantPreview: input.record.observedAssistantPreview,
+    reason: input.reason,
+  };
+}

--- a/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy.ts
@@ -135,9 +135,11 @@ export function isOpenCodePromptDeliveryStalePending(
  * observation that still did not settle it.
  *
  * - Primary (lead) lane, non-user message, turn ended (assistant message seen
- *   and session not busy): settle as `responded_plain_text` right away. Lead
- *   replies to teammate reports and system notifications are optional, so a
- *   plain-text turn end is a complete response and read-commit may proceed.
+ *   and the session observed idle): settle as `responded_plain_text` right
+ *   away. Lead replies to teammate reports and system notifications are
+ *   optional, so a plain-text turn end is a complete response and read-commit
+ *   may proceed. An unknown session is never a turn end - only the stale
+ *   window below bounds a record the bridge reports nothing about.
  * - Any lane, reply-optional delivery (informational notice or teammate
  *   report), turn ended: same settlement. The member owed no reply, so a
  *   finished turn is the whole contract; without this the record sat pending
@@ -165,7 +167,10 @@ export function decideOpenCodeStalePendingResolution(input: {
   const assistantMessageSeen = Boolean(
     input.observation?.assistantMessageId?.trim() || record.observedAssistantMessageId?.trim()
   );
-  const turnEnded = assistantMessageSeen && activity !== 'busy';
+  // A turn end has to be observed, not inferred from silence: the assistant
+  // message row already exists while the turn runs, and `unknown` only means
+  // the observation said nothing about the session.
+  const turnEnded = assistantMessageSeen && activity === 'idle';
 
   if (input.laneKind === 'primary' && !isUserPrompt && turnEnded) {
     return { action: 'settle_plain_text', reason: OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON };

--- a/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator.ts
@@ -229,8 +229,8 @@ export class OpenCodePromptDeliveryWatchdogCoordinator {
   }
 
   private notifyLeadTurnIdle(record: OpenCodePromptDeliveryLedgerRecord): void {
-    // The lead's OpenCode lane is persisted with laneId 'primary'; secondary
-    // lanes carry member-scoped ids and never drive lead activity.
+    // The consumer validates canonical lead identity and current run ownership.
+    // Primary also contains same-model teammates, so lane alone is not proof.
     if (record.laneId !== 'primary' || !this.ports.notifyLeadTurnActivity) {
       return;
     }
@@ -239,6 +239,7 @@ export class OpenCodePromptDeliveryWatchdogCoordinator {
         teamName: record.teamName,
         memberName: record.memberName,
         laneId: record.laneId,
+        runId: record.runId,
         state: 'idle',
       });
     } catch (error) {

--- a/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator.ts
@@ -27,7 +27,10 @@ import type {
   OpenCodeTeamRuntimeMessageInput,
   OpenCodeTeamRuntimeMessageResult,
 } from '../../runtime';
-import type { OpenCodeRuntimeMessageAdapter } from './OpenCodeMemberMessageDeliveryPorts';
+import type {
+  OpenCodeLeadTurnActivityNotification,
+  OpenCodeRuntimeMessageAdapter,
+} from './OpenCodeMemberMessageDeliveryPorts';
 import type { OpenCodePromptDeliveryWatchdogScheduler } from './OpenCodePromptDeliveryWatchdogScheduler';
 import type { OpenCodeVisibleReplyProofService } from './OpenCodeVisibleReplyProofService';
 import type { AgentActionMode, InboxMessage, TaskRef } from '@shared/types/team';
@@ -79,6 +82,8 @@ export interface OpenCodePromptDeliveryWatchdogCoordinatorPorts {
     messageId?: string | null;
     delayMs: number;
   }): void;
+  /** Lead turn settled asynchronously on the OpenCode primary lane (see delivery service). */
+  notifyLeadTurnActivity?(input: OpenCodeLeadTurnActivityNotification): void;
   canDeliverToTeamRuntime(teamName: string): boolean;
   recoverRuntimeLanesForWatchdog(
     teamName: string,
@@ -219,7 +224,30 @@ export class OpenCodePromptDeliveryWatchdogCoordinator {
     this.ports.logPromptDeliveryEvent('opencode_prompt_delivery_terminal_failure', failed, {
       ...failurePlan.eventExtra,
     });
+    this.notifyLeadTurnIdle(failed);
     return failed;
+  }
+
+  private notifyLeadTurnIdle(record: OpenCodePromptDeliveryLedgerRecord): void {
+    // The lead's OpenCode lane is persisted with laneId 'primary'; secondary
+    // lanes carry member-scoped ids and never drive lead activity.
+    if (record.laneId !== 'primary' || !this.ports.notifyLeadTurnActivity) {
+      return;
+    }
+    try {
+      this.ports.notifyLeadTurnActivity({
+        teamName: record.teamName,
+        memberName: record.memberName,
+        laneId: record.laneId,
+        state: 'idle',
+      });
+    } catch (error) {
+      this.ports.warn(
+        `[${record.teamName}] OpenCode lead turn activity (idle) notification failed: ${this.ports.getErrorMessage(
+          error
+        )}`
+      );
+    }
   }
 
   async observeDirectUserDeliveryInlineIfNeeded(input: {

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeLeadTurnActivity.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeLeadTurnActivity.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveOpenCodeMemberIdentityFromDirectory } from '../../../provisioning/TeamProvisioningOpenCodeMemberIdentity';
+import { isOpenCodeLeadRecipient } from '../OpenCodeLeadTurnActivity';
+
+import type { OpenCodeMemberDirectory } from '../OpenCodeMemberMessageDeliveryPorts';
+
+const directory: OpenCodeMemberDirectory = {
+  config: {
+    name: 'fixture-team',
+    projectPath: '/sandbox/fixture',
+    members: [
+      { name: 'captain', agentType: 'team-lead', providerId: 'opencode', model: 'test/shared' },
+      { name: 'builder', providerId: 'opencode', model: 'test/shared', cwd: '/sandbox/fixture' },
+    ],
+  },
+  teamMeta: { providerId: 'opencode' },
+  metaMembers: [],
+};
+
+describe('OpenCode lead recipient identity', () => {
+  it('separates a real same-model primary teammate from the configured lead', () => {
+    const identity = resolveOpenCodeMemberIdentityFromDirectory({
+      memberName: 'builder',
+      directory,
+      runtimeAdapterProviderId: 'opencode',
+    });
+    expect(identity).toMatchObject({ ok: true, laneIdentity: { laneKind: 'primary' } });
+    expect(isOpenCodeLeadRecipient('builder', directory)).toBe(false);
+    expect(isOpenCodeLeadRecipient(' CAPTAIN ', directory)).toBe(true);
+    expect(isOpenCodeLeadRecipient('team-lead', directory)).toBe(true);
+  });
+
+  it('accepts the solo alias only for a real solo roster', () => {
+    expect(isOpenCodeLeadRecipient('solo', directory)).toBe(false);
+    expect(
+      isOpenCodeLeadRecipient('solo', {
+        ...directory,
+        config: { ...directory.config!, members: [] },
+      })
+    ).toBe(true);
+  });
+});

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.leadTurnActivity.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.leadTurnActivity.test.ts
@@ -14,6 +14,7 @@ import {
   createOpenCodePromptDeliveryLedgerStore,
   type OpenCodePromptDeliveryLedgerRecord,
 } from '../OpenCodePromptDeliveryLedger';
+import { OPENCODE_STALE_PENDING_POLICY_CONFIG } from '../OpenCodePromptDeliveryStalePendingPolicy';
 
 import type { OpenCodeTeamRuntimeMessageResult } from '../../../runtime';
 
@@ -112,6 +113,7 @@ function createDeps(input: {
           ledgerRecord
       ),
     },
+    openCodeStalePendingPolicyConfig: OPENCODE_STALE_PENDING_POLICY_CONFIG,
     isOpenCodeDeliveryResponseReadCommitAllowed: vi.fn(
       async ({ ledgerRecord }: { ledgerRecord?: OpenCodePromptDeliveryLedgerRecord | null }) =>
         input.readAllowed(ledgerRecord)

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.leadTurnActivity.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.leadTurnActivity.test.ts
@@ -1,0 +1,279 @@
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  type OpenCodeLeadTurnActivityNotification,
+  type OpenCodeMemberLaneIdentity,
+  type OpenCodeMemberMessageDeliveryInput,
+  type OpenCodeMemberMessageDeliveryServiceDependencies,
+} from '../OpenCodeMemberMessageDeliveryPorts';
+import { OpenCodeMemberMessageDeliveryService } from '../OpenCodeMemberMessageDeliveryService';
+import {
+  createOpenCodePromptDeliveryLedgerStore,
+  type OpenCodePromptDeliveryLedgerRecord,
+} from '../OpenCodePromptDeliveryLedger';
+
+import type { OpenCodeTeamRuntimeMessageResult } from '../../../runtime';
+
+const PRIMARY_LANE: OpenCodeMemberLaneIdentity = {
+  laneId: 'primary',
+  laneKind: 'primary',
+  laneOwnerProviderId: 'opencode',
+};
+
+const SECONDARY_LANE: OpenCodeMemberLaneIdentity = {
+  laneId: 'secondary:opencode:muse',
+  laneKind: 'secondary',
+  laneOwnerProviderId: 'opencode',
+};
+
+function acceptedResult(memberName: string): OpenCodeTeamRuntimeMessageResult {
+  return {
+    ok: true,
+    providerId: 'opencode',
+    memberName,
+    sessionId: 'session-1',
+    runtimePromptMessageId: 'prompt-1',
+    diagnostics: [],
+  };
+}
+
+/** Read-commit gate that settles only once the runtime has accepted the prompt. */
+const settleAfterAcceptance = (record?: OpenCodePromptDeliveryLedgerRecord | null): boolean =>
+  record != null && record.status !== 'pending';
+
+function createDeps(input: {
+  ledgerDir: string;
+  laneIdentity: OpenCodeMemberLaneIdentity;
+  memberName: string;
+  send: () => Promise<OpenCodeTeamRuntimeMessageResult>;
+  readAllowed: (record?: OpenCodePromptDeliveryLedgerRecord | null) => boolean;
+  notify: ReturnType<typeof vi.fn>;
+}): OpenCodeMemberMessageDeliveryServiceDependencies {
+  const ledger = createOpenCodePromptDeliveryLedgerStore({
+    filePath: join(input.ledgerDir, `${input.laneIdentity.laneId.replace(/:/g, '_')}.json`),
+  });
+  const passthroughProof = vi.fn(async ({ ledgerRecord }: { ledgerRecord: unknown }) => ({
+    ledgerRecord,
+    visibleReply: null,
+  }));
+  return {
+    getOpenCodeRuntimeMessageAdapter: vi.fn(
+      () => ({ sendMessageToMember: vi.fn(async () => await input.send()) }) as never
+    ),
+    readOpenCodeMemberDirectory: vi.fn(async () => ({
+      config: { name: 'team-a', projectPath: '/repo', members: [] } as never,
+      teamMeta: null,
+      metaMembers: [{ name: input.memberName, providerId: 'opencode' as const }],
+    })),
+    resolveOpenCodeMemberIdentityFromDirectory: vi.fn(() => ({
+      ok: true as const,
+      canonicalMemberName: input.memberName,
+      laneId: input.laneIdentity.laneId,
+      laneIdentity: input.laneIdentity,
+      metaMember: { name: input.memberName, providerId: 'opencode' as const },
+      memberRuntimeCwd: '/repo',
+    })),
+    stoppingSecondaryRuntimeTeams: { has: () => false },
+    readPersistedTeamProjectPath: vi.fn(() => '/repo'),
+    resolveDeliverableTrackedRuntimeRunId: vi.fn(() => 'run-1'),
+    runs: { get: vi.fn(() => ({ mixedSecondaryLanes: [] })) },
+    getCurrentOpenCodeRuntimeRunId: vi.fn(() => 'runtime-run-1'),
+    resolveCurrentOpenCodeRuntimeRunId: vi.fn(async () => 'runtime-run-1'),
+    isOpenCodeRuntimeLaneIndexActive: vi.fn(async () => true),
+    tryRecoverOpenCodeRuntimeLaneBeforeDelivery: vi.fn(async () => false),
+    tryRecoverOpenCodeRuntimeLaneFromCommittedSessionBeforeDelivery: vi.fn(async () => false),
+    deleteSecondaryRuntimeRun: vi.fn(),
+    cleanupStoppedTeamOpenCodeRuntimeLanesInBackground: vi.fn(),
+    findDeliverableOpenCodeRuntimeBootstrapSessionEvidence: vi.fn(
+      async () => ({ appMcpTransportHash: 'hash' }) as never
+    ),
+    getOpenCodeAppMcpTransportMismatchDiagnostic: vi.fn(() => null),
+    stampOpenCodeAppMcpTransportEvidenceIfMissing: vi.fn(async () => undefined),
+    resolveControlApiBaseUrl: vi.fn(async () => null),
+    sendOpenCodeMemberMessageToRuntimeSerialized: vi.fn(
+      async ({ send }: { send: () => Promise<OpenCodeTeamRuntimeMessageResult> }) => await send()
+    ),
+    rememberOpenCodeRuntimePidFromBridge: vi.fn(async () => undefined),
+    maybeSyncOpenCodeRuntimePermissionsAfterDelivery: vi.fn(async () => undefined),
+    isLegacyOpenCodeMemberWorkSyncReadCommitAllowed: vi.fn(async () => true),
+    createOpenCodePromptDeliveryLedger: vi.fn(() => ledger),
+    openCodeVisibleReplyProofService: {
+      applyDestinationProof: passthroughProof as never,
+      materializePlainTextReplyIfNeeded: passthroughProof as never,
+      findByRelayOfMessageId: vi.fn(async () => null),
+    },
+    openCodePromptDeliveryWatchdogScheduler: { isEnabled: () => true },
+    openCodePromptDeliveryFollowUpPolicy: {
+      schedule: vi.fn(
+        async ({ ledgerRecord }: { ledgerRecord: OpenCodePromptDeliveryLedgerRecord }) =>
+          ledgerRecord
+      ),
+    },
+    isOpenCodeDeliveryResponseReadCommitAllowed: vi.fn(
+      async ({ ledgerRecord }: { ledgerRecord?: OpenCodePromptDeliveryLedgerRecord | null }) =>
+        input.readAllowed(ledgerRecord)
+    ),
+    getOpenCodeDeliveryPendingReason: vi.fn(() => 'opencode_delivery_response_pending'),
+    markOpenCodeAcceptedDeliveryMissingPromptProofForRetry: vi.fn(
+      async ({ ledgerRecord }: { ledgerRecord: OpenCodePromptDeliveryLedgerRecord }) => ledgerRecord
+    ),
+    scheduleOpenCodePromptDeliveryWatchdog: vi.fn(),
+    logOpenCodePromptDeliveryEvent: vi.fn(),
+    requeueOpenCodeRuntimeManifestWatermarkDeliveryIfNeeded: vi.fn(
+      async ({ ledgerRecord }: { ledgerRecord: OpenCodePromptDeliveryLedgerRecord }) => ledgerRecord
+    ),
+    emitOpenCodePromptDeliveryTaskLogChange: vi.fn(),
+    notifyOpenCodeLeadTurnActivity: input.notify as never,
+    observeOpenCodeDirectUserDeliveryInlineIfNeeded: vi.fn(
+      async ({ ledgerRecord }: { ledgerRecord: OpenCodePromptDeliveryLedgerRecord }) => ({
+        ledgerRecord,
+        visibleReply: null,
+      })
+    ),
+  };
+}
+
+function states(notify: ReturnType<typeof vi.fn>): OpenCodeLeadTurnActivityNotification['state'][] {
+  return notify.mock.calls.map(([call]) => (call as OpenCodeLeadTurnActivityNotification).state);
+}
+
+const leadMessage: OpenCodeMemberMessageDeliveryInput = {
+  memberName: 'team-lead',
+  text: 'plan the sprint',
+  messageId: 'user-1',
+  messageKind: 'default',
+  source: 'ui-send',
+};
+
+describe('OpenCodeMemberMessageDeliveryService lead turn activity', () => {
+  let ledgerDir: string;
+
+  beforeEach(async () => {
+    ledgerDir = await mkdtemp(join(tmpdir(), 'opencode-lead-turn-activity-'));
+  });
+
+  afterEach(async () => {
+    await rm(ledgerDir, { recursive: true, force: true });
+  });
+
+  it("emits 'active' on acceptance and 'idle' once the primary-lane response is read-committable", async () => {
+    const notify = vi.fn();
+    const service = new OpenCodeMemberMessageDeliveryService(
+      createDeps({
+        ledgerDir,
+        laneIdentity: PRIMARY_LANE,
+        memberName: 'team-lead',
+        send: async () => acceptedResult('team-lead'),
+        readAllowed: settleAfterAcceptance,
+        notify,
+      })
+    );
+
+    const delivery = await service.deliver('team-a', leadMessage);
+
+    expect(delivery.accepted).toBe(true);
+    expect(delivery.responsePending).toBe(false);
+    expect(states(notify)).toEqual(['active', 'idle']);
+    expect(notify).toHaveBeenCalledWith({
+      teamName: 'team-a',
+      memberName: 'team-lead',
+      laneId: 'primary',
+      state: 'active',
+    });
+  });
+
+  it("keeps the lead 'active' while an accepted primary-lane turn is still pending", async () => {
+    const notify = vi.fn();
+    const service = new OpenCodeMemberMessageDeliveryService(
+      createDeps({
+        ledgerDir,
+        laneIdentity: PRIMARY_LANE,
+        memberName: 'team-lead',
+        send: async () => acceptedResult('team-lead'),
+        readAllowed: () => false,
+        notify,
+      })
+    );
+
+    const delivery = await service.deliver('team-a', leadMessage);
+
+    expect(delivery.accepted).toBe(true);
+    expect(delivery.responsePending).toBe(true);
+    expect(states(notify)).toEqual(['active']);
+  });
+
+  it("emits 'idle' when the primary-lane send throws", async () => {
+    const notify = vi.fn();
+    const service = new OpenCodeMemberMessageDeliveryService(
+      createDeps({
+        ledgerDir,
+        laneIdentity: PRIMARY_LANE,
+        memberName: 'team-lead',
+        send: async () => {
+          throw new Error('bridge down');
+        },
+        readAllowed: () => false,
+        notify,
+      })
+    );
+
+    const delivery = await service.deliver('team-a', leadMessage);
+
+    expect(delivery.delivered).toBe(false);
+    expect(states(notify)).toEqual(['idle']);
+  });
+
+  it('never reports lead activity for a secondary lane', async () => {
+    const notify = vi.fn();
+    const service = new OpenCodeMemberMessageDeliveryService(
+      createDeps({
+        ledgerDir,
+        laneIdentity: SECONDARY_LANE,
+        memberName: 'Muse',
+        send: async () => acceptedResult('Muse'),
+        readAllowed: settleAfterAcceptance,
+        notify,
+      })
+    );
+
+    const delivery = await service.deliver('team-a', { ...leadMessage, memberName: 'Muse' });
+
+    expect(delivery.accepted).toBe(true);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('swallows notification failures without affecting the delivery result', async () => {
+    const notify = vi.fn(() => {
+      throw new Error('renderer gone');
+    });
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const service = new OpenCodeMemberMessageDeliveryService(
+      createDeps({
+        ledgerDir,
+        laneIdentity: PRIMARY_LANE,
+        memberName: 'team-lead',
+        send: async () => acceptedResult('team-lead'),
+        readAllowed: settleAfterAcceptance,
+        notify,
+      })
+    );
+
+    try {
+      const delivery = await service.deliver('team-a', leadMessage);
+
+      expect(delivery.accepted).toBe(true);
+      expect(delivery.responsePending).toBe(false);
+      expect(states(notify)).toEqual(['active', 'idle']);
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[Service:OpenCodeMemberMessageDelivery]',
+        expect.stringContaining('lead turn activity (active) notification failed: renderer gone')
+      );
+    } finally {
+      consoleWarnSpy.mockRestore();
+    }
+  });
+});

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.leadTurnActivity.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.leadTurnActivity.test.ts
@@ -183,6 +183,7 @@ describe('OpenCodeMemberMessageDeliveryService lead turn activity', () => {
       teamName: 'team-a',
       memberName: 'team-lead',
       laneId: 'primary',
+      runId: 'run-1',
       state: 'active',
     });
   });
@@ -234,6 +235,25 @@ describe('OpenCodeMemberMessageDeliveryService lead turn activity', () => {
       createDeps({
         ledgerDir,
         laneIdentity: SECONDARY_LANE,
+        memberName: 'Muse',
+        send: async () => acceptedResult('Muse'),
+        readAllowed: settleAfterAcceptance,
+        notify,
+      })
+    );
+
+    const delivery = await service.deliver('team-a', { ...leadMessage, memberName: 'Muse' });
+
+    expect(delivery.accepted).toBe(true);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('never reports lead activity for a same-model primary teammate', async () => {
+    const notify = vi.fn();
+    const service = new OpenCodeMemberMessageDeliveryService(
+      createDeps({
+        ledgerDir,
+        laneIdentity: PRIMARY_LANE,
         memberName: 'Muse',
         send: async () => acceptedResult('Muse'),
         readAllowed: settleAfterAcceptance,

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.stalePending.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.stalePending.test.ts
@@ -331,6 +331,7 @@ describe('OpenCodeMemberMessageDeliveryService stale-pending guard', () => {
     });
     expect(harness.followUpSchedule).not.toHaveBeenCalled();
     expect(harness.notify).toHaveBeenCalledWith(expect.objectContaining({ state: 'idle' }));
+    expect(harness.notify).not.toHaveBeenCalledWith(expect.objectContaining({ state: 'active' }));
   });
 
   it('keeps a fresh busy non-user delivery pending (normal observe follow-up)', async () => {

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.stalePending.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.stalePending.test.ts
@@ -19,7 +19,6 @@ import { isOpenCodeDeliveryResponseReadCommitAllowed } from '../OpenCodePromptDe
 import {
   OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON,
   OPENCODE_STALE_PENDING_POLICY_CONFIG,
-  OPENCODE_STALE_PENDING_PREEMPTED_REASON,
   OPENCODE_STALE_PENDING_TERMINAL_REASON,
   type OpenCodeStalePendingPolicyConfig,
 } from '../OpenCodePromptDeliveryStalePendingPolicy';
@@ -135,6 +134,7 @@ async function seedAcceptedPendingRecord(
     replyRecipient: input.replyRecipient ?? 'user',
     actionMode: input.actionMode ?? null,
     messageKind: input.messageKind ?? null,
+    workSyncIntent: input.workSyncIntent,
     taskRefs: input.taskRefs ?? [],
     payloadHash: hashOpenCodePromptDeliveryPayload({
       text: input.text,
@@ -439,30 +439,54 @@ describe('OpenCodeMemberMessageDeliveryService stale-pending guard', () => {
     ).toBeNull();
   });
 
-  it('lets a new user message preempt a stale non-user record and delivers it', async () => {
-    const harness = createHarness({ ledgerDir, send: async () => acceptedSendResult() });
-    await seedAcceptedPendingRecord(harness.ledger, taskCommentNotification, { ageMinutes: 32 });
+  it.each([
+    userMessage,
+    taskCommentNotification,
+    {
+      ...taskCommentNotification,
+      messageId: 'task-start',
+      messageKind: 'default' as const,
+      text: 'Start working on task now. Use task_get and task_complete.',
+      taskRefs: [{ taskId: 'task-1', displayId: '1', teamName: TEAM }],
+    },
+    {
+      ...taskCommentNotification,
+      messageId: 'work-sync',
+      messageKind: 'member_work_sync_nudge' as const,
+      workSyncIntent: 'agenda_sync' as const,
+    },
+  ])('preserves stale busy or unknown accepted work: $messageId', async (message) => {
+    for (const diagnostics of [[BUSY], []]) {
+      const harness = createHarness({
+        ledgerDir,
+        observe: async () => observedResult({ observation: pendingObservation(), diagnostics }),
+      });
+      await seedAcceptedPendingRecord(harness.ledger, message, { ageMinutes: 90 });
+      const delivery = await harness.service.deliver(TEAM, message);
+      expect(delivery).toMatchObject({ accepted: true, responsePending: true });
+      expect(harness.send).not.toHaveBeenCalled();
+      expect(harness.notify).not.toHaveBeenCalledWith(expect.objectContaining({ state: 'idle' }));
+    }
+  });
 
-    const delivery = await harness.service.deliver(TEAM, userMessage);
-
-    expect(harness.send).toHaveBeenCalledTimes(1);
-    expect(delivery).toMatchObject({ delivered: true, accepted: true });
-    expect(delivery.queuedBehindMessageId).toBeUndefined();
-    const records = await harness.ledger.list();
-    const stale = records.find(
-      (record) => record.inboxMessageId === taskCommentNotification.messageId
-    );
-    const fresh = records.find((record) => record.inboxMessageId === userMessage.messageId);
-    expect(stale).toMatchObject({
-      status: 'responded',
-      responseState: 'responded_plain_text',
-      lastReason: OPENCODE_STALE_PENDING_PREEMPTED_REASON,
+  it('queues a new user behind stale busy non-user work until a fresh idle observation', async () => {
+    const harness = createHarness({
+      ledgerDir,
+      send: async () => acceptedSendResult(),
+      observe: async () =>
+        observedResult({ observation: pendingObservation(), diagnostics: [TREATED_IDLE] }),
     });
-    expect(fresh).toMatchObject({ status: 'accepted', replyRecipient: 'user' });
-    // The settled row is handed back to the watchdog so the relay read-commits it.
-    expect(harness.scheduleWatchdog).toHaveBeenCalledWith(
-      expect.objectContaining({ messageId: taskCommentNotification.messageId, delayMs: 500 })
-    );
+    await seedAcceptedPendingRecord(harness.ledger, taskCommentNotification, { ageMinutes: 90 });
+    expect(await harness.service.deliver(TEAM, userMessage)).toMatchObject({
+      queuedBehindMessageId: taskCommentNotification.messageId,
+    });
+    expect(harness.send).not.toHaveBeenCalled();
+    expect(await harness.service.deliver(TEAM, taskCommentNotification)).toMatchObject({
+      delivered: true,
+      responsePending: false,
+    });
+    expect(await harness.service.deliver(TEAM, userMessage)).toMatchObject({ accepted: true });
+    expect(harness.send).toHaveBeenCalledOnce();
   });
 
   it('still queues a user message behind a non-stale non-user record', async () => {
@@ -478,30 +502,6 @@ describe('OpenCodeMemberMessageDeliveryService stale-pending guard', () => {
       reason: 'opencode_delivery_response_pending',
     });
     expect(await harness.ledger.list()).toHaveLength(1);
-  });
-
-  it('bounds the lane by the windows it was composed with', async () => {
-    // The record above stays queued at two minutes under the shipped 5-minute
-    // window; the only change here is the config the service was built with.
-    const harness = createHarness({
-      ledgerDir,
-      send: async () => acceptedSendResult(),
-      stalePendingConfig: { staleAfterMs: 60_000, hardCapMs: 6 * 60_000 },
-    });
-    await seedAcceptedPendingRecord(harness.ledger, taskCommentNotification, { ageMinutes: 2 });
-
-    const delivery = await harness.service.deliver(TEAM, userMessage);
-
-    expect(harness.send).toHaveBeenCalledTimes(1);
-    expect(delivery).toMatchObject({ delivered: true, accepted: true });
-    expect(delivery.queuedBehindMessageId).toBeUndefined();
-    const stale = (await harness.ledger.list()).find(
-      (record) => record.inboxMessageId === taskCommentNotification.messageId
-    );
-    expect(stale).toMatchObject({
-      status: 'responded',
-      lastReason: OPENCODE_STALE_PENDING_PREEMPTED_REASON,
-    });
   });
 
   it('never preempts a stale user prompt with another user message', async () => {
@@ -521,4 +521,61 @@ describe('OpenCodeMemberMessageDeliveryService stale-pending guard', () => {
       queuedBehindMessageId: 'user-1',
     });
   });
+  it.each(['pending', 'prompt_not_indexed'] as const)(
+    'marks the lead active when unknown acceptance is proven busy by observe (%s)',
+    async (state) => {
+      const ledgerDir = await mkdtemp(join(tmpdir(), 'review565-acceptance-recovery-'));
+      try {
+        const harness = createHarness({
+          ledgerDir,
+          observe: async () =>
+            observedResult({
+              observation: pendingObservation({ state }),
+              diagnostics: [BUSY],
+            }),
+        });
+        const seeded = await harness.ledger.ensurePending({
+          teamName: TEAM,
+          memberName: LEAD,
+          laneId: 'primary',
+          runId: 'run-1',
+          inboxMessageId: userMessage.messageId!,
+          inboxTimestamp: userMessage.inboxTimestamp!,
+          source: userMessage.source!,
+          replyRecipient: userMessage.replyRecipient!,
+          actionMode: userMessage.actionMode,
+          messageKind: userMessage.messageKind,
+          taskRefs: [],
+          now: minutesAgoIso(1),
+          payloadHash: hashOpenCodePromptDeliveryPayload({
+            text: userMessage.text,
+            replyRecipient: userMessage.replyRecipient!,
+            actionMode: userMessage.actionMode,
+            taskRefs: [],
+            source: userMessage.source,
+          }),
+        });
+        await harness.ledger.markAcceptanceUnknown({
+          id: seeded.id,
+          nextAttemptAt: minutesAgoIso(0),
+          reason: 'opencode_prompt_acceptance_missing_runtime_prompt_id',
+          diagnostics: ['send timeout; acceptance unknown'],
+          markedAt: minutesAgoIso(1),
+        });
+        const before = (await harness.ledger.list())[0];
+        expect(before.status).toBe('failed_retryable');
+        expect(before.acceptanceUnknown).toBe(true);
+        expect(before.acceptedAt).toBeNull();
+        expect(before.runtimePromptMessageId).toBeNull();
+        const delivered = await harness.service.deliver(TEAM, userMessage);
+        expect(delivered).toMatchObject({ accepted: true, responsePending: true });
+        expect(harness.observe).toHaveBeenCalledOnce();
+        expect(harness.send).not.toHaveBeenCalled();
+        expect(harness.notify).not.toHaveBeenCalledWith(expect.objectContaining({ state: 'idle' }));
+        expect(harness.notify).toHaveBeenCalledWith(expect.objectContaining({ state: 'active' }));
+      } finally {
+        await rm(ledgerDir, { recursive: true, force: true });
+      }
+    }
+  );
 });

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.stalePending.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.stalePending.test.ts
@@ -1,0 +1,501 @@
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  type OpenCodeMemberLaneIdentity,
+  type OpenCodeMemberMessageDeliveryInput,
+  type OpenCodeMemberMessageDeliveryServiceDependencies,
+} from '../OpenCodeMemberMessageDeliveryPorts';
+import { OpenCodeMemberMessageDeliveryService } from '../OpenCodeMemberMessageDeliveryService';
+import {
+  createOpenCodePromptDeliveryLedgerStore,
+  hashOpenCodePromptDeliveryPayload,
+  type OpenCodePromptDeliveryLedgerRecord,
+  type OpenCodePromptDeliveryLedgerStore,
+} from '../OpenCodePromptDeliveryLedger';
+import { isOpenCodeDeliveryResponseReadCommitAllowed } from '../OpenCodePromptDeliveryReadCommitPolicy';
+import {
+  OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON,
+  OPENCODE_STALE_PENDING_POLICY_CONFIG,
+  OPENCODE_STALE_PENDING_PREEMPTED_REASON,
+  OPENCODE_STALE_PENDING_TERMINAL_REASON,
+  type OpenCodeStalePendingPolicyConfig,
+} from '../OpenCodePromptDeliveryStalePendingPolicy';
+
+import type { OpenCodeTeamRuntimeMessageResult } from '../../../runtime';
+import type { OpenCodeDeliveryResponseObservation } from '../../bridge/OpenCodeBridgeCommandContract';
+
+/** The read-commit input the delivery service actually hands to this port. */
+type ReadCommitPortInput = Parameters<
+  OpenCodeMemberMessageDeliveryServiceDependencies['isOpenCodeDeliveryResponseReadCommitAllowed']
+>[0];
+
+const PRIMARY_LANE: OpenCodeMemberLaneIdentity = {
+  laneId: 'primary',
+  laneKind: 'primary',
+  laneOwnerProviderId: 'opencode',
+};
+
+const TEAM = 'reportteam';
+const LEAD = 'team-lead';
+const BUSY = 'OpenCode session status busy';
+const TREATED_IDLE =
+  'OpenCode session status was busy but transcript has a completed assistant response for the latest user message; treating session as idle';
+
+function minutesAgoIso(minutes: number): string {
+  return new Date(Date.now() - minutes * 60_000).toISOString();
+}
+
+function pendingObservation(
+  overrides: Partial<OpenCodeDeliveryResponseObservation> = {}
+): OpenCodeDeliveryResponseObservation {
+  return {
+    state: 'pending',
+    deliveredUserMessageId: 'msg_prompt',
+    assistantMessageId: 'msg_assistant',
+    toolCallNames: ['glob'],
+    visibleMessageToolCallId: null,
+    visibleReplyMessageId: null,
+    visibleReplyCorrelation: null,
+    latestAssistantPreview: null,
+    reason: 'assistant_response_pending',
+    ...overrides,
+  };
+}
+
+function observedResult(input: {
+  observation: OpenCodeDeliveryResponseObservation;
+  diagnostics: string[];
+}): OpenCodeTeamRuntimeMessageResult {
+  return {
+    ok: true,
+    providerId: 'opencode',
+    memberName: LEAD,
+    sessionId: 'ses_1',
+    runtimePromptMessageId: 'msg_prompt',
+    responseObservation: input.observation,
+    diagnostics: input.diagnostics,
+  };
+}
+
+function acceptedSendResult(): OpenCodeTeamRuntimeMessageResult {
+  return {
+    ok: true,
+    providerId: 'opencode',
+    memberName: LEAD,
+    sessionId: 'ses_1',
+    runtimePromptMessageId: 'msg_prompt_new',
+    responseObservation: pendingObservation({
+      deliveredUserMessageId: 'msg_prompt_new',
+      assistantMessageId: null,
+      toolCallNames: [],
+    }),
+    diagnostics: [BUSY],
+  };
+}
+
+const taskCommentNotification: OpenCodeMemberMessageDeliveryInput = {
+  memberName: LEAD,
+  text: 'Task comment: Scribe finished the report section.',
+  messageId: 'task-comment-forward:reportteam:1',
+  replyRecipient: 'system',
+  messageKind: 'task_comment_notification',
+  source: 'watcher',
+  inboxTimestamp: minutesAgoIso(32),
+};
+
+const userMessage: OpenCodeMemberMessageDeliveryInput = {
+  memberName: LEAD,
+  text: 'Please wrap up and send ALL DONE.',
+  messageId: 'user-2',
+  replyRecipient: 'user',
+  actionMode: 'delegate',
+  messageKind: 'default',
+  source: 'watcher',
+  inboxTimestamp: minutesAgoIso(0),
+};
+
+/** Seed an accepted/pending record exactly like the live stuck ledger row. */
+async function seedAcceptedPendingRecord(
+  ledger: OpenCodePromptDeliveryLedgerStore,
+  input: OpenCodeMemberMessageDeliveryInput,
+  options: { ageMinutes: number; assistantMessageId?: string | null }
+): Promise<OpenCodePromptDeliveryLedgerRecord> {
+  const at = minutesAgoIso(options.ageMinutes);
+  const created = await ledger.ensurePending({
+    teamName: TEAM,
+    memberName: LEAD,
+    laneId: PRIMARY_LANE.laneId,
+    runId: 'run-1',
+    inboxMessageId: input.messageId!,
+    inboxTimestamp: input.inboxTimestamp ?? at,
+    source: input.source ?? 'watcher',
+    replyRecipient: input.replyRecipient ?? 'user',
+    actionMode: input.actionMode ?? null,
+    messageKind: input.messageKind ?? null,
+    taskRefs: input.taskRefs ?? [],
+    payloadHash: hashOpenCodePromptDeliveryPayload({
+      text: input.text,
+      replyRecipient: input.replyRecipient ?? 'user',
+      actionMode: input.actionMode ?? null,
+      taskRefs: input.taskRefs ?? [],
+      attachments: input.attachments,
+      source: input.source,
+    }),
+    now: at,
+  });
+  return await ledger.applyDeliveryResult({
+    id: created.id,
+    accepted: true,
+    attempted: true,
+    responseObservation: pendingObservation({
+      assistantMessageId:
+        options.assistantMessageId === undefined ? 'msg_assistant' : options.assistantMessageId,
+    }),
+    sessionId: 'ses_1',
+    runtimePromptMessageId: 'msg_prompt',
+    deliveryAttemptId: `${created.id}:1`,
+    diagnostics: [BUSY],
+    reason: 'assistant_response_pending',
+    now: at,
+  });
+}
+
+interface Harness {
+  service: OpenCodeMemberMessageDeliveryService;
+  ledger: OpenCodePromptDeliveryLedgerStore;
+  observe: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  followUpSchedule: ReturnType<typeof vi.fn>;
+  scheduleWatchdog: ReturnType<typeof vi.fn>;
+  notify: ReturnType<typeof vi.fn>;
+  logEvent: ReturnType<typeof vi.fn>;
+}
+
+function createHarness(input: {
+  ledgerDir: string;
+  observe?: () => Promise<OpenCodeTeamRuntimeMessageResult>;
+  send?: () => Promise<OpenCodeTeamRuntimeMessageResult>;
+  /** Defaults to the windows the production composition wires in. */
+  stalePendingConfig?: OpenCodeStalePendingPolicyConfig;
+}): Harness {
+  const ledger = createOpenCodePromptDeliveryLedgerStore({
+    filePath: join(input.ledgerDir, 'primary.json'),
+  });
+  const observe = vi.fn(async () => {
+    if (!input.observe) throw new Error('observe not expected');
+    return await input.observe();
+  });
+  const send = vi.fn(async () => {
+    if (!input.send) throw new Error('send not expected');
+    return await input.send();
+  });
+  const passthroughProof = vi.fn(async ({ ledgerRecord }: { ledgerRecord: unknown }) => ({
+    ledgerRecord,
+    visibleReply: null,
+  }));
+  const followUpSchedule = vi.fn(
+    async ({ ledgerRecord }: { ledgerRecord: OpenCodePromptDeliveryLedgerRecord }) => ledgerRecord
+  );
+  const scheduleWatchdog = vi.fn();
+  const notify = vi.fn();
+  const logEvent = vi.fn();
+  const deps: OpenCodeMemberMessageDeliveryServiceDependencies = {
+    getOpenCodeRuntimeMessageAdapter: vi.fn(
+      () => ({ sendMessageToMember: send, observeMessageDelivery: observe }) as never
+    ),
+    readOpenCodeMemberDirectory: vi.fn(async () => ({
+      config: { name: TEAM, projectPath: '/repo', members: [] } as never,
+      teamMeta: null,
+      metaMembers: [{ name: LEAD, providerId: 'opencode' as const }],
+    })),
+    resolveOpenCodeMemberIdentityFromDirectory: vi.fn(() => ({
+      ok: true as const,
+      canonicalMemberName: LEAD,
+      laneId: PRIMARY_LANE.laneId,
+      laneIdentity: PRIMARY_LANE,
+      metaMember: { name: LEAD, providerId: 'opencode' as const },
+      memberRuntimeCwd: '/repo',
+    })),
+    stoppingSecondaryRuntimeTeams: { has: () => false },
+    readPersistedTeamProjectPath: vi.fn(() => '/repo'),
+    resolveDeliverableTrackedRuntimeRunId: vi.fn(() => 'run-1'),
+    runs: { get: vi.fn(() => ({ mixedSecondaryLanes: [] })) },
+    getCurrentOpenCodeRuntimeRunId: vi.fn(() => 'run-1'),
+    resolveCurrentOpenCodeRuntimeRunId: vi.fn(async () => 'run-1'),
+    isOpenCodeRuntimeLaneIndexActive: vi.fn(async () => true),
+    tryRecoverOpenCodeRuntimeLaneBeforeDelivery: vi.fn(async () => false),
+    tryRecoverOpenCodeRuntimeLaneFromCommittedSessionBeforeDelivery: vi.fn(async () => false),
+    deleteSecondaryRuntimeRun: vi.fn(),
+    cleanupStoppedTeamOpenCodeRuntimeLanesInBackground: vi.fn(),
+    findDeliverableOpenCodeRuntimeBootstrapSessionEvidence: vi.fn(
+      async () => ({ appMcpTransportHash: 'hash' }) as never
+    ),
+    getOpenCodeAppMcpTransportMismatchDiagnostic: vi.fn(() => null),
+    stampOpenCodeAppMcpTransportEvidenceIfMissing: vi.fn(async () => undefined),
+    resolveControlApiBaseUrl: vi.fn(async () => null),
+    sendOpenCodeMemberMessageToRuntimeSerialized: vi.fn(
+      async ({ send: run }: { send: () => Promise<OpenCodeTeamRuntimeMessageResult> }) =>
+        await run()
+    ),
+    rememberOpenCodeRuntimePidFromBridge: vi.fn(async () => undefined),
+    maybeSyncOpenCodeRuntimePermissionsAfterDelivery: vi.fn(async () => undefined),
+    isLegacyOpenCodeMemberWorkSyncReadCommitAllowed: vi.fn(async () => true),
+    createOpenCodePromptDeliveryLedger: vi.fn(() => ledger),
+    openCodeVisibleReplyProofService: {
+      applyDestinationProof: passthroughProof as never,
+      materializePlainTextReplyIfNeeded: passthroughProof as never,
+      findByRelayOfMessageId: vi.fn(async () => null),
+    },
+    openCodePromptDeliveryWatchdogScheduler: { isEnabled: () => true },
+    openCodePromptDeliveryFollowUpPolicy: { schedule: followUpSchedule },
+    openCodeStalePendingPolicyConfig:
+      input.stalePendingConfig ?? OPENCODE_STALE_PENDING_POLICY_CONFIG,
+    // Real read-commit semantics: plain-text settles non-user messages only.
+    isOpenCodeDeliveryResponseReadCommitAllowed: vi.fn(async (readInput: ReadCommitPortInput) =>
+      isOpenCodeDeliveryResponseReadCommitAllowed({
+        ...readInput,
+        hasAcceptedMemberWorkSyncReport: async () => false,
+        taskRefsIncludeAll: () => true,
+      })
+    ),
+    getOpenCodeDeliveryPendingReason: vi.fn(() => 'assistant_response_pending'),
+    markOpenCodeAcceptedDeliveryMissingPromptProofForRetry: vi.fn(
+      async ({ ledgerRecord }: { ledgerRecord: OpenCodePromptDeliveryLedgerRecord }) => ledgerRecord
+    ),
+    scheduleOpenCodePromptDeliveryWatchdog: scheduleWatchdog,
+    logOpenCodePromptDeliveryEvent: logEvent,
+    requeueOpenCodeRuntimeManifestWatermarkDeliveryIfNeeded: vi.fn(
+      async ({ ledgerRecord }: { ledgerRecord: OpenCodePromptDeliveryLedgerRecord }) => ledgerRecord
+    ),
+    emitOpenCodePromptDeliveryTaskLogChange: vi.fn(),
+    notifyOpenCodeLeadTurnActivity: notify as never,
+    observeOpenCodeDirectUserDeliveryInlineIfNeeded: vi.fn(
+      async ({ ledgerRecord }: { ledgerRecord: OpenCodePromptDeliveryLedgerRecord }) => ({
+        ledgerRecord,
+        visibleReply: null,
+      })
+    ),
+  };
+  return {
+    service: new OpenCodeMemberMessageDeliveryService(deps),
+    ledger,
+    observe,
+    send,
+    followUpSchedule,
+    scheduleWatchdog,
+    notify,
+    logEvent,
+  };
+}
+
+describe('OpenCodeMemberMessageDeliveryService stale-pending guard', () => {
+  let ledgerDir: string;
+
+  beforeEach(async () => {
+    ledgerDir = await mkdtemp(join(tmpdir(), 'opencode-stale-pending-'));
+  });
+
+  afterEach(async () => {
+    await rm(ledgerDir, { recursive: true, force: true });
+  });
+
+  it('settles a lead non-user delivery as a plain-text turn end when the bridge keeps answering pending but idle', async () => {
+    const harness = createHarness({
+      ledgerDir,
+      observe: async () =>
+        observedResult({ observation: pendingObservation(), diagnostics: [BUSY, TREATED_IDLE] }),
+    });
+    // Fresh record: the plain-text turn-end rule does not need the stale window.
+    await seedAcceptedPendingRecord(harness.ledger, taskCommentNotification, { ageMinutes: 1 });
+
+    const delivery = await harness.service.deliver(TEAM, taskCommentNotification);
+
+    expect(harness.observe).toHaveBeenCalledTimes(1);
+    expect(harness.send).not.toHaveBeenCalled();
+    expect(delivery).toMatchObject({
+      delivered: true,
+      accepted: true,
+      responsePending: false,
+      ledgerStatus: 'responded',
+      responseState: 'responded_plain_text',
+    });
+    const [record] = await harness.ledger.list();
+    expect(record).toMatchObject({
+      status: 'responded',
+      responseState: 'responded_plain_text',
+      lastReason: OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON,
+      observedAssistantMessageId: 'msg_assistant',
+    });
+    expect(harness.followUpSchedule).not.toHaveBeenCalled();
+    expect(harness.notify).toHaveBeenCalledWith(expect.objectContaining({ state: 'idle' }));
+  });
+
+  it('keeps a fresh busy non-user delivery pending (normal observe follow-up)', async () => {
+    const harness = createHarness({
+      ledgerDir,
+      observe: async () =>
+        observedResult({ observation: pendingObservation(), diagnostics: [BUSY] }),
+    });
+    await seedAcceptedPendingRecord(harness.ledger, taskCommentNotification, { ageMinutes: 1 });
+
+    const delivery = await harness.service.deliver(TEAM, taskCommentNotification);
+
+    expect(delivery).toMatchObject({ accepted: true, responsePending: true });
+    expect(harness.followUpSchedule).toHaveBeenCalledTimes(1);
+    expect(harness.followUpSchedule.mock.calls[0]?.[0]).toMatchObject({ retry: false });
+    const [record] = await harness.ledger.list();
+    expect(record?.status).toBe('accepted');
+  });
+
+  it('keeps observing a stale non-user delivery while the session is still busy', async () => {
+    const harness = createHarness({
+      ledgerDir,
+      observe: async () =>
+        observedResult({
+          observation: pendingObservation({ assistantMessageId: null, toolCallNames: [] }),
+          diagnostics: [BUSY],
+        }),
+    });
+    await seedAcceptedPendingRecord(harness.ledger, taskCommentNotification, {
+      ageMinutes: 10,
+      assistantMessageId: null,
+    });
+
+    const delivery = await harness.service.deliver(TEAM, taskCommentNotification);
+
+    expect(delivery).toMatchObject({ accepted: true, responsePending: true });
+    expect(harness.followUpSchedule).toHaveBeenCalledTimes(1);
+    expect(harness.followUpSchedule.mock.calls[0]?.[0]).toMatchObject({ retry: false });
+    expect(harness.logEvent).not.toHaveBeenCalledWith(
+      'opencode_prompt_delivery_terminal_failure',
+      expect.anything(),
+      expect.anything()
+    );
+    const [record] = await harness.ledger.list();
+    expect(record?.status).toBe('accepted');
+  });
+
+  it('marks a stale idle user prompt terminal instead of leaving it pending forever', async () => {
+    const harness = createHarness({
+      ledgerDir,
+      observe: async () =>
+        observedResult({ observation: pendingObservation(), diagnostics: [BUSY, TREATED_IDLE] }),
+    });
+    const staleUserPrompt: OpenCodeMemberMessageDeliveryInput = {
+      ...userMessage,
+      messageId: 'user-1',
+      inboxTimestamp: minutesAgoIso(20),
+    };
+    await seedAcceptedPendingRecord(harness.ledger, staleUserPrompt, { ageMinutes: 20 });
+
+    const delivery = await harness.service.deliver(TEAM, staleUserPrompt);
+
+    expect(delivery).toMatchObject({
+      delivered: false,
+      accepted: true,
+      responsePending: false,
+      ledgerStatus: 'failed_terminal',
+      reason: OPENCODE_STALE_PENDING_TERMINAL_REASON,
+    });
+    expect(harness.send).not.toHaveBeenCalled();
+    const [record] = await harness.ledger.list();
+    expect(record).toMatchObject({
+      status: 'failed_terminal',
+      lastReason: OPENCODE_STALE_PENDING_TERMINAL_REASON,
+    });
+    expect(harness.notify).toHaveBeenCalledWith(expect.objectContaining({ state: 'idle' }));
+    expect(
+      await harness.ledger.getActiveForMember({
+        teamName: TEAM,
+        memberName: LEAD,
+        laneId: 'primary',
+      })
+    ).toBeNull();
+  });
+
+  it('lets a new user message preempt a stale non-user record and delivers it', async () => {
+    const harness = createHarness({ ledgerDir, send: async () => acceptedSendResult() });
+    await seedAcceptedPendingRecord(harness.ledger, taskCommentNotification, { ageMinutes: 32 });
+
+    const delivery = await harness.service.deliver(TEAM, userMessage);
+
+    expect(harness.send).toHaveBeenCalledTimes(1);
+    expect(delivery).toMatchObject({ delivered: true, accepted: true });
+    expect(delivery.queuedBehindMessageId).toBeUndefined();
+    const records = await harness.ledger.list();
+    const stale = records.find(
+      (record) => record.inboxMessageId === taskCommentNotification.messageId
+    );
+    const fresh = records.find((record) => record.inboxMessageId === userMessage.messageId);
+    expect(stale).toMatchObject({
+      status: 'responded',
+      responseState: 'responded_plain_text',
+      lastReason: OPENCODE_STALE_PENDING_PREEMPTED_REASON,
+    });
+    expect(fresh).toMatchObject({ status: 'accepted', replyRecipient: 'user' });
+    // The settled row is handed back to the watchdog so the relay read-commits it.
+    expect(harness.scheduleWatchdog).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: taskCommentNotification.messageId, delayMs: 500 })
+    );
+  });
+
+  it('still queues a user message behind a non-stale non-user record', async () => {
+    const harness = createHarness({ ledgerDir, send: async () => acceptedSendResult() });
+    await seedAcceptedPendingRecord(harness.ledger, taskCommentNotification, { ageMinutes: 2 });
+
+    const delivery = await harness.service.deliver(TEAM, userMessage);
+
+    expect(harness.send).not.toHaveBeenCalled();
+    expect(delivery).toMatchObject({
+      responsePending: true,
+      queuedBehindMessageId: taskCommentNotification.messageId,
+      reason: 'opencode_delivery_response_pending',
+    });
+    expect(await harness.ledger.list()).toHaveLength(1);
+  });
+
+  it('bounds the lane by the windows it was composed with', async () => {
+    // The record above stays queued at two minutes under the shipped 5-minute
+    // window; the only change here is the config the service was built with.
+    const harness = createHarness({
+      ledgerDir,
+      send: async () => acceptedSendResult(),
+      stalePendingConfig: { staleAfterMs: 60_000, hardCapMs: 6 * 60_000 },
+    });
+    await seedAcceptedPendingRecord(harness.ledger, taskCommentNotification, { ageMinutes: 2 });
+
+    const delivery = await harness.service.deliver(TEAM, userMessage);
+
+    expect(harness.send).toHaveBeenCalledTimes(1);
+    expect(delivery).toMatchObject({ delivered: true, accepted: true });
+    expect(delivery.queuedBehindMessageId).toBeUndefined();
+    const stale = (await harness.ledger.list()).find(
+      (record) => record.inboxMessageId === taskCommentNotification.messageId
+    );
+    expect(stale).toMatchObject({
+      status: 'responded',
+      lastReason: OPENCODE_STALE_PENDING_PREEMPTED_REASON,
+    });
+  });
+
+  it('never preempts a stale user prompt with another user message', async () => {
+    const harness = createHarness({ ledgerDir, send: async () => acceptedSendResult() });
+    const staleUserPrompt: OpenCodeMemberMessageDeliveryInput = {
+      ...userMessage,
+      messageId: 'user-1',
+      inboxTimestamp: minutesAgoIso(40),
+    };
+    await seedAcceptedPendingRecord(harness.ledger, staleUserPrompt, { ageMinutes: 40 });
+
+    const delivery = await harness.service.deliver(TEAM, userMessage);
+
+    expect(harness.send).not.toHaveBeenCalled();
+    expect(delivery).toMatchObject({
+      responsePending: true,
+      queuedBehindMessageId: 'user-1',
+    });
+  });
+});

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.stalePending.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.stalePending.test.ts
@@ -350,6 +350,29 @@ describe('OpenCodeMemberMessageDeliveryService stale-pending guard', () => {
     expect(record?.status).toBe('accepted');
   });
 
+  it('keeps a fresh non-user delivery pending when the bridge reports no session activity', async () => {
+    // The observation says `pending` with an assistant message - the state of a
+    // turn whose tool calls are still running - and the bridge said nothing
+    // about the session. That is not a turn end, so nothing is settled.
+    const harness = createHarness({
+      ledgerDir,
+      observe: async () => observedResult({ observation: pendingObservation(), diagnostics: [] }),
+    });
+    await seedAcceptedPendingRecord(harness.ledger, taskCommentNotification, { ageMinutes: 1 });
+
+    const delivery = await harness.service.deliver(TEAM, taskCommentNotification);
+
+    expect(delivery).toMatchObject({ accepted: true, responsePending: true });
+    expect(harness.followUpSchedule).toHaveBeenCalledTimes(1);
+    const [record] = await harness.ledger.list();
+    expect(record).toMatchObject({ status: 'accepted', responseState: 'pending' });
+    expect(harness.logEvent).not.toHaveBeenCalledWith(
+      'opencode_prompt_delivery_response_observed',
+      expect.anything(),
+      expect.objectContaining({ stalePendingSettledAsPlainText: true })
+    );
+  });
+
   it('keeps observing a stale non-user delivery while the session is still busy', async () => {
     const harness = createHarness({
       ledgerDir,

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryStalePendingPolicy.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryStalePendingPolicy.test.ts
@@ -1,0 +1,485 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildOpenCodeStalePendingPlainTextObservation,
+  decideOpenCodeStalePendingResolution,
+  decideOpenCodeStalePendingUserPreemption,
+  getOpenCodeObservedSessionActivity,
+  getOpenCodePromptDeliveryPendingAgeMs,
+  isOpenCodePromptDeliveryStalePending,
+  OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON,
+  OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS,
+  OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS,
+  OPENCODE_STALE_PENDING_HARD_CAP_REASON,
+  OPENCODE_STALE_PENDING_POLICY_CONFIG,
+  OPENCODE_STALE_PENDING_PREEMPTED_REASON,
+  OPENCODE_STALE_PENDING_TERMINAL_REASON,
+} from '../OpenCodePromptDeliveryStalePendingPolicy';
+
+import type { OpenCodePromptDeliveryLedgerRecord } from '../OpenCodePromptDeliveryLedger';
+
+const NOW_MS = Date.parse('2026-08-22T18:20:00.000Z');
+/** The shipped windows. The policy has no defaults, so every call states them. */
+const POLICY = OPENCODE_STALE_PENDING_POLICY_CONFIG;
+const BUSY = 'OpenCode session status busy';
+const TREATED_IDLE =
+  'OpenCode session status was busy but transcript has a completed assistant response for the latest user message; treating session as idle';
+
+function minutesAgo(minutes: number): string {
+  return new Date(NOW_MS - minutes * 60_000).toISOString();
+}
+
+/** Mirrors the live stuck record: accepted task-comment notification, pending forever. */
+function record(
+  overrides: Partial<OpenCodePromptDeliveryLedgerRecord> = {}
+): OpenCodePromptDeliveryLedgerRecord {
+  return {
+    id: 'opencode-prompt:stuck',
+    teamName: 'reportrun16',
+    memberName: 'team-lead',
+    laneId: 'primary',
+    runId: 'run-1',
+    runtimeSessionId: 'ses_1',
+    runtimePromptMessageId: 'msg_prompt',
+    runtimePromptMessageIds: ['msg_prompt'],
+    lastRuntimePromptMessageId: 'msg_prompt',
+    inboxMessageId: 'task-comment-forward:1',
+    inboxTimestamp: minutesAgo(32),
+    source: 'watcher',
+    messageKind: 'task_comment_notification',
+    workSyncIntent: null,
+    replyRecipient: 'system',
+    actionMode: null,
+    taskRefs: [],
+    payloadHash: 'sha256:payload',
+    status: 'accepted',
+    responseState: 'pending',
+    attempts: 1,
+    maxAttempts: 3,
+    acceptanceUnknown: false,
+    nextAttemptAt: null,
+    lastAttemptAt: minutesAgo(32),
+    lastObservedAt: minutesAgo(0),
+    acceptedAt: minutesAgo(32),
+    respondedAt: null,
+    failedAt: null,
+    inboxReadCommittedAt: null,
+    inboxReadCommitError: null,
+    prePromptCursor: null,
+    postPromptCursor: null,
+    deliveredUserMessageId: 'msg_prompt',
+    observedAssistantMessageId: 'msg_assistant',
+    observedAssistantPreview: null,
+    observedToolCallNames: ['glob'],
+    observedVisibleMessageId: null,
+    visibleReplyMessageId: null,
+    visibleReplyInbox: null,
+    visibleReplyCorrelation: null,
+    lastReason: 'assistant_response_pending',
+    diagnostics: [],
+    createdAt: minutesAgo(32),
+    updatedAt: minutesAgo(0),
+    ...overrides,
+  };
+}
+
+describe('getOpenCodeObservedSessionActivity', () => {
+  it('classifies busy, treated-idle, and unknown bridge diagnostics', () => {
+    expect(getOpenCodeObservedSessionActivity([BUSY])).toBe('busy');
+    expect(getOpenCodeObservedSessionActivity([BUSY, TREATED_IDLE])).toBe('idle');
+    expect(getOpenCodeObservedSessionActivity(['OpenCode session status idle'])).toBe('idle');
+    expect(getOpenCodeObservedSessionActivity(['OpenCode app MCP is connected.'])).toBe('unknown');
+    expect(getOpenCodeObservedSessionActivity(undefined)).toBe('unknown');
+  });
+});
+
+describe('stale-pending detection', () => {
+  it('measures age from the last send/acceptance, not from the last observation', () => {
+    expect(getOpenCodePromptDeliveryPendingAgeMs(record(), NOW_MS)).toBe(32 * 60_000);
+    expect(
+      getOpenCodePromptDeliveryPendingAgeMs(
+        record({ lastAttemptAt: null, acceptedAt: null, createdAt: minutesAgo(7) }),
+        NOW_MS
+      )
+    ).toBe(7 * 60_000);
+    expect(
+      getOpenCodePromptDeliveryPendingAgeMs(
+        { lastAttemptAt: null, acceptedAt: null, createdAt: 'not-a-date' },
+        NOW_MS
+      )
+    ).toBeNull();
+  });
+
+  it('only flags accepted observe-only records past the stale window', () => {
+    expect(isOpenCodePromptDeliveryStalePending(record(), NOW_MS, POLICY.staleAfterMs)).toBe(true);
+    expect(
+      isOpenCodePromptDeliveryStalePending(
+        record({ lastAttemptAt: minutesAgo(4), acceptedAt: minutesAgo(4) }),
+        NOW_MS,
+        POLICY.staleAfterMs
+      )
+    ).toBe(false);
+    expect(
+      isOpenCodePromptDeliveryStalePending(
+        record({ status: 'responded' }),
+        NOW_MS,
+        POLICY.staleAfterMs
+      )
+    ).toBe(false);
+    expect(
+      isOpenCodePromptDeliveryStalePending(
+        record({ status: 'retry_scheduled' }),
+        NOW_MS,
+        POLICY.staleAfterMs
+      )
+    ).toBe(false);
+    expect(
+      isOpenCodePromptDeliveryStalePending(
+        record({ responseState: 'permission_blocked' }),
+        NOW_MS,
+        POLICY.staleAfterMs
+      )
+    ).toBe(false);
+    expect(
+      isOpenCodePromptDeliveryStalePending(
+        record({ responseState: 'session_stale' }),
+        NOW_MS,
+        POLICY.staleAfterMs
+      )
+    ).toBe(false);
+    expect(
+      isOpenCodePromptDeliveryStalePending(
+        record({ inboxReadCommittedAt: minutesAgo(1) }),
+        NOW_MS,
+        POLICY.staleAfterMs
+      )
+    ).toBe(false);
+  });
+});
+
+describe('decideOpenCodeStalePendingResolution', () => {
+  it('ships the named windows as the composition config', () => {
+    expect(OPENCODE_STALE_PENDING_POLICY_CONFIG).toEqual({
+      staleAfterMs: OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS,
+      hardCapMs: OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS,
+    });
+  });
+
+  it('bounds a delivery by the windows its caller states, never by windows of its own', () => {
+    // Same record, same observation, two configs: only the config differs, so
+    // whatever the policy decides here came from the caller.
+    const tenMinutesIdle = {
+      record: record({
+        observedAssistantMessageId: null,
+        lastAttemptAt: minutesAgo(10),
+        acceptedAt: minutesAgo(10),
+      }),
+      laneKind: 'primary' as const,
+      observation: { state: 'pending' as const, assistantMessageId: null },
+      observedDiagnostics: [TREATED_IDLE],
+      nowMs: NOW_MS,
+    };
+    expect(
+      decideOpenCodeStalePendingResolution({ ...tenMinutesIdle, config: POLICY })
+    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_TERMINAL_REASON });
+    expect(
+      decideOpenCodeStalePendingResolution({
+        ...tenMinutesIdle,
+        config: { staleAfterMs: 20 * 60_000, hardCapMs: POLICY.hardCapMs },
+      })
+    ).toEqual({ action: 'none' });
+
+    const tenMinutesBusy = { ...tenMinutesIdle, observedDiagnostics: [BUSY] };
+    expect(decideOpenCodeStalePendingResolution({ ...tenMinutesBusy, config: POLICY })).toEqual({
+      action: 'keep_observing',
+      reason: 'opencode_stale_pending_session_busy',
+    });
+    expect(
+      decideOpenCodeStalePendingResolution({
+        ...tenMinutesBusy,
+        config: { staleAfterMs: POLICY.staleAfterMs, hardCapMs: 6 * 60_000 },
+      })
+    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_HARD_CAP_REASON });
+  });
+
+  it('settles a lead non-user message immediately once the turn ended (live stuck record)', () => {
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record({ lastAttemptAt: minutesAgo(0), acceptedAt: minutesAgo(0) }),
+        laneKind: 'primary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: [BUSY, TREATED_IDLE],
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'settle_plain_text', reason: OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON });
+  });
+
+  it('does not settle a lead non-user message while the session is busy and fresh', () => {
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record({ lastAttemptAt: minutesAgo(1), acceptedAt: minutesAgo(1) }),
+        laneKind: 'primary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: [BUSY],
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'none' });
+  });
+
+  it('keeps observing a stale busy record until the non-user hard cap, then goes terminal', () => {
+    const busy = {
+      laneKind: 'primary' as const,
+      observation: { state: 'pending' as const, assistantMessageId: null },
+      observedDiagnostics: [BUSY],
+      nowMs: NOW_MS,
+      config: POLICY,
+    };
+    expect(
+      decideOpenCodeStalePendingResolution({
+        ...busy,
+        record: record({
+          observedAssistantMessageId: null,
+          lastAttemptAt: minutesAgo(10),
+          acceptedAt: minutesAgo(10),
+        }),
+      })
+    ).toEqual({ action: 'keep_observing', reason: 'opencode_stale_pending_session_busy' });
+    const overCap = minutesAgo(OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS / 60_000 + 1);
+    expect(
+      decideOpenCodeStalePendingResolution({
+        ...busy,
+        record: record({
+          observedAssistantMessageId: null,
+          lastAttemptAt: overCap,
+          acceptedAt: overCap,
+        }),
+      })
+    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_HARD_CAP_REASON });
+    // Boundaries, exactly: a busy session at the stale window is still only
+    // "slow", and it is the hard cap - not the stale window - that ends it.
+    const atStaleWindow = minutesAgo(OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS / 60_000);
+    expect(
+      decideOpenCodeStalePendingResolution({
+        ...busy,
+        record: record({
+          observedAssistantMessageId: null,
+          lastAttemptAt: atStaleWindow,
+          acceptedAt: atStaleWindow,
+        }),
+      })
+    ).toEqual({ action: 'keep_observing', reason: 'opencode_stale_pending_session_busy' });
+    const atCap = minutesAgo(OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS / 60_000);
+    expect(
+      decideOpenCodeStalePendingResolution({
+        ...busy,
+        record: record({
+          observedAssistantMessageId: null,
+          lastAttemptAt: atCap,
+          acceptedAt: atCap,
+        }),
+      })
+    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_HARD_CAP_REASON });
+  });
+
+  it('never hard-caps a busy user prompt', () => {
+    const overCap = minutesAgo(OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS / 60_000 + 5);
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record({ replyRecipient: 'user', lastAttemptAt: overCap, acceptedAt: overCap }),
+        laneKind: 'primary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: [BUSY],
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'keep_observing', reason: 'opencode_stale_pending_session_busy' });
+  });
+
+  it('marks a stale idle user prompt terminal instead of faking a plain-text reply', () => {
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record({ replyRecipient: 'user' }),
+        laneKind: 'primary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: [BUSY, TREATED_IDLE],
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_TERMINAL_REASON });
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record({
+          replyRecipient: 'user',
+          lastAttemptAt: minutesAgo(2),
+          acceptedAt: minutesAgo(2),
+        }),
+        laneKind: 'primary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: [TREATED_IDLE],
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'none' });
+  });
+
+  it('does not settle secondary-lane non-user records as plain text, only bounds them', () => {
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record({ laneId: 'secondary:opencode:scribe', replyRecipient: 'team-lead' }),
+        laneKind: 'secondary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: [TREATED_IDLE],
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_TERMINAL_REASON });
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record({
+          laneId: 'secondary:opencode:scribe',
+          replyRecipient: 'team-lead',
+          lastAttemptAt: minutesAgo(1),
+          acceptedAt: minutesAgo(1),
+        }),
+        laneKind: 'secondary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: [TREATED_IDLE],
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'none' });
+  });
+
+  it('ignores records that are not observe-only accepted prompts', () => {
+    for (const overrides of [
+      { status: 'retry_scheduled' as const },
+      { status: 'responded' as const, responseState: 'responded_plain_text' as const },
+      { responseState: 'session_stale' as const },
+      { responseState: 'permission_blocked' as const },
+      {
+        acceptedAt: null,
+        runtimePromptMessageId: null,
+        runtimePromptMessageIds: [],
+        lastRuntimePromptMessageId: null,
+        deliveredUserMessageId: null,
+      },
+    ]) {
+      expect(
+        decideOpenCodeStalePendingResolution({
+          record: record(overrides),
+          laneKind: 'primary',
+          observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+          observedDiagnostics: [TREATED_IDLE],
+          nowMs: NOW_MS,
+          config: POLICY,
+        })
+      ).toEqual({ action: 'none' });
+    }
+  });
+});
+
+describe('decideOpenCodeStalePendingUserPreemption', () => {
+  it('lets a new user message preempt a stale non-user record on the lead lane', () => {
+    expect(
+      decideOpenCodeStalePendingUserPreemption({
+        activeRecord: record(),
+        incomingReplyRecipient: 'user',
+        laneKind: 'primary',
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'settle_plain_text', reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON });
+    expect(
+      decideOpenCodeStalePendingUserPreemption({
+        activeRecord: record({ observedAssistantMessageId: null }),
+        incomingReplyRecipient: 'user',
+        laneKind: 'primary',
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON });
+    expect(
+      decideOpenCodeStalePendingUserPreemption({
+        activeRecord: record({ laneId: 'secondary:opencode:scribe', replyRecipient: 'team-lead' }),
+        incomingReplyRecipient: 'user',
+        laneKind: 'secondary',
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON });
+  });
+
+  it('keeps queue-behind semantics for non-user senders, user-prompt blockers, and fresh records', () => {
+    expect(
+      decideOpenCodeStalePendingUserPreemption({
+        activeRecord: record(),
+        incomingReplyRecipient: 'Scribe',
+        laneKind: 'primary',
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'none' });
+    expect(
+      decideOpenCodeStalePendingUserPreemption({
+        activeRecord: record({ replyRecipient: 'user' }),
+        incomingReplyRecipient: 'user',
+        laneKind: 'primary',
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'none' });
+    expect(
+      decideOpenCodeStalePendingUserPreemption({
+        activeRecord: record({
+          lastAttemptAt: minutesAgo(OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS / 60_000 - 1),
+          acceptedAt: minutesAgo(OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS / 60_000 - 1),
+        }),
+        incomingReplyRecipient: 'user',
+        laneKind: 'primary',
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'none' });
+  });
+
+  it('takes the stale window from its caller too', () => {
+    const fresh = {
+      activeRecord: record({ lastAttemptAt: minutesAgo(2), acceptedAt: minutesAgo(2) }),
+      incomingReplyRecipient: 'user',
+      laneKind: 'primary' as const,
+      nowMs: NOW_MS,
+    };
+    expect(decideOpenCodeStalePendingUserPreemption({ ...fresh, config: POLICY })).toEqual({
+      action: 'none',
+    });
+    expect(
+      decideOpenCodeStalePendingUserPreemption({
+        ...fresh,
+        config: { staleAfterMs: 60_000, hardCapMs: POLICY.hardCapMs },
+      })
+    ).toEqual({ action: 'settle_plain_text', reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON });
+  });
+});
+
+describe('buildOpenCodeStalePendingPlainTextObservation', () => {
+  it('carries the observed assistant evidence into a responded_plain_text observation', () => {
+    expect(
+      buildOpenCodeStalePendingPlainTextObservation({
+        record: record(),
+        reason: OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON,
+      })
+    ).toEqual({
+      state: 'responded_plain_text',
+      deliveredUserMessageId: 'msg_prompt',
+      assistantMessageId: 'msg_assistant',
+      toolCallNames: ['glob'],
+      visibleMessageToolCallId: null,
+      visibleReplyMessageId: null,
+      visibleReplyCorrelation: null,
+      latestAssistantPreview: null,
+      reason: OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON,
+    });
+  });
+});

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryStalePendingPolicy.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryStalePendingPolicy.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   buildOpenCodeStalePendingPlainTextObservation,
   decideOpenCodeStalePendingResolution,
-  decideOpenCodeStalePendingUserPreemption,
   getOpenCodeObservedSessionActivity,
   getOpenCodePromptDeliveryPendingAgeMs,
   isOpenCodePromptDeliveryStalePending,
@@ -11,9 +10,7 @@ import {
   OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS,
   OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS,
   OPENCODE_REPLY_OPTIONAL_TURN_END_REASON,
-  OPENCODE_STALE_PENDING_HARD_CAP_REASON,
   OPENCODE_STALE_PENDING_POLICY_CONFIG,
-  OPENCODE_STALE_PENDING_PREEMPTED_REASON,
   OPENCODE_STALE_PENDING_TERMINAL_REASON,
 } from '../OpenCodePromptDeliveryStalePendingPolicy';
 
@@ -200,7 +197,7 @@ describe('decideOpenCodeStalePendingResolution', () => {
         ...tenMinutesBusy,
         config: { staleAfterMs: POLICY.staleAfterMs, hardCapMs: 6 * 60_000 },
       })
-    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_HARD_CAP_REASON });
+    ).toMatchObject({ action: 'keep_observing', reason: 'opencode_stale_pending_session_busy' });
   });
 
   it('settles a lead non-user message immediately once the turn ended (live stuck record)', () => {
@@ -273,10 +270,7 @@ describe('decideOpenCodeStalePendingResolution', () => {
     ).toEqual({ action: 'none' });
   });
 
-  it('still bounds a lane that never reports its session activity', () => {
-    // A lane with no idle evidence at all is not settled as a finished turn,
-    // but it does not block the lane either: at the stale window the unknown
-    // session goes terminal, exactly like an idle one.
+  it('keeps observing a stale lane without fresh session activity', () => {
     expect(
       decideOpenCodeStalePendingResolution({
         record: record(),
@@ -286,10 +280,10 @@ describe('decideOpenCodeStalePendingResolution', () => {
         nowMs: NOW_MS,
         config: POLICY,
       })
-    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_TERMINAL_REASON });
+    ).toMatchObject({ action: 'keep_observing', reason: 'opencode_stale_pending_session_unknown' });
   });
 
-  it('keeps observing a stale busy record until the non-user hard cap, then goes terminal', () => {
+  it('keeps observing busy records past every age window', () => {
     const busy = {
       laneKind: 'primary' as const,
       observation: { state: 'pending' as const, assistantMessageId: null },
@@ -317,9 +311,8 @@ describe('decideOpenCodeStalePendingResolution', () => {
           acceptedAt: overCap,
         }),
       })
-    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_HARD_CAP_REASON });
-    // Boundaries, exactly: a busy session at the stale window is still only
-    // "slow", and it is the hard cap - not the stale window - that ends it.
+    ).toMatchObject({ action: 'keep_observing', reason: 'opencode_stale_pending_session_busy' });
+    // Age boundaries do not change the runtime evidence.
     const atStaleWindow = minutesAgo(OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS / 60_000);
     expect(
       decideOpenCodeStalePendingResolution({
@@ -341,7 +334,7 @@ describe('decideOpenCodeStalePendingResolution', () => {
           acceptedAt: atCap,
         }),
       })
-    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_HARD_CAP_REASON });
+    ).toMatchObject({ action: 'keep_observing', reason: 'opencode_stale_pending_session_busy' });
   });
 
   it('never hard-caps a busy user prompt', () => {
@@ -493,89 +486,6 @@ describe('decideOpenCodeStalePendingResolution', () => {
         })
       ).toEqual({ action: 'none' });
     }
-  });
-});
-
-describe('decideOpenCodeStalePendingUserPreemption', () => {
-  it('lets a new user message preempt a stale non-user record on the lead lane', () => {
-    expect(
-      decideOpenCodeStalePendingUserPreemption({
-        activeRecord: record(),
-        incomingReplyRecipient: 'user',
-        laneKind: 'primary',
-        nowMs: NOW_MS,
-        config: POLICY,
-      })
-    ).toEqual({ action: 'settle_plain_text', reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON });
-    expect(
-      decideOpenCodeStalePendingUserPreemption({
-        activeRecord: record({ observedAssistantMessageId: null }),
-        incomingReplyRecipient: 'user',
-        laneKind: 'primary',
-        nowMs: NOW_MS,
-        config: POLICY,
-      })
-    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON });
-    expect(
-      decideOpenCodeStalePendingUserPreemption({
-        activeRecord: record({ laneId: 'secondary:opencode:scribe', replyRecipient: 'team-lead' }),
-        incomingReplyRecipient: 'user',
-        laneKind: 'secondary',
-        nowMs: NOW_MS,
-        config: POLICY,
-      })
-    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON });
-  });
-
-  it('keeps queue-behind semantics for non-user senders, user-prompt blockers, and fresh records', () => {
-    expect(
-      decideOpenCodeStalePendingUserPreemption({
-        activeRecord: record(),
-        incomingReplyRecipient: 'Scribe',
-        laneKind: 'primary',
-        nowMs: NOW_MS,
-        config: POLICY,
-      })
-    ).toEqual({ action: 'none' });
-    expect(
-      decideOpenCodeStalePendingUserPreemption({
-        activeRecord: record({ replyRecipient: 'user' }),
-        incomingReplyRecipient: 'user',
-        laneKind: 'primary',
-        nowMs: NOW_MS,
-        config: POLICY,
-      })
-    ).toEqual({ action: 'none' });
-    expect(
-      decideOpenCodeStalePendingUserPreemption({
-        activeRecord: record({
-          lastAttemptAt: minutesAgo(OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS / 60_000 - 1),
-          acceptedAt: minutesAgo(OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS / 60_000 - 1),
-        }),
-        incomingReplyRecipient: 'user',
-        laneKind: 'primary',
-        nowMs: NOW_MS,
-        config: POLICY,
-      })
-    ).toEqual({ action: 'none' });
-  });
-
-  it('takes the stale window from its caller too', () => {
-    const fresh = {
-      activeRecord: record({ lastAttemptAt: minutesAgo(2), acceptedAt: minutesAgo(2) }),
-      incomingReplyRecipient: 'user',
-      laneKind: 'primary' as const,
-      nowMs: NOW_MS,
-    };
-    expect(decideOpenCodeStalePendingUserPreemption({ ...fresh, config: POLICY })).toEqual({
-      action: 'none',
-    });
-    expect(
-      decideOpenCodeStalePendingUserPreemption({
-        ...fresh,
-        config: { staleAfterMs: 60_000, hardCapMs: POLICY.hardCapMs },
-      })
-    ).toEqual({ action: 'settle_plain_text', reason: OPENCODE_STALE_PENDING_PREEMPTED_REASON });
   });
 });
 

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryStalePendingPolicy.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryStalePendingPolicy.test.ts
@@ -229,6 +229,66 @@ describe('decideOpenCodeStalePendingResolution', () => {
     ).toEqual({ action: 'none' });
   });
 
+  it('does not settle a fresh record while the observation carries no session activity', () => {
+    // An assistant message row exists from the first observation of a running
+    // turn (the bridge classifies "direct child has running tool calls" as
+    // `pending`), so the assistant message alone is not proof the turn ended.
+    // Absent diagnostics, or a raw status this policy does not read as busy,
+    // are not idle evidence either: without one the record keeps waiting.
+    const running = {
+      record: record({ lastAttemptAt: minutesAgo(1), acceptedAt: minutesAgo(1) }),
+      laneKind: 'primary' as const,
+      observation: { state: 'pending' as const, assistantMessageId: 'msg_assistant' },
+      nowMs: NOW_MS,
+      config: POLICY,
+    };
+    expect(
+      decideOpenCodeStalePendingResolution({ ...running, observedDiagnostics: undefined })
+    ).toEqual({ action: 'none' });
+    expect(decideOpenCodeStalePendingResolution({ ...running, observedDiagnostics: [] })).toEqual({
+      action: 'none',
+    });
+    expect(
+      decideOpenCodeStalePendingResolution({
+        ...running,
+        observedDiagnostics: ['OpenCode session status retry'],
+      })
+    ).toEqual({ action: 'none' });
+    // Same for the reply-optional contract, which settles on any lane.
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record({
+          laneId: 'secondary:opencode:scribe',
+          memberName: 'Scribe',
+          replyRecipient: 'system',
+          lastAttemptAt: minutesAgo(1),
+          acceptedAt: minutesAgo(1),
+        }),
+        laneKind: 'secondary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: undefined,
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'none' });
+  });
+
+  it('still bounds a lane that never reports its session activity', () => {
+    // A lane with no idle evidence at all is not settled as a finished turn,
+    // but it does not block the lane either: at the stale window the unknown
+    // session goes terminal, exactly like an idle one.
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record(),
+        laneKind: 'primary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: undefined,
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toMatchObject({ action: 'fail_terminal', reason: OPENCODE_STALE_PENDING_TERMINAL_REASON });
+  });
+
   it('keeps observing a stale busy record until the non-user hard cap, then goes terminal', () => {
     const busy = {
       laneKind: 'primary' as const,

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryStalePendingPolicy.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryStalePendingPolicy.test.ts
@@ -10,6 +10,7 @@ import {
   OPENCODE_LEAD_PLAIN_TEXT_TURN_END_REASON,
   OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS,
   OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS,
+  OPENCODE_REPLY_OPTIONAL_TURN_END_REASON,
   OPENCODE_STALE_PENDING_HARD_CAP_REASON,
   OPENCODE_STALE_PENDING_POLICY_CONFIG,
   OPENCODE_STALE_PENDING_PREEMPTED_REASON,
@@ -346,6 +347,61 @@ describe('decideOpenCodeStalePendingResolution', () => {
         laneKind: 'secondary',
         observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
         observedDiagnostics: [TREATED_IDLE],
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'none' });
+  });
+
+  it('settles secondary-lane reply-optional records (informational, teammate report) once the turn ended', () => {
+    // On live runs a dep-resolved notice to a teammate sat pending for five
+    // minutes although the member had finished its turn - and its task - long
+    // before: nothing in the notice asked for a reply.
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record({
+          laneId: 'secondary:opencode:scribe',
+          memberName: 'Scribe',
+          replyRecipient: 'system',
+          lastAttemptAt: minutesAgo(1),
+          acceptedAt: minutesAgo(1),
+        }),
+        laneKind: 'secondary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: [TREATED_IDLE],
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'settle_plain_text', reason: OPENCODE_REPLY_OPTIONAL_TURN_END_REASON });
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record({
+          laneId: 'secondary:opencode:scribe',
+          memberName: 'Scribe',
+          replyRecipient: 'Muse',
+          lastAttemptAt: minutesAgo(1),
+          acceptedAt: minutesAgo(1),
+        }),
+        laneKind: 'secondary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: [TREATED_IDLE],
+        nowMs: NOW_MS,
+        config: POLICY,
+      })
+    ).toEqual({ action: 'settle_plain_text', reason: OPENCODE_REPLY_OPTIONAL_TURN_END_REASON });
+    // Still busy: keep waiting.
+    expect(
+      decideOpenCodeStalePendingResolution({
+        record: record({
+          laneId: 'secondary:opencode:scribe',
+          memberName: 'Scribe',
+          replyRecipient: 'system',
+          lastAttemptAt: minutesAgo(1),
+          acceptedAt: minutesAgo(1),
+        }),
+        laneKind: 'secondary',
+        observation: { state: 'pending', assistantMessageId: 'msg_assistant' },
+        observedDiagnostics: [BUSY],
         nowMs: NOW_MS,
         config: POLICY,
       })

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryWatchdogCoordinator.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryWatchdogCoordinator.test.ts
@@ -84,14 +84,20 @@ function taskRefsIncludeAll(
   );
 }
 
-function makeCoordinator(overrides: {
-  scheduler?: Pick<OpenCodePromptDeliveryWatchdogScheduler, 'isEnabled' | 'schedule' | 'isStaleError'>;
-  ledger?: OpenCodePromptDeliveryLedgerStore;
-  inboxMessages?: InboxMessage[];
-  activeLaneIds?: string[] | null;
-  members?: string[];
-  logPromptDeliveryEvent?: ReturnType<typeof vi.fn>;
-} = {}) {
+function makeCoordinator(
+  overrides: {
+    scheduler?: Pick<
+      OpenCodePromptDeliveryWatchdogScheduler,
+      'isEnabled' | 'schedule' | 'isStaleError'
+    >;
+    ledger?: OpenCodePromptDeliveryLedgerStore;
+    inboxMessages?: InboxMessage[];
+    activeLaneIds?: string[] | null;
+    members?: string[];
+    logPromptDeliveryEvent?: ReturnType<typeof vi.fn>;
+    notifyLeadTurnActivity?: ReturnType<typeof vi.fn>;
+  } = {}
+) {
   const scheduler =
     overrides.scheduler ??
     ({
@@ -128,6 +134,7 @@ function makeCoordinator(overrides: {
     hasStableInboxMessageId: (message): message is InboxMessage & { messageId: string } =>
       typeof message.messageId === 'string' && message.messageId.trim().length > 0,
     logPromptDeliveryEvent: overrides.logPromptDeliveryEvent ?? vi.fn(),
+    notifyLeadTurnActivity: overrides.notifyLeadTurnActivity,
     nowIso: () => ISO,
     sleep: vi.fn(async () => undefined),
   });
@@ -203,6 +210,48 @@ describe('OpenCodePromptDeliveryWatchdogCoordinator', () => {
       reason: 'opencode_prompt_delivery_requeued_after_terminal_no_assistant_response',
       scheduledAt: ISO,
     });
+  });
+
+  it("reports the lead turn as 'idle' when a primary-lane delivery is marked terminal", async () => {
+    const notifyLeadTurnActivity = vi.fn();
+    const coordinator = makeCoordinator({ notifyLeadTurnActivity });
+    const markFailedTerminal = vi.fn(async (input: { id: string }) =>
+      record({
+        id: input.id,
+        laneId: 'primary',
+        memberName: 'team-lead',
+        status: 'failed_terminal',
+      })
+    );
+
+    await coordinator.markLedgerFailedTerminal({
+      ledger: { markFailedTerminal } as unknown as OpenCodePromptDeliveryLedgerStore,
+      id: 'record-1',
+      reason: 'opencode_prompt_delivery_failed_terminal',
+      failedAt: ISO,
+    });
+
+    expect(notifyLeadTurnActivity).toHaveBeenCalledWith({
+      teamName: 'team',
+      memberName: 'team-lead',
+      laneId: 'primary',
+      state: 'idle',
+    });
+  });
+
+  it('does not report lead turn activity for secondary-lane terminal marks', async () => {
+    const notifyLeadTurnActivity = vi.fn();
+    const coordinator = makeCoordinator({ notifyLeadTurnActivity });
+    const markFailedTerminal = vi.fn(async () => record({ status: 'failed_terminal' }));
+
+    await coordinator.markLedgerFailedTerminal({
+      ledger: { markFailedTerminal } as unknown as OpenCodePromptDeliveryLedgerStore,
+      id: 'record-1',
+      reason: 'opencode_prompt_delivery_failed_terminal',
+      failedAt: ISO,
+    });
+
+    expect(notifyLeadTurnActivity).not.toHaveBeenCalled();
   });
 
   it('rebuilds missing watchdog ledger records from unread inbox messages', async () => {

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryWatchdogCoordinator.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryWatchdogCoordinator.test.ts
@@ -235,6 +235,7 @@ describe('OpenCodePromptDeliveryWatchdogCoordinator', () => {
       teamName: 'team',
       memberName: 'team-lead',
       laneId: 'primary',
+      runId: 'run-1',
       state: 'idle',
     });
   });

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeDeliveryComposition.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeDeliveryComposition.ts
@@ -17,6 +17,9 @@ export interface TeamProvisioningOpenCodeDeliveryCompositionPorts {
   scheduleOpenCodePromptDeliveryWatchdog: NonNullable<
     OpenCodePromptDeliveryWatchdogCoordinatorPorts['schedulePromptDeliveryWatchdog']
   >;
+  notifyOpenCodeLeadTurnActivity: NonNullable<
+    OpenCodePromptDeliveryWatchdogCoordinatorPorts['notifyLeadTurnActivity']
+  >;
   canDeliverToOpenCodeRuntimeForTeam: OpenCodePromptDeliveryWatchdogCoordinatorPorts['canDeliverToTeamRuntime'];
   tryRecoverOpenCodeRuntimeLanesForDeliveryWatchdog: OpenCodePromptDeliveryWatchdogCoordinatorPorts['recoverRuntimeLanesForWatchdog'];
   openCodeStoppedLaneCleanup: {

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeDeliveryComposition.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeDeliveryComposition.ts
@@ -1,0 +1,31 @@
+import type { OpenCodePromptDeliveryWatchdogCoordinatorPorts } from '../opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator';
+
+/**
+ * Service-side ports the OpenCode prompt-delivery pipeline is composed from.
+ *
+ * These live next to the OpenCode provisioning modules rather than inside
+ * `TeamProvisioningServiceComposition`, which sits at its frozen size cap:
+ * growing the delivery pipeline by one port would otherwise mean shrinking an
+ * unrelated part of the composition module in the same commit.
+ */
+export interface TeamProvisioningOpenCodeDeliveryCompositionPorts {
+  memberWorkSyncProofBoundary: {
+    hasAcceptedMemberWorkSyncReport: OpenCodePromptDeliveryWatchdogCoordinatorPorts['hasAcceptedMemberWorkSyncReport'];
+  };
+  maybeSyncOpenCodeRuntimePermissionsAfterDelivery: OpenCodePromptDeliveryWatchdogCoordinatorPorts['maybeSyncRuntimePermissionsAfterDelivery'];
+  rememberOpenCodeRuntimePidFromBridge: OpenCodePromptDeliveryWatchdogCoordinatorPorts['rememberRuntimePidFromBridge'];
+  scheduleOpenCodePromptDeliveryWatchdog: NonNullable<
+    OpenCodePromptDeliveryWatchdogCoordinatorPorts['schedulePromptDeliveryWatchdog']
+  >;
+  canDeliverToOpenCodeRuntimeForTeam: OpenCodePromptDeliveryWatchdogCoordinatorPorts['canDeliverToTeamRuntime'];
+  tryRecoverOpenCodeRuntimeLanesForDeliveryWatchdog: OpenCodePromptDeliveryWatchdogCoordinatorPorts['recoverRuntimeLanesForWatchdog'];
+  openCodeStoppedLaneCleanup: {
+    stopOpenCodeRuntimeLanesForStoppedTeam: OpenCodePromptDeliveryWatchdogCoordinatorPorts['stopRuntimeLanesForStoppedTeam'];
+  };
+  createOpenCodePromptDeliveryLedger: OpenCodePromptDeliveryWatchdogCoordinatorPorts['createLedger'];
+  openCodeRuntimeRecoveryIdentity: {
+    resolveOpenCodeMembersForRuntimeLane: OpenCodePromptDeliveryWatchdogCoordinatorPorts['resolveMembersForRuntimeLane'];
+    resolveCurrentOpenCodeRuntimeRunId: OpenCodePromptDeliveryWatchdogCoordinatorPorts['resolveCurrentRuntimeRunId'];
+  };
+  logOpenCodePromptDeliveryEvent: OpenCodePromptDeliveryWatchdogCoordinatorPorts['logPromptDeliveryEvent'];
+}

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberInboxRelay.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberInboxRelay.ts
@@ -345,7 +345,16 @@ async function runOpenCodeMemberInboxRelayWork(
     return taskRefInferenceTasks;
   };
 
-  for (const message of unread) {
+  // Cursor-driven walk: a pending non-user delivery may skip ahead to a newer
+  // user message (see findNextUnreadUserMessageIndex) instead of breaking.
+  let cursor = 0;
+  while (cursor < unread.length) {
+    const index = cursor;
+    cursor += 1;
+    const message = unread[index];
+    if (!message) {
+      break;
+    }
     let existingRecord = await promptLedger
       .getByInboxMessage({
         teamName,
@@ -579,6 +588,18 @@ async function runOpenCodeMemberInboxRelayWork(
         ...(result.diagnostics ?? []),
         ...(delivery.diagnostics ?? [delivery.reason ?? 'opencode_delivery_response_pending']),
       ];
+      // A pending non-user delivery (teammate report, system/task notification)
+      // must not starve a newer user message: hand that message to the delivery
+      // service, which preempts a stale non-user record or queues behind it.
+      const nextUserMessageIndex = findNextUnreadUserMessageIndex({
+        unread,
+        afterIndex: index,
+        currentReplyRecipient: deliveryDecision.replyRecipient,
+      });
+      if (nextUserMessageIndex > index) {
+        cursor = nextUserMessageIndex;
+        continue;
+      }
       break;
     }
     const readCommit = await commitOpenCodeInboxRelayReadAfterDelivery({
@@ -610,6 +631,28 @@ async function runOpenCodeMemberInboxRelayWork(
   }
 
   return dedupeOpenCodeMemberInboxRelayDiagnostics(result);
+}
+
+/**
+ * Index of the first unread user message after `afterIndex`, or -1. Only a
+ * pending non-user delivery yields to a user message; a pending user delivery
+ * keeps the inbox order (the next user message queues behind it).
+ */
+export function findNextUnreadUserMessageIndex(input: {
+  unread: readonly RelayInboxMessage[];
+  afterIndex: number;
+  currentReplyRecipient: string;
+}): number {
+  if (input.currentReplyRecipient.trim().toLowerCase() === 'user') {
+    return -1;
+  }
+  for (let index = input.afterIndex + 1; index < input.unread.length; index += 1) {
+    const candidate = input.unread[index];
+    if (candidate && !candidate.read && candidate.from.trim().toLowerCase() === 'user') {
+      return index;
+    }
+  }
+  return -1;
 }
 
 export function selectOpenCodeMemberInboxRelayUnreadMessages(input: {

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberInboxRelay.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberInboxRelay.ts
@@ -590,7 +590,7 @@ async function runOpenCodeMemberInboxRelayWork(
       ];
       // A pending non-user delivery (teammate report, system/task notification)
       // must not starve a newer user message: hand that message to the delivery
-      // service, which preempts a stale non-user record or queues behind it.
+      // service, which queues it until fresh observation settles the blocker.
       const nextUserMessageIndex = findNextUnreadUserMessageIndex({
         unread,
         afterIndex: index,
@@ -824,7 +824,7 @@ export function projectOpenCodeInboxDeliveryFailure(input: {
   result: OpenCodeMemberInboxRelayResult;
   shouldLogWarning: boolean;
 } {
-  if (input.delivery.accepted === true) {
+  if (input.delivery.accepted === true && input.delivery.ledgerStatus !== 'failed_terminal') {
     const diagnostics = input.delivery.diagnostics ?? [
       input.delivery.reason ?? 'opencode_delivery_response_pending',
     ];

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.ts
@@ -163,7 +163,9 @@ export class TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService<
   > {
     return createOpenCodeMemberMessageDeliveryServiceFromHost({
       ...this.deps.createDeliveryHost(),
-      notifyOpenCodeLeadTurnActivity: (input) => this.notifyOpenCodeLeadTurnActivity(input),
+      notifyOpenCodeLeadTurnActivity: (input) => {
+        void this.notifyOpenCodeLeadTurnActivity(input);
+      },
     });
   }
 
@@ -318,7 +320,7 @@ export abstract class TeamProvisioningOpenCodeMemberMessageDeliveryCompatibility
   }
 
   protected notifyOpenCodeLeadTurnActivity(input: OpenCodeLeadTurnActivityNotification): void {
-    this.openCodeMemberMessageDeliveryCompatibility.notifyOpenCodeLeadTurnActivity(input);
+    void this.openCodeMemberMessageDeliveryCompatibility.notifyOpenCodeLeadTurnActivity(input);
   }
 
   async deliverOpenCodeMemberMessage(

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.ts
@@ -2,6 +2,7 @@ import { getErrorMessage } from '@shared/utils/errorHandling';
 import { createLogger } from '@shared/utils/logger';
 
 import {
+  type OpenCodeLeadTurnActivityNotification,
   type OpenCodeMemberInboxDelivery,
   type OpenCodeMemberMessageDeliveryInput,
 } from '../opencode/delivery/OpenCodeMemberMessageDeliveryPorts';
@@ -44,10 +45,16 @@ const logger = createLogger('Service:TeamProvisioning');
 type OpenCodeMemberMessageDeliveryCompatibilityRuntimeIdentity =
   TeamProvisioningOpenCodeMemberInboxRelayBoundaryDeps['openCodeRuntimeRecoveryIdentity'];
 
+type OpenCodeMemberMessageDeliveryHostRun = NonNullable<
+  ReturnType<TeamProvisioningOpenCodeMemberMessageDeliveryHost['runs']['get']>
+>;
+
 export interface TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityServiceDeps<
   TRun extends TeamProvisioningSendMessageToRunRun,
 > {
   createDeliveryHost(): TeamProvisioningOpenCodeMemberMessageDeliveryHost;
+  /** Tracked run that owns the OpenCode primary lane for a team, if any. */
+  resolveLeadActivityRun(teamName: string): TRun | null;
   inboxRelayHost: TeamProvisioningOpenCodeMemberInboxRelayHost;
   getInboxReader(): ReturnType<
     TeamProvisioningOpenCodeMemberInboxRelayBoundaryDeps['getInboxReader']
@@ -59,7 +66,7 @@ export interface TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityServi
   >;
   getCleanedStoppedTeamOpenCodeRuntimeLanes(): TeamProvisioningOpenCodeMemberInboxRelayBoundaryDeps['cleanedStoppedTeamOpenCodeRuntimeLanes'];
   isCurrentTrackedRun(run: TRun): boolean;
-  setLeadActivity(run: TRun, state: 'active'): void;
+  setLeadActivity(run: TRun, state: OpenCodeLeadTurnActivityNotification['state']): void;
   logger: TeamProvisioningOpenCodeMemberInboxRelayBoundaryDeps['logger'];
   nowIso: TeamProvisioningOpenCodeMemberInboxRelayBoundaryDeps['nowIso'];
   getErrorMessage: TeamProvisioningOpenCodeMemberInboxRelayBoundaryDeps['getErrorMessage'];
@@ -79,8 +86,9 @@ export interface TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityServi
   openCodeRuntimeRecoveryIdentity: OpenCodeMemberMessageDeliveryCompatibilityRuntimeIdentity;
   openCodeVisibleReplyProofService: TeamProvisioningOpenCodeMemberMessageDeliveryServiceHost['openCodeVisibleReplyProofService'];
   cleanedStoppedTeamOpenCodeRuntimeLanes: TeamProvisioningOpenCodeMemberInboxRelayBoundaryDeps['cleanedStoppedTeamOpenCodeRuntimeLanes'];
+  runs: { get(runId: string): (TRun & OpenCodeMemberMessageDeliveryHostRun) | undefined };
   isCurrentTrackedRun(run: TRun): boolean;
-  setLeadActivity(run: TRun, state: 'active'): void;
+  setLeadActivity(run: TRun, state: OpenCodeLeadTurnActivityNotification['state']): void;
 }
 
 export class TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService<
@@ -151,7 +159,21 @@ export class TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService<
   protected createOpenCodeMemberMessageDeliveryService(): ReturnType<
     typeof createOpenCodeMemberMessageDeliveryServiceFromHost
   > {
-    return createOpenCodeMemberMessageDeliveryServiceFromHost(this.deps.createDeliveryHost());
+    return createOpenCodeMemberMessageDeliveryServiceFromHost({
+      ...this.deps.createDeliveryHost(),
+      notifyOpenCodeLeadTurnActivity: (input) => this.notifyOpenCodeLeadTurnActivity(input),
+    });
+  }
+
+  /**
+   * Mirrors `sendMessageToRun` -> `setLeadActivity(run, 'active')` for the
+   * OpenCode primary lane, whose lead has no stdin stream. No-op when the team
+   * has no deliverable tracked run.
+   */
+  notifyOpenCodeLeadTurnActivity(input: OpenCodeLeadTurnActivityNotification): void {
+    const run = this.deps.resolveLeadActivityRun(input.teamName);
+    if (!run) return;
+    this.deps.setLeadActivity(run, input.state);
   }
 
   async deliverOpenCodeMemberMessage(
@@ -186,6 +208,10 @@ export function createTeamProvisioningOpenCodeMemberMessageDeliveryCompatibility
   return new TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService<TRun>({
     createDeliveryHost: () =>
       createTeamProvisioningOpenCodeMemberMessageDeliveryHostFromService(service),
+    resolveLeadActivityRun: (teamName) => {
+      const runId = service.runTracking.resolveDeliverableTrackedRuntimeRunId(teamName);
+      return (runId ? service.runs.get(runId) : undefined) ?? null;
+    },
     inboxRelayHost: createTeamProvisioningOpenCodeMemberInboxRelayHostFromService(
       service as unknown as TeamProvisioningOpenCodeMemberInboxRelayServiceHost
     ),
@@ -253,6 +279,10 @@ export abstract class TeamProvisioningOpenCodeMemberMessageDeliveryCompatibility
         >;
       }
     ).createOpenCodeMemberMessageDeliveryService();
+  }
+
+  protected notifyOpenCodeLeadTurnActivity(input: OpenCodeLeadTurnActivityNotification): void {
+    this.openCodeMemberMessageDeliveryCompatibility.notifyOpenCodeLeadTurnActivity(input);
   }
 
   async deliverOpenCodeMemberMessage(

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.ts
@@ -1,6 +1,7 @@
 import { getErrorMessage } from '@shared/utils/errorHandling';
 import { createLogger } from '@shared/utils/logger';
 
+import { isOpenCodeLeadRecipient } from '../opencode/delivery/OpenCodeLeadTurnActivity';
 import {
   type OpenCodeLeadTurnActivityNotification,
   type OpenCodeMemberInboxDelivery,
@@ -52,6 +53,7 @@ type OpenCodeMemberMessageDeliveryHostRun = NonNullable<
 export interface TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityServiceDeps<
   TRun extends TeamProvisioningSendMessageToRunRun,
 > {
+  readLeadActivityDirectory: TeamProvisioningOpenCodeMemberMessageDeliveryServiceHost['openCodeRuntimeRecoveryFacade']['readOpenCodeMemberDirectory'];
   createDeliveryHost(): TeamProvisioningOpenCodeMemberMessageDeliveryHost;
   /** Tracked run that owns the OpenCode primary lane for a team, if any. */
   resolveLeadActivityRun(teamName: string): TRun | null;
@@ -165,15 +167,47 @@ export class TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService<
     });
   }
 
+  private readonly leadActivityPending = new Map<string, Promise<void>>();
+
   /**
    * Mirrors `sendMessageToRun` -> `setLeadActivity(run, 'active')` for the
    * OpenCode primary lane, whose lead has no stdin stream. No-op when the team
    * has no deliverable tracked run.
    */
-  notifyOpenCodeLeadTurnActivity(input: OpenCodeLeadTurnActivityNotification): void {
-    const run = this.deps.resolveLeadActivityRun(input.teamName);
-    if (!run) return;
-    this.deps.setLeadActivity(run, input.state);
+  notifyOpenCodeLeadTurnActivity(input: OpenCodeLeadTurnActivityNotification): Promise<void> {
+    const key = input.teamName;
+    const pending = (this.leadActivityPending.get(key) ?? Promise.resolve()).then(() =>
+      this.applyOpenCodeLeadTurnActivity(input)
+    );
+    this.leadActivityPending.set(key, pending);
+    void pending.finally(() => {
+      if (this.leadActivityPending.get(key) === pending) this.leadActivityPending.delete(key);
+    });
+    return pending;
+  }
+
+  private async applyOpenCodeLeadTurnActivity(
+    input: OpenCodeLeadTurnActivityNotification
+  ): Promise<void> {
+    if (input.laneId !== 'primary' || !input.runId) return;
+    try {
+      const directory = await this.deps.readLeadActivityDirectory(input.teamName);
+      if (!isOpenCodeLeadRecipient(input.memberName, directory)) return;
+      const run = this.deps.resolveLeadActivityRun(input.teamName);
+      if (
+        !run ||
+        run.runId !== input.runId ||
+        run.processKilled ||
+        run.cancelRequested ||
+        !this.deps.isCurrentTrackedRun(run)
+      )
+        return;
+      this.deps.setLeadActivity(run, input.state);
+    } catch (error) {
+      this.deps.logger.warn(
+        `OpenCode lead activity notification failed: ${this.deps.getErrorMessage(error)}`
+      );
+    }
   }
 
   async deliverOpenCodeMemberMessage(
@@ -206,6 +240,8 @@ export function createTeamProvisioningOpenCodeMemberMessageDeliveryCompatibility
   >
 ): TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService<TRun> {
   return new TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService<TRun>({
+    readLeadActivityDirectory: (teamName) =>
+      service.openCodeRuntimeRecoveryFacade.readOpenCodeMemberDirectory(teamName),
     createDeliveryHost: () =>
       createTeamProvisioningOpenCodeMemberMessageDeliveryHostFromService(service),
     resolveLeadActivityRun: (teamName) => {

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryServiceFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryServiceFactory.ts
@@ -1,4 +1,5 @@
 import { OpenCodeMemberMessageDeliveryService } from '../opencode/delivery/OpenCodeMemberMessageDeliveryService';
+import { OPENCODE_STALE_PENDING_POLICY_CONFIG } from '../opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy';
 
 import {
   createDefaultOpenCodeRuntimeBootstrapEvidencePorts,
@@ -72,6 +73,7 @@ export interface TeamProvisioningOpenCodeMemberMessageDeliveryHost {
   openCodeVisibleReplyProofService: OpenCodeMemberMessageDeliveryFactoryPorts['openCodeVisibleReplyProofService'];
   openCodePromptDeliveryWatchdogScheduler: OpenCodeMemberMessageDeliveryFactoryPorts['openCodePromptDeliveryWatchdogScheduler'];
   openCodePromptDeliveryFollowUpPolicy: OpenCodeMemberMessageDeliveryFactoryPorts['openCodePromptDeliveryFollowUpPolicy'];
+  openCodeStalePendingPolicyConfig: OpenCodeMemberMessageDeliveryFactoryPorts['openCodeStalePendingPolicyConfig'];
   isOpenCodeDeliveryResponseReadCommitAllowed: OpenCodeMemberMessageDeliveryFactoryPorts['isOpenCodeDeliveryResponseReadCommitAllowed'];
   getOpenCodeDeliveryPendingReason: OpenCodeMemberMessageDeliveryFactoryPorts['getOpenCodeDeliveryPendingReason'];
   markOpenCodeAcceptedDeliveryMissingPromptProofForRetry: OpenCodeMemberMessageDeliveryFactoryPorts['markOpenCodeAcceptedDeliveryMissingPromptProofForRetry'];
@@ -83,9 +85,14 @@ export interface TeamProvisioningOpenCodeMemberMessageDeliveryHost {
   observeOpenCodeDirectUserDeliveryInlineIfNeeded: OpenCodeMemberMessageDeliveryFactoryPorts['observeOpenCodeDirectUserDeliveryInlineIfNeeded'];
 }
 
+/**
+ * The provisioning service supplies every delivery port except the runtime
+ * adapter (reached through its app-shell boundary) and the stale-pending
+ * windows, which this module composes in from the policy module.
+ */
 export type TeamProvisioningOpenCodeMemberMessageDeliveryServiceHost = Omit<
   TeamProvisioningOpenCodeMemberMessageDeliveryHost,
-  'getOpenCodeRuntimeMessageAdapter'
+  'getOpenCodeRuntimeMessageAdapter' | 'openCodeStalePendingPolicyConfig'
 > & {
   appShellBoundary: {
     getOpenCodeRuntimeMessageAdapter: TeamProvisioningOpenCodeMemberMessageDeliveryHost['getOpenCodeRuntimeMessageAdapter'];
@@ -179,6 +186,7 @@ export function createOpenCodeMemberMessageDeliveryServiceFromHost(
     openCodeVisibleReplyProofService: host.openCodeVisibleReplyProofService,
     openCodePromptDeliveryWatchdogScheduler: host.openCodePromptDeliveryWatchdogScheduler,
     openCodePromptDeliveryFollowUpPolicy: host.openCodePromptDeliveryFollowUpPolicy,
+    openCodeStalePendingPolicyConfig: host.openCodeStalePendingPolicyConfig,
     isOpenCodeDeliveryResponseReadCommitAllowed: (input) =>
       host.isOpenCodeDeliveryResponseReadCommitAllowed(input),
     getOpenCodeDeliveryPendingReason: (input) => host.getOpenCodeDeliveryPendingReason(input),
@@ -245,6 +253,8 @@ export function createTeamProvisioningOpenCodeMemberMessageDeliveryHostFromServi
     openCodeVisibleReplyProofService: service.openCodeVisibleReplyProofService,
     openCodePromptDeliveryWatchdogScheduler: service.openCodePromptDeliveryWatchdogScheduler,
     openCodePromptDeliveryFollowUpPolicy: service.openCodePromptDeliveryFollowUpPolicy,
+    // The shipped stale-pending windows enter the pipeline here, once.
+    openCodeStalePendingPolicyConfig: OPENCODE_STALE_PENDING_POLICY_CONFIG,
     isOpenCodeDeliveryResponseReadCommitAllowed: (input) =>
       service.isOpenCodeDeliveryResponseReadCommitAllowed(input),
     getOpenCodeDeliveryPendingReason: (input) => service.getOpenCodeDeliveryPendingReason(input),

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryServiceFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryServiceFactory.ts
@@ -79,6 +79,7 @@ export interface TeamProvisioningOpenCodeMemberMessageDeliveryHost {
   logOpenCodePromptDeliveryEvent: OpenCodeMemberMessageDeliveryFactoryPorts['logOpenCodePromptDeliveryEvent'];
   requeueOpenCodeRuntimeManifestWatermarkDeliveryIfNeeded: OpenCodeMemberMessageDeliveryFactoryPorts['requeueOpenCodeRuntimeManifestWatermarkDeliveryIfNeeded'];
   emitOpenCodePromptDeliveryTaskLogChange: OpenCodeMemberMessageDeliveryFactoryPorts['emitOpenCodePromptDeliveryTaskLogChange'];
+  notifyOpenCodeLeadTurnActivity?: OpenCodeMemberMessageDeliveryFactoryPorts['notifyOpenCodeLeadTurnActivity'];
   observeOpenCodeDirectUserDeliveryInlineIfNeeded: OpenCodeMemberMessageDeliveryFactoryPorts['observeOpenCodeDirectUserDeliveryInlineIfNeeded'];
 }
 
@@ -191,6 +192,7 @@ export function createOpenCodeMemberMessageDeliveryServiceFromHost(
       host.requeueOpenCodeRuntimeManifestWatermarkDeliveryIfNeeded(input),
     emitOpenCodePromptDeliveryTaskLogChange: (record, detail) =>
       host.emitOpenCodePromptDeliveryTaskLogChange(record, detail),
+    notifyOpenCodeLeadTurnActivity: (input) => host.notifyOpenCodeLeadTurnActivity?.(input),
     observeOpenCodeDirectUserDeliveryInlineIfNeeded: (input) =>
       host.observeOpenCodeDirectUserDeliveryInlineIfNeeded(input),
   });

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerFactory.ts
@@ -1,7 +1,10 @@
+import { OPENCODE_STALE_PENDING_TERMINAL_REASON } from '../opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy';
 import {
   OpenCodePromptDeliveryWatchdogScheduler,
   type OpenCodePromptDeliveryWatchdogSchedulerDependencies,
 } from '../opencode/delivery/OpenCodePromptDeliveryWatchdogScheduler';
+
+import type { OpenCodeMemberInboxRelayResult } from './TeamProvisioningOpenCodeMemberInboxRelay';
 
 export interface TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerServiceHost {
   canDeliverToOpenCodeRuntimeForTeam(teamName: string): boolean;
@@ -12,8 +15,8 @@ export interface TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerServiceH
   relayOpenCodeMemberInboxMessages(
     teamName: string,
     memberName: string,
-    options: { onlyMessageId: string; source: 'watchdog' }
-  ): Promise<unknown>;
+    options: { onlyMessageId?: string; source: 'watchdog' }
+  ): Promise<OpenCodeMemberInboxRelayResult>;
   inboxReader: {
     getMessagesFor(
       teamName: string,
@@ -50,10 +53,25 @@ export function createOpenCodePromptDeliveryWatchdogSchedulerDepsFromService(
     recoverBeforeDelivery: (input) =>
       service.tryRecoverOpenCodeRuntimeLaneForConfiguredMemberBeforeDelivery(input),
     relay: async (input) => {
-      await service.relayOpenCodeMemberInboxMessages(input.teamName, input.memberName, {
-        onlyMessageId: input.messageId,
-        source: 'watchdog',
-      });
+      const result = await service.relayOpenCodeMemberInboxMessages(
+        input.teamName,
+        input.memberName,
+        {
+          onlyMessageId: input.messageId,
+          source: 'watchdog',
+        }
+      );
+      // Terminal ledger writes do not emit an inbox event. Wake queued rows once,
+      // while preserving the failed row as unread for explicit manual recovery.
+      if (
+        result.lastDelivery?.ledgerStatus === 'failed_terminal' &&
+        result.lastDelivery.reason === OPENCODE_STALE_PENDING_TERMINAL_REASON &&
+        service.canDeliverToOpenCodeRuntimeForTeam(input.teamName)
+      ) {
+        await service.relayOpenCodeMemberInboxMessages(input.teamName, input.memberName, {
+          source: 'watchdog',
+        });
+      }
     },
     getInboxMessages: (input) =>
       service.inboxReader.getMessagesFor(input.teamName, input.memberName),

--- a/src/main/services/team/provisioning/TeamProvisioningServiceComposition.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningServiceComposition.ts
@@ -14,7 +14,6 @@ import { getConfiguredCliCommandLabel } from '../cliFlavor';
 import {
   createOpenCodePromptDeliveryWatchdogCoordinator,
   type OpenCodePromptDeliveryWatchdogCoordinator,
-  type OpenCodePromptDeliveryWatchdogCoordinatorPorts,
 } from '../opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator';
 import { type OpenCodePromptDeliveryWatchdogScheduler } from '../opencode/delivery/OpenCodePromptDeliveryWatchdogScheduler';
 import { openCodeTaskRefsIncludeAll as openCodeTaskRefsIncludeAllValue } from '../opencode/delivery/OpenCodeRuntimeDeliveryProofMatching';
@@ -100,6 +99,7 @@ import {
   type TeamProvisioningMemberMcpLaunchConfigServiceHost,
 } from './TeamProvisioningMemberMcpLaunchConfig';
 import { createInitialMemberSpawnStatusEntry } from './TeamProvisioningMemberSpawnStatusPolicy';
+import { type TeamProvisioningOpenCodeDeliveryCompositionPorts } from './TeamProvisioningOpenCodeDeliveryComposition';
 import {
   createOpenCodePromptDeliveryWatchdogSchedulerFromService,
   type TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerServiceHost,
@@ -204,27 +204,8 @@ export interface RuntimeAdapterRunByTeamEntry {
   members?: Record<string, TeamRuntimeMemberLaunchEvidence>;
 }
 
-interface ServiceCompositionPorts {
+interface ServiceCompositionPorts extends TeamProvisioningOpenCodeDeliveryCompositionPorts {
   createOpenCodeRuntimeDeliveryBoundaryHost(): TeamProvisioningOpenCodeRuntimeDeliveryBoundaryHost<ProvisioningRun>;
-  memberWorkSyncProofBoundary: {
-    hasAcceptedMemberWorkSyncReport: OpenCodePromptDeliveryWatchdogCoordinatorPorts['hasAcceptedMemberWorkSyncReport'];
-  };
-  maybeSyncOpenCodeRuntimePermissionsAfterDelivery: OpenCodePromptDeliveryWatchdogCoordinatorPorts['maybeSyncRuntimePermissionsAfterDelivery'];
-  rememberOpenCodeRuntimePidFromBridge: OpenCodePromptDeliveryWatchdogCoordinatorPorts['rememberRuntimePidFromBridge'];
-  scheduleOpenCodePromptDeliveryWatchdog: NonNullable<
-    OpenCodePromptDeliveryWatchdogCoordinatorPorts['schedulePromptDeliveryWatchdog']
-  >;
-  canDeliverToOpenCodeRuntimeForTeam: OpenCodePromptDeliveryWatchdogCoordinatorPorts['canDeliverToTeamRuntime'];
-  tryRecoverOpenCodeRuntimeLanesForDeliveryWatchdog: OpenCodePromptDeliveryWatchdogCoordinatorPorts['recoverRuntimeLanesForWatchdog'];
-  openCodeStoppedLaneCleanup: {
-    stopOpenCodeRuntimeLanesForStoppedTeam: OpenCodePromptDeliveryWatchdogCoordinatorPorts['stopRuntimeLanesForStoppedTeam'];
-  };
-  createOpenCodePromptDeliveryLedger: OpenCodePromptDeliveryWatchdogCoordinatorPorts['createLedger'];
-  openCodeRuntimeRecoveryIdentity: {
-    resolveOpenCodeMembersForRuntimeLane: OpenCodePromptDeliveryWatchdogCoordinatorPorts['resolveMembersForRuntimeLane'];
-    resolveCurrentOpenCodeRuntimeRunId: OpenCodePromptDeliveryWatchdogCoordinatorPorts['resolveCurrentRuntimeRunId'];
-  };
-  logOpenCodePromptDeliveryEvent: OpenCodePromptDeliveryWatchdogCoordinatorPorts['logPromptDeliveryEvent'];
 }
 
 export interface TeamProvisioningServiceComposition {

--- a/src/main/services/team/provisioning/TeamProvisioningServiceComposition.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningServiceComposition.ts
@@ -694,6 +694,7 @@ export function createTeamProvisioningServiceComposition(
       watchdogScheduler: openCodePromptDeliveryWatchdogScheduler,
       schedulePromptDeliveryWatchdog: (input) =>
         servicePorts.scheduleOpenCodePromptDeliveryWatchdog(input),
+      notifyLeadTurnActivity: (input) => servicePorts.notifyOpenCodeLeadTurnActivity(input),
       canDeliverToTeamRuntime: (teamName) =>
         servicePorts.canDeliverToOpenCodeRuntimeForTeam(teamName),
       recoverRuntimeLanesForWatchdog: (teamName, options) =>

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberInboxRelay.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberInboxRelay.test.ts
@@ -638,6 +638,117 @@ describe('TeamProvisioningOpenCodeMemberInboxRelay', () => {
     });
   });
 
+  it('hands a newer user message to the delivery service when a non-user delivery stays pending', async () => {
+    const pendingNotification = message({
+      messageId: 'task-comment-forward:1',
+      from: 'system',
+      source: 'system_notification',
+      messageKind: 'task_comment_notification',
+      text: 'Task comment: section done.',
+    });
+    const teammateReport = message({
+      messageId: 'teammate-report',
+      from: 'Scribe',
+      text: 'done with section 2',
+    });
+    const userFollowUp = message({ messageId: 'user-2', from: 'user', text: 'wrap up please' });
+    const deliverOpenCodeMemberMessage = vi.fn(
+      (_teamName: string, input: { messageId?: string; replyRecipient?: string }) =>
+        Promise.resolve(
+          input.replyRecipient === 'user'
+            ? { delivered: true, accepted: true, responsePending: false, laneId: 'primary' }
+            : {
+                delivered: true,
+                accepted: true,
+                responsePending: true,
+                reason: 'opencode_delivery_response_pending',
+              }
+        )
+    );
+    const markInboxMessagesRead = vi.fn().mockResolvedValue(undefined);
+
+    const result = await relayOpenCodeMemberInboxMessagesWithPorts(
+      { teamName: 'team', memberName: 'team-lead', relayKey: 'team/team-lead' },
+      createRelayPorts({
+        readInboxMessages: vi
+          .fn()
+          .mockResolvedValue([pendingNotification, teammateReport, userFollowUp]),
+        deliverOpenCodeMemberMessage: deliverOpenCodeMemberMessage as never,
+        markInboxMessagesRead,
+      })
+    );
+
+    // The pending notification is attempted, the teammate report is skipped
+    // (it would only queue behind), and the user message reaches deliver().
+    expect(deliverOpenCodeMemberMessage).toHaveBeenCalledTimes(2);
+    expect(deliverOpenCodeMemberMessage.mock.calls.map(([, input]) => input.messageId)).toEqual([
+      'task-comment-forward:1',
+      'user-2',
+    ]);
+    expect(markInboxMessagesRead).toHaveBeenCalledWith('team', 'team-lead', [userFollowUp]);
+    expect(result).toMatchObject({ attempted: 2, delivered: 1, relayed: 1, failed: 0 });
+  });
+
+  it('stops at a pending non-user delivery when no unread user message follows', async () => {
+    const pendingNotification = message({
+      messageId: 'task-comment-forward:1',
+      from: 'system',
+      source: 'system_notification',
+      messageKind: 'task_comment_notification',
+      text: 'Task comment: section done.',
+    });
+    const teammateReport = message({
+      messageId: 'teammate-report',
+      from: 'Scribe',
+      text: 'done with section 2',
+    });
+    const deliverOpenCodeMemberMessage = vi.fn().mockResolvedValue({
+      delivered: true,
+      accepted: true,
+      responsePending: true,
+      reason: 'opencode_delivery_response_pending',
+    });
+
+    const result = await relayOpenCodeMemberInboxMessagesWithPorts(
+      { teamName: 'team', memberName: 'team-lead', relayKey: 'team/team-lead' },
+      createRelayPorts({
+        readInboxMessages: vi.fn().mockResolvedValue([pendingNotification, teammateReport]),
+        deliverOpenCodeMemberMessage,
+      })
+    );
+
+    // Only a user message earns the skip; another non-user notice would just
+    // queue behind the same blocker, so the walk stops instead of looping.
+    expect(deliverOpenCodeMemberMessage).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ attempted: 1, delivered: 0 });
+  });
+
+  it('keeps inbox order when the pending delivery is itself a user prompt', async () => {
+    const firstUserPrompt = message({ messageId: 'user-1', from: 'user', text: 'plan it' });
+    const secondUserPrompt = message({ messageId: 'user-2', from: 'user', text: 'and ship it' });
+    const deliverOpenCodeMemberMessage = vi.fn().mockResolvedValue({
+      delivered: true,
+      accepted: true,
+      responsePending: true,
+      reason: 'opencode_delivery_response_pending',
+    });
+
+    const result = await relayOpenCodeMemberInboxMessagesWithPorts(
+      { teamName: 'team', memberName: 'team-lead', relayKey: 'team/team-lead' },
+      createRelayPorts({
+        readInboxMessages: vi.fn().mockResolvedValue([firstUserPrompt, secondUserPrompt]),
+        deliverOpenCodeMemberMessage,
+      })
+    );
+
+    expect(deliverOpenCodeMemberMessage).toHaveBeenCalledOnce();
+    expect(deliverOpenCodeMemberMessage).toHaveBeenCalledWith(
+      'team',
+      expect.objectContaining({ messageId: 'user-1' })
+    );
+    expect(result).toMatchObject({ attempted: 1, delivered: 0 });
+  });
+
   it('projects already-read rows with committed ledger proof as explicit accepted delivery', async () => {
     const committed = ledgerRecord({
       id: 'committed-record',

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberInboxRelay.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberInboxRelay.test.ts
@@ -1167,6 +1167,20 @@ describe('TeamProvisioningOpenCodeMemberInboxRelay', () => {
     });
   });
 
+  it('surfaces accepted terminal failures instead of projecting them as pending', () => {
+    expect(
+      projectOpenCodeInboxDeliveryFailure({
+        delivery: {
+          delivered: false,
+          accepted: true,
+          ledgerStatus: 'failed_terminal',
+          reason: 'idle_without_required_reply',
+        },
+        suppressRuntimeInactiveWarning: false,
+      })
+    ).toMatchObject({ result: { failed: 1 }, shouldLogWarning: true });
+  });
+
   it('projects delivery failures without warning for pending acceptance or suppressed runtime inactive', () => {
     expect(
       projectOpenCodeInboxDeliveryFailure({

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.test.ts
@@ -135,6 +135,46 @@ describe('TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService', ()
     expect(deps.getOpenCodeVisibleReplyProofService).toHaveBeenCalled();
     expect(deps.getCleanedStoppedTeamOpenCodeRuntimeLanes).toHaveBeenCalled();
   });
+
+  it('forwards OpenCode lead turn activity to setLeadActivity for the tracked run only', () => {
+    const run = {
+      teamName: 'team-a',
+      runId: 'run-1',
+      processKilled: false,
+      cancelRequested: false,
+      request: {},
+      child: null,
+    } satisfies TestSendRun;
+    const setLeadActivity = vi.fn();
+    const resolveLeadActivityRun = vi.fn((teamName: string) =>
+      teamName === 'team-a' ? run : null
+    );
+    const service = createService({ setLeadActivity, resolveLeadActivityRun });
+
+    service.notifyOpenCodeLeadTurnActivity({
+      teamName: 'team-a',
+      memberName: 'team-lead',
+      laneId: 'primary',
+      state: 'active',
+    });
+    service.notifyOpenCodeLeadTurnActivity({
+      teamName: 'team-a',
+      memberName: 'team-lead',
+      laneId: 'primary',
+      state: 'idle',
+    });
+    service.notifyOpenCodeLeadTurnActivity({
+      teamName: 'team-b',
+      memberName: 'team-lead',
+      laneId: 'primary',
+      state: 'active',
+    });
+
+    expect(setLeadActivity.mock.calls).toEqual([
+      [run, 'active'],
+      [run, 'idle'],
+    ]);
+  });
 });
 
 function createService(
@@ -194,6 +234,7 @@ function createDeps(overrides: Partial<TestDeps> = {}): TestDeps {
     })),
     isCurrentTrackedRun: vi.fn(() => true),
     setLeadActivity: vi.fn(),
+    resolveLeadActivityRun: vi.fn(() => null),
     logger: {
       warn: vi.fn(),
     },

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.test.ts
@@ -136,7 +136,43 @@ describe('TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService', ()
     expect(deps.getCleanedStoppedTeamOpenCodeRuntimeLanes).toHaveBeenCalled();
   });
 
-  it('forwards OpenCode lead turn activity to setLeadActivity for the tracked run only', () => {
+  it('ignores an old turn that finishes after a replacement run starts', async () => {
+    let releaseDirectory!: (
+      directory: Awaited<ReturnType<TestDeps['readLeadActivityDirectory']>>
+    ) => void;
+    const directory = new Promise<Awaited<ReturnType<TestDeps['readLeadActivityDirectory']>>>(
+      (resolve) => {
+        releaseDirectory = resolve;
+      }
+    );
+    let run: TestSendRun = {
+      teamName: 'team-a',
+      runId: 'old-run',
+      processKilled: false,
+      cancelRequested: false,
+      request: {},
+      child: null,
+    };
+    const setLeadActivity = vi.fn();
+    const service = createService({
+      setLeadActivity,
+      resolveLeadActivityRun: () => run,
+      readLeadActivityDirectory: () => directory,
+    });
+    const notification = service.notifyOpenCodeLeadTurnActivity({
+      teamName: 'team-a',
+      memberName: 'team-lead',
+      laneId: 'primary',
+      runId: 'old-run',
+      state: 'idle',
+    });
+    run = { ...run, runId: 'new-run' };
+    releaseDirectory({ config: null, teamMeta: null, metaMembers: [] });
+    await notification;
+    expect(setLeadActivity).not.toHaveBeenCalled();
+  });
+
+  it('forwards OpenCode lead turn activity to setLeadActivity for the tracked run only', async () => {
     const run = {
       teamName: 'team-a',
       runId: 'run-1',
@@ -151,25 +187,35 @@ describe('TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService', ()
     );
     const service = createService({ setLeadActivity, resolveLeadActivityRun });
 
-    service.notifyOpenCodeLeadTurnActivity({
+    await service.notifyOpenCodeLeadTurnActivity({
       teamName: 'team-a',
       memberName: 'team-lead',
       laneId: 'primary',
+      runId: 'run-1',
       state: 'active',
     });
-    service.notifyOpenCodeLeadTurnActivity({
+    await service.notifyOpenCodeLeadTurnActivity({
       teamName: 'team-a',
       memberName: 'team-lead',
       laneId: 'primary',
+      runId: 'run-1',
       state: 'idle',
     });
-    service.notifyOpenCodeLeadTurnActivity({
+    await service.notifyOpenCodeLeadTurnActivity({
       teamName: 'team-b',
       memberName: 'team-lead',
       laneId: 'primary',
+      runId: 'run-1',
       state: 'active',
     });
 
+    for (const input of [
+      { memberName: 'builder', runId: 'run-1', laneId: 'primary' },
+      { memberName: 'team-lead', runId: 'old-run', laneId: 'primary' },
+      { memberName: 'team-lead', runId: 'run-1', laneId: 'secondary:opencode:builder' },
+    ]) {
+      await service.notifyOpenCodeLeadTurnActivity({ teamName: 'team-a', state: 'idle', ...input });
+    }
     expect(setLeadActivity.mock.calls).toEqual([
       [run, 'active'],
       [run, 'idle'],
@@ -235,6 +281,11 @@ function createDeps(overrides: Partial<TestDeps> = {}): TestDeps {
     isCurrentTrackedRun: vi.fn(() => true),
     setLeadActivity: vi.fn(),
     resolveLeadActivityRun: vi.fn(() => null),
+    readLeadActivityDirectory: vi.fn(async () => ({
+      config: null,
+      teamMeta: null,
+      metaMembers: [],
+    })),
     logger: {
       warn: vi.fn(),
     },

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberMessageDeliveryServiceFactory.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberMessageDeliveryServiceFactory.test.ts
@@ -3,6 +3,10 @@ import path from 'path';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS,
+  OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS,
+} from '../../opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy';
+import {
   createOpenCodeMemberMessageDeliveryService,
   createOpenCodeMemberMessageDeliveryServiceFromHost,
   createOpenCodeRuntimeBootstrapEvidencePorts,
@@ -140,5 +144,11 @@ describe('TeamProvisioningOpenCodeMemberMessageDeliveryServiceFactory', () => {
       )
     ).toBe(true);
     expect(host.providerRuntime.resolveControlApiBaseUrl()).toBe('http://127.0.0.1:1234');
+    // The stale-pending windows are composed in here, not defaulted inside the
+    // policy, so the shipped pipeline states them exactly once.
+    expect(host.openCodeStalePendingPolicyConfig).toEqual({
+      staleAfterMs: OPENCODE_PROMPT_DELIVERY_STALE_PENDING_MS,
+      hardCapMs: OPENCODE_PROMPT_DELIVERY_STALE_PENDING_HARD_CAP_MS,
+    });
   });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerFactory.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerFactory.test.ts
@@ -12,7 +12,13 @@ describe('TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerFactory', () =>
     const service = {
       canDeliverToOpenCodeRuntimeForTeam: vi.fn(() => true),
       tryRecoverOpenCodeRuntimeLaneForConfiguredMemberBeforeDelivery: vi.fn(async () => true),
-      relayOpenCodeMemberInboxMessages: vi.fn(async () => undefined),
+      relayOpenCodeMemberInboxMessages: vi.fn(async () => ({
+        attempted: 0,
+        delivered: 0,
+        relayed: 0,
+        failed: 0,
+        skipped: 0,
+      })),
       inboxReader: {
         getMessagesFor: vi.fn(async () => [{ messageId: 'message-1', read: false }]),
       },
@@ -68,6 +74,40 @@ describe('TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerFactory', () =>
       service.openCodeRuntimeRecoveryIdentity.isOpenCodeRuntimeLaneIndexActive
     ).toHaveBeenCalledWith('alpha', 'lane-builder');
 
+    service.relayOpenCodeMemberInboxMessages.mockClear();
+    service.relayOpenCodeMemberInboxMessages.mockResolvedValueOnce({
+      attempted: 1,
+      delivered: 0,
+      relayed: 0,
+      failed: 1,
+      skipped: 0,
+      lastDelivery: {
+        delivered: false,
+        accepted: true,
+        ledgerStatus: 'failed_terminal',
+        reason: 'opencode_stale_pending_observe_window_exhausted',
+      },
+    } as never);
+    await deps.relay({ teamName: 'alpha', memberName: 'Builder', messageId: 'message-1' });
+    expect(service.relayOpenCodeMemberInboxMessages.mock.calls).toEqual([
+      ['alpha', 'Builder', { onlyMessageId: 'message-1', source: 'watchdog' }],
+      ['alpha', 'Builder', { source: 'watchdog' }],
+    ]);
+
+    for (const reason of ['opencode_prompt_delivery_cancelled', 'force_stop_requested']) {
+      service.relayOpenCodeMemberInboxMessages.mockClear();
+      service.relayOpenCodeMemberInboxMessages.mockResolvedValueOnce({
+        attempted: 0,
+        delivered: 0,
+        relayed: 0,
+        failed: 1,
+        skipped: 0,
+        lastDelivery: { delivered: false, ledgerStatus: 'failed_terminal', reason },
+      } as never);
+      await deps.relay({ teamName: 'alpha', memberName: 'Builder', messageId: 'old-run-message' });
+      expect(service.relayOpenCodeMemberInboxMessages).toHaveBeenCalledOnce();
+    }
+
     deps.info('info');
     deps.warn('warn');
     deps.debug('debug');
@@ -81,7 +121,13 @@ describe('TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerFactory', () =>
       {
         canDeliverToOpenCodeRuntimeForTeam: () => true,
         tryRecoverOpenCodeRuntimeLaneForConfiguredMemberBeforeDelivery: async () => true,
-        relayOpenCodeMemberInboxMessages: async () => undefined,
+        relayOpenCodeMemberInboxMessages: async () => ({
+          attempted: 0,
+          delivered: 0,
+          relayed: 0,
+          failed: 0,
+          skipped: 0,
+        }),
         inboxReader: {
           getMessagesFor: async () => [],
         },

--- a/test/main/services/team/OpenCodeMemberMessageDeliveryService.test.ts
+++ b/test/main/services/team/OpenCodeMemberMessageDeliveryService.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { OpenCodeMemberMessageDeliveryService } from '../../../../src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService';
+import { OPENCODE_STALE_PENDING_POLICY_CONFIG } from '../../../../src/main/services/team/opencode/delivery/OpenCodePromptDeliveryStalePendingPolicy';
 
 import type {
   OpenCodeMemberMessageDeliveryServiceDependencies,
@@ -8,9 +9,7 @@ import type {
 } from '../../../../src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryPorts';
 import type { OpenCodePromptDeliveryLedgerRecord } from '../../../../src/main/services/team/opencode/delivery/OpenCodePromptDeliveryLedger';
 
-function makeAdapter(
-  sendMessageToMember = vi.fn()
-): OpenCodeRuntimeMessageAdapter {
+function makeAdapter(sendMessageToMember = vi.fn()): OpenCodeRuntimeMessageAdapter {
   return {
     providerId: 'opencode',
     prepare: vi.fn(),
@@ -150,6 +149,7 @@ function makeDeps(
     openCodePromptDeliveryFollowUpPolicy: {
       schedule: vi.fn(async () => unexpected('openCodePromptDeliveryFollowUpPolicy.schedule')),
     },
+    openCodeStalePendingPolicyConfig: OPENCODE_STALE_PENDING_POLICY_CONFIG,
     isOpenCodeDeliveryResponseReadCommitAllowed: vi.fn(async () => true),
     getOpenCodeDeliveryPendingReason: vi.fn(() => 'opencode_delivery_response_pending'),
     markOpenCodeAcceptedDeliveryMissingPromptProofForRetry: vi.fn(async () =>
@@ -171,29 +171,26 @@ function makeDeps(
 }
 
 describe('OpenCodeMemberMessageDeliveryService', () => {
-  it(
-    'returns bridge unavailable before reading member directory when runtime adapter is missing',
-    async () => {
-      const readOpenCodeMemberDirectory = vi.fn(async () =>
-        unexpected('readOpenCodeMemberDirectory')
-      );
-      const deps = makeDeps({
-        getOpenCodeRuntimeMessageAdapter: () => null,
-        readOpenCodeMemberDirectory,
-      });
+  it('returns bridge unavailable before reading member directory when runtime adapter is missing', async () => {
+    const readOpenCodeMemberDirectory = vi.fn(async () =>
+      unexpected('readOpenCodeMemberDirectory')
+    );
+    const deps = makeDeps({
+      getOpenCodeRuntimeMessageAdapter: () => null,
+      readOpenCodeMemberDirectory,
+    });
 
-      await expect(
-        new OpenCodeMemberMessageDeliveryService(deps).deliver('team-a', {
-          memberName: 'alice',
-          text: 'hello',
-        })
-      ).resolves.toEqual({
-        delivered: false,
-        reason: 'opencode_runtime_message_bridge_unavailable',
-      });
-      expect(readOpenCodeMemberDirectory).not.toHaveBeenCalled();
-    }
-  );
+    await expect(
+      new OpenCodeMemberMessageDeliveryService(deps).deliver('team-a', {
+        memberName: 'alice',
+        text: 'hello',
+      })
+    ).resolves.toEqual({
+      delivered: false,
+      reason: 'opencode_runtime_message_bridge_unavailable',
+    });
+    expect(readOpenCodeMemberDirectory).not.toHaveBeenCalled();
+  });
 
   it('keeps the legacy unavailable-recipient reason mapping at the facade boundary', async () => {
     const deps = makeDeps({
@@ -354,9 +351,11 @@ describe('OpenCodeMemberMessageDeliveryService', () => {
     };
     const deps = makeDeps({
       getOpenCodeRuntimeMessageAdapter: () =>
-        makeAdapter(vi.fn(async () => {
-          throw new Error('bridge down');
-        })),
+        makeAdapter(
+          vi.fn(async () => {
+            throw new Error('bridge down');
+          })
+        ),
       createOpenCodePromptDeliveryLedger: vi.fn(() => ledger as never),
       openCodePromptDeliveryWatchdogScheduler: { isEnabled: vi.fn(() => true) },
       openCodeVisibleReplyProofService: {

--- a/test/main/services/team/TeamProvisioningServiceRelay.test.ts
+++ b/test/main/services/team/TeamProvisioningServiceRelay.test.ts
@@ -2853,7 +2853,7 @@ Messages:
     expect(rows[0].read).toBe(false);
   });
 
-  it('keeps accepted OpenCode prompt rows pending without warning when response proof is terminally absent', async () => {
+  it('reports accepted OpenCode terminal proof failures while preserving the unread inbox row', async () => {
     const service = new TeamProvisioningService();
     const teamName = 'my-team';
     hoisted.files.set(
@@ -2897,7 +2897,7 @@ Messages:
       relayed: 0,
       attempted: 1,
       delivered: 0,
-      failed: 0,
+      failed: 1,
       lastDelivery: {
         delivered: false,
         accepted: true,
@@ -2906,9 +2906,11 @@ Messages:
         reason: 'empty_assistant_turn',
       },
     });
-    expect(vi.mocked(console.warn)).not.toHaveBeenCalledWith(
-      expect.stringContaining('OpenCode inbox relay failed')
+    expect(vi.mocked(console.warn)).toHaveBeenCalledOnce();
+    expect(vi.mocked(console.warn).mock.calls[0]?.join(' ')).toContain(
+      '[my-team] OpenCode inbox relay failed for jack/opencode-accepted-terminal-empty-1: empty_assistant_turn'
     );
+    vi.mocked(console.warn).mockClear();
     const rows = JSON.parse(hoisted.files.get(`/mock/teams/${teamName}/inboxes/jack.json`) ?? '[]');
     expect(rows[0].read).toBe(false);
   });

--- a/test/renderer/features/runtime-provider-management/useRuntimeProviderManagement.test.ts
+++ b/test/renderer/features/runtime-provider-management/useRuntimeProviderManagement.test.ts
@@ -1,5 +1,5 @@
 import React, { act } from 'react';
-import { createRoot } from 'react-dom/client';
+import { createRoot as createReactRoot } from 'react-dom/client';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -126,9 +126,16 @@ function createEmptyDirectoryResponse(
 }
 
 describe('useRuntimeProviderManagement', () => {
+  const roots = new Set<ReturnType<typeof createReactRoot>>();
   let host: HTMLDivElement;
   let state: RuntimeProviderManagementState | null = null;
   let actions: RuntimeProviderManagementActions | null = null;
+
+  function createRoot(container: HTMLDivElement): ReturnType<typeof createReactRoot> {
+    const root = createReactRoot(container);
+    roots.add(root);
+    return root;
+  }
 
   function Harness(): React.ReactElement {
     const hook = useRuntimeProviderManagement({
@@ -199,7 +206,12 @@ describe('useRuntimeProviderManagement', () => {
     actions = null;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Removing DOM alone leaves effects alive and able to overwrite the next test's state.
+    await act(async () => {
+      for (const root of roots) root.unmount();
+    });
+    roots.clear();
     Reflect.deleteProperty(window, 'electronAPI');
     document.body.innerHTML = '';
     vi.unstubAllGlobals();


### PR DESCRIPTION
OpenCode deliveries can keep a lane blocked after a completed plain-text turn, while a bridge-driven lead stays Idle. This change uses observed session activity to settle eligible deliveries and reports activity for the current canonical lead.

- A reply-optional delivery settles only after assistant evidence and a fresh, explicitly idle observation.
- Busy and unknown sessions remain observed regardless of age. Accepted prompts are not resent to make room for a newer message.
- A stale required-reply delivery with explicit idle evidence ends with a diagnostic failure, remains unread, and wakes the queue once. It is not reported as a successful answer.
- Acceptance recovered through observe emits Active without another send. Same-model teammates and callbacks from superseded runs cannot update lead activity.
- Delivery helpers keep the existing process boundaries and frozen architecture limits.

Validation: focused policy, real-service relay, activity, identity and callback-race tests; typecheck, source-size/provisioning guards and lint. Current CI is attached to the PR head. Review verification used mocks and fresh temporary stores; no real user project or runtime was launched.

Original feature implementation was authored with Claude (Fable 5) and verified on Windows by the PR author. This description reflects the subsequent review corrections as well.
