### PR TITLE
fix(team): a lead relay redelivery is proved by activity and announces itself

### DIFF
--- a/src/main/services/team/provisioning/TeamProvisioningCleanup.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningCleanup.ts
@@ -2,6 +2,10 @@ import {
   removeDeterministicBootstrapSpecFile,
   removeDeterministicBootstrapUserPromptFile,
 } from './TeamProvisioningBootstrapSpec';
+import {
+  cancelRunLeadRelayCapture,
+  type LeadRelayCaptureOwner,
+} from './TeamProvisioningLeadRelayCancellation';
 
 import type { TeamProvisioningProgress } from '@shared/types';
 import type { ChildProcess } from 'child_process';
@@ -36,7 +40,7 @@ export function clearGeminiPostLaunchHydrationState(run: GeminiPostLaunchHydrati
 }
 
 export interface TeamProvisioningCleanupRun
-  extends PostCompactReminderStateRun, GeminiPostLaunchHydrationStateRun {
+  extends PostCompactReminderStateRun, GeminiPostLaunchHydrationStateRun, LeadRelayCaptureOwner {
   runId: string;
   teamName: string;
   progress: TeamProvisioningProgress;
@@ -199,6 +203,7 @@ export function cleanupProvisioningRun<TRun extends TeamProvisioningCleanupRun>(
   run: TRun,
   ports: TeamProvisioningCleanupPorts<TRun>
 ): void {
+  cancelRunLeadRelayCapture(run);
   const currentProvisioningRunId = ports.provisioningRunByTeam.get(run.teamName) ?? null;
   const currentAliveRunId = ports.aliveRunByTeam.get(run.teamName) ?? null;
   const currentTrackedRunId = ports.getTrackedRunId(run.teamName);

--- a/src/main/services/team/provisioning/TeamProvisioningInboxRelayPolicy.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningInboxRelayPolicy.ts
@@ -618,6 +618,7 @@ export function buildLeadInboxRelayPrompt(input: {
   replyVisibility: 'user' | 'internal_activity';
   teammates: { name: string; role?: string }[];
   workSyncControlUrl: string | null;
+  redeliveredMessageIds?: ReadonlySet<string>;
 }): string {
   const rosterContextBlock = buildLeadRosterContextBlock(
     input.teamName,
@@ -668,11 +669,21 @@ export function buildLeadInboxRelayPrompt(input: {
     ),
     ``,
     `Messages:`,
-    ...input.batch.flatMap((message, idx) => formatLeadRelayMessageLines(message, idx)),
+    ...input.batch.flatMap((message, idx) =>
+      formatLeadRelayMessageLines(
+        message,
+        idx,
+        input.redeliveredMessageIds?.has(message.messageId) === true
+      )
+    ),
   ].join('\n');
 }
 
-function formatLeadRelayMessageLines(message: RelayInboxMessage, idx: number): string[] {
+function formatLeadRelayMessageLines(
+  message: RelayInboxMessage,
+  idx: number,
+  isRedelivery = false
+): string[] {
   const summaryLine = message.summary?.trim() ? `Summary: ${message.summary.trim()}` : null;
   const isTaskCreateFromMessageEligible = message.source === 'user_sent';
   const provenanceLines = isTaskCreateFromMessageEligible
@@ -681,6 +692,12 @@ function formatLeadRelayMessageLines(message: RelayInboxMessage, idx: number): s
   const structuredTaskContextBlock = buildLeadInboxTaskContextBlock(message);
   return [
     `${idx + 1}) From: ${message.from || 'unknown'}`,
+    ...(isRedelivery
+      ? [
+          `   REDELIVERY: this exact message was already delivered to you in an earlier turn and you may have already fully handled it.`,
+          `   Before acting on it, check the current board and recent messages (task_list etc.). Do NOT re-create tasks, re-send messages, or repeat any side effect that already exists for this message; if everything is already handled, produce no output for it.`,
+        ]
+      : []),
     `   Timestamp: ${message.timestamp}`,
     ...(summaryLine ? [`   ${summaryLine}`] : []),
     ...(typeof message.messageKind === 'string' && message.messageKind.trim()

--- a/src/main/services/team/provisioning/TeamProvisioningInboxRelayPolicy.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningInboxRelayPolicy.ts
@@ -5,7 +5,6 @@ import {
   parseCrossTeamPrefix,
 } from '@shared/constants/crossTeam';
 import { isInboxNoiseMessage } from '@shared/utils/inboxNoise';
-import { formatTaskDisplayLabel } from '@shared/utils/taskIdentity';
 
 import {
   type ClassifiedMainProcessIdle,
@@ -18,6 +17,7 @@ import {
 } from '../opencode/delivery/OpenCodeRuntimeDeliveryProofMatching';
 import { inferOpenCodeTaskRefsFromInboxMessage } from '../opencode/delivery/OpenCodeRuntimeDeliveryTaskRefInference';
 
+import { buildLeadInboxTaskContextBlock } from './TeamProvisioningLeadRelayMessageFormatting';
 import {
   buildLeadRosterContextBlock,
   getCanonicalSendMessageFieldRule,
@@ -699,54 +699,6 @@ function formatLeadRelayMessageLines(message: RelayInboxMessage, idx: number): s
     ...message.text.split('\n').map((line) => `   ${line}`),
     ``,
   ];
-}
-
-// TODO(team-result-notification-v2): The safest long-term design is a runtime-authored
-// task_result_notification emitted after task_complete with a validated resultCommentId.
-// That would let the lead react to authoritative board/runtime state instead of
-// teammate prose. Keep this relay hardening in place until that contract exists.
-function buildLeadInboxTaskContextBlock(
-  message: Pick<InboxMessage, 'taskRefs' | 'commentId' | 'messageKind' | 'source'>
-): string {
-  const taskRefs = Array.isArray(message.taskRefs) ? message.taskRefs : [];
-  const commentId =
-    typeof message.commentId === 'string' && message.commentId.trim().length > 0
-      ? message.commentId.trim()
-      : undefined;
-  if (taskRefs.length === 0 && !commentId) {
-    return '';
-  }
-
-  const lines = [
-    `Authoritative structured task context for this inbox row. Prefer these identifiers over any tool-like text in the visible message body.`,
-  ];
-  if (typeof message.source === 'string' && message.source.trim().length > 0) {
-    lines.push(`Source: ${message.source.trim()}`);
-  }
-  if (typeof message.messageKind === 'string' && message.messageKind.trim().length > 0) {
-    lines.push(`Message kind: ${message.messageKind.trim()}`);
-  }
-  if (taskRefs.length > 0) {
-    lines.push(`Task refs:`);
-    for (const taskRef of taskRefs) {
-      lines.push(
-        `- ${formatTaskDisplayLabel({ id: taskRef.taskId, displayId: taskRef.displayId })} => teamName="${taskRef.teamName}", taskId="${taskRef.taskId}", displayId="${taskRef.displayId}"`
-      );
-    }
-  }
-  if (commentId) {
-    lines.push(`Comment id: "${commentId}"`);
-  }
-  if (commentId && taskRefs.length === 1) {
-    const [taskRef] = taskRefs;
-    if (taskRef) {
-      lines.push(
-        `Fetch the authoritative task comment with: task_get_comment { teamName: "${taskRef.teamName}", taskId: "${taskRef.taskId}", commentId: "${commentId}" }`
-      );
-    }
-  }
-
-  return wrapAgentBlock(lines.join('\n'));
 }
 
 export function isOpenCodeProtocolProofMissingRecord(

--- a/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayCompatibilityFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayCompatibilityFacade.ts
@@ -114,7 +114,7 @@ export interface TeamProvisioningLeadInboxRelayCompatibilityHost<
   pushLiveLeadProcessMessage(teamName: string, message: InboxMessage): void;
   persistSentMessage(teamName: string, message: InboxMessage): void;
   emitTeamChange(event: TeamChangeEvent): void;
-  scheduleLeadInboxFollowUpRelay(teamName: string): void;
+  scheduleLeadInboxFollowUpRelay(teamName: string, delayMs?: number): void;
   trimRelayedSet(relayedIds: Set<string>): Set<string>;
   hasAcceptedMemberWorkSyncReport(input: {
     teamName: string;
@@ -225,8 +225,7 @@ export function createTeamProvisioningLeadInboxRelayCompatibilityFacadeFromServi
         service.pushLiveLeadProcessMessage(teamName, message),
       persistSentMessage: (teamName, message) => service.persistSentMessage(teamName, message),
       emitTeamChange: (event) => service.teamChangeEmitter?.(event),
-      scheduleLeadInboxFollowUpRelay: (teamName) =>
-        service.scheduleLeadInboxFollowUpRelay(teamName),
+      scheduleLeadInboxFollowUpRelay: (...args) => service.scheduleLeadInboxFollowUpRelay(...args),
       trimRelayedSet: (relayedIds) => service.trimRelayedSet(relayedIds),
       hasAcceptedMemberWorkSyncReport: (input) =>
         service.memberWorkSyncProofBoundary.hasAcceptedMemberWorkSyncReport(input),
@@ -299,8 +298,8 @@ export class TeamProvisioningLeadInboxRelayCompatibilityFacade<
         this.host.pushLiveLeadProcessMessage(teamName, message),
       persistSentMessage: (teamName, message) => this.host.persistSentMessage(teamName, message),
       emitTeamChange: (event) => this.host.emitTeamChange(event),
-      scheduleLeadInboxFollowUpRelay: (teamName) =>
-        this.host.scheduleLeadInboxFollowUpRelay(teamName),
+      scheduleLeadInboxFollowUpRelay: (...args) =>
+        this.host.scheduleLeadInboxFollowUpRelay(...args),
       rememberLeadRecoveryMessage: (teamName, messageId) =>
         this.rememberLeadRecoveryMessage(teamName, messageId),
       rememberSuccessfulLeadRecoveryMessage: (teamName, messageId) =>

--- a/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayFlow.ts
@@ -599,9 +599,17 @@ function startLeadRelayCapture<TRun extends LeadInboxRelayFlowRun>(
       // producing duplicate task sets and near-identical user messages.
       touch: () => {
         if (capture.settled) return;
-        if (ports.nowMs() - captureStartedAtMs >= LEAD_RELAY_CAPTURE_ABSOLUTE_CAP_MS) return;
+        const remainingCapMs =
+          LEAD_RELAY_CAPTURE_ABSOLUTE_CAP_MS - (ports.nowMs() - captureStartedAtMs);
+        if (remainingCapMs <= 0) return;
         ports.clearTimeout(capture.timeoutHandle);
-        capture.timeoutHandle = ports.setTimeout(onCaptureDeadline, captureTimeoutMs);
+        // The re-armed deadline may never outlive the absolute cap: activity just before the cap
+        // would otherwise buy another full base deadline and keep a wedged lane captured for far
+        // longer than the cap promises.
+        capture.timeoutHandle = ports.setTimeout(
+          onCaptureDeadline,
+          Math.min(captureTimeoutMs, remainingCapMs)
+        );
       },
       resolveOnce: (text: string) => {
         if (capture.settled) return;

--- a/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayFlow.ts
@@ -24,6 +24,7 @@ import {
 } from './TeamProvisioningInboxRelayPolicy';
 import { scanLeadInboxPermissionRequests } from './TeamProvisioningLeadPermissionScan';
 import { joinLeadRelayCaptureText } from './TeamProvisioningLeadProcessMessages';
+import { cancelRunLeadRelayCapture } from './TeamProvisioningLeadRelayCancellation';
 import { projectLeadRelayReply } from './TeamProvisioningLeadRelayProjection';
 
 import type { InboxMessage, TeamChangeEvent } from '@shared/types';
@@ -368,6 +369,7 @@ async function runLeadInboxRelayForTeam<TRun extends LeadInboxRelayFlowRun>(
   const { nativeMatchedMessageIds, persisted: sameTeamPersisted } =
     await ports.confirmSameTeamNativeMatches(teamName, leadName, remainingUnread);
 
+  if (isStaleRelayRun()) return 0;
   const runStartedAtMs = Date.parse(run.startedAt);
   const deferredByAge = remainingUnread.filter(
     (message) =>
@@ -441,6 +443,7 @@ async function runLeadInboxRelayForTeam<TRun extends LeadInboxRelayFlowRun>(
       ...(member.role?.trim() ? { role: member.role.trim() } : {}),
     }));
   const workSyncControlUrl = await ports.resolveControlApiBaseUrl();
+  if (isStaleRelayRun()) return 0;
   run.activeCrossTeamReplyHints = buildLeadActiveCrossTeamReplyHints(batch);
   const redeliveredMessageIds = markLeadRelayAttemptsAndCollectRedeliveries(
     ports.relayedLeadInboxMessageIds,
@@ -465,17 +468,18 @@ async function runLeadInboxRelayForTeam<TRun extends LeadInboxRelayFlowRun>(
     ports
   );
 
+  // Observe rejection before sending: stop/cleanup may cancel while transport is pending.
+  const finalizedCapture = finalizeLeadRelayCapture(run, capturePromise, ports);
   try {
-    await ports.sendMessageToRun(run, message);
+    await Promise.race([ports.sendMessageToRun(run, message), finalizedCapture]);
   } catch {
-    if (run.leadRelayCapture) {
-      ports.clearTimeout(run.leadRelayCapture.timeoutHandle);
-      run.leadRelayCapture = null;
-    }
+    cancelRunLeadRelayCapture(run);
+    await finalizedCapture;
     return 0;
   }
 
-  const captureResult = await finalizeLeadRelayCapture(run, capturePromise, ports);
+  const captureResult = await finalizedCapture;
+  if (isStaleRelayRun()) return 0;
   if (!captureResult.deliveryConfirmed) {
     run.activeCrossTeamReplyHints = [];
     ports.logger.debug(
@@ -505,6 +509,7 @@ async function runLeadInboxRelayForTeam<TRun extends LeadInboxRelayFlowRun>(
     hasAcceptedLeadWorkSyncReport: ports.hasAcceptedLeadWorkSyncReport,
     scheduleLeadProofMissingWorkSyncRecovery: ports.scheduleLeadProofMissingWorkSyncRecovery,
   });
+  if (isStaleRelayRun()) return 0;
   for (const m of readCommitBatch) {
     relayedIds.add(m.messageId);
   }
@@ -517,6 +522,7 @@ async function runLeadInboxRelayForTeam<TRun extends LeadInboxRelayFlowRun>(
     }
   }
 
+  if (isStaleRelayRun()) return 0;
   const replyProjection = projectLeadRelayReply({
     replyText: captureResult.replyText,
     relayPrompt: message,
@@ -578,7 +584,7 @@ function startLeadRelayCapture<TRun extends LeadInboxRelayFlowRun>(
   const captureStartedAtMs = ports.nowMs();
   return new Promise<string>((resolve, reject) => {
     const onCaptureDeadline = (): void => {
-      reject(new Error('Timed out waiting for lead reply'));
+      capture.rejectOnce('Timed out waiting for lead reply');
     };
     const timeoutHandle = ports.setTimeout(onCaptureDeadline, captureTimeoutMs);
     const capture: LeadInboxRelayCapture = {

--- a/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayFlow.ts
@@ -57,6 +57,7 @@ export interface LeadInboxRelayCapture {
   settled: boolean;
   idleHandle: NodeJS.Timeout | null;
   idleMs: number;
+  touch?: () => void;
   resolveOnce: (text: string) => void;
   rejectOnce: (error: string) => void;
   timeoutHandle: NodeJS.Timeout;
@@ -113,7 +114,7 @@ export interface LeadInboxRelayFlowPorts<TRun extends LeadInboxRelayFlowRun> {
   pushLiveLeadProcessMessage(teamName: string, message: InboxMessage): void;
   persistSentMessage(teamName: string, message: InboxMessage): void;
   emitTeamChange(event: TeamChangeEvent): void;
-  scheduleLeadInboxFollowUpRelay(teamName: string): void;
+  scheduleLeadInboxFollowUpRelay(teamName: string, delayMs?: number): void;
   rememberLeadRecoveryMessage(teamName: string, messageId: string): void;
   rememberSuccessfulLeadRecoveryMessage(teamName: string, messageId: string): void;
   relayedLeadInboxMessageIds: Map<string, Set<string>>;
@@ -134,7 +135,62 @@ export interface LeadInboxRelayOptions {
   onlyMessageId?: string;
 }
 
+// A lead turn that is running tools produces no assistant text, so a short reply deadline used to
+// declare a delivered message undelivered mid-turn. The deadline is now generous and activity
+// extends it; the absolute cap still bounds a wedged lane.
+const LEAD_RELAY_CAPTURE_TIMEOUT_MS = 120_000;
+const LEAD_RELAY_CAPTURE_ABSOLUTE_CAP_MS = 600_000;
+const LEAD_RELAY_NO_PROOF_RETRY_DELAY_MS = 10_000;
+const LEAD_RELAY_ATTEMPTED_ID_LIMIT = 300;
+
 const leadInboxRelayQueues = new WeakMap<Map<string, Set<string>>, Map<string, Promise<number>>>();
+
+// Message ids already sent to the lead at least once, even without delivery proof, keyed by the
+// same per-service identity map as the relay queues. A retry of such a message is marked as a
+// redelivery in the relay prompt so a memoryless lead checks board state before repeating side
+// effects it may already have performed.
+const attemptedLeadRelayIdsRegistry = new WeakMap<
+  Map<string, Set<string>>,
+  Map<string, Set<string>>
+>();
+
+function getAttemptedLeadRelayIdsByTeam(
+  identity: Map<string, Set<string>>
+): Map<string, Set<string>> {
+  let byTeam = attemptedLeadRelayIdsRegistry.get(identity);
+  if (!byTeam) {
+    byTeam = new Map();
+    attemptedLeadRelayIdsRegistry.set(identity, byTeam);
+  }
+  return byTeam;
+}
+
+function markLeadRelayAttemptsAndCollectRedeliveries(
+  identity: Map<string, Set<string>>,
+  teamName: string,
+  batch: readonly { messageId: string }[]
+): Set<string> {
+  const attemptedByTeam = getAttemptedLeadRelayIdsByTeam(identity);
+  let attemptedIds = attemptedByTeam.get(teamName);
+  if (!attemptedIds) {
+    attemptedIds = new Set<string>();
+    attemptedByTeam.set(teamName, attemptedIds);
+  }
+  const redeliveredMessageIds = new Set(
+    batch
+      .filter((relayMessage) => attemptedIds.has(relayMessage.messageId))
+      .map((relayMessage) => relayMessage.messageId)
+  );
+  for (const relayMessage of batch) {
+    attemptedIds.add(relayMessage.messageId);
+  }
+  while (attemptedIds.size > LEAD_RELAY_ATTEMPTED_ID_LIMIT) {
+    const oldest = attemptedIds.values().next().value;
+    if (oldest === undefined) break;
+    attemptedIds.delete(oldest);
+  }
+  return redeliveredMessageIds;
+}
 
 export async function relayLeadInboxMessagesForTeam<TRun extends LeadInboxRelayFlowRun>(
   teamName: string,
@@ -386,6 +442,11 @@ async function runLeadInboxRelayForTeam<TRun extends LeadInboxRelayFlowRun>(
     }));
   const workSyncControlUrl = await ports.resolveControlApiBaseUrl();
   run.activeCrossTeamReplyHints = buildLeadActiveCrossTeamReplyHints(batch);
+  const redeliveredMessageIds = markLeadRelayAttemptsAndCollectRedeliveries(
+    ports.relayedLeadInboxMessageIds,
+    teamName,
+    batch
+  );
   const message = buildLeadInboxRelayPrompt({
     teamName,
     leadName,
@@ -393,6 +454,7 @@ async function runLeadInboxRelayForTeam<TRun extends LeadInboxRelayFlowRun>(
     replyVisibility,
     teammates: teammateRoster,
     workSyncControlUrl,
+    redeliveredMessageIds,
   });
 
   const capturePromise = startLeadRelayCapture(
@@ -419,7 +481,7 @@ async function runLeadInboxRelayForTeam<TRun extends LeadInboxRelayFlowRun>(
     ports.logger.debug(
       `[${teamName}] lead relay did not receive delivery proof; leaving ${batch.length} message(s) unread for retry`
     );
-    ports.scheduleLeadInboxFollowUpRelay(teamName);
+    ports.scheduleLeadInboxFollowUpRelay(teamName, LEAD_RELAY_NO_PROOF_RETRY_DELAY_MS);
     return 0;
   }
   if (recoveryMessageId && captureResult.terminalResultSucceeded) {
@@ -506,17 +568,19 @@ function startLeadRelayCapture<TRun extends LeadInboxRelayFlowRun>(
   leadName: string,
   replyVisibility: 'user' | 'internal_activity',
   recoveryMessageId: string | undefined,
-  ports: Pick<LeadInboxRelayFlowPorts<TRun>, 'clearTimeout' | 'nowIso' | 'setTimeout'>
+  ports: Pick<LeadInboxRelayFlowPorts<TRun>, 'clearTimeout' | 'nowIso' | 'nowMs' | 'setTimeout'>
 ): Promise<string> {
-  const captureTimeoutMs = 15_000;
+  const captureTimeoutMs = LEAD_RELAY_CAPTURE_TIMEOUT_MS;
   // The target stream parser resolves ordinary captures after a short text-idle window. Recovery
   // delivery needs stronger proof: keep its idle deadline beyond the hard capture timeout so only
   // a terminal result can resolve it before the timeout rejects the delivery.
   const captureIdleMs = recoveryMessageId ? captureTimeoutMs + 1 : 800;
+  const captureStartedAtMs = ports.nowMs();
   return new Promise<string>((resolve, reject) => {
-    const timeoutHandle = ports.setTimeout(() => {
+    const onCaptureDeadline = (): void => {
       reject(new Error('Timed out waiting for lead reply'));
-    }, captureTimeoutMs);
+    };
+    const timeoutHandle = ports.setTimeout(onCaptureDeadline, captureTimeoutMs);
     const capture: LeadInboxRelayCapture = {
       leadName,
       startedAt: ports.nowIso(),
@@ -529,6 +593,16 @@ function startLeadRelayCapture<TRun extends LeadInboxRelayFlowRun>(
       idleHandle: null,
       idleMs: captureIdleMs,
       timeoutHandle,
+      // Any lead stream activity (text, tool_use, tool_result) proves the relayed prompt reached a
+      // live lead turn. Extend the reply deadline instead of failing delivery mid-turn: a false
+      // "not delivered" verdict re-sends the same message and a memoryless lead executes it again,
+      // producing duplicate task sets and near-identical user messages.
+      touch: () => {
+        if (capture.settled) return;
+        if (ports.nowMs() - captureStartedAtMs >= LEAD_RELAY_CAPTURE_ABSOLUTE_CAP_MS) return;
+        ports.clearTimeout(capture.timeoutHandle);
+        capture.timeoutHandle = ports.setTimeout(onCaptureDeadline, captureTimeoutMs);
+      },
       resolveOnce: (text: string) => {
         if (capture.settled) return;
         if (recoveryMessageId) {

--- a/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayFlow.ts
@@ -24,7 +24,10 @@ import {
 } from './TeamProvisioningInboxRelayPolicy';
 import { scanLeadInboxPermissionRequests } from './TeamProvisioningLeadPermissionScan';
 import { joinLeadRelayCaptureText } from './TeamProvisioningLeadProcessMessages';
-import { cancelRunLeadRelayCapture } from './TeamProvisioningLeadRelayCancellation';
+import {
+  cancelRunLeadRelayCapture,
+  observeRunLeadRelayCancellation,
+} from './TeamProvisioningLeadRelayCancellation';
 import { projectLeadRelayReply } from './TeamProvisioningLeadRelayProjection';
 
 import type { InboxMessage, TeamChangeEvent } from '@shared/types';
@@ -468,17 +471,39 @@ async function runLeadInboxRelayForTeam<TRun extends LeadInboxRelayFlowRun>(
     ports
   );
 
-  // Observe rejection before sending: stop/cleanup may cancel while transport is pending.
+  // Cancellation stays owned until transport settles, even if reply capture finishes first.
+  const cancellation = observeRunLeadRelayCancellation(run);
+  const transportDeadline = ports.setTimeout(
+    () => cancelRunLeadRelayCapture(run),
+    LEAD_RELAY_CAPTURE_ABSOLUTE_CAP_MS
+  );
   const finalizedCapture = finalizeLeadRelayCapture(run, capturePromise, ports);
+  let captureResult: Awaited<typeof finalizedCapture>;
   try {
-    await Promise.race([ports.sendMessageToRun(run, message), finalizedCapture]);
+    const send = Promise.resolve().then(() => {
+      if (cancellation.isCancelled() || isStaleRelayRun()) return;
+      return ports.sendMessageToRun(run, message);
+    });
+    captureResult = await Promise.race([
+      cancellation.cancelled,
+      // Failed capture drains pending transport; successful capture requires transport success.
+      finalizedCapture.then((result) =>
+        result.deliveryConfirmed ? send.then(() => result) : result
+      ),
+      send.then(() => {
+        ports.clearTimeout(transportDeadline);
+        return finalizedCapture;
+      }),
+    ]);
   } catch {
     cancelRunLeadRelayCapture(run);
     await finalizedCapture;
     return 0;
+  } finally {
+    cancellation.dispose();
+    ports.clearTimeout(transportDeadline);
   }
 
-  const captureResult = await finalizedCapture;
   if (isStaleRelayRun()) return 0;
   if (!captureResult.deliveryConfirmed) {
     run.activeCrossTeamReplyHints = [];
@@ -507,7 +532,10 @@ async function runLeadInboxRelayForTeam<TRun extends LeadInboxRelayFlowRun>(
     leadName,
     batch,
     hasAcceptedLeadWorkSyncReport: ports.hasAcceptedLeadWorkSyncReport,
-    scheduleLeadProofMissingWorkSyncRecovery: ports.scheduleLeadProofMissingWorkSyncRecovery,
+    scheduleLeadProofMissingWorkSyncRecovery: (input) =>
+      isStaleRelayRun()
+        ? Promise.resolve(false)
+        : ports.scheduleLeadProofMissingWorkSyncRecovery(input),
   });
   if (isStaleRelayRun()) return 0;
   for (const m of readCommitBatch) {

--- a/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayPortsFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayPortsFactory.ts
@@ -238,11 +238,22 @@ export function createTeamProvisioningLeadInboxRelayPortsBoundary<
       const onlyMessageId = options?.onlyMessageId?.trim() || null;
       const relayKey = teamName;
       const existing = deps.leadInboxRelayInFlight.get(relayKey);
+      // A caller's 120s observation budget is not the activity-extended capture lifetime.
+      // Keep ownership until the work settles (or lifecycle cleanup removes this run).
+      const releaseOwnershipWhenSettled = (work: Promise<number>): void => {
+        const release = (): void => {
+          if (deps.leadInboxRelayInFlight.get(relayKey) === work) {
+            deps.leadInboxRelayInFlight.delete(relayKey);
+          }
+        };
+        void work.then(release, release);
+      };
       const canShareExisting =
         existing &&
         (!leadInboxRelayScopes.has(existing) ||
           leadInboxRelayScopes.get(existing) === onlyMessageId);
       if (existing && canShareExisting) {
+        releaseOwnershipWhenSettled(existing);
         try {
           return await waitForInFlight({
             promise: existing,
@@ -257,10 +268,6 @@ export function createTeamProvisioningLeadInboxRelayPortsBoundary<
             `[${teamName}] lead_inbox_relay_timed_out: ${deps.getErrorMessage(error)}`
           );
           return 0;
-        } finally {
-          if (deps.leadInboxRelayInFlight.get(relayKey) === existing) {
-            deps.leadInboxRelayInFlight.delete(relayKey);
-          }
         }
       }
 
@@ -271,6 +278,7 @@ export function createTeamProvisioningLeadInboxRelayPortsBoundary<
 
       leadInboxRelayScopes.set(work, onlyMessageId);
       deps.leadInboxRelayInFlight.set(relayKey, work);
+      releaseOwnershipWhenSettled(work);
       try {
         return await waitForInFlight({
           promise: work,
@@ -285,10 +293,6 @@ export function createTeamProvisioningLeadInboxRelayPortsBoundary<
           `[${teamName}] lead_inbox_relay_timed_out: ${deps.getErrorMessage(error)}`
         );
         return 0;
-      } finally {
-        if (deps.leadInboxRelayInFlight.get(relayKey) === work) {
-          deps.leadInboxRelayInFlight.delete(relayKey);
-        }
       }
     },
   };

--- a/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayPortsFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLeadInboxRelayPortsFactory.ts
@@ -144,7 +144,7 @@ export function createTeamProvisioningLeadInboxRelayFlowPorts<TRun extends LeadI
       deps.pushLiveLeadProcessMessage(teamName, message),
     persistSentMessage: (teamName, message) => deps.persistSentMessage(teamName, message),
     emitTeamChange: (event) => deps.emitTeamChange(event),
-    scheduleLeadInboxFollowUpRelay: (teamName) => deps.scheduleLeadInboxFollowUpRelay(teamName),
+    scheduleLeadInboxFollowUpRelay: (...args) => deps.scheduleLeadInboxFollowUpRelay(...args),
     rememberLeadRecoveryMessage: (teamName, messageId) =>
       deps.rememberLeadRecoveryMessage(teamName, messageId),
     rememberSuccessfulLeadRecoveryMessage: (teamName, messageId) =>
@@ -202,7 +202,7 @@ export function createTeamProvisioningLeadInboxRelayPortsDepsFromService<
       service.pushLiveLeadProcessMessage(teamName, message),
     persistSentMessage: (teamName, message) => service.persistSentMessage(teamName, message),
     emitTeamChange: (event) => service.teamChangeEmitter?.(event),
-    scheduleLeadInboxFollowUpRelay: (teamName) => service.scheduleLeadInboxFollowUpRelay(teamName),
+    scheduleLeadInboxFollowUpRelay: (...args) => service.scheduleLeadInboxFollowUpRelay(...args),
     rememberLeadRecoveryMessage: (teamName, messageId) =>
       service.rememberLeadRecoveryMessage(teamName, messageId),
     rememberSuccessfulLeadRecoveryMessage: (teamName, messageId) =>

--- a/src/main/services/team/provisioning/TeamProvisioningLeadRelayCancellation.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLeadRelayCancellation.ts
@@ -1,0 +1,9 @@
+export interface LeadRelayCaptureOwner {
+  leadRelayCapture?: { rejectOnce(error: string): void } | null;
+}
+
+/** Cancel only this run's capture; a replacement run owns its own capture. */
+export function cancelRunLeadRelayCapture(run: LeadRelayCaptureOwner): void {
+  run.leadRelayCapture?.rejectOnce('Lead relay run stopped');
+  run.leadRelayCapture = null;
+}

--- a/src/main/services/team/provisioning/TeamProvisioningLeadRelayCancellation.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLeadRelayCancellation.ts
@@ -2,8 +2,35 @@ export interface LeadRelayCaptureOwner {
   leadRelayCapture?: { rejectOnce(error: string): void } | null;
 }
 
+const pendingRelayCancellations = new WeakMap<LeadRelayCaptureOwner, () => void>();
+
+/** Keep cancellation live even when reply capture finishes before transport delivery. */
+export function observeRunLeadRelayCancellation(run: LeadRelayCaptureOwner): {
+  cancelled: Promise<never>;
+  isCancelled(): boolean;
+  dispose(): void;
+} {
+  let didCancel = false;
+  let cancel!: () => void;
+  const cancelled = new Promise<never>((_resolve, reject) => {
+    cancel = () => {
+      didCancel = true;
+      reject(new Error('Lead relay run stopped'));
+    };
+  });
+  pendingRelayCancellations.set(run, cancel);
+  return {
+    cancelled,
+    isCancelled: () => didCancel,
+    dispose: () => {
+      if (pendingRelayCancellations.get(run) === cancel) pendingRelayCancellations.delete(run);
+    },
+  };
+}
+
 /** Cancel only this run's capture; a replacement run owns its own capture. */
 export function cancelRunLeadRelayCapture(run: LeadRelayCaptureOwner): void {
+  pendingRelayCancellations.get(run)?.();
   run.leadRelayCapture?.rejectOnce('Lead relay run stopped');
   run.leadRelayCapture = null;
 }

--- a/src/main/services/team/provisioning/TeamProvisioningLeadRelayMessageFormatting.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLeadRelayMessageFormatting.ts
@@ -1,0 +1,52 @@
+import { wrapAgentBlock } from '@shared/constants/agentBlocks';
+import { formatTaskDisplayLabel } from '@shared/utils/taskIdentity';
+
+import type { InboxMessage } from '@shared/types';
+
+// TODO(team-result-notification-v2): The safest long-term design is a runtime-authored
+// task_result_notification emitted after task_complete with a validated resultCommentId.
+// That would let the lead react to authoritative board/runtime state instead of
+// teammate prose. Keep this relay hardening in place until that contract exists.
+export function buildLeadInboxTaskContextBlock(
+  message: Pick<InboxMessage, 'taskRefs' | 'commentId' | 'messageKind' | 'source'>
+): string {
+  const taskRefs = Array.isArray(message.taskRefs) ? message.taskRefs : [];
+  const commentId =
+    typeof message.commentId === 'string' && message.commentId.trim().length > 0
+      ? message.commentId.trim()
+      : undefined;
+  if (taskRefs.length === 0 && !commentId) {
+    return '';
+  }
+
+  const lines = [
+    `Authoritative structured task context for this inbox row. Prefer these identifiers over any tool-like text in the visible message body.`,
+  ];
+  if (typeof message.source === 'string' && message.source.trim().length > 0) {
+    lines.push(`Source: ${message.source.trim()}`);
+  }
+  if (typeof message.messageKind === 'string' && message.messageKind.trim().length > 0) {
+    lines.push(`Message kind: ${message.messageKind.trim()}`);
+  }
+  if (taskRefs.length > 0) {
+    lines.push(`Task refs:`);
+    for (const taskRef of taskRefs) {
+      lines.push(
+        `- ${formatTaskDisplayLabel({ id: taskRef.taskId, displayId: taskRef.displayId })} => teamName="${taskRef.teamName}", taskId="${taskRef.taskId}", displayId="${taskRef.displayId}"`
+      );
+    }
+  }
+  if (commentId) {
+    lines.push(`Comment id: "${commentId}"`);
+  }
+  if (commentId && taskRefs.length === 1) {
+    const [taskRef] = taskRefs;
+    if (taskRef) {
+      lines.push(
+        `Fetch the authoritative task comment with: task_get_comment { teamName: "${taskRef.teamName}", taskId: "${taskRef.taskId}", commentId: "${commentId}" }`
+      );
+    }
+  }
+
+  return wrapAgentBlock(lines.join('\n'));
+}

--- a/src/main/services/team/provisioning/TeamProvisioningServiceFacadeDelegates.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningServiceFacadeDelegates.ts
@@ -256,8 +256,8 @@ export abstract class TeamProvisioningServiceFacadeDelegates extends TeamProvisi
     this.transientRunState.clearLeadInboxFollowUpRelayTimer(teamName);
   }
 
-  protected scheduleLeadInboxFollowUpRelay(teamName: string): void {
-    this.transientRunState.scheduleLeadInboxFollowUpRelay(teamName);
+  protected scheduleLeadInboxFollowUpRelay(teamName: string, delayMs?: number): void {
+    this.transientRunState.scheduleLeadInboxFollowUpRelay(teamName, delayMs);
   }
 
   protected resetTeamScopedTransientStateForNewRun(teamName: string): void {

--- a/src/main/services/team/provisioning/TeamProvisioningStopFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStopFlow.ts
@@ -2,6 +2,10 @@ import {
   type AnthropicApiKeyHelperRunOwner,
   cleanupRunOwnedAnthropicApiKeyHelper,
 } from './TeamProvisioningAnthropicApiKeyHelperLease';
+import {
+  cancelRunLeadRelayCapture,
+  type LeadRelayCaptureOwner,
+} from './TeamProvisioningLeadRelayCancellation';
 
 import type { TeamProvisioningProgress } from '@shared/types';
 
@@ -24,7 +28,8 @@ async function awaitAllOwnedProcessStops(stops: Promise<void>[]): Promise<void> 
   }
 }
 
-export interface TeamProvisioningStopRun extends AnthropicApiKeyHelperRunOwner {
+export interface TeamProvisioningStopRun
+  extends AnthropicApiKeyHelperRunOwner, LeadRelayCaptureOwner {
   runId: string;
   teamName: string;
   processKilled: boolean;
@@ -157,6 +162,7 @@ async function stopTeamRuntimeFlow<TRun extends TeamProvisioningStopRun>(
     }
     return;
   }
+  cancelRunLeadRelayCapture(run);
   if (run.processKilled || run.cancelRequested) {
     await awaitAllOwnedProcessStops([
       ports.killTeamProcessAndWait(run.child),

--- a/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
@@ -669,6 +669,9 @@ export function handleTeamProvisioningStreamJsonMessage<TRun extends TeamProvisi
         );
       }
     }
+    if (content.some((block) => block?.type === 'tool_result')) {
+      run.leadRelayCapture?.touch?.();
+    }
     for (const block of content) {
       if (block?.type !== 'tool_result' || typeof block.tool_use_id !== 'string') continue;
       ports.finishRuntimeToolActivity(
@@ -683,6 +686,7 @@ export function handleTeamProvisioningStreamJsonMessage<TRun extends TeamProvisi
   }
   if (msg.type === 'assistant') {
     const content = extractStreamContentBlocks(msg);
+    run.leadRelayCapture?.touch?.();
 
     const hasVisibleSendMessage = hasCapturedVisibleSendMessage(content, run.teamName);
     if (run.leadRelayCapture) {

--- a/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
@@ -642,6 +642,7 @@ export function handleTeamProvisioningStreamJsonMessage<TRun extends TeamProvisi
   msg: Record<string, unknown>,
   ports: TeamProvisioningStreamEventPorts<TRun>
 ): void {
+  if (run.processKilled || run.cancelRequested) return;
   if (!run.detectedSessionId) {
     const sid = typeof msg.session_id === 'string' ? msg.session_id : undefined;
     if (sid && sid.trim().length > 0) {
@@ -651,7 +652,6 @@ export function handleTeamProvisioningStreamJsonMessage<TRun extends TeamProvisi
       );
     }
   }
-
   if (msg.type === 'user') {
     ports.resetLiveLeadTextBuffer(run);
     const rawUserText = extractStreamUserText(msg);

--- a/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
@@ -9,6 +9,12 @@ import { isAgentTeamsToolUse } from '../agentTeamsToolNames';
 import { isWorkspaceTrustLaunchFailureText } from '../TeamLaunchFailureArtifactPack';
 
 import {
+  appendLeadRelayCaptureAssistantText,
+  isSyntheticLeadTextChunk,
+  type LeadRelayCaptureStreamState,
+  resolveLeadRelayCaptureOnTerminalResult,
+} from './leadRelayCaptureStreamHooks';
+import {
   clearGeminiPostLaunchHydrationState,
   clearPostCompactReminderState,
 } from './TeamProvisioningCleanup';
@@ -57,20 +63,7 @@ export interface TeamProvisioningStreamRun {
   memberSpawnStatuses: Map<string, MemberSpawnStatusEntry>;
   isLaunch: boolean;
   anthropicApiKeyHelper: { directory: string } | null;
-  leadRelayCapture: {
-    textParts: string[];
-    textJoinMode?: 'block' | 'stream';
-    recoveryMessageId?: string;
-    requireTerminalResult?: boolean;
-    terminalResultSucceeded?: boolean;
-    hasVisibleSendMessage?: boolean;
-    hasUserVisibleSendMessage?: boolean;
-    settled: boolean;
-    idleHandle: NodeJS.Timeout | null;
-    idleMs: number;
-    resolveOnce: (text: string) => void;
-    rejectOnce: (error: string) => void;
-  } | null;
+  leadRelayCapture: LeadRelayCaptureStreamState | null;
   pendingToolCalls: ToolCallMeta[];
   liveLeadTextBuffer: unknown;
   silentUserDmForward: { mode: 'user_dm' | 'member_inbox_relay' } | null;
@@ -411,17 +404,6 @@ export function getStableLeadThoughtMessageId(msg: Record<string, unknown>): str
   return null;
 }
 
-function isSyntheticLeadTextChunk(msg: Record<string, unknown>): boolean {
-  const message = (msg.message ?? msg) as Record<string, unknown>;
-  return message.model === '<synthetic>' && message.type === 'message';
-}
-
-function joinLeadRelayCaptureText(
-  capture: NonNullable<TeamProvisioningStreamRun['leadRelayCapture']>
-): string {
-  return capture.textParts.join(capture.textJoinMode === 'stream' ? '' : '\n').trim();
-}
-
 function recordDeterministicBootstrapTracking(
   run: TeamProvisioningStreamRun,
   event: string,
@@ -734,23 +716,11 @@ export function handleTeamProvisioningStreamJsonMessage<TRun extends TeamProvisi
       }
 
       if (run.leadRelayCapture && !run.leadRelayCapture.settled) {
-        const capture = run.leadRelayCapture;
-        if (isSyntheticLeadTextChunk(msg)) {
-          capture.textJoinMode = 'stream';
-        } else if (!capture.textJoinMode) {
-          capture.textJoinMode = 'block';
-        }
-        capture.textParts.push(text);
-        capture.textParts = ports.boundProgressAssistantParts(capture.textParts);
-        if (capture.idleHandle) {
-          clearTimeout(capture.idleHandle);
-        }
-        if (!capture.requireTerminalResult) {
-          capture.idleHandle = setTimeout(() => {
-            const combined = joinLeadRelayCaptureText(capture);
-            capture.resolveOnce(combined);
-          }, capture.idleMs);
-        }
+        appendLeadRelayCaptureAssistantText(run.leadRelayCapture, {
+          text,
+          isSyntheticChunk: isSyntheticLeadTextChunk(msg),
+          boundTextParts: (parts) => ports.boundProgressAssistantParts(parts),
+        });
       } else if (run.provisioningComplete) {
         if (
           !run.silentUserDmForward &&
@@ -978,12 +948,7 @@ function handleSuccessResultMessage<TRun extends TeamProvisioningStreamRun>(
       detail: 'sentMessages.json',
     });
   }
-  if (run.leadRelayCapture) {
-    const capture = run.leadRelayCapture;
-    capture.terminalResultSucceeded = true;
-    const combined = joinLeadRelayCaptureText(capture);
-    capture.resolveOnce(combined);
-  }
+  resolveLeadRelayCaptureOnTerminalResult(run.leadRelayCapture);
   ports.resetLiveLeadTextBuffer(run);
   run.activeCrossTeamReplyHints = [];
   run.pendingInboxRelayCandidates = [];

--- a/src/main/services/team/provisioning/TeamProvisioningTransientRunState.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningTransientRunState.ts
@@ -175,7 +175,7 @@ export class TeamProvisioningTransientRunState {
     }
   }
 
-  scheduleLeadInboxFollowUpRelay(teamName: string): void {
+  scheduleLeadInboxFollowUpRelay(teamName: string, delayMs = 50): void {
     const key = `lead-inbox-follow-up:${teamName}`;
     if (this.ports.pendingTimeouts.has(key)) return;
 
@@ -186,7 +186,7 @@ export class TeamProvisioningTransientRunState {
         .catch((error: unknown) =>
           this.ports.warn(`[${teamName}] lead inbox follow-up relay failed: ${String(error)}`)
         );
-    }, 50);
+    }, delayMs);
     timer.unref?.();
     this.ports.pendingTimeouts.set(key, timer);
   }

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadInboxRelayFlow.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadInboxRelayFlow.test.ts
@@ -455,6 +455,43 @@ describe('lead inbox relay flow', () => {
     expect(ports.scheduleLeadInboxFollowUpRelay).toHaveBeenCalledWith('alpha', 10_000);
   });
 
+  it('re-arms a touched deadline within what is left of the absolute delivery cap', async () => {
+    const run = createRun();
+    const ports = createPorts(run, [createMessage()]);
+    const timers = createTimerHarness(ports);
+
+    // One millisecond before the cap the lane is still alive, so activity still re-arms the reply
+    // deadline - but a full 120s base deadline here would let the capture run to roughly 720s and
+    // outlive the cap that is supposed to bound a wedged lane.
+    const elapsedMs = 599_999;
+    let retiredDeadlineArmedAtSend = false;
+    let rearmedMs: number | null = null;
+    let pendingMsAfterTouch: number[] = [];
+
+    vi.mocked(ports.sendMessageToRun).mockImplementation(async () => {
+      const capture = run.leadRelayCapture;
+      if (!capture) throw new Error('missing capture');
+      const armedAtSendHandle = timers.pending().find(({ ms }) => ms === 120_000)?.handle;
+
+      timers.advance(elapsedMs);
+      capture.touch?.();
+
+      retiredDeadlineArmedAtSend =
+        armedAtSendHandle !== undefined && timers.cleared().includes(armedAtSendHandle);
+      pendingMsAfterTouch = timers.pending().map(({ ms }) => ms);
+      const rearmed = timers.pending().at(-1);
+      rearmedMs = rearmed?.ms ?? null;
+      rearmed?.callback();
+    });
+
+    await expect(relayLeadInboxMessagesForTeam('alpha', ports)).resolves.toBe(0);
+
+    expect(retiredDeadlineArmedAtSend).toBe(true);
+    expect(rearmedMs).toBe(600_000 - elapsedMs);
+    expect(pendingMsAfterTouch).not.toContain(120_000);
+    expect(ports.scheduleLeadInboxFollowUpRelay).toHaveBeenCalledWith('alpha', 10_000);
+  });
+
   it('backs off before retrying a delivery that produced no proof at all', async () => {
     const run = createRun();
     const ports = createPorts(run, [createMessage()]);

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadInboxRelayFlow.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadInboxRelayFlow.test.ts
@@ -398,8 +398,10 @@ describe('lead inbox relay flow', () => {
     run.cancelRequested = true;
     releaseFirstSend?.();
 
-    await expect(Promise.all([first, queued])).resolves.toEqual([1, 0]);
+    await expect(Promise.all([first, queued])).resolves.toEqual([0, 0]);
     expect(ports.sendMessageToRun).toHaveBeenCalledTimes(1);
+    expect(ports.markInboxMessagesRead).not.toHaveBeenCalled();
+    expect(ports.persistSentMessage).not.toHaveBeenCalled();
   });
 
   it('keeps a delivery alive while the lead proves the turn is running with stream activity', async () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadInboxRelayFlow.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadInboxRelayFlow.test.ts
@@ -139,6 +139,46 @@ function createPorts(
   };
 }
 
+interface ScheduledTimer {
+  callback: () => void;
+  ms: number;
+  handle: NodeJS.Timeout;
+}
+
+/**
+ * Replaces the flow's timer ports with an observable clock so a test can see which deadline is
+ * armed, which one was retired, and how far the capture believes it has run.
+ */
+function createTimerHarness(ports: TestLeadInboxRelayFlowPorts): {
+  advance: (ms: number) => void;
+  cleared: () => NodeJS.Timeout[];
+  pending: () => ScheduledTimer[];
+} {
+  const scheduled: ScheduledTimer[] = [];
+  const clearedHandles: NodeJS.Timeout[] = [];
+  let clock = 123;
+
+  vi.mocked(ports.nowMs).mockImplementation(() => clock);
+  vi.mocked(ports.setTimeout).mockImplementation((callback, ms) => {
+    const handle = {} as NodeJS.Timeout;
+    scheduled.push({ callback, ms, handle });
+    return handle;
+  });
+  vi.mocked(ports.clearTimeout).mockImplementation((handle) => {
+    clearedHandles.push(handle);
+    const index = scheduled.findIndex((timer) => timer.handle === handle);
+    if (index >= 0) scheduled.splice(index, 1);
+  });
+
+  return {
+    advance: (ms: number) => {
+      clock += ms;
+    },
+    cleared: () => [...clearedHandles],
+    pending: () => [...scheduled],
+  };
+}
+
 describe('lead inbox relay flow', () => {
   it('scans permission requests before provisioning is complete and does not relay', async () => {
     const run = createRun({ provisioningComplete: false });
@@ -206,11 +246,12 @@ describe('lead inbox relay flow', () => {
       scheduled.push({ callback, ms });
       return {} as NodeJS.Timeout;
     });
+    const observedCapture: { requireTerminalResult?: boolean; idleMs?: number } = {};
     vi.mocked(ports.sendMessageToRun).mockImplementation(async () => {
       const capture = run.leadRelayCapture;
       if (!capture) throw new Error('missing capture');
-      expect(capture.requireTerminalResult).toBe(true);
-      expect(capture.idleMs).toBe(15_001);
+      observedCapture.requireTerminalResult = capture.requireTerminalResult;
+      observedCapture.idleMs = capture.idleMs;
       capture.textParts.push('Partial recovery reply.');
       capture.idleHandle = ports.setTimeout(
         () => capture.resolveOnce('Partial recovery reply.'),
@@ -222,8 +263,13 @@ describe('lead inbox relay flow', () => {
       onlyMessageId: 'recovery-1',
     });
     await vi.waitFor(() => expect(ports.sendMessageToRun).toHaveBeenCalledOnce());
-    scheduled.find(({ ms }) => ms === 15_000)?.callback();
+    const captureDeadline = scheduled.find(({ ms }) => ms === 120_000);
+    expect(captureDeadline).toBeDefined();
+    captureDeadline?.callback();
 
+    // Asserted out here, not inside the send mock: the flow swallows a throw from
+    // sendMessageToRun, which would silently turn a failing expectation into a passing test.
+    expect(observedCapture).toEqual({ requireTerminalResult: true, idleMs: 120_001 });
     await expect(relay).resolves.toBe(0);
     expect(ports.rememberSuccessfulLeadRecoveryMessage).not.toHaveBeenCalled();
     expect(ports.relayedLeadInboxMessageIds.get('alpha')?.has('recovery-1') ?? false).toBe(false);
@@ -354,5 +400,104 @@ describe('lead inbox relay flow', () => {
 
     await expect(Promise.all([first, queued])).resolves.toEqual([1, 0]);
     expect(ports.sendMessageToRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a delivery alive while the lead proves the turn is running with stream activity', async () => {
+    const run = createRun();
+    const ports = createPorts(run, [createMessage()]);
+    const timers = createTimerHarness(ports);
+
+    vi.mocked(ports.sendMessageToRun).mockImplementation(async () => {
+      const capture = run.leadRelayCapture;
+      if (!capture) throw new Error('missing capture');
+      const armedAtSend = timers.pending();
+      expect(armedAtSend.map(({ ms }) => ms)).toContain(120_000);
+
+      // A tool-only lead turn: no assistant text, only activity. The relay flow's touch must
+      // retire the deadline that was armed at send time instead of letting it fire and declare
+      // the delivered message undelivered.
+      timers.advance(119_000);
+      capture.touch?.();
+      expect(timers.cleared()).toContain(armedAtSend[0]?.handle);
+      expect(timers.pending().map(({ ms }) => ms)).toContain(120_000);
+
+      capture.resolveOnce('Created the tasks.');
+    });
+
+    await expect(relayLeadInboxMessagesForTeam('alpha', ports)).resolves.toBe(1);
+
+    expect(ports.sendMessageToRun).toHaveBeenCalledTimes(1);
+    expect(ports.scheduleLeadInboxFollowUpRelay).not.toHaveBeenCalled();
+    expect(ports.relayedLeadInboxMessageIds.get('alpha')?.has('msg-1')).toBe(true);
+    expect(ports.markInboxMessagesRead).toHaveBeenLastCalledWith(
+      'alpha',
+      'team-lead',
+      expect.arrayContaining([expect.objectContaining({ messageId: 'msg-1' })])
+    );
+  });
+
+  it('stops touching a capture that has outlived the absolute delivery cap', async () => {
+    const run = createRun();
+    const ports = createPorts(run, [createMessage()]);
+    const timers = createTimerHarness(ports);
+
+    vi.mocked(ports.sendMessageToRun).mockImplementation(async () => {
+      const capture = run.leadRelayCapture;
+      if (!capture) throw new Error('missing capture');
+      const armedAtSend = timers.pending()[0];
+      timers.advance(600_000);
+      capture.touch?.();
+      expect(timers.cleared()).not.toContain(armedAtSend?.handle);
+      armedAtSend?.callback();
+    });
+
+    await expect(relayLeadInboxMessagesForTeam('alpha', ports)).resolves.toBe(0);
+    expect(ports.scheduleLeadInboxFollowUpRelay).toHaveBeenCalledWith('alpha', 10_000);
+  });
+
+  it('backs off before retrying a delivery that produced no proof at all', async () => {
+    const run = createRun();
+    const ports = createPorts(run, [createMessage()]);
+    const timers = createTimerHarness(ports);
+
+    vi.mocked(ports.sendMessageToRun).mockImplementation(async () => {
+      timers
+        .pending()
+        .find(({ ms }) => ms === 120_000)
+        ?.callback();
+    });
+
+    await expect(relayLeadInboxMessagesForTeam('alpha', ports)).resolves.toBe(0);
+
+    expect(ports.scheduleLeadInboxFollowUpRelay).toHaveBeenCalledWith('alpha', 10_000);
+    expect(ports.markInboxMessagesRead).not.toHaveBeenCalled();
+    expect(ports.relayedLeadInboxMessageIds.get('alpha')?.has('msg-1') ?? false).toBe(false);
+  });
+
+  it('announces a resent message as a redelivery and leaves a fresh row unmarked', async () => {
+    const run = createRun();
+    const ports = createPorts(run, [createMessage()]);
+    const timers = createTimerHarness(ports);
+    vi.mocked(ports.sendMessageToRun).mockImplementationOnce(async (_run, message: string) => {
+      ports.sentMessages.push(message);
+      timers
+        .pending()
+        .find(({ ms }) => ms === 120_000)
+        ?.callback();
+    });
+
+    await expect(relayLeadInboxMessagesForTeam('alpha', ports)).resolves.toBe(0);
+    expect(ports.sentMessages[0]).not.toContain('REDELIVERY:');
+
+    vi.mocked(ports.readLeadInboxMessages).mockResolvedValue([
+      createMessage(),
+      createMessage({ messageId: 'msg-2', text: 'A brand new request.' }),
+    ]);
+    await expect(relayLeadInboxMessagesForTeam('alpha', ports)).resolves.toBe(2);
+
+    const retryPrompt = ports.sentMessages[1] ?? '';
+    const rows = retryPrompt.slice(retryPrompt.indexOf('Messages:')).split(/^(?=\d\) From: )/m);
+    expect(rows[1]).toContain('REDELIVERY: this exact message was already delivered to you');
+    expect(rows[2]).not.toContain('REDELIVERY:');
   });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadInboxRelayFlow.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadInboxRelayFlow.test.ts
@@ -5,6 +5,7 @@ import {
   type LeadInboxRelayFlowRun,
   relayLeadInboxMessagesForTeam,
 } from '../TeamProvisioningLeadInboxRelayFlow';
+import { cancelRunLeadRelayCapture } from '../TeamProvisioningLeadRelayCancellation';
 
 import type { InboxMessage, TeamChangeEvent } from '@shared/types';
 
@@ -224,6 +225,73 @@ describe('lead inbox relay flow', () => {
       { type: 'inbox', teamName: 'alpha', detail: 'lead-process-reply' },
     ]);
     expect(run.leadRelayCapture).toBeNull();
+  });
+
+  it('does not dispatch transport when cancellation wins the queued microtask', async () => {
+    const run = createRun();
+    const ports = createPorts(run, [createMessage()]);
+    ports.setTimeout.mockImplementation((_callback, ms) => {
+      if (ms === 600_000) queueMicrotask(() => cancelRunLeadRelayCapture(run));
+      return {} as NodeJS.Timeout;
+    });
+    expect(await relayLeadInboxMessagesForTeam('alpha', ports)).toBe(0);
+    expect(ports.sendMessageToRun).not.toHaveBeenCalled();
+    expect(ports.markInboxMessagesRead).not.toHaveBeenCalled();
+    expect(ports.persistSentMessage).not.toHaveBeenCalled();
+  });
+
+  it.each(['resolve', 'reject'] as const)(
+    'waits for transport after successful capture (%s)',
+    async (outcome) => {
+      const run = createRun();
+      const ports = createPorts(run, [createMessage()]);
+      let resolveSend!: () => void;
+      let rejectSend!: (error: Error) => void;
+      const send = new Promise<void>((resolve, reject) => {
+        resolveSend = resolve;
+        rejectSend = reject;
+      });
+      ports.sendMessageToRun.mockImplementation(() => {
+        run.leadRelayCapture?.resolveOnce('Handled your request.');
+        return send;
+      });
+      let completed = false;
+      const delivery = relayLeadInboxMessagesForTeam('alpha', ports).then((result) => {
+        completed = true;
+        return result;
+      });
+      await vi.waitFor(() => expect(ports.sendMessageToRun).toHaveBeenCalledTimes(1));
+      expect(completed).toBe(false);
+      expect(ports.markInboxMessagesRead).not.toHaveBeenCalled();
+      expect(ports.persistSentMessage).not.toHaveBeenCalled();
+      expect(ports.relayedLeadInboxMessageIds.get('alpha')?.has('msg-1') ?? false).toBe(false);
+
+      if (outcome === 'resolve') resolveSend();
+      else rejectSend(new Error('Transport failed after reply capture'));
+      expect(await delivery).toBe(outcome === 'resolve' ? 1 : 0);
+      expect(ports.markInboxMessagesRead).toHaveBeenCalledTimes(outcome === 'resolve' ? 1 : 0);
+      expect(ports.persistSentMessage).toHaveBeenCalledTimes(outcome === 'resolve' ? 1 : 0);
+    }
+  );
+
+  it('does not schedule work-sync recovery after cancellation during proof lookup', async () => {
+    const run = createRun();
+    const ports = createPorts(run, [createMessage({ messageKind: 'member_work_sync_nudge' })]);
+    let resolveProof!: (accepted: boolean) => void;
+    ports.hasAcceptedLeadWorkSyncReport = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveProof = resolve;
+        })
+    );
+    const delivery = relayLeadInboxMessagesForTeam('alpha', ports);
+    await vi.waitFor(() => expect(ports.hasAcceptedLeadWorkSyncReport).toHaveBeenCalledTimes(1));
+    run.cancelRequested = true;
+    resolveProof(false);
+    expect(await delivery).toBe(0);
+    expect(ports.scheduleLeadProofMissingWorkSyncRecovery).not.toHaveBeenCalled();
+    expect(ports.markInboxMessagesRead).not.toHaveBeenCalled();
+    expect(ports.persistSentMessage).not.toHaveBeenCalled();
   });
 
   it('records recovery delivery only after terminal-result capture resolution', async () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadInboxRelayPortsFactory.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadInboxRelayPortsFactory.test.ts
@@ -282,6 +282,6 @@ describe('TeamProvisioningLeadInboxRelayPortsFactory', () => {
     expect(deps.logger.warn).toHaveBeenCalledWith(
       '[alpha] lead_inbox_relay_timed_out: lead_inbox_relay timed out after 120000ms: alpha'
     );
-    expect(deps.leadInboxRelayInFlight.has('alpha')).toBe(false);
+    expect(deps.leadInboxRelayInFlight.has('alpha')).toBe(true);
   });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayCaptureTouch.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayCaptureTouch.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  handleTeamProvisioningStreamJsonMessage,
+  type TeamProvisioningStreamEventPorts,
+  type TeamProvisioningStreamRun,
+} from '../TeamProvisioningStreamEvents';
+
+import type { TeamProvisioningProgress } from '@shared/types';
+
+const NOW = '2026-09-01T10:00:00.000Z';
+
+function createRun(overrides: Partial<TeamProvisioningStreamRun> = {}): TeamProvisioningStreamRun {
+  return {
+    runId: 'run-1',
+    teamName: 'alpha',
+    detectedSessionId: 'session-1',
+    deterministicBootstrapMemberSpawnSeen: false,
+    deterministicBootstrapMemberResultSeen: false,
+    lastDeterministicBootstrapSeq: 0,
+    requiresFirstRealTurnSuccess: false,
+    provisioningComplete: true,
+    cancelRequested: false,
+    processKilled: false,
+    progress: {
+      runId: 'run-1',
+      teamName: 'alpha',
+      state: 'ready',
+      message: 'ready',
+      startedAt: NOW,
+      updatedAt: NOW,
+    } as TeamProvisioningProgress,
+    onProgress: () => {},
+    child: null,
+    pendingMemberRestarts: new Map(),
+    memberSpawnStatuses: new Map(),
+    isLaunch: false,
+    anthropicApiKeyHelper: null,
+    leadRelayCapture: null,
+    pendingToolCalls: [],
+    liveLeadTextBuffer: null,
+    silentUserDmForward: null,
+    suppressPostCompactReminderOutput: false,
+    pendingDirectCrossTeamSendRefresh: false,
+    pendingPostCompactReminder: false,
+    postCompactReminderInFlight: false,
+    pendingGeminiPostLaunchHydration: false,
+    geminiPostLaunchHydrationInFlight: false,
+    suppressGeminiPostLaunchHydrationOutput: false,
+    activeCrossTeamReplyHints: [],
+    pendingInboxRelayCandidates: [],
+    silentUserDmForwardClearHandle: null,
+    leadContextUsage: null,
+    apiRetryWarningIndex: null,
+    provisioningOutputParts: [],
+    lastRetryAt: 0,
+    apiErrorWarningEmitted: false,
+    ...overrides,
+  } as TeamProvisioningStreamRun;
+}
+
+function createPorts(): TeamProvisioningStreamEventPorts<TeamProvisioningStreamRun> {
+  return {
+    resetLiveLeadTextBuffer: vi.fn(),
+    finishRuntimeToolActivity: vi.fn(),
+    startRuntimeToolActivity: vi.fn(),
+    getRunLeadName: vi.fn(() => 'lead'),
+    handleNativeTeammateUserMessage: vi.fn(),
+    handleTeammatePermissionRequest: vi.fn(),
+    handleAuthFailureInOutput: vi.fn(),
+    hasApiError: vi.fn(() => false),
+    isAuthFailureWarning: vi.fn(() => false),
+    failProvisioningWithApiError: vi.fn(),
+    appendProvisioningAssistantText: vi.fn(),
+    boundProgressAssistantParts: vi.fn((parts: string[]) => parts),
+    pushLiveLeadTextMessage: vi.fn(),
+    captureTeamSpawnEvents: vi.fn(),
+    captureSendMessages: vi.fn(),
+    updateLeadContextUsageFromUsage: vi.fn(),
+    emitLeadContextUsage: vi.fn(),
+  } as Partial<
+    TeamProvisioningStreamEventPorts<TeamProvisioningStreamRun>
+  > as TeamProvisioningStreamEventPorts<TeamProvisioningStreamRun>;
+}
+
+function createCapture(
+  touch: () => void
+): NonNullable<TeamProvisioningStreamRun['leadRelayCapture']> {
+  return {
+    textParts: [],
+    settled: false,
+    idleHandle: null,
+    idleMs: 800,
+    touch,
+    resolveOnce: vi.fn(),
+    rejectOnce: vi.fn(),
+  };
+}
+
+function toolResultMessage(): Record<string, unknown> {
+  return {
+    type: 'user',
+    message: {
+      content: [{ type: 'tool_result', tool_use_id: 'tool-1', content: 'ok', is_error: false }],
+    },
+  };
+}
+
+function assistantMessage(): Record<string, unknown> {
+  return {
+    type: 'assistant',
+    message: { id: 'assistant-1', content: [{ type: 'text', text: 'Working on it.' }] },
+  };
+}
+
+describe('lead relay capture activity proof', () => {
+  it('touches the capture when the lead stream reports a tool result', () => {
+    const touch = vi.fn();
+    const run = createRun({ leadRelayCapture: createCapture(touch) });
+
+    handleTeamProvisioningStreamJsonMessage(run, toolResultMessage(), createPorts());
+
+    expect(touch).toHaveBeenCalledTimes(1);
+  });
+
+  it('touches the capture when the lead stream reports an assistant message', () => {
+    const touch = vi.fn();
+    const run = createRun({ leadRelayCapture: createCapture(touch) });
+
+    handleTeamProvisioningStreamJsonMessage(run, assistantMessage(), createPorts());
+
+    expect(touch).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles the same stream events without a capture and without throwing', () => {
+    const run = createRun({ leadRelayCapture: null });
+    const ports = createPorts();
+
+    expect(() => {
+      handleTeamProvisioningStreamJsonMessage(run, toolResultMessage(), ports);
+      handleTeamProvisioningStreamJsonMessage(run, assistantMessage(), ports);
+    }).not.toThrow();
+    expect(run.leadRelayCapture).toBeNull();
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayCaptureTouch.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayCaptureTouch.test.ts
@@ -132,6 +132,23 @@ describe('lead relay capture activity proof', () => {
     expect(touch).toHaveBeenCalledTimes(1);
   });
 
+  it.each(['processKilled', 'cancelRequested'] as const)(
+    'ignores late stream events after %s',
+    (flag) => {
+      const touch = vi.fn();
+      const run = createRun({ [flag]: true, leadRelayCapture: createCapture(touch) });
+      const ports = createPorts();
+      handleTeamProvisioningStreamJsonMessage(run, toolResultMessage(), ports);
+      handleTeamProvisioningStreamJsonMessage(run, assistantMessage(), ports);
+      handleTeamProvisioningStreamJsonMessage(run, { type: 'result', result: 'Late reply' }, ports);
+      expect(touch).not.toHaveBeenCalled();
+      expect(run.leadRelayCapture?.resolveOnce).not.toHaveBeenCalled();
+      expect(ports.pushLiveLeadTextMessage).not.toHaveBeenCalled();
+      expect(ports.captureSendMessages).not.toHaveBeenCalled();
+      expect(ports.startRuntimeToolActivity).not.toHaveBeenCalled();
+    }
+  );
+
   it('handles the same stream events without a capture and without throwing', () => {
     const run = createRun({ leadRelayCapture: null });
     const ports = createPorts();

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayLifecycle.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayLifecycle.test.ts
@@ -123,7 +123,7 @@ function cleanupRun(
     activeCrossTeamReplyHints: [{}],
     pendingInboxRelayCandidates: [{}],
     pendingApprovals: new Map([['approval-1', {}]]),
-    mcpConfigPath: '/tmp/team-a-mcp.json',
+    mcpConfigPath: null,
     bootstrapSpecPath: null,
     bootstrapUserPromptPath: null,
     pendingPostCompactReminder: true,
@@ -249,9 +249,9 @@ function makePorts(
 describe('lead relay lifecycle integration', () => {
   afterEach(() => vi.useRealTimers());
 
-  it.each([false, true])(
-    'releases stopped capture before relaunch (transport pending: %s)',
-    async (pendingSend) => {
+  it.each(['sent', 'pending', 'captured-pending'] as const)(
+    'releases stopped capture before relaunch (transport: %s)',
+    async (transport) => {
       vi.useFakeTimers();
       const oldRun = {
         ...cleanupRun({
@@ -264,6 +264,7 @@ describe('lead relay lifecycle integration', () => {
         child: new ChildProcess(),
       };
       let currentRun: LeadInboxRelayFlowRun = oldRun;
+      let rejectOldSend: ((error: Error) => void) | undefined;
       const deps = createDeps({
         getAliveRunId: () => currentRun.runId,
         getRun: (id) => (id === currentRun.runId ? currentRun : undefined),
@@ -287,14 +288,19 @@ describe('lead relay lifecycle integration', () => {
         nowMs: () => Date.now(),
         sendMessageToRun: vi.fn(async (run) => {
           if (run.runId === 'run-2') run.leadRelayCapture?.resolveOnce('Handled');
-          else if (pendingSend) await new Promise<void>(() => undefined);
+          else if (transport !== 'sent') {
+            if (transport === 'captured-pending') run.leadRelayCapture?.resolveOnce('Early reply');
+            await new Promise<void>((_resolve, reject) => {
+              rejectOldSend = reject;
+            });
+          }
         }),
       });
       const boundary = createTeamProvisioningLeadInboxRelayPortsBoundary(deps);
       const first = boundary.relayLeadInboxMessages('alpha');
       await vi.advanceTimersByTimeAsync(1);
       expect(deps.sendMessageToRun).toHaveBeenCalledTimes(1);
-      const oldCapture = oldRun.leadRelayCapture!;
+      const oldCapture = oldRun.leadRelayCapture;
       oldRun.cancelRequested = true;
       oldRun.processKilled = true;
       cleanupProvisioningRun(oldRun, {
@@ -314,10 +320,11 @@ describe('lead relay lifecycle integration', () => {
       expect(await first).toBe(0);
       expect(await second).toBe(1);
       expect(deps.sendMessageToRun).toHaveBeenCalledTimes(2);
-      expect(oldCapture.settled).toBe(true);
+      if (oldCapture) expect(oldCapture.settled).toBe(true);
       expect(oldRun.leadRelayCapture).toBeNull();
-      oldCapture.touch?.();
-      oldCapture.resolveOnce('Late reply from old run');
+      rejectOldSend?.(new Error('Late transport rejection'));
+      oldCapture?.touch?.();
+      oldCapture?.resolveOnce('Late reply from old run');
       await vi.advanceTimersByTimeAsync(600_000);
       expect(deps.markInboxMessagesRead).toHaveBeenCalledTimes(1);
       expect(deps.markInboxMessagesRead).toHaveBeenCalledWith('alpha', 'team-lead', [
@@ -372,6 +379,50 @@ describe('lead relay lifecycle integration', () => {
     expect(deps.markInboxMessagesRead).not.toHaveBeenCalled();
     expect(deps.scheduleLeadInboxFollowUpRelay).toHaveBeenCalledWith('alpha', 10_000);
     capture.touch?.();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('bounds pending transport at 600 seconds even after successful capture', async () => {
+    vi.useFakeTimers();
+    const run = createRun();
+    const deps = createDeps({
+      getRun: () => run,
+      readConfigForObservation: async () => ({
+        members: [{ name: 'team-lead', agentType: 'team-lead' }],
+      }),
+      readLeadInboxMessages: async () => [
+        {
+          from: 'user',
+          to: 'team-lead',
+          text: 'Continue my task',
+          messageId: 'msg-1',
+          timestamp: '2026-01-01T00:01:00.000Z',
+          read: false,
+          source: 'user_sent',
+        },
+      ],
+      setTimeout: (cb, ms) => setTimeout(cb, ms),
+      clearTimeout: (timer) => clearTimeout(timer),
+      nowMs: () => Date.now(),
+      sendMessageToRun: () => {
+        run.leadRelayCapture?.resolveOnce('Early reply');
+        return new Promise<void>(() => undefined);
+      },
+    });
+    let completed = false;
+    const delivery = relayLeadInboxMessagesForTeam(
+      'alpha',
+      createTeamProvisioningLeadInboxRelayFlowPorts(deps)
+    ).then((result) => {
+      completed = true;
+      return result;
+    });
+    await vi.advanceTimersByTimeAsync(599_999);
+    expect(completed).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await delivery).toBe(0);
+    expect(deps.markInboxMessagesRead).not.toHaveBeenCalled();
+    expect(deps.persistSentMessage).not.toHaveBeenCalled();
     expect(vi.getTimerCount()).toBe(0);
   });
 

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayLifecycle.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayLifecycle.test.ts
@@ -1,0 +1,417 @@
+import { ChildProcess } from 'node:child_process';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildIncompleteLaunchCleanupReason,
+  cleanupProvisioningRun,
+  shouldFinalizeIncompleteLaunchState,
+  type TeamProvisioningCleanupPorts,
+  type TeamProvisioningCleanupRun,
+} from '../TeamProvisioningCleanup';
+import { relayLeadInboxMessagesForTeam } from '../TeamProvisioningLeadInboxRelayFlow';
+import {
+  createTeamProvisioningLeadInboxRelayFlowPorts,
+  createTeamProvisioningLeadInboxRelayPortsBoundary,
+  type TeamProvisioningLeadInboxRelayPortsFactoryDeps,
+} from '../TeamProvisioningLeadInboxRelayPortsFactory';
+import {
+  createTeamProvisioningTransientRunStatePorts,
+  TeamProvisioningTransientRunState,
+  type TeamProvisioningTransientRunStatePorts,
+} from '../TeamProvisioningTransientRunState';
+
+import type { LeadInboxRelayFlowRun } from '../TeamProvisioningLeadInboxRelayFlow';
+import type { TeamProvisioningProgress } from '@shared/types';
+
+function createRun(overrides: Partial<LeadInboxRelayFlowRun> = {}): LeadInboxRelayFlowRun {
+  return {
+    runId: 'run-1',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    child: {},
+    processKilled: false,
+    cancelRequested: false,
+    provisioningComplete: true,
+    leadRelayCapture: null,
+    activeCrossTeamReplyHints: [],
+    ...overrides,
+  };
+}
+
+function createDeps(
+  overrides: Partial<TeamProvisioningLeadInboxRelayPortsFactoryDeps<LeadInboxRelayFlowRun>> = {}
+): TeamProvisioningLeadInboxRelayPortsFactoryDeps<LeadInboxRelayFlowRun> {
+  const run = createRun();
+  return {
+    leadInboxRelayInFlight: new Map(),
+    getAliveRunId: vi.fn().mockReturnValue(run.runId),
+    getProvisioningRunId: vi.fn().mockReturnValue(null),
+    getRun: vi.fn().mockReturnValue(run),
+    isCurrentTrackedRun: vi.fn().mockReturnValue(true),
+    readConfigForObservation: vi.fn().mockResolvedValue({ members: [] }),
+    readLeadInboxMessages: vi.fn().mockResolvedValue([]),
+    markInboxMessagesRead: vi.fn().mockResolvedValue(undefined),
+    handleTeammatePermissionRequest: vi.fn(),
+    refreshMemberSpawnStatusesFromLeadInbox: vi.fn().mockResolvedValue(undefined),
+    confirmSameTeamNativeMatches: vi
+      .fn()
+      .mockResolvedValue({ nativeMatchedMessageIds: new Set<string>(), persisted: true }),
+    scheduleSameTeamPersistRetry: vi.fn(),
+    scheduleSameTeamDeferredRetry: vi.fn(),
+    resolveControlApiBaseUrl: vi.fn().mockResolvedValue('http://127.0.0.1:3000'),
+    sendMessageToRun: vi.fn().mockResolvedValue(undefined),
+    hasAcceptedLeadWorkSyncReport: vi.fn().mockResolvedValue(true),
+    scheduleLeadProofMissingWorkSyncRecovery: vi.fn().mockResolvedValue(false),
+    pushLiveLeadTextMessage: vi.fn(),
+    pushLiveLeadProcessMessage: vi.fn(),
+    persistSentMessage: vi.fn(),
+    emitTeamChange: vi.fn(),
+    scheduleLeadInboxFollowUpRelay: vi.fn(),
+    rememberLeadRecoveryMessage: vi.fn(),
+    rememberSuccessfulLeadRecoveryMessage: vi.fn(),
+    relayedLeadInboxMessageIds: new Map(),
+    trimRelayedSet: vi.fn((relayedIds) => relayedIds),
+    pendingCrossTeamFirstReplies: new Map(),
+    recentCrossTeamLeadDeliveryMessageIds: new Map(),
+    sameTeamRunStartSkewMs: 1_000,
+    sameTeamNativeDeliveryGraceMs: 15_000,
+    recentCrossTeamDeliveryTtlMs: 600_000,
+    logger: { debug: vi.fn(), warn: vi.fn() },
+    getErrorMessage: (error) => (error instanceof Error ? error.message : String(error)),
+    nowIso: vi.fn().mockReturnValue('2026-01-01T00:01:00.000Z'),
+    nowMs: vi.fn().mockReturnValue(123),
+    setTimeout: vi.fn().mockReturnValue({} as NodeJS.Timeout),
+    clearTimeout: vi.fn(),
+    ...overrides,
+  };
+}
+
+function progress(overrides: Partial<TeamProvisioningProgress> = {}): TeamProvisioningProgress {
+  return {
+    runId: 'run-1',
+    teamName: 'team-a',
+    state: 'spawning',
+    message: 'Spawning teammates',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:01.000Z',
+    ...overrides,
+  };
+}
+
+function cleanupRun(
+  overrides: Partial<TeamProvisioningCleanupRun> = {}
+): TeamProvisioningCleanupRun {
+  const teamName = overrides.teamName ?? 'team-a';
+  const runId = overrides.runId ?? 'run-1';
+  return {
+    runId,
+    teamName,
+    progress: progress({ runId, teamName }),
+    isLaunch: true,
+    launchStateClearedForRun: true,
+    provisioningComplete: false,
+    cancelRequested: false,
+    launchCleanupStateFinalized: false,
+    pendingDirectCrossTeamSendRefresh: true,
+    timeoutHandle: null,
+    silentUserDmForwardClearHandle: null,
+    child: null,
+    memberSpawnStatuses: new Map([
+      ['worker-a', {}],
+      ['worker-b', {}],
+    ]),
+    activeCrossTeamReplyHints: [{}],
+    pendingInboxRelayCandidates: [{}],
+    pendingApprovals: new Map([['approval-1', {}]]),
+    mcpConfigPath: '/tmp/team-a-mcp.json',
+    bootstrapSpecPath: null,
+    bootstrapUserPromptPath: null,
+    pendingPostCompactReminder: true,
+    postCompactReminderInFlight: true,
+    suppressPostCompactReminderOutput: true,
+    pendingGeminiPostLaunchHydration: true,
+    geminiPostLaunchHydrationInFlight: true,
+    suppressGeminiPostLaunchHydrationOutput: true,
+    ...overrides,
+  };
+}
+
+function makeCleanupPorts(
+  trackedRunId: string | null
+): TeamProvisioningCleanupPorts<TeamProvisioningCleanupRun> & {
+  provisioningRunByTeam: Map<string, string>;
+  aliveRunByTeam: Map<string, string>;
+  leadInboxRelayInFlight: Map<string, string>;
+  relayedLeadInboxMessageIds: Map<string, string>;
+  leadRecoveryMessageIds: Map<string, string>;
+  successfulLeadRecoveryMessageIds: Map<string, string>;
+  pendingCrossTeamFirstReplies: Map<string, string>;
+  recentCrossTeamLeadDeliveryMessageIds: Map<string, string>;
+  recentSameTeamNativeFingerprints: Map<string, string>;
+  pendingTimeouts: Map<string, NodeJS.Timeout>;
+  memberInboxRelayInFlight: Map<string, string>;
+  openCodeMemberInboxRelayInFlight: Map<string, string>;
+  openCodeMemberSendInFlightByLane: Map<string, string>;
+  relayedMemberInboxMessageIds: Map<string, string>;
+  liveLeadProcessMessages: Map<string, string>;
+  inFlightResponses: Map<string, string>;
+  retainedClaudeLogsByTeam: Map<string, { lines: string[]; updatedAt?: string }>;
+  runs: Map<string, string>;
+} {
+  return {
+    getTrackedRunId: vi.fn(() => trackedRunId),
+    isRunIdTracked: vi.fn(() => true),
+    buildRetainedClaudeLogsSnapshot: vi.fn(() => ({
+      lines: ['log line'],
+      updatedAt: '2026-01-01T00:00:02.000Z',
+    })),
+    shouldFinalizeIncompleteLaunchState,
+    buildIncompleteLaunchCleanupReason,
+    markIncompleteLaunchStateFinalized: vi.fn(),
+    persistLaunchStateSnapshot: vi.fn(() => Promise.resolve()),
+    writeLaunchFailureArtifactPackBestEffort: vi.fn(),
+    resetRuntimeToolActivity: vi.fn(),
+    setLeadActivity: vi.fn(),
+    stopStallWatchdog: vi.fn(),
+    stopFilesystemMonitor: vi.fn(),
+    provisioningRunByTeam: new Map(),
+    aliveRunByTeam: new Map(),
+    deleteAliveRunId: vi.fn(),
+    clearSecondaryRuntimeRuns: vi.fn(),
+    invalidateRuntimeSnapshotCaches: vi.fn(),
+    invalidateMemberSpawnStatusesCache: vi.fn(),
+    leadInboxRelayInFlight: new Map(),
+    relayedLeadInboxMessageIds: new Map(),
+    leadRecoveryMessageIds: new Map(),
+    successfulLeadRecoveryMessageIds: new Map(),
+    pendingCrossTeamFirstReplies: new Map(),
+    recentCrossTeamLeadDeliveryMessageIds: new Map(),
+    recentSameTeamNativeFingerprints: new Map(),
+    clearSameTeamRetryTimers: vi.fn(),
+    clearLeadInboxFollowUpRelayTimer: vi.fn(),
+    getMemberLaunchGraceKey: vi.fn(
+      (cleanup, memberName: string) => `member-launch-grace:${cleanup.runId}:${memberName}`
+    ),
+    pendingTimeouts: new Map(),
+    memberInboxRelayInFlight: new Map(),
+    openCodeMemberInboxRelayInFlight: new Map(),
+    openCodeMemberSendInFlightByLane: new Map(),
+    openCodePromptDeliveryWatchdogScheduler: { cancelTeam: vi.fn() },
+    openCodeRuntimeDeliveryAdvisory: { cancelTeam: vi.fn() },
+    relayedMemberInboxMessageIds: new Map(),
+    liveLeadProcessMessages: new Map(),
+    pruneLiveLeadMessagesForCleanedRun: vi.fn(),
+    clearApprovalTimeout: vi.fn(),
+    inFlightResponses: new Map(),
+    dismissApprovalNotification: vi.fn(),
+    emitToolApprovalEvent: vi.fn(),
+    mcpConfigBuilder: { removeConfigFile: vi.fn() },
+    removeRunMemberMcpConfigFilesLater: vi.fn(),
+    retainedClaudeLogsByTeam: new Map(),
+    retainProvisioningProgress: vi.fn(),
+    runs: new Map(),
+  };
+}
+
+function makePorts(
+  overrides: Partial<TeamProvisioningTransientRunStatePorts> = {}
+): TeamProvisioningTransientRunStatePorts {
+  return createTeamProvisioningTransientRunStatePorts({
+    pendingTimeouts: new Map(),
+    teamOpLocks: new Map(),
+    cancelPendingAutoResume: vi.fn(),
+    clearOpenCodeRuntimeToolApprovals: vi.fn(),
+    invalidateRuntimeSnapshotCaches: vi.fn(),
+    clearRuntimeProcessRowsForTeam: vi.fn(),
+    retainedClaudeLogsByTeam: new Map(),
+    persistedTranscriptClaudeLogs: { invalidate: vi.fn() },
+    leadInboxRelayInFlight: new Map(),
+    relayedLeadInboxMessageIds: new Map(),
+    leadRecoveryMessageIds: new Map(),
+    successfulLeadRecoveryMessageIds: new Map(),
+    pendingCrossTeamFirstReplies: new Map(),
+    recentCrossTeamLeadDeliveryMessageIds: new Map(),
+    recentSameTeamNativeFingerprints: new Map(),
+    memberInboxRelayInFlight: new Map(),
+    openCodeMemberInboxRelayInFlight: new Map(),
+    openCodeMemberSendInFlightByLane: new Map(),
+    openCodePromptDeliveryWatchdogScheduler: { cancelTeam: vi.fn() },
+    openCodeRuntimeDeliveryAdvisory: { cancelTeam: vi.fn(), resetTeamForNewRun: vi.fn() },
+    relayedMemberInboxMessageIds: new Map(),
+    liveLeadProcessMessages: new Map(),
+    relayLeadInboxMessages: vi.fn().mockResolvedValue(0),
+    warn: vi.fn(),
+    nowMs: () => Date.parse('2026-01-02T03:04:05.000Z'),
+    ...overrides,
+  });
+}
+
+describe('lead relay lifecycle integration', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it.each([false, true])(
+    'releases stopped capture before relaunch (transport pending: %s)',
+    async (pendingSend) => {
+      vi.useFakeTimers();
+      const oldRun = {
+        ...cleanupRun({
+          teamName: 'alpha',
+          mcpConfigPath: null,
+          timeoutHandle: null,
+          silentUserDmForwardClearHandle: null,
+        }),
+        ...createRun(),
+        child: new ChildProcess(),
+      };
+      let currentRun: LeadInboxRelayFlowRun = oldRun;
+      const deps = createDeps({
+        getAliveRunId: () => currentRun.runId,
+        getRun: (id) => (id === currentRun.runId ? currentRun : undefined),
+        isCurrentTrackedRun: (run) => run === currentRun,
+        readConfigForObservation: async () => ({
+          members: [{ name: 'team-lead', agentType: 'team-lead' }],
+        }),
+        readLeadInboxMessages: async () => [
+          {
+            from: 'user',
+            to: 'team-lead',
+            text: 'Continue my task',
+            messageId: currentRun.runId,
+            timestamp: '2026-01-01T00:01:00.000Z',
+            read: false,
+            source: 'user_sent',
+          },
+        ],
+        setTimeout: (cb, ms) => setTimeout(cb, ms),
+        clearTimeout: (timer) => clearTimeout(timer),
+        nowMs: () => Date.now(),
+        sendMessageToRun: vi.fn(async (run) => {
+          if (run.runId === 'run-2') run.leadRelayCapture?.resolveOnce('Handled');
+          else if (pendingSend) await new Promise<void>(() => undefined);
+        }),
+      });
+      const boundary = createTeamProvisioningLeadInboxRelayPortsBoundary(deps);
+      const first = boundary.relayLeadInboxMessages('alpha');
+      await vi.advanceTimersByTimeAsync(1);
+      expect(deps.sendMessageToRun).toHaveBeenCalledTimes(1);
+      const oldCapture = oldRun.leadRelayCapture!;
+      oldRun.cancelRequested = true;
+      oldRun.processKilled = true;
+      cleanupProvisioningRun(oldRun, {
+        ...makeCleanupPorts(oldRun.runId),
+        leadInboxRelayInFlight: deps.leadInboxRelayInFlight,
+        relayedLeadInboxMessageIds: deps.relayedLeadInboxMessageIds,
+      });
+      new TeamProvisioningTransientRunState(
+        makePorts({
+          leadInboxRelayInFlight: deps.leadInboxRelayInFlight,
+          relayedLeadInboxMessageIds: deps.relayedLeadInboxMessageIds,
+        })
+      ).resetTeamScopedTransientStateForNewRun('alpha');
+      currentRun = createRun({ runId: 'run-2' });
+      const second = boundary.relayLeadInboxMessages('alpha');
+      await vi.advanceTimersByTimeAsync(1);
+      expect(await first).toBe(0);
+      expect(await second).toBe(1);
+      expect(deps.sendMessageToRun).toHaveBeenCalledTimes(2);
+      expect(oldCapture.settled).toBe(true);
+      expect(oldRun.leadRelayCapture).toBeNull();
+      oldCapture.touch?.();
+      oldCapture.resolveOnce('Late reply from old run');
+      await vi.advanceTimersByTimeAsync(600_000);
+      expect(deps.markInboxMessagesRead).toHaveBeenCalledTimes(1);
+      expect(deps.markInboxMessagesRead).toHaveBeenCalledWith('alpha', 'team-lead', [
+        expect.objectContaining({ messageId: 'run-2' }),
+      ]);
+      expect(deps.relayedLeadInboxMessageIds.get('alpha')).toEqual(new Set(['run-2']));
+      expect(deps.persistSentMessage).toHaveBeenCalledTimes(1);
+      expect(deps.scheduleLeadInboxFollowUpRelay).not.toHaveBeenCalled();
+    }
+  );
+
+  it('bounds repeated activity extensions at 600 seconds and leaves no-proof delivery retryable', async () => {
+    vi.useFakeTimers();
+    const run = createRun();
+    const deps = createDeps({
+      getRun: () => run,
+      readConfigForObservation: async () => ({
+        members: [{ name: 'team-lead', agentType: 'team-lead' }],
+      }),
+      readLeadInboxMessages: async () => [
+        {
+          from: 'user',
+          to: 'team-lead',
+          text: 'Continue my task',
+          messageId: 'msg-1',
+          timestamp: '2026-01-01T00:01:00.000Z',
+          read: false,
+          source: 'user_sent',
+        },
+      ],
+      setTimeout: (cb, ms) => setTimeout(cb, ms),
+      clearTimeout: (timer) => clearTimeout(timer),
+      nowMs: () => Date.now(),
+    });
+    const delivery = relayLeadInboxMessagesForTeam(
+      'alpha',
+      createTeamProvisioningLeadInboxRelayFlowPorts(deps)
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    const capture = run.leadRelayCapture!;
+    for (let turn = 0; turn < 5; turn++) {
+      await vi.advanceTimersByTimeAsync(110_000);
+      capture.touch?.();
+      expect(capture.settled).toBe(false);
+    }
+    await vi.advanceTimersByTimeAsync(49_999);
+    capture.touch?.();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await delivery).toBe(0);
+    expect(capture.settled).toBe(true);
+    expect(run.leadRelayCapture).toBeNull();
+    expect(deps.markInboxMessagesRead).not.toHaveBeenCalled();
+    expect(deps.scheduleLeadInboxFollowUpRelay).toHaveBeenCalledWith('alpha', 10_000);
+    capture.touch?.();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('keeps healthy capture ownership beyond caller timeout and shares its result', async () => {
+    vi.useFakeTimers();
+    const run = createRun();
+    const deps = createDeps({
+      getRun: () => run,
+      readConfigForObservation: async () => ({
+        members: [{ name: 'team-lead', agentType: 'team-lead' }],
+      }),
+      readLeadInboxMessages: async () => [
+        {
+          from: 'user',
+          to: 'team-lead',
+          text: 'Continue my task',
+          messageId: 'msg-1',
+          timestamp: '2026-01-01T00:01:00.000Z',
+          read: false,
+          source: 'user_sent',
+        },
+      ],
+      setTimeout: (cb, ms) => setTimeout(cb, ms),
+      clearTimeout: (timer) => clearTimeout(timer),
+      nowMs: () => Date.now(),
+    });
+    const boundary = createTeamProvisioningLeadInboxRelayPortsBoundary(deps);
+    const first = boundary.relayLeadInboxMessages('alpha');
+    await vi.advanceTimersByTimeAsync(110_000);
+    run.leadRelayCapture?.touch?.();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(await first).toBe(0);
+    expect(run.leadRelayCapture?.settled).toBe(false);
+    expect(deps.leadInboxRelayInFlight.has('alpha')).toBe(true);
+    const second = boundary.relayLeadInboxMessages('alpha');
+    run.leadRelayCapture?.resolveOnce('Handled');
+    await vi.advanceTimersByTimeAsync(1);
+    expect(await second).toBe(1);
+    expect(deps.sendMessageToRun).toHaveBeenCalledTimes(1);
+    expect(deps.relayedLeadInboxMessageIds.get('alpha')?.has('msg-1')).toBe(true);
+    expect(deps.leadInboxRelayInFlight.has('alpha')).toBe(false);
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayPrompt.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayPrompt.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildLeadInboxRelayPrompt,
+  type RelayInboxMessage,
+} from '../TeamProvisioningInboxRelayPolicy';
+
+// Byte-for-byte record of the lead relay prompt this repository produced before the lead relay
+// row formatting was split out of the inbox relay policy. The relayed prompt is the only contract
+// a memoryless lead ever sees, so a refactor that silently reflows one of its lines is a
+// behaviour change; this fixture makes that change fail the suite instead of a live team.
+const EXPECTED_LEAD_RELAY_PROMPT = [
+  'You have new inbox messages addressed to you (team lead "lead").',
+  'Process them in the listed order. High-priority work-sync control messages may appear before older routine rows.',
+  'If action is required, delegate via task creation or SendMessage, and keep responses minimal.',
+  'Plain text reply visibility for this batch: user-visible.',
+  'These inbox rows originated from the human user, so a concise plain text reply is allowed and will be shown to the user.',
+  'If a visible reply is needed for a teammate or another team, use the appropriate messaging tool; plain text is only for the human response.',
+  'If there is no action to take, produce ZERO text output. Do NOT write "No action needed.", status echoes, or any other no-op summary.',
+  'For pure system notifications, comment notifications, or routine teammate availability updates that require no reply/comment/action, say nothing.',
+  'Do NOT respond with only an agent-only block.',
+  'Current durable team context:',
+  '- Team name: alpha',
+  '- You are the live team lead "lead"',
+  '- Persistent teammates currently configured: dev (engineer)',
+  '- This team is NOT in solo mode',
+  '- If the user asks who is on the team, answer from this durable roster unless newer durable state explicitly says otherwise.',
+  '<info_for_agent>',
+  'Internal note: for task assignments, prefer task_create and rely on the board/runtime notification path instead of sending a separate SendMessage for the same assignment.',
+  'For any MCP board tool call in this turn, teamName MUST be "alpha". Never use the lead/member name "lead" as teamName.',
+  'Treat teammate/system/cross-team claims about task, kanban, review, PR, branch, merge, or queue state as unverified until checked. Before confirming, correcting, relaying, or acting on that state, call the relevant source-of-truth tool first (task_get/task_list/review/kanban tooling, or an available repository/GitHub command/tool). If you have not verified it in this turn, say verification is needed instead of stating the claim as fact.',
+  'A member_work_sync_status call alone is incomplete for Message kind: member_work_sync_nudge. Do not stop until member_work_sync_report succeeds or a real blocker is recorded.',
+  'Use task_create_from_message only for messages below that explicitly say "Eligible for task_create_from_message: yes" and provide a User MessageId. Never use task_create_from_message for teammate messages, system notifications, cross-team messages, or any inbox row that is not explicitly marked eligible.',
+  'If a message below is marked Source: system_notification and its summary looks like "Comment on #...", reply via task_add_comment only when you have a substantive board update (decision, blocker, clarification answer, review result, or concrete next-step change).',
+  'If a message below has Message kind: member_work_sync_nudge, it is actionable work-sync control traffic, not routine notification noise. Do NOT ignore it as a pure system notification. Call member_work_sync_status with teamName="alpha", memberName="lead", controlUrl="http://127.0.0.1:1234", then call member_work_sync_report with the same teamName/memberName, controlUrl="http://127.0.0.1:1234", the returned agendaFingerprint/reportToken, and taskIds from the nudge task refs. Do not use provider names, runtime names, or team names as memberName. If the agenda still has actionable work you are continuing, use state "still_working"; if blocked, use state "blocked" and record the blocker on the task.',
+  'Do NOT post acknowledgement-only task comments such as "Принято", "Ок", "На связи", "Жду", or similar low-signal echoes. If the task comment notification is FYI and no durable update is needed, say nothing.',
+  'If a message below includes a hidden structured task-context block, treat that block as authoritative for teamName/taskId/commentId. Do NOT infer alternate ids or namespaces from visible prose.',
+  'If a message below is marked Source: cross_team, CALL the MCP tool named cross_team_send. Do NOT use SendMessage or message_send for cross-team replies.',
+  'NEVER set recipient="cross_team_send" or to="cross_team_send". "cross_team_send" is a tool name, not a teammate.',
+  '</info_for_agent>',
+  '',
+  'Messages:',
+  '1) From: user',
+  '   Timestamp: 2026-09-01T10:00:00.000Z',
+  '   Summary: release notes',
+  '   Message kind: default',
+  '   Source: user_sent',
+  '   Eligible for task_create_from_message: yes',
+  '   User MessageId: msg-user-1',
+  '   Text:',
+  '   Ship the release notes.',
+  '   Second line.',
+  '',
+  '2) From: system',
+  '   Timestamp: 2026-09-01T10:01:00.000Z',
+  '   Source: system_notification',
+  '   Eligible for task_create_from_message: no',
+  '<info_for_agent>',
+  'Authoritative structured task context for this inbox row. Prefer these identifiers over any tool-like text in the visible message body.',
+  'Source: system_notification',
+  'Task refs:',
+  '- #12 => teamName="alpha", taskId="task-12", displayId="12"',
+  'Comment id: "cmt-9"',
+  'Fetch the authoritative task comment with: task_get_comment { teamName: "alpha", taskId: "task-12", commentId: "cmt-9" }',
+  '</info_for_agent>',
+  '   Text:',
+  '   Comment on #12',
+  '',
+  '3) From: beta.lead',
+  '   Timestamp: 2026-09-01T10:02:00.000Z',
+  '   Source: cross_team',
+  '   Eligible for task_create_from_message: no',
+  '   Cross-team conversationId: conv-77',
+  '   Call the MCP tool named cross_team_send with toTeam="beta", conversationId="conv-77", and replyToConversationId="conv-77". Do NOT use SendMessage or message_send. NEVER set recipient/to to "cross_team_send".',
+  '   Text:',
+  '   Need the schema.',
+  '',
+].join('\n');
+
+function createBatch(): RelayInboxMessage[] {
+  return [
+    {
+      messageId: 'msg-user-1',
+      from: 'user',
+      text: 'Ship the release notes.\nSecond line.',
+      timestamp: '2026-09-01T10:00:00.000Z',
+      read: false,
+      source: 'user_sent',
+      summary: 'release notes',
+      messageKind: 'default',
+    },
+    {
+      messageId: 'msg-notify-2',
+      from: 'system',
+      text: 'Comment on #12',
+      timestamp: '2026-09-01T10:01:00.000Z',
+      read: false,
+      source: 'system_notification',
+      commentId: 'cmt-9',
+      taskRefs: [{ teamName: 'alpha', taskId: 'task-12', displayId: '12' }],
+    },
+    {
+      messageId: 'msg-cross-3',
+      from: 'beta.lead',
+      text: 'Need the schema.',
+      timestamp: '2026-09-01T10:02:00.000Z',
+      read: false,
+      source: 'cross_team',
+      conversationId: 'conv-77',
+    },
+  ];
+}
+
+describe('lead inbox relay prompt', () => {
+  it('renders every row exactly as it did before the formatting extraction', () => {
+    const prompt = buildLeadInboxRelayPrompt({
+      teamName: 'alpha',
+      leadName: 'lead',
+      batch: createBatch(),
+      replyVisibility: 'user',
+      teammates: [{ name: 'dev', role: 'engineer' }],
+      workSyncControlUrl: 'http://127.0.0.1:1234',
+    });
+
+    expect(prompt).toBe(EXPECTED_LEAD_RELAY_PROMPT);
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayPrompt.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayPrompt.test.ts
@@ -124,4 +124,57 @@ describe('lead inbox relay prompt', () => {
 
     expect(prompt).toBe(EXPECTED_LEAD_RELAY_PROMPT);
   });
+
+  it('marks only the message ids named as redelivered', () => {
+    const prompt = buildLeadInboxRelayPrompt({
+      teamName: 'alpha',
+      leadName: 'lead',
+      batch: createBatch(),
+      replyVisibility: 'user',
+      teammates: [{ name: 'dev', role: 'engineer' }],
+      workSyncControlUrl: 'http://127.0.0.1:1234',
+      redeliveredMessageIds: new Set(['msg-notify-2']),
+    });
+
+    const rows = prompt.slice(prompt.indexOf('Messages:')).split(/^(?=\d\) From: )/m);
+    const [, firstRow, secondRow, thirdRow] = rows;
+    expect(firstRow).not.toContain('REDELIVERY:');
+    expect(secondRow).toContain(
+      '   REDELIVERY: this exact message was already delivered to you in an earlier turn'
+    );
+    expect(secondRow).toContain('Do NOT re-create tasks, re-send messages, or repeat any side');
+    expect(thirdRow).not.toContain('REDELIVERY:');
+  });
+
+  it('announces the redelivery before the row it belongs to, not after it', () => {
+    const prompt = buildLeadInboxRelayPrompt({
+      teamName: 'alpha',
+      leadName: 'lead',
+      batch: createBatch(),
+      replyVisibility: 'user',
+      teammates: [],
+      workSyncControlUrl: null,
+      redeliveredMessageIds: new Set(['msg-user-1']),
+    });
+    const lines = prompt.split('\n');
+    const rowIndex = lines.indexOf('1) From: user');
+
+    expect(lines[rowIndex + 1]).toContain('REDELIVERY:');
+    expect(lines[rowIndex + 3]).toBe('   Timestamp: 2026-09-01T10:00:00.000Z');
+  });
+
+  it('leaves a first delivery unmarked when the redelivered set is empty or absent', () => {
+    const withEmptySet = buildLeadInboxRelayPrompt({
+      teamName: 'alpha',
+      leadName: 'lead',
+      batch: createBatch(),
+      replyVisibility: 'user',
+      teammates: [{ name: 'dev', role: 'engineer' }],
+      workSyncControlUrl: 'http://127.0.0.1:1234',
+      redeliveredMessageIds: new Set<string>(),
+    });
+
+    expect(withEmptySet).not.toContain('REDELIVERY:');
+    expect(withEmptySet).toBe(EXPECTED_LEAD_RELAY_PROMPT);
+  });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningStopFlow.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningStopFlow.test.ts
@@ -132,6 +132,31 @@ function makePorts(
 }
 
 describe('team provisioning stop flow', () => {
+  it('cancels the owning relay before waiting for process termination', async () => {
+    const rejectOnce = vi.fn();
+    const run = { ...makeRun('run-1'), leadRelayCapture: { rejectOnce } };
+    const ports = makePorts(
+      'team-a',
+      new Map([[run.runId, run]]),
+      new Map([['team-a', run.runId]])
+    );
+    let finishStop!: () => void;
+    ports.killTeamProcessAndWait.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishStop = resolve;
+        })
+    );
+    const stopping = stopTeamFlow('team-a', ports);
+    await vi.waitFor(() => expect(ports.killTeamProcessAndWait).toHaveBeenCalled());
+    expect(rejectOnce).toHaveBeenCalledOnce();
+    expect(run.leadRelayCapture).toBeNull();
+    expect(ports.cleanupRun).not.toHaveBeenCalled();
+    finishStop();
+    await stopping;
+    expect(ports.cleanupRun).toHaveBeenCalledWith(run);
+  });
+
   it('cancels pending adapter launches before waiting for a slow roster-aware team stop', async () => {
     let releaseInitialStop!: () => void;
     const initialStopGate = new Promise<void>((resolve) => {

--- a/src/main/services/team/provisioning/leadRelayCaptureStreamHooks.ts
+++ b/src/main/services/team/provisioning/leadRelayCaptureStreamHooks.ts
@@ -15,6 +15,8 @@ export interface LeadRelayCaptureStreamState {
   settled: boolean;
   idleHandle: NodeJS.Timeout | null;
   idleMs: number;
+  /** Extends the capture's reply deadline; set by the relay flow that owns the capture. */
+  touch?: () => void;
   resolveOnce: (text: string) => void;
   rejectOnce: (error: string) => void;
 }

--- a/src/main/services/team/provisioning/leadRelayCaptureStreamHooks.ts
+++ b/src/main/services/team/provisioning/leadRelayCaptureStreamHooks.ts
@@ -1,0 +1,65 @@
+/**
+ * Stream-side state of an in-flight lead inbox relay capture.
+ *
+ * The relay flow owns the richer capture record; this is the subset the
+ * stream-json handler is allowed to see and mutate while a lead turn runs.
+ */
+export interface LeadRelayCaptureStreamState {
+  textParts: string[];
+  textJoinMode?: 'block' | 'stream';
+  recoveryMessageId?: string;
+  requireTerminalResult?: boolean;
+  terminalResultSucceeded?: boolean;
+  hasVisibleSendMessage?: boolean;
+  hasUserVisibleSendMessage?: boolean;
+  settled: boolean;
+  idleHandle: NodeJS.Timeout | null;
+  idleMs: number;
+  resolveOnce: (text: string) => void;
+  rejectOnce: (error: string) => void;
+}
+
+export function isSyntheticLeadTextChunk(msg: Record<string, unknown>): boolean {
+  const message = (msg.message ?? msg) as Record<string, unknown>;
+  return message.model === '<synthetic>' && message.type === 'message';
+}
+
+export function joinLeadRelayCaptureText(capture: LeadRelayCaptureStreamState): string {
+  return capture.textParts.join(capture.textJoinMode === 'stream' ? '' : '\n').trim();
+}
+
+export function appendLeadRelayCaptureAssistantText(
+  capture: LeadRelayCaptureStreamState,
+  input: {
+    text: string;
+    isSyntheticChunk: boolean;
+    boundTextParts: (parts: string[]) => string[];
+  }
+): void {
+  const { text, isSyntheticChunk, boundTextParts } = input;
+  if (isSyntheticChunk) {
+    capture.textJoinMode = 'stream';
+  } else if (!capture.textJoinMode) {
+    capture.textJoinMode = 'block';
+  }
+  capture.textParts.push(text);
+  capture.textParts = boundTextParts(capture.textParts);
+  if (capture.idleHandle) {
+    clearTimeout(capture.idleHandle);
+  }
+  if (!capture.requireTerminalResult) {
+    capture.idleHandle = setTimeout(() => {
+      const combined = joinLeadRelayCaptureText(capture);
+      capture.resolveOnce(combined);
+    }, capture.idleMs);
+  }
+}
+
+export function resolveLeadRelayCaptureOnTerminalResult(
+  capture: LeadRelayCaptureStreamState | null
+): void {
+  if (!capture) return;
+  capture.terminalResultSucceeded = true;
+  const combined = joinLeadRelayCaptureText(capture);
+  capture.resolveOnce(combined);
+}

--- a/src/main/services/team/runtime/OpenCodeRuntimeMessageText.ts
+++ b/src/main/services/team/runtime/OpenCodeRuntimeMessageText.ts
@@ -161,7 +161,7 @@ export function buildOpenCodeRuntimeMessageText(input: OpenCodeTeamRuntimeMessag
       ? `<opencode_delivery_context>${deliveryContext}</opencode_delivery_context>`
       : null,
     'You are running in OpenCode, not Claude Code or Codex native.',
-    'REPLAY GUARD: this same inbound message may reach you more than once (delivery retries and session rebuilds replay it). Before acting, check the current task board and your recent sent messages. If they already reflect this message (tasks already created, work already started, reply already sent), do NOT repeat any action and do NOT send another reply; end the turn with one short plain-text line noting it was already handled. Never declare overall completion (for example "ALL DONE") unless the required final state verifiably exists right now.',
+    'REPLAY GUARD: this same inbound message may reach you more than once (delivery retries and session rebuilds replay it). Before acting, check the current task board and your recent sent messages for what this message already produced. Do NOT redo an action that is already complete: do not create a task that already exists, and do not re-send a reply you already sent. Work that is only started or partly done is NOT handled: continue it and finish what is missing. Only when everything this message asked for is verifiably complete, end the turn with one short plain-text line noting it was already handled. Never declare overall completion (for example "ALL DONE") unless the required final state verifiably exists right now.',
     actionModeWorkScopeReminder,
     ...responseInstructions,
     'Do not call runtime_bootstrap_checkin or member_briefing just to answer this delivered app message.',

--- a/src/main/services/team/runtime/OpenCodeRuntimeMessageText.ts
+++ b/src/main/services/team/runtime/OpenCodeRuntimeMessageText.ts
@@ -161,6 +161,7 @@ export function buildOpenCodeRuntimeMessageText(input: OpenCodeTeamRuntimeMessag
       ? `<opencode_delivery_context>${deliveryContext}</opencode_delivery_context>`
       : null,
     'You are running in OpenCode, not Claude Code or Codex native.',
+    'REPLAY GUARD: this same inbound message may reach you more than once (delivery retries and session rebuilds replay it). Before acting, check the current task board and your recent sent messages. If they already reflect this message (tasks already created, work already started, reply already sent), do NOT repeat any action and do NOT send another reply; end the turn with one short plain-text line noting it was already handled. Never declare overall completion (for example "ALL DONE") unless the required final state verifiably exists right now.',
     actionModeWorkScopeReminder,
     ...responseInstructions,
     'Do not call runtime_bootstrap_checkin or member_briefing just to answer this delivered app message.',

--- a/src/main/services/team/runtime/__tests__/OpenCodeTeamRuntimeAdapter.test.ts
+++ b/src/main/services/team/runtime/__tests__/OpenCodeTeamRuntimeAdapter.test.ts
@@ -231,6 +231,45 @@ describe('OpenCodeTeamRuntimeAdapter delivery prompt contracts', () => {
     expect(text).toContain('to="user"');
     expect(text).not.toContain('informational system notice');
   });
+
+  it('carries the replay guard on every delivered app message, whatever the reply contract', async () => {
+    for (const replyRecipient of [undefined, 'user', 'team-lead', 'alice', 'system']) {
+      const text = await deliveredPromptText(replyRecipient);
+
+      expect(text).toContain(
+        'REPLAY GUARD: this same inbound message may reach you more than once'
+      );
+      expect(text).toContain('Before acting, check the current task board and your recent sent');
+      expect(text).toContain('do NOT repeat any action and do NOT send another reply');
+      expect(text).toContain('Never declare overall completion (for example "ALL DONE")');
+    }
+  });
+
+  it('states the replay guard before the reply instructions it constrains', async () => {
+    const lines = (await deliveredPromptText('team-lead')).split('\n');
+    const guardIndex = lines.findIndex((line) => line.startsWith('REPLAY GUARD:'));
+    const replyIndex = lines.findIndex((line) =>
+      line.startsWith('Required message_send argument envelope')
+    );
+
+    expect(guardIndex).toBeGreaterThanOrEqual(0);
+    expect(replyIndex).toBeGreaterThan(guardIndex);
+  });
+
+  it('keeps the replay guard out of the bootstrap check-in retry envelope', () => {
+    const text = buildOpenCodeRuntimeMessageText({
+      runId: 'run-1',
+      teamName: 'team-a',
+      laneId: 'lane-worker',
+      memberName: 'Worker',
+      cwd: '/repo',
+      text: 'Attach and commit runtime evidence.',
+      bootstrapCheckinRetry: { runtimeSessionId: 'session-1' },
+    });
+
+    expect(text).toContain('<opencode_runtime_bootstrap_checkin_retry>');
+    expect(text).not.toContain('REPLAY GUARD');
+  });
 });
 
 describe('buildOpenCodeRuntimeMessageText bootstrap check-in retry', () => {
@@ -329,6 +368,17 @@ describe('buildMemberBootstrapPrompt', () => {
     // The rationale has to hold for any team on any runtime: no host-specific
     // or model-specific justification may leak into a launch briefing.
     expect(prompt).not.toMatch(/gpu|local model/i);
+  });
+
+  it('does not carry the delivered-message replay guard', () => {
+    const input = launchInput();
+
+    const prompt = buildMemberBootstrapPrompt(input, input.expectedMembers[0]);
+
+    // The launch briefing is not a delivered message: there is nothing to have already
+    // handled, and a replay guard there would tell a fresh member to check a board that
+    // cannot yet reflect any work of its own.
+    expect(prompt).not.toContain('REPLAY GUARD');
   });
 });
 

--- a/src/main/services/team/runtime/__tests__/OpenCodeTeamRuntimeAdapter.test.ts
+++ b/src/main/services/team/runtime/__tests__/OpenCodeTeamRuntimeAdapter.test.ts
@@ -240,8 +240,27 @@ describe('OpenCodeTeamRuntimeAdapter delivery prompt contracts', () => {
         'REPLAY GUARD: this same inbound message may reach you more than once'
       );
       expect(text).toContain('Before acting, check the current task board and your recent sent');
-      expect(text).toContain('do NOT repeat any action and do NOT send another reply');
+      expect(text).toContain('Do NOT redo an action that is already complete');
+      expect(text).toContain('do not create a task that already exists');
+      expect(text).toContain('do not re-send a reply you already sent');
       expect(text).toContain('Never declare overall completion (for example "ALL DONE")');
+    }
+  });
+
+  it('treats unfinished work as work to resume, not as proof the message was handled', async () => {
+    for (const replyRecipient of [undefined, 'user', 'team-lead', 'alice', 'system']) {
+      const text = await deliveredPromptText(replyRecipient);
+
+      expect(text).toContain(
+        'Work that is only started or partly done is NOT handled: continue it and finish what is missing.'
+      );
+      expect(text).toContain(
+        'Only when everything this message asked for is verifiably complete, end the turn'
+      );
+      // The guard must never accept partial progress as proof of handling: a replay that follows
+      // an interruption would then read "work already started" and end the turn on a half-done job.
+      expect(text).not.toContain('work already started');
+      expect(text).not.toContain('do NOT repeat any action and do NOT send another reply');
     }
   });
 

--- a/test/main/services/team/TeamProvisioningServiceRelay.test.ts
+++ b/test/main/services/team/TeamProvisioningServiceRelay.test.ts
@@ -4116,7 +4116,7 @@ Messages:
     }
   });
 
-  it('times out a hung existing lead relay in-flight lock', async () => {
+  it('retains a hung lead relay lock after timeout to prevent duplicate delivery', async () => {
     vi.useFakeTimers();
     const service = new TeamProvisioningService();
     const teamName = 'my-team';
@@ -4137,7 +4137,7 @@ Messages:
             leadInboxRelayInFlight: Map<string, Promise<number>>;
           }
         ).leadInboxRelayInFlight.has(teamName)
-      ).toBe(false);
+      ).toBe(true);
       expect(vi.mocked(console.warn).mock.calls[0]?.join(' ')).toContain(
         'lead_inbox_relay_timed_out'
       );

--- a/test/renderer/features/runtime-provider-management/useRuntimeProviderManagement.test.ts
+++ b/test/renderer/features/runtime-provider-management/useRuntimeProviderManagement.test.ts
@@ -1,5 +1,5 @@
 import React, { act } from 'react';
-import { createRoot } from 'react-dom/client';
+import { createRoot as createReactRoot } from 'react-dom/client';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -126,9 +126,16 @@ function createEmptyDirectoryResponse(
 }
 
 describe('useRuntimeProviderManagement', () => {
+  const roots = new Set<ReturnType<typeof createReactRoot>>();
   let host: HTMLDivElement;
   let state: RuntimeProviderManagementState | null = null;
   let actions: RuntimeProviderManagementActions | null = null;
+
+  function createRoot(container: HTMLDivElement): ReturnType<typeof createReactRoot> {
+    const root = createReactRoot(container);
+    roots.add(root);
+    return root;
+  }
 
   function Harness(): React.ReactElement {
     const hook = useRuntimeProviderManagement({
@@ -199,7 +206,12 @@ describe('useRuntimeProviderManagement', () => {
     actions = null;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Removing DOM alone leaves effects alive and able to overwrite the next test's state.
+    await act(async () => {
+      for (const root of roots) root.unmount();
+    });
+    roots.clear();
     Reflect.deleteProperty(window, 'electronAPI');
     document.body.innerHTML = '';
     vi.unstubAllGlobals();


### PR DESCRIPTION
Builds on #556 (merged), which landed the reply-optional delivery contract. Independent of the rest of the delivery series. Commits 4 and 6 edit `runtime/OpenCodeRuntimeMessageText.ts`, which #556 also touched.

## Problem

**A lead that answered by working was judged undelivered.** A relayed lead inbox message counted as delivered only if the lead produced text within 15 seconds. A lead that answers by working (three `task_create` calls, then a board cleanup) produces no text in that window, so the relay declared the delivery failed, left the rows unread, and re-sent the same batch 50 milliseconds later. An ACP lead has no memory of the earlier turn, so it executed the message again: duplicate task sets, duplicate board cleanups, and a run of near-identical user messages all carrying the same `relayOfMessageId`. Seen on every Cursor-led run of the earlier campaign.

**A replayed message looked new to the lane.** The same inbound message can reach an OpenCode lane more than once (the delivery watchdog retries an unacknowledged send, a session rebuild replays history), and the lane treated every copy as new work: it repeated user-facing replies and once announced overall completion for work it had merely read about a second time.

## Fix

Six commits: two pure extractions that pay for the lines, two fixes, and two answering the review on this PR.

1. `refactor(team): extract lead relay message formatting from the inbox relay policy`: `TeamProvisioningInboxRelayPolicy.ts` sat exactly on its frozen cap (890). `buildLeadInboxTaskContextBlock` (47 lines with its comment, including an existing upstream `TODO` note that moves with it verbatim) goes to `TeamProvisioningLeadRelayMessageFormatting.ts`. Deliberately not more: the row formatter next to it calls a cross-team helper, so moving both would either drag two more helpers out and drop the file below the 800 floor that retires its legacy entry, or create an import cycle the repo forbids. 890 → 859. The module takes its row type from the shared types so the edge runs one way, and the rest of the formatter can join it later.
2. `refactor(team): extract the lead relay capture stream hooks`: the capture shape, the text join and the synthetic-chunk predicate move out of `TeamProvisioningStreamEvents.ts` (1212, frozen cap) into `leadRelayCaptureStreamHooks.ts`, and the assistant-text append and terminal-result resolve become hook functions. This one is an extraction rather than a byte-identical move (signatures and one call argument changed), and the commit says so. 1212 → 1181.
3. `fix(team): a lead relay redelivery is proved by activity, not by a resend`: every lead stream event, an assistant message or a tool result, touches the capture and re-arms its reply deadline, so a live turn can no longer be judged undelivered halfway through. The base deadline moves from 15 s to 120 s and an absolute cap of 600 s bounds a lane that never finishes; a delivery that produced no proof at all backs off 10 s instead of 50 ms before the retry. Retries are no longer silent: the flow remembers which message ids were already sent to the lead at least once and marks exactly those rows in the next prompt with a `REDELIVERY:` block telling the lead to check board state before repeating side effects; a first delivery is untouched, byte for byte. The registry is keyed by the same per-service identity map as the relay queues, so it lives and dies with the service instance and cannot leak between teams or tests; it is trimmed at 300 ids. The forwarding wrappers on the follow-up relay ports pass only the arguments they were given, so an existing assertion on the one-argument form keeps holding.
4. `fix(opencode): a replayed inbound message must be recognised before it is acted on`: every delivered app message envelope opens with a replay guard: check the board and your own recent sent messages first, do not repeat an action or a reply already recorded, end the turn with one short line saying it was already handled, never declare completion unless the final state verifiably exists now. Stated before the reply instructions it constrains, and deliberately absent from the launch briefing and the bootstrap check-in retry, which are not delivered messages. The controller half of this rule (skipping the blocked-owner notification) is in the controller PR.

Two further commits answer the CodeRabbit review.

5. `fix(team): a re-armed lead relay deadline must stay inside the absolute cap`: `touch` refused to extend a capture already past the 600 s cap, but any touch before it armed a full 120 s base deadline, so activity at 599,999 ms armed a deadline firing near 720 s and every further touch pushed it out again. It now arms the smaller of the base deadline and what is left of the cap; the early return keeps its meaning, an early touch still arms the full 120 s, and a late touch ends the capture exactly at the cap. The test advances the clock to one millisecond before the cap, touches, and asserts a 1 ms re-arm; without the fix it reads 120000.
6. `fix(opencode): started work is not proof that a replayed message was handled`: the replay guard listed "work already started" beside "tasks already created" and "reply already sent" as evidence that nothing more was needed, then told the lane to end the turn - so a replay after an interruption or a session rebuild, which is exactly the case where the first delivery got partway and stopped, could abandon the unfinished half and report it handled. The guard now forbids only the duplicate of a completed action (do not create a task that already exists, do not re-send a reply already sent), states that started or partly done work is NOT handled and must be continued to the end, and allows the short "already handled" exit only when everything the message asked for is verifiably complete. The completion rule is unchanged. The lead relay `REDELIVERY:` block was checked for the same defect and needs no change: it already conditions its silence on everything being handled.

The three timing constants (120 s base deadline, 600 s absolute cap, 10 s no-proof backoff) are empirical; if you want one configurable, the base deadline is the only sensible knob. The capture shape is still declared structurally in two places after commit 2 (the run model and the flow); unifying them is a separate change.

Sizes: `TeamProvisioningInboxRelayPolicy.ts` 859/890 (59 above the floor), `TeamProvisioningStreamEvents.ts` 1181/1212, `TeamProvisioningLeadInboxRelayFlow.ts` 684/800, `OpenCodeRuntimeMessageText.ts` 190; new modules 52 and 67. `scripts/ci/source-file-size-baseline.json` untouched.

## Tests

The two source changes shipped with no tests at all in the wave they came from; every test here is new, and each control was mutation-checked (the rule was broken, the named tests went red, the rule restored):

- A 65-line byte-for-byte golden of the pre-change relay prompt (user row, task-context row, cross-team row); an empty redelivery set reproduces it exactly, so the extraction is proven to have changed nothing. Any future wording change has to update that fixture, a deliberate trade; I can narrow it to the messages section if you prefer.
- The `REDELIVERY:` block marks only the named ids and sits directly above its row; marking every row fails four tests, dropping the block fails three.
- Activity retires the deadline armed at send time and no follow-up is scheduled; touch past the 600 s cap stops extending; an unproven delivery schedules the 10 s backoff; a resent id is announced while a fresh id in the same batch is not. Reverting the deadline to 15 s fails four tests.
- `touch` is called on `tool_result` and on `assistant`, and nothing throws when no capture is set. A touch one millisecond before the absolute cap re-arms for the remaining millisecond and not for another base deadline.
- The replay guard is present for all five reply contracts, positioned before the reply envelope, and absent from the check-in retry and the launch briefing; leaking it into either fails its test. A second five-contract case asserts that unfinished work is to be resumed and that the old "already started" phrasing is gone; restoring the previous text fails both cases.
- In commit 1, 48 of the 49 lines the policy loses reappear byte-identical in the new module; the 49th is the signature line, which only gains the `export` keyword. One existing test that asserted inside a swallowed mock throw, and so could never fail, now observes outside the mock.

On the rebased tip: `pnpm typecheck`, the source-file size guard, the team-provisioning architecture guard, `prettier --check` on every changed `src/` file, and `eslint` on the same files at 0 errors - the warning set for those files is rule for rule the same 66 warnings `origin/main` already reports for them, the single `sonarjs/todo-tag` being the upstream TODO that moved in commit 1. The three CI lint shards report 0 errors each. Targeted vitest over the changed test files plus every relay, inbox-writer and stream-event suite covering the changed modules, 22 files: 340 tests, all passing. Sweep over `src/main/services/team` + `test/main/services/team`: 5942 tests, the same 3 failing. Full suite: 15223 tests, failing only on the three Windows-only `TeamProvisioningService` liveness cases the unmodified base commit produces on this machine (#554 fixes those); the failing set is identical to the base, nothing new.

## Tested on

Windows 11 Pro, from source, against `origin/main @ 243769c81`. The duplicated task sets were reproduced on live runs with a Cursor lead during the earlier campaign; with activity as proof the batch was delivered once, and a genuine retry carried the redelivery block and produced no second task set. Not tested on macOS or Linux; nothing here is platform-specific.

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved handling of redelivered messages so verified actions aren’t repeated while unfinished work continues.
  * Extended lead-reply capture windows and refreshed them during active streaming, with safeguards against indefinite delays.
  * Added delayed follow-up relays when delivery confirmation is unavailable.
  * Improved task context and replay instructions for more accurate message processing.
  * Added cancellation safeguards when provisioning runs stop or are cleaned up.

* **Tests**
  * Added coverage for redeliveries, capture timing, cancellation, stream activity, follow-up retries, lifecycle handling, and replay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->