### PR TITLE
fix(test): the Windows CLI fallback fixture cleanup keeps its retry budget

### DIFF
--- a/test/main/utils/childProcess.windows.test.ts
+++ b/test/main/utils/childProcess.windows.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
 import { execCli, spawnCli } from '@main/utils/childProcess';
 import { once } from 'events';
-import { copyFileSync, linkSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { copyFileSync, linkSync, mkdtempSync, writeFileSync } from 'fs';
+import { rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
@@ -35,6 +36,24 @@ function createWindowsArgvFixture(): WindowsArgvFixture {
   return { binaryPath, echoScriptPath, root };
 }
 
+/**
+ * Remove a fixture tree, absorbing the short window in which Windows still
+ * refuses the removal.
+ *
+ * Every process the fixture launches has exited by the time cleanup runs, but
+ * Windows can keep a handle somewhere inside the tree for a few hundred
+ * milliseconds afterwards (antivirus, the search indexer, or handles the kernel
+ * has not reclaimed yet), and the refusal surfaces as EPERM on the fixture
+ * root. `rmSync` cannot absorb that: it reports the first refusal instead of
+ * applying `maxRetries`/`retryDelay` to it, so the synchronous call has no
+ * retry budget at all for this error. The asynchronous `rm` does apply the
+ * budget to EPERM, which is why every other temp-tree cleanup in this suite
+ * awaits it.
+ */
+async function removeFixtureTree(root: string): Promise<void> {
+  await rm(root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
+}
+
 describe.skipIf(process.platform !== 'win32')('Windows CLI shell fallback round trip', () => {
   it('preserves adversarial argv through execCli for a spaced non-ASCII executable path', async () => {
     const fixture = createWindowsArgvFixture();
@@ -49,7 +68,7 @@ describe.skipIf(process.platform !== 'win32')('Windows CLI shell fallback round 
       expect(JSON.parse(stdout)).toEqual(ADVERSARIAL_ARGS);
       expect(stdout).not.toContain('INJECTED\r\n');
     } finally {
-      rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
+      await removeFixtureTree(fixture.root);
     }
   }, 30_000);
 
@@ -79,7 +98,7 @@ describe.skipIf(process.platform !== 'win32')('Windows CLI shell fallback round 
       expect({ exitCode, signal, stderr }).toEqual({ exitCode: 0, signal: null, stderr: '' });
       expect(JSON.parse(stdout)).toEqual(ADVERSARIAL_ARGS);
     } finally {
-      rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
+      await removeFixtureTree(fixture.root);
     }
   }, 30_000);
 
@@ -102,7 +121,7 @@ describe.skipIf(process.platform !== 'win32')('Windows CLI shell fallback round 
       expect(stderr).toBe('');
       expect(JSON.parse(stdout)).toEqual(ADVERSARIAL_ARGS);
     } finally {
-      rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
+      await removeFixtureTree(fixture.root);
     }
   }, 30_000);
 
@@ -126,7 +145,7 @@ describe.skipIf(process.platform !== 'win32')('Windows CLI shell fallback round 
       expect(stderr).toBe('');
       expect(JSON.parse(stdout)).toEqual(safeArgs);
     } finally {
-      rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
+      await removeFixtureTree(fixture.root);
     }
   }, 30_000);
 
@@ -148,7 +167,7 @@ describe.skipIf(process.platform !== 'win32')('Windows CLI shell fallback round 
         })
       ).rejects.toThrow('Unsafe Windows batch positional argument');
     } finally {
-      rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 });
+      await removeFixtureTree(fixture.root);
     }
   }, 30_000);
 });


### PR DESCRIPTION
Single commit, test-only, independent of every other open PR.

## Problem

The `Task change ledger Windows smoke` job in `.github/workflows/ci.yml` runs
`pnpm exec vitest run test/main/utils/childProcess.windows.test.ts` on a
`windows-latest` runner. One run of that job failed with

```
FAIL test/main/utils/childProcess.windows.test.ts > Windows CLI shell fallback round trip > preserves adversarial argv through a batch launcher that forwards %*
Error: EPERM, Permission denied: \\?\C:\Users\RUNNER~1\AppData\Local\Temp\child-process-Jane Müller-JoV89G   (syscall: 'rm', errno 1)
```

The failure is in the fixture cleanup, not in an assertion: every expectation
in the test had already passed. It is rare, one failure in the last twelve runs
of that job, and the same job passed on `main` at bb9b2f5f4 minutes earlier, so
the change under test is never the cause.

## Root cause

Two independent facts, both measured.

**Nothing the fixture launched is still running.** The failing case builds a
temp directory whose name contains a space and a non-ASCII character, hardlinks
`node.exe` into it as `Node Runtime.exe`, writes `proxy launcher.cmd`, and calls
`execCli(..., { preferShellForWindowsBatch: true })`, which runs
`cmd.exe /d /s /v:off /c` over the launcher. That is a three-level tree:
cmd.exe, the batch, and the hardlinked node.exe. It is fully drained before
cleanup runs. Recording the pid of the node grandchild and of its parent
cmd.exe from inside the launched script, then testing both with `kill(pid, 0)`
at the instant `execCli` resolved, gave 0 survivors out of 1240 launches (40
through `execCli` itself, 1200 through the same cmd.exe chain driven by eight
concurrent workers). The batch waits for the executable, cmd.exe waits for the
batch, and `execFile` reports `close` only after the process exited and every
inherited stdio pipe ended, so the round trip cannot leak a live process. No
handle is leaked by `src/main/utils/childProcess.ts` either.

What can still hold the tree is exactly what `src/main/utils/transientFsRetry.ts`
already documents for renames: for a few hundred milliseconds after the last
process exits, some other handle inside the tree (antivirus, the search indexer,
or handles the kernel has not reclaimed yet) makes Windows refuse the removal,
and the refusal surfaces as EPERM. Two local reproductions produce the CI error
verbatim, including the `\\?\` prefix, the `syscall: 'rm'` and `errno 1`:
a live process whose cwd is the directory, and a running executable image
inside the directory. In both cases the reported path is the tree root rather
than the entry that is actually held, so the CI message identifies the tree,
not the blocker.

**The cleanup asked for a retry budget that it never got.** The `finally`
blocks called

```ts
rmSync(fixture.root, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 })
```

`rmSync` does not apply `maxRetries` or `retryDelay` to EPERM. Measured on Node
24.19.0 against a directory held for 250 ms:

| cleanup call | outcome |
| --- | --- |
| `rmSync`, `maxRetries: 5`, `retryDelay: 100` | EPERM after 1 ms |
| `rmSync`, `maxRetries: 50`, `retryDelay: 100` | EPERM after 0 ms |
| manual poll loop, 10 ms interval | cleared after 274 ms |
| `await rm`, `maxRetries: 5`, `retryDelay: 100` | cleared after 307 ms |

So the synchronous call had no tolerance at all for this error class, and the
first transient refusal on the runner became a red build. The asynchronous `rm`
applies the same declared budget to EPERM and rides the refusal out.

## Fix

The five fixture cleanups in the file now go through one documented helper,
`removeFixtureTree`, which awaits `rm` with the budget the test always intended
to have. The numbers are unchanged, only the call that honours them.

This aligns the file with the rest of the suite. `test/main/ipc/review.test.ts`
and `test/main/services/runtime/OpenCodeRuntimeNvmResolution.safe-e2e.test.ts`,
the sibling step of this very CI job, already await `rm` with
`maxRetries: 5, retryDelay: 100`. `childProcess.windows.test.ts` was the only
place that declared a retry budget and then let the first refusal fail the test.

No assertion is weakened, no test is skipped, no error is swallowed, and no
production code changes. The production removal path is not affected:
`removePathWithIdentityFenceAsync` in `src/main/utils/durablePathOperations.ts`
already uses the asynchronous `fs.promises.rm`.

## Tests

Reproduction of the natural flake, both loops running at the same time:

| | runs | failures |
| --- | --- | --- |
| before the fix | 60 | 0 |
| after the fix | 60 | 0 |

The transient refusal does not occur on this machine, which is why the loop
alone proves nothing, so the failure was reproduced deterministically instead.
Injecting a 250 ms handle on the fixture root immediately after the real
`execCli` round trip, with the same fixture and the same launcher:

| cleanup under test | iterations | failures |
| --- | --- | --- |
| previous `rmSync` with the same budget | 20 | 20, all EPERM |
| `removeFixtureTree` as committed | 20 | 0 |

That is the negative control: the old cleanup fails every time on the exact
condition the runner hit, the new one never does.

Targeted suites, all green: `childProcess.windows.test.ts` (5 tests),
`childProcess.test.ts` (53 tests),
`OpenCodeRuntimeNvmResolution.safe-e2e.test.ts`, and `pnpm test:task-change-ledger`
(9 files, 257 tests), which together are every step of the CI job that failed.
Gates: `pnpm typecheck`, `node ./scripts/ci/check-source-file-size.mjs`, and
`prettier --check` on the changed file. `eslint` on the changed file reports the
same 2 errors and 5 warnings as on `main` for the fixture code this PR does not
touch, and the CI lint job does not cover `test/`.

## Tested on

Windows 11 Pro, from source. Every measurement above was taken on Node 24.19.0;
`.node-version` pins the CI runner to Node 24.16.0. The CI failure itself was
observed on the upstream `windows-latest` runner. Not run on macOS or Linux
locally.

Base: main @ bb9b2f5f43bfd3d18cf1d20c370c23b7ebd22ee9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows test fixture cleanup to retry transient permission errors, reducing cleanup failures during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->