### PR TITLE
fix(models): sort newer versions first and remove duplicate labels

### DIFF
--- a/src/renderer/components/runtime/ProviderModelBadges.tsx
+++ b/src/renderer/components/runtime/ProviderModelBadges.tsx
@@ -116,8 +116,23 @@ export const ProviderModelBadges = ({
   const [collapsedModelLimit, setCollapsedModelLimit] = useState<number | null>(null);
   const [measureTick, setMeasureTick] = useState(0);
   const listRef = useRef<HTMLDivElement | null>(null);
-  const visibleModels = getVisibleTeamProviderModels(providerId, models, providerStatus);
   const displayModelAvailability = providerId === 'opencode' ? undefined : modelAvailability;
+  const seenModelBadges = new Set<string>();
+  const visibleModels = getVisibleTeamProviderModels(providerId, models, providerStatus).filter(
+    (model) => {
+      // Collapse aliases/snapshots only in this summary, preserving launch IDs in selectors.
+      // Different availability or pricing information must remain visible.
+      const key = JSON.stringify([
+        providerId === 'anthropic' ? formatModelBadgeLabel(providerId, model) : model,
+        getAvailabilityStatus(model, displayModelAvailability),
+        getAvailabilityReason(model, displayModelAvailability),
+        isCatalogModelFree(model, providerStatus),
+      ]);
+      if (seenModelBadges.has(key)) return false;
+      seenModelBadges.add(key);
+      return true;
+    }
+  );
   const shouldCollapse =
     typeof collapseAfter === 'number' && collapseAfter > 0 && visibleModels.length > collapseAfter;
   const collapsedBaseLimit = shouldCollapse ? collapseAfter : visibleModels.length;

--- a/src/renderer/utils/teamModelCatalog.ts
+++ b/src/renderer/utils/teamModelCatalog.ts
@@ -72,28 +72,6 @@ const ANTHROPIC_VISIBLE_MODEL_FALLBACKS = [
   'claude-opus-4-7[1m]',
 ] as const;
 
-const ANTHROPIC_MODEL_ORDER = [
-  'fable',
-  'claude-fable-5',
-  'claude-mythos-5',
-  'haiku',
-  'claude-haiku-4-5-20251001',
-  'claude-haiku-4-5',
-  'opus',
-  'opus[1m]',
-  'claude-opus-4-8',
-  'claude-opus-4-8[1m]',
-  'claude-opus-4-7',
-  'claude-opus-4-7[1m]',
-  'claude-opus-4-6',
-  'claude-opus-4-6[1m]',
-  'claude-sonnet-5',
-  'sonnet',
-  'sonnet[1m]',
-  'claude-sonnet-4-6',
-  'claude-sonnet-4-6[1m]',
-] as const;
-
 const TEAM_MODEL_LABEL_OVERRIDES: Record<string, string> = {
   default: 'Default',
   ...ANTHROPIC_ALIAS_LABELS,
@@ -181,7 +159,7 @@ const TEAM_PROVIDER_MODEL_OPTIONS: Record<SupportedProviderId, readonly TeamProv
 type AnthropicAliasFamily = keyof typeof ANTHROPIC_ALIAS_LABELS;
 
 const TEAM_PROVIDER_MODEL_ORDER: Record<SupportedProviderId, Map<string, number>> = {
-  anthropic: new Map(ANTHROPIC_MODEL_ORDER.map((model, index) => [model, index])),
+  anthropic: new Map(),
   codex: new Map(TEAM_PROVIDER_MODEL_OPTIONS.codex.map((option, index) => [option.value, index])),
   gemini: new Map(TEAM_PROVIDER_MODEL_OPTIONS.gemini.map((option, index) => [option.value, index])),
   opencode: new Map(
@@ -257,6 +235,11 @@ function formatParsedClaudeModelLabel(model: string): string | null {
   }
 
   const { baseModel, hasOneMillion } = splitOneMillionContextSuffix(trimmed);
+  const simpleModel = /^claude-([a-z]+)-(\d+(?:\.\d+)?)$/i.exec(baseModel);
+  if (simpleModel) {
+    const family = simpleModel[1].toLowerCase();
+    return `${family.charAt(0).toUpperCase()}${family.slice(1)} ${simpleModel[2]}${hasOneMillion ? ' (1M)' : ''}`;
+  }
   const parsedModel = parseModelString(baseModel);
   if (!parsedModel) {
     return null;
@@ -634,8 +617,12 @@ export function sortTeamProviderModels(
   const order = TEAM_PROVIDER_MODEL_ORDER[providerId];
 
   const sorted = [...deduped].sort((left, right) => {
-    if (providerId === 'codex') {
-      const versionOrder = compareTeamModelVersionsDescending(left, right);
+    const leftLabel =
+      providerId === 'anthropic' ? (getTeamModelBadgeLabel(providerId, left) ?? left) : left;
+    const rightLabel =
+      providerId === 'anthropic' ? (getTeamModelBadgeLabel(providerId, right) ?? right) : right;
+    if (providerId !== 'opencode') {
+      const versionOrder = compareTeamModelVersionsDescending(leftLabel, rightLabel);
       if (versionOrder !== 0) {
         return versionOrder;
       }
@@ -645,7 +632,7 @@ export function sortTeamProviderModels(
     if (leftRank !== rightRank) {
       return leftRank - rightRank;
     }
-    return left.localeCompare(right);
+    return leftLabel.localeCompare(rightLabel) || left.localeCompare(right);
   });
 
   if (providerId !== 'opencode') {

--- a/test/renderer/components/runtime/ProviderModelBadges.test.tsx
+++ b/test/renderer/components/runtime/ProviderModelBadges.test.tsx
@@ -428,6 +428,75 @@ describe('ProviderModelBadges', () => {
     expect(renderedModelLabels).toContain('Opus 4.8 (1M)');
   });
 
+  it('shows newer Anthropic versions first and deduplicates aliases and dated snapshots', () => {
+    const host = render(
+      <ProviderModelBadges
+        providerId="anthropic"
+        models={[
+          'fable',
+          'claude-fable-5',
+          'claude-fable-5-1',
+          'haiku',
+          'claude-haiku-4-5',
+          'claude-haiku-4-5-20251001',
+          'opus',
+          'claude-opus-4-8',
+          'opus[1m]',
+          'claude-opus-4-8[1m]',
+          'sonnet',
+          'claude-sonnet-4-6',
+          'sonnet[1m]',
+          'claude-sonnet-4-6[1m]',
+        ]}
+        collapseAfter={2}
+      />
+    );
+
+    expect(host.textContent).toBe('Fable 5.1,Fable 5+8 more');
+    act(() => {
+      host.querySelector('button')?.click();
+    });
+    const labels = Array.from(host.firstElementChild?.firstElementChild?.children ?? []).map(
+      (item) => item.firstElementChild?.textContent
+    );
+    expect(labels).toEqual([
+      'Fable 5.1',
+      'Fable 5',
+      'Sonnet 5',
+      'Opus 4.8',
+      'Opus 4.8 (1M)',
+      'Opus 4.7',
+      'Opus 4.7 (1M)',
+      'Sonnet 4.6',
+      'Sonnet 4.6 (1M)',
+      'Haiku 4.5',
+    ]);
+  });
+
+  it('preserves distinct availability information for otherwise identical Anthropic labels', () => {
+    const host = render(
+      <ProviderModelBadges
+        providerId="anthropic"
+        models={['opus', 'claude-opus-4-8']}
+        modelAvailability={[
+          { modelId: 'opus', status: 'available', checkedAt: '2026-09-04T00:00:00Z' },
+          {
+            modelId: 'claude-opus-4-8',
+            status: 'unavailable',
+            reason: 'Access denied',
+            checkedAt: '2026-09-04T00:00:00Z',
+          },
+        ]}
+      />
+    );
+
+    expect(host.textContent).toContain('Unavailable');
+    const labels = Array.from(host.firstElementChild?.children ?? []).map(
+      (item) => item.firstElementChild?.textContent
+    );
+    expect(labels.filter((label) => label === 'Opus 4.8')).toHaveLength(2);
+  });
+
   it('collapses long model lists and expands them inline without an internal scroll area', () => {
     const models = Array.from(
       { length: 18 },

--- a/test/renderer/utils/teamModelCatalog.test.ts
+++ b/test/renderer/utils/teamModelCatalog.test.ts
@@ -5,6 +5,7 @@ import {
   isAnthropicOneMillionContextTeamModel,
   isAnthropicSonnetOneMillionContextTeamModel,
   isAnthropicSonnetTeamModel,
+  sortTeamProviderModels,
 } from '@renderer/utils/teamModelCatalog';
 import { describe, expect, it } from 'vitest';
 
@@ -19,6 +20,59 @@ describe('teamModelCatalog', () => {
       'gpt-5.5',
       'glm-5',
       'glm-4.7',
+    ]);
+  });
+
+  it('sorts future Anthropic versions before older curated models and resolves alias versions', () => {
+    const models = ['fable', 'claude-fable-5-1', 'claude-fable-5-10', 'claude-opus-5', 'opus'];
+    const original = [...models];
+
+    expect(sortTeamProviderModels('anthropic', models)).toEqual([
+      'claude-fable-5-10',
+      'claude-fable-5-1',
+      'fable',
+      'claude-opus-5',
+      'opus',
+    ]);
+    expect(models).toEqual(original);
+    expect(getTeamModelBadgeLabel('anthropic', 'claude-opus-5')).toBe('Opus 5');
+    expect(getTeamModelBadgeLabel('anthropic', 'claude-fable-5.1')).toBe('Fable 5.1');
+  });
+
+  it('ignores dated Anthropic snapshots when comparing versions and keeps distinct launch ids', () => {
+    const models = [
+      'claude-haiku-4-5-20251001',
+      'haiku',
+      'claude-opus-4-8[1m]',
+      'opus',
+      'claude-opus-4-8',
+      'claude-3-7-sonnet-20250219',
+    ];
+
+    expect(sortTeamProviderModels('anthropic', models)).toEqual([
+      'claude-opus-4-8',
+      'opus',
+      'claude-opus-4-8[1m]',
+      'claude-haiku-4-5-20251001',
+      'haiku',
+      'claude-3-7-sonnet-20250219',
+    ]);
+    expect(getTeamModelBadgeLabel('anthropic', 'claude-opus-5[1m]')).toBe('Opus 5 (1M)');
+  });
+
+  it('sorts newer Gemini versions ahead of curated models and preserves equal-version priorities', () => {
+    expect(
+      sortTeamProviderModels('gemini', [
+        'gemini-2.5-flash',
+        'gemini-3.1-pro-preview',
+        'gemini-2.5-pro',
+        'gemini-3.10-pro-preview',
+      ])
+    ).toEqual([
+      'gemini-3.10-pro-preview',
+      'gemini-3.1-pro-preview',
+      'gemini-2.5-pro',
+      'gemini-2.5-flash',
     ]);
   });
 
@@ -48,16 +102,16 @@ describe('teamModelCatalog', () => {
       ])
     ).toEqual([
       'fable',
-      'claude-haiku-4-5-20251001',
+      'claude-sonnet-5',
       'claude-opus-4-8',
       'claude-opus-4-8[1m]',
       'claude-opus-4-7',
       'claude-opus-4-7[1m]',
       'claude-opus-4-6',
       'claude-opus-4-6[1m]',
-      'claude-sonnet-5',
       'claude-sonnet-4-6',
       'claude-sonnet-4-6[1m]',
+      'claude-haiku-4-5-20251001',
     ]);
   });
 


### PR DESCRIPTION
Provider model lists placed newly discovered Anthropic versions after a fixed list of known IDs and showed repeated names for aliases and dated snapshots. Sort Anthropic and Gemini versions numerically in descending order, so Fable 5.10 appears before 5.1 and 5, and format major-only Claude IDs consistently.

Deduplicate equivalent Anthropic labels before collapsing the summary and calculating the remaining count. Keep 1M context variants and entries with different availability or pricing information separate, and preserve launch IDs in model selectors.

Validation:
- 78 focused catalog, summary, availability and selector tests pass.
- TypeScript typecheck and focused fast lint pass.
- Source file size guard passes in the clean PR worktree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Model lists now display the newest versions first across supported providers.
  * Duplicate model badges are consolidated while preserving meaningful differences in availability and status.
  * Model aliases, dated snapshots, and version labels are ordered and displayed more consistently.
  * Expanded model lists retain the correct ordering and provide clearer selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->