### PR TITLE
feat(team): the stall monitor reads the OpenCode lane turn state and escalates a task nobody picks up

### DIFF
--- a/agent-teams-controller/src/internal/workSync.js
+++ b/agent-teams-controller/src/internal/workSync.js
@@ -278,11 +278,18 @@ async function memberWorkSyncStatus(context, flags = {}) {
  * member work sync report member: ." and sent the caller into a retry loop.
  * The payload is read only as a fallback identity hint; the app still verifies
  * the signature and the member/agenda binding.
+ *
+ * The shape test is exactly the one the app's verifier applies
+ * (HmacMemberWorkSyncReportTokenAdapter.verify): three non-empty segments and
+ * no fourth. Both segments are base64url, which cannot contain a '.', so a
+ * token of any other arity was never minted here and yields no identity. A
+ * looser test would let a truncated or padded token name a member and queue a
+ * report the app can only reject later.
  */
 function memberNameFromReportToken(token) {
   if (typeof token !== 'string') return '';
   const parts = token.trim().split('.');
-  if (parts.length < 2 || parts[0] !== 'wrs:v1') return '';
+  if (parts.length !== 3 || parts[0] !== 'wrs:v1' || !parts[1] || !parts[2]) return '';
   try {
     const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
     return payload && typeof payload.memberName === 'string' ? payload.memberName.trim() : '';

--- a/agent-teams-controller/src/internal/workSync.js
+++ b/agent-teams-controller/src/internal/workSync.js
@@ -271,10 +271,35 @@ async function memberWorkSyncStatus(context, flags = {}) {
   );
 }
 
+/**
+ * The report token (issued by member_work_sync_status) carries the member it
+ * was minted for: `wrs:v1.<base64url payload>.<signature>`. A caller that
+ * copies the token but drops memberName made every report fail with "Unknown
+ * member work sync report member: ." and sent the caller into a retry loop.
+ * The payload is read only as a fallback identity hint; the app still verifies
+ * the signature and the member/agenda binding.
+ */
+function memberNameFromReportToken(token) {
+  if (typeof token !== 'string') return '';
+  const parts = token.trim().split('.');
+  if (parts.length < 2 || parts[0] !== 'wrs:v1') return '';
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+    return payload && typeof payload.memberName === 'string' ? payload.memberName.trim() : '';
+  } catch {
+    return '';
+  }
+}
+
 async function memberWorkSyncReport(context, flags = {}) {
+  const explicitMemberName =
+    (typeof flags.memberName === 'string' && flags.memberName.trim()) ||
+    (typeof flags.member === 'string' && flags.member.trim()) ||
+    (typeof flags.from === 'string' && flags.from.trim()) ||
+    '';
   const memberName = runtimeHelpers.assertExplicitTeamMemberName(
     context.paths,
-    flags.memberName || flags.member || flags.from,
+    explicitMemberName || memberNameFromReportToken(flags.reportToken || flags['report-token']),
     'member work sync report member'
   );
   const body = compactReportBody(context, memberName, flags);
@@ -305,6 +330,7 @@ async function memberWorkSyncReport(context, flags = {}) {
 }
 
 module.exports = {
+  memberNameFromReportToken,
   memberWorkSyncStatus,
   memberWorkSyncReport,
 };

--- a/agent-teams-controller/test/controller.test.js
+++ b/agent-teams-controller/test/controller.test.js
@@ -4477,6 +4477,127 @@ controller.messages.sendMessage({
     expect(boardNotices()).toHaveLength(2);
   });
 
+  function reportToken(payload) {
+    return `wrs:v1.${Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')}.signature`;
+  }
+
+  function readReportIntents(claudeDir) {
+    const intentFile = path.join(
+      claudeDir,
+      'teams',
+      'my-team',
+      '.member-work-sync',
+      'pending-reports.json'
+    );
+    return Object.values(JSON.parse(fs.readFileSync(intentFile, 'utf8')).intents);
+  }
+
+  it('derives the report member from the report token when the caller omits memberName', async () => {
+    const claudeDir = makeClaudeDir();
+    const controller = createController({ teamName: 'my-team', claudeDir });
+    const token = reportToken({
+      version: 1,
+      teamName: 'my-team',
+      memberName: 'bob',
+      agendaFingerprint: 'agenda:v1:abc',
+      expiresAt: '2026-01-01T00:15:00.000Z',
+    });
+
+    const pending = await controller.workSync.memberWorkSyncReport({
+      state: 'still_working',
+      agendaFingerprint: 'agenda:v1:abc',
+      reportToken: token,
+    });
+
+    expect(pending.pendingValidation).toBe(true);
+    expect(readReportIntents(claudeDir)).toEqual([
+      expect.objectContaining({
+        memberName: 'bob',
+        request: expect.objectContaining({ memberName: 'bob', reportToken: token }),
+      }),
+    ]);
+  });
+
+  it('never lets a report token stand in for another member or another agenda', async () => {
+    const bobToken = reportToken({
+      version: 1,
+      teamName: 'my-team',
+      memberName: 'bob',
+      agendaFingerprint: 'agenda:v1:abc',
+      expiresAt: '2026-01-01T00:15:00.000Z',
+    });
+
+    // An explicit caller identity wins: the token is a fallback hint, never an
+    // override, so a token cannot silently retarget a report at its own member.
+    const explicitDir = makeClaudeDir();
+    await createController({
+      teamName: 'my-team',
+      claudeDir: explicitDir,
+    }).workSync.memberWorkSyncReport({
+      memberName: 'alice',
+      state: 'still_working',
+      agendaFingerprint: 'agenda:v1:abc',
+      reportToken: bobToken,
+    });
+    expect(readReportIntents(explicitDir)).toEqual([
+      expect.objectContaining({
+        memberName: 'alice',
+        request: expect.objectContaining({ memberName: 'alice', reportToken: bobToken }),
+      }),
+    ]);
+
+    // The token's own agenda is never substituted for the one the caller
+    // reported: the app still receives both and verifies the binding itself.
+    const agendaDir = makeClaudeDir();
+    await createController({
+      teamName: 'my-team',
+      claudeDir: agendaDir,
+    }).workSync.memberWorkSyncReport({
+      state: 'still_working',
+      agendaFingerprint: 'agenda:v1:other',
+      reportToken: bobToken,
+    });
+    expect(readReportIntents(agendaDir)).toEqual([
+      expect.objectContaining({
+        memberName: 'bob',
+        request: expect.objectContaining({
+          memberName: 'bob',
+          agendaFingerprint: 'agenda:v1:other',
+          reportToken: bobToken,
+        }),
+      }),
+    ]);
+  });
+
+  it.each([
+    ['a payload that is not base64url JSON', 'wrs:v1.not-a-payload.signature'],
+    [
+      'a payload with no member name',
+      `wrs:v1.${Buffer.from(JSON.stringify({ version: 1, teamName: 'my-team' }), 'utf8').toString(
+        'base64url'
+      )}.signature`,
+    ],
+    [
+      'a token of a different version prefix',
+      `wrs:v2.${Buffer.from(JSON.stringify({ memberName: 'bob' }), 'utf8').toString(
+        'base64url'
+      )}.signature`,
+    ],
+    ['a token with no payload segment at all', 'wrs:v1'],
+    ['a value that is not a token', 'bob'],
+  ])('refuses a report identified only by %s', async (_label, token) => {
+    const claudeDir = makeClaudeDir();
+    const controller = createController({ teamName: 'my-team', claudeDir });
+
+    await expect(
+      controller.workSync.memberWorkSyncReport({
+        state: 'still_working',
+        agendaFingerprint: 'agenda:v1:abc',
+        reportToken: token,
+      })
+    ).rejects.toThrow('Unknown member work sync report member');
+  });
+
   it('does not record pending work sync intents for app-side validation rejections', async () => {
     const claudeDir = makeClaudeDir();
     const controller = createController({ teamName: 'my-team', claudeDir });

--- a/agent-teams-controller/test/controller.test.js
+++ b/agent-teams-controller/test/controller.test.js
@@ -4585,6 +4585,19 @@ controller.messages.sendMessage({
     ],
     ['a token with no payload segment at all', 'wrs:v1'],
     ['a value that is not a token', 'bob'],
+    // The two below carry a payload that does name a configured member, so
+    // only the segment count can refuse them. The app's verifier requires
+    // exactly three non-empty segments, so a token of any other arity names
+    // nobody here either, instead of queueing a report for app validation that
+    // the app can only ever reject.
+    [
+      'an unsigned two-segment token',
+      `wrs:v1.${Buffer.from(JSON.stringify({ version: 1, teamName: 'my-team', memberName: 'bob' }), 'utf8').toString('base64url')}`,
+    ],
+    [
+      'a token with a trailing extra segment',
+      `wrs:v1.${Buffer.from(JSON.stringify({ version: 1, teamName: 'my-team', memberName: 'bob' }), 'utf8').toString('base64url')}.signature.extra`,
+    ],
   ])('refuses a report identified only by %s', async (_label, token) => {
     const claudeDir = makeClaudeDir();
     const controller = createController({ teamName: 'my-team', claudeDir });
@@ -4596,6 +4609,13 @@ controller.messages.sendMessage({
         reportToken: token,
       })
     ).rejects.toThrow('Unknown member work sync report member');
+    // Refused before anything is written: no pending intent is queued for a
+    // report that never had a usable identity.
+    expect(
+      fs.existsSync(
+        path.join(claudeDir, 'teams', 'my-team', '.member-work-sync', 'pending-reports.json')
+      )
+    ).toBe(false);
   });
 
   it('does not record pending work sync intents for app-side validation rejections', async () => {

--- a/src/features/member-work-sync/core/application/MemberWorkSyncNudgeActivationPolicy.ts
+++ b/src/features/member-work-sync/core/application/MemberWorkSyncNudgeActivationPolicy.ts
@@ -23,9 +23,21 @@ export type MemberWorkSyncNudgeActivationReason =
   | 'native_stale_assigned_work'
   | 'status_not_nudgeable'
   | 'blocking_metrics'
+  | 'opencode_quiet_window'
   | 'phase2_not_ready';
 
 const NATIVE_STALE_IN_PROGRESS_MIN_AGE_MS = 6 * 60_000;
+/**
+ * An OpenCode member runs one turn at a time, and a turn can legitimately take
+ * minutes. An agenda-sync nudge delivered right after the agenda changed lands
+ * mid-turn and interrupts the very work that change started: observed as a
+ * nudge 20 s after task_start, after which the member looped on
+ * member_work_sync_report instead of doing the task. Targeted OpenCode
+ * recovery for a member with an owned in_progress task therefore waits until
+ * the current needs_sync agenda has been stable this long; a member that has
+ * genuinely stopped is the stall monitor's job, not this one's.
+ */
+export const OPENCODE_TARGETED_RECOVERY_MIN_QUIET_MS = 10 * 60_000;
 const NATIVE_STALE_IN_PROGRESS_PROVIDERS = new Set(['anthropic', 'codex', 'gemini']);
 const NATIVE_TASK_PROTOCOL_REPAIR_PROVIDERS = new Set(['codex']);
 const NATIVE_TASK_PROTOCOL_REPAIR_TURN_SETTLED_DIAGNOSTIC = `${MEMBER_WORK_SYNC_RUNTIME_STALL_TRIGGER_DIAGNOSTIC_PREFIX}turn_settled`;
@@ -261,6 +273,29 @@ function getNativeStaleWorkRecoveryReason(input: {
     : 'native_stale_assigned_work';
 }
 
+function isOpenCodeTargetedRecoveryInsideQuietWindow(input: {
+  status: MemberWorkSyncStatus;
+  metrics: MemberWorkSyncTeamMetrics;
+}): boolean {
+  // Only a member that is visibly working (an owned task it moved to
+  // in_progress) gets the quiet window; assigned-but-unstarted work may still
+  // be nudged promptly.
+  if (!input.status.agenda.items.some(isOwnedInProgressWorkItem)) {
+    return false;
+  }
+  const nowMs = parseTime(input.metrics.generatedAt) ?? parseTime(input.status.evaluatedAt);
+  if (nowMs == null) {
+    return false;
+  }
+  const stableSinceMs = getCurrentFingerprintStableSinceMs(input.status, input.metrics, nowMs);
+  // Unknown age (no needs_sync sample recorded yet) does not block: the first
+  // reconcile sample arrives with the status that is being evaluated.
+  if (stableSinceMs == null) {
+    return false;
+  }
+  return nowMs - stableSinceMs < OPENCODE_TARGETED_RECOVERY_MIN_QUIET_MS;
+}
+
 function isReviewPickupRequiredCandidate(status: MemberWorkSyncStatus): boolean {
   return (
     status.state === 'needs_sync' &&
@@ -296,6 +331,12 @@ export function decideMemberWorkSyncNudgeActivation(input: {
 
   const targetedRecovery = decideMemberWorkSyncTargetedRecovery(input.status);
   if (targetedRecovery.active) {
+    if (
+      targetedRecovery.capability === 'opencode_runtime_delivery' &&
+      isOpenCodeTargetedRecoveryInsideQuietWindow(input)
+    ) {
+      return { active: false, reason: 'opencode_quiet_window' };
+    }
     if (targetedRecovery.reason !== 'native_targeted_shadow_collecting') {
       return { active: true, reason: targetedRecovery.reason };
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2096,7 +2096,7 @@ async function initializeServices(): Promise<void> {
   const taskChangePresenceRepository = new JsonTaskChangePresenceRepository();
   teamTaskStallMonitor = new TeamTaskStallMonitor(
     new ActiveTeamRegistry(teamDataService, teamLogSourceTracker),
-    new TeamTaskStallSnapshotSource(teamTranscriptSourceLocator),
+    new TeamTaskStallSnapshotSource({ transcriptSourceLocator: teamTranscriptSourceLocator }),
     new TeamTaskStallPolicy(),
     new TeamTaskStallJournal({ store: internalStorageFeature.taskStallJournalStore }),
     new TeamTaskStallNotifier(teamDataService, teamProvisioningService)

--- a/src/main/services/team/opencode/delivery/OpenCodeLaneTurnActivityRegistry.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeLaneTurnActivityRegistry.ts
@@ -1,0 +1,131 @@
+/**
+ * In-memory record of the last prompt-delivery turn state per OpenCode lane.
+ *
+ * The delivery service knows exactly when a lane's turn starts ('active', a
+ * prompt was accepted) and when it settles ('idle'); nothing else in the app
+ * sees a secondary lane's turn end (the orchestrator transcript projection
+ * carries no turn-end row, so log-based stall detection could only classify a
+ * silent member as "mid turn" and wait for the 10-minute mid-turn threshold).
+ * The stall monitor reads the settle time from here instead.
+ */
+
+export type OpenCodeLaneTurnState = 'active' | 'idle';
+
+export interface OpenCodeLaneTurnActivitySample {
+  laneId: string;
+  state: OpenCodeLaneTurnState;
+  /** ISO timestamp of the observation. */
+  observedAt: string;
+}
+
+/**
+ * Team and member are folded into one map key. The separator is written as the
+ * `\u0000` escape on purpose: a literal NUL byte in a source file has been
+ * committed twice in this repository already, and `test/main/sourceControlCharacters.test.ts`
+ * fails the build if one comes back.
+ */
+function memberKey(teamName: string, memberName: string): string {
+  return `${teamName.trim().toLowerCase()}\u0000${memberName.trim().toLowerCase()}`;
+}
+
+export class OpenCodeLaneTurnActivityRegistry {
+  private readonly samples = new Map<string, OpenCodeLaneTurnActivitySample>();
+
+  note(input: {
+    teamName: string;
+    memberName: string;
+    laneId: string;
+    state: OpenCodeLaneTurnState;
+    observedAt?: string;
+  }): void {
+    this.samples.set(memberKey(input.teamName, input.memberName), {
+      laneId: input.laneId,
+      state: input.state,
+      observedAt: input.observedAt ?? new Date().toISOString(),
+    });
+  }
+
+  get(teamName: string, memberName: string): OpenCodeLaneTurnActivitySample | null {
+    return this.samples.get(memberKey(teamName, memberName)) ?? null;
+  }
+
+  /** ISO time since which the member's lane has been idle, or null while active/unknown. */
+  getIdleSince(teamName: string, memberName: string): string | null {
+    const sample = this.get(teamName, memberName);
+    return sample?.state === 'idle' ? sample.observedAt : null;
+  }
+
+  /** Snapshot of every member of a team: member name (lower-case) -> sample. */
+  listTeam(teamName: string): Map<string, OpenCodeLaneTurnActivitySample> {
+    const prefix = `${teamName.trim().toLowerCase()}\u0000`;
+    const result = new Map<string, OpenCodeLaneTurnActivitySample>();
+    for (const [key, sample] of this.samples) {
+      if (key.startsWith(prefix)) {
+        result.set(key.slice(prefix.length), sample);
+      }
+    }
+    return result;
+  }
+
+  clear(): void {
+    this.samples.clear();
+  }
+}
+
+export const openCodeLaneTurnActivityRegistry = new OpenCodeLaneTurnActivityRegistry();
+
+/**
+ * Record a lane's turn state, and mirror it to the lead-activity notifier when
+ * the caller identified the recipient as the team lead - the OpenCode lead has
+ * no stdin stream, so this is the only signal that turns its card from
+ * "processing" back to idle.
+ *
+ * Lead identity is the caller's decision (`isOpenCodeLeadRecipient`), not this
+ * module's: the primary lane is shared by same-model teammates, so being on it
+ * is not proof of being the lead.
+ *
+ * The registry write happens first and unconditionally: a secondary lane has no
+ * lead card to update but its turn state is exactly what the stall monitor needs,
+ * and a notifier that throws must not cost the caller the sample it just observed.
+ */
+export function noteOpenCodeLaneTurnActivity(
+  input: {
+    teamName: string;
+    memberName: string;
+    laneId: string;
+    /** Resolved by the caller with `isOpenCodeLeadRecipient`. */
+    isLeadRecipient: boolean;
+    state: OpenCodeLaneTurnState;
+    observedAt: string;
+  },
+  ports: {
+    notifyLeadTurnActivity?(notification: {
+      teamName: string;
+      memberName: string;
+      laneId: string;
+      state: OpenCodeLaneTurnState;
+    }): void;
+    logger: { warn(message: string): void };
+  }
+): void {
+  const { teamName, memberName, laneId, state } = input;
+  openCodeLaneTurnActivityRegistry.note({
+    teamName,
+    memberName,
+    laneId,
+    state,
+    observedAt: input.observedAt,
+  });
+  if (!input.isLeadRecipient || !ports.notifyLeadTurnActivity) {
+    return;
+  }
+  try {
+    ports.notifyLeadTurnActivity({ teamName, memberName, laneId, state });
+  } catch (error) {
+    ports.logger.warn(
+      `[${teamName}] OpenCode lead turn activity (${state}) notification failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}

--- a/src/main/services/team/opencode/delivery/OpenCodeLaneTurnActivityRegistry.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeLaneTurnActivityRegistry.ts
@@ -28,6 +28,25 @@ function memberKey(teamName: string, memberName: string): string {
   return `${teamName.trim().toLowerCase()}\u0000${memberName.trim().toLowerCase()}`;
 }
 
+/**
+ * How many (team, member) samples the registry keeps at once.
+ *
+ * The default registry is a module singleton in a main process that outlives
+ * every run, and nothing in `src/` calls `clear()`: a stopped team's samples
+ * stay in the map for the life of the app, one entry per member that ever took
+ * a turn. Evicting the least recently written entry costs nothing, because a
+ * member with no sample is judged exactly as it was before the stall monitor
+ * learned to read lanes at all.
+ *
+ * Note what eviction does NOT have to fix: a sample left behind by a previous
+ * run of the same team cannot escalate anything. `evaluatePendingPickupTask`
+ * starts its clock at `Math.max(readyAt, laneIdleSince)`, and a relaunched
+ * team's `readyAt` is always newer than a sample from before the stop, so a
+ * stale entry can only ever delay a nudge (for at most the freshness window),
+ * never bring one forward.
+ */
+export const OPENCODE_LANE_TURN_ACTIVITY_MAX_SAMPLES = 512;
+
 export class OpenCodeLaneTurnActivityRegistry {
   private readonly samples = new Map<string, OpenCodeLaneTurnActivitySample>();
 
@@ -38,11 +57,31 @@ export class OpenCodeLaneTurnActivityRegistry {
     state: OpenCodeLaneTurnState;
     observedAt?: string;
   }): void {
-    this.samples.set(memberKey(input.teamName, input.memberName), {
+    const key = memberKey(input.teamName, input.memberName);
+    // Delete-then-set keeps the Map in write-recency order, so the eviction
+    // below always drops the entry nothing has written to for the longest.
+    this.samples.delete(key);
+    if (this.samples.size >= OPENCODE_LANE_TURN_ACTIVITY_MAX_SAMPLES) {
+      const oldestKey = this.samples.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.samples.delete(oldestKey);
+      }
+    }
+    this.samples.set(key, {
       laneId: input.laneId,
       state: input.state,
       observedAt: input.observedAt ?? new Date().toISOString(),
     });
+  }
+
+  /** Drops every sample of one team, e.g. once that team has stopped. */
+  clearTeam(teamName: string): void {
+    const prefix = `${teamName.trim().toLowerCase()}\u0000`;
+    for (const key of [...this.samples.keys()]) {
+      if (key.startsWith(prefix)) {
+        this.samples.delete(key);
+      }
+    }
   }
 
   get(teamName: string, memberName: string): OpenCodeLaneTurnActivitySample | null {

--- a/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
@@ -14,6 +14,7 @@ import {
 } from '../store/OpenCodeRuntimeManifestEvidenceReader';
 
 import { recoverOpenCodeActiveDeliveryBlocker } from './OpenCodeActiveDeliveryPreemption';
+import { noteOpenCodeLaneTurnActivity } from './OpenCodeLaneTurnActivityRegistry';
 import { isOpenCodeLeadRecipient } from './OpenCodeLeadTurnActivity';
 import { deliverOpenCodeMemberMessageWithoutWatchdog } from './OpenCodeLegacyMemberMessageDelivery';
 import {
@@ -454,21 +455,23 @@ export class OpenCodeMemberMessageDeliveryService {
       laneIdentity.laneKind === 'primary' &&
       isOpenCodeLeadRecipient(canonicalMemberName, directory);
     const activityRunId = runtimeRunId;
+    const notifyLeadTurnActivity = activityRunId
+      ? (notification: Omit<OpenCodeLeadTurnActivityNotification, 'runId'>): void => {
+          this.deps.notifyOpenCodeLeadTurnActivity?.({ ...notification, runId: activityRunId });
+        }
+      : undefined;
     const notifyActivity = (state: OpenCodeLeadTurnActivityNotification['state']): void => {
-      if (!isLeadRecipient || !activityRunId) return;
-      try {
-        this.deps.notifyOpenCodeLeadTurnActivity?.({
+      noteOpenCodeLaneTurnActivity(
+        {
           teamName,
           memberName: canonicalMemberName,
           laneId: laneIdentity.laneId,
-          runId: activityRunId,
+          isLeadRecipient,
           state,
-        });
-      } catch (error) {
-        logger.warn(
-          `[${teamName}] OpenCode lead turn activity (${state}) notification failed: ${getErrorMessage(error)}`
-        );
-      }
+          observedAt: nowIso(),
+        },
+        { notifyLeadTurnActivity, logger }
+      );
     };
     const messageId = input.messageId?.trim();
     const ledger = messageId

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeLaneTurnActivityRegistry.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeLaneTurnActivityRegistry.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  noteOpenCodeLaneTurnActivity,
+  OpenCodeLaneTurnActivityRegistry,
+  openCodeLaneTurnActivityRegistry,
+} from '../OpenCodeLaneTurnActivityRegistry';
+
+describe('OpenCodeLaneTurnActivityRegistry', () => {
+  it('keeps the latest turn state per team member, case-insensitively', () => {
+    const registry = new OpenCodeLaneTurnActivityRegistry();
+    registry.note({
+      teamName: 'Team',
+      memberName: 'Worker',
+      laneId: 'secondary:opencode:Worker',
+      state: 'active',
+      observedAt: '2026-08-23T01:30:00.000Z',
+    });
+    expect(registry.getIdleSince('team', 'worker')).toBeNull();
+    expect(registry.listTeam('team').get('worker')).toMatchObject({ state: 'active' });
+
+    registry.note({
+      teamName: 'team',
+      memberName: 'worker',
+      laneId: 'secondary:opencode:Worker',
+      state: 'idle',
+      observedAt: '2026-08-23T01:33:46.000Z',
+    });
+    expect(registry.getIdleSince('Team', 'Worker')).toBe('2026-08-23T01:33:46.000Z');
+
+    registry.note({
+      teamName: 'team',
+      memberName: 'team-lead',
+      laneId: 'primary',
+      state: 'idle',
+    });
+    expect([...registry.listTeam('team').keys()].sort((a, b) => a.localeCompare(b))).toEqual([
+      'team-lead',
+      'worker',
+    ]);
+    expect(registry.listTeam('other').size).toBe(0);
+  });
+
+  it('separates members whose names would otherwise concatenate into the same key', () => {
+    const registry = new OpenCodeLaneTurnActivityRegistry();
+    registry.note({
+      teamName: 'ab',
+      memberName: 'c',
+      laneId: 'lane-1',
+      state: 'active',
+      observedAt: '2026-08-23T01:30:00.000Z',
+    });
+    registry.note({
+      teamName: 'a',
+      memberName: 'bc',
+      laneId: 'lane-2',
+      state: 'idle',
+      observedAt: '2026-08-23T01:31:00.000Z',
+    });
+
+    expect(registry.get('ab', 'c')).toMatchObject({ laneId: 'lane-1', state: 'active' });
+    expect(registry.get('a', 'bc')).toMatchObject({ laneId: 'lane-2', state: 'idle' });
+    expect(registry.listTeam('a').size).toBe(1);
+  });
+});
+
+describe('noteOpenCodeLaneTurnActivity', () => {
+  beforeEach(() => {
+    openCodeLaneTurnActivityRegistry.clear();
+  });
+
+  it('records a secondary lane without ever emitting lead activity for it', () => {
+    const notifyLeadTurnActivity = vi.fn();
+    const logger = { warn: vi.fn() };
+
+    noteOpenCodeLaneTurnActivity(
+      {
+        teamName: 'team',
+        memberName: 'worker',
+        laneId: 'secondary:opencode:worker',
+        isLeadRecipient: false,
+        state: 'idle',
+        observedAt: '2026-08-23T01:33:46.000Z',
+      },
+      { notifyLeadTurnActivity, logger }
+    );
+
+    // Recorded: this is the only place a secondary lane's turn end is observable.
+    expect(openCodeLaneTurnActivityRegistry.get('team', 'worker')).toMatchObject({
+      laneId: 'secondary:opencode:worker',
+      state: 'idle',
+      observedAt: '2026-08-23T01:33:46.000Z',
+    });
+    // Not mirrored: a secondary lane has no lead card, so nothing is emitted.
+    expect(notifyLeadTurnActivity).not.toHaveBeenCalled();
+
+    noteOpenCodeLaneTurnActivity(
+      {
+        teamName: 'team',
+        memberName: 'team-lead',
+        laneId: 'primary',
+        isLeadRecipient: true,
+        state: 'active',
+        observedAt: '2026-08-23T01:34:00.000Z',
+      },
+      { notifyLeadTurnActivity, logger }
+    );
+
+    expect(notifyLeadTurnActivity.mock.calls).toEqual([
+      [
+        {
+          teamName: 'team',
+          memberName: 'team-lead',
+          laneId: 'primary',
+          state: 'active',
+        },
+      ],
+    ]);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps the recorded sample when the lead notifier throws', () => {
+    const logger = { warn: vi.fn() };
+
+    expect(() =>
+      noteOpenCodeLaneTurnActivity(
+        {
+          teamName: 'team',
+          memberName: 'team-lead',
+          laneId: 'primary',
+          isLeadRecipient: true,
+          state: 'idle',
+          observedAt: '2026-08-23T01:35:00.000Z',
+        },
+        {
+          notifyLeadTurnActivity: () => {
+            throw new Error('lead run went away');
+          },
+          logger,
+        }
+      )
+    ).not.toThrow();
+
+    expect(openCodeLaneTurnActivityRegistry.getIdleSince('team', 'team-lead')).toBe(
+      '2026-08-23T01:35:00.000Z'
+    );
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn.mock.calls[0]?.[0]).toContain('lead run went away');
+  });
+
+  it('records a primary lane even when no lead notifier is wired', () => {
+    const logger = { warn: vi.fn() };
+
+    noteOpenCodeLaneTurnActivity(
+      {
+        teamName: 'team',
+        memberName: 'team-lead',
+        laneId: 'primary',
+        isLeadRecipient: true,
+        state: 'active',
+        observedAt: '2026-08-23T01:36:00.000Z',
+      },
+      { logger }
+    );
+
+    expect(openCodeLaneTurnActivityRegistry.get('team', 'team-lead')).toMatchObject({
+      state: 'active',
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('records a primary lane for a teammate the caller did not identify as the lead', () => {
+    const notifyLeadTurnActivity = vi.fn();
+    const logger = { warn: vi.fn() };
+
+    noteOpenCodeLaneTurnActivity(
+      {
+        teamName: 'team',
+        memberName: 'builder',
+        laneId: 'primary',
+        // Same-model teammates share the primary lane; only the lead card is mirrored.
+        isLeadRecipient: false,
+        state: 'active',
+        observedAt: '2026-08-23T01:37:00.000Z',
+      },
+      { notifyLeadTurnActivity, logger }
+    );
+
+    expect(openCodeLaneTurnActivityRegistry.get('team', 'builder')).toMatchObject({
+      laneId: 'primary',
+      state: 'active',
+    });
+    expect(notifyLeadTurnActivity).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeLaneTurnActivityRegistry.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeLaneTurnActivityRegistry.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   noteOpenCodeLaneTurnActivity,
+  OPENCODE_LANE_TURN_ACTIVITY_MAX_SAMPLES,
   OpenCodeLaneTurnActivityRegistry,
   openCodeLaneTurnActivityRegistry,
 } from '../OpenCodeLaneTurnActivityRegistry';
@@ -192,5 +193,61 @@ describe('noteOpenCodeLaneTurnActivity', () => {
     });
     expect(notifyLeadTurnActivity).not.toHaveBeenCalled();
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+  it('bounds the map and evicts the least recently written sample', () => {
+    // The default registry is a process-lifetime singleton nothing clears, so
+    // without a bound one entry per member that ever took a turn is retained
+    // for the life of the app.
+    const registry = new OpenCodeLaneTurnActivityRegistry();
+    for (let index = 0; index < OPENCODE_LANE_TURN_ACTIVITY_MAX_SAMPLES; index += 1) {
+      registry.note({
+        teamName: 'team',
+        memberName: `member-${index}`,
+        laneId: 'secondary:opencode:member',
+        state: 'idle',
+        observedAt: '2026-08-23T01:30:00.000Z',
+      });
+    }
+    expect(registry.listTeam('team').size).toBe(OPENCODE_LANE_TURN_ACTIVITY_MAX_SAMPLES);
+
+    // Touching the oldest entry makes it the most recent, so the next insert
+    // must evict the one after it instead.
+    registry.note({
+      teamName: 'team',
+      memberName: 'member-0',
+      laneId: 'secondary:opencode:member',
+      state: 'active',
+      observedAt: '2026-08-23T01:31:00.000Z',
+    });
+    registry.note({
+      teamName: 'team',
+      memberName: 'newcomer',
+      laneId: 'secondary:opencode:newcomer',
+      state: 'active',
+      observedAt: '2026-08-23T01:32:00.000Z',
+    });
+
+    expect(registry.listTeam('team').size).toBe(OPENCODE_LANE_TURN_ACTIVITY_MAX_SAMPLES);
+    expect(registry.get('team', 'newcomer')).not.toBeNull();
+    expect(registry.get('team', 'member-0')).not.toBeNull();
+    expect(registry.get('team', 'member-1')).toBeNull();
+  });
+
+  it('drops one team without touching another', () => {
+    const registry = new OpenCodeLaneTurnActivityRegistry();
+    for (const teamName of ['alpha', 'beta']) {
+      registry.note({
+        teamName,
+        memberName: 'worker',
+        laneId: 'secondary:opencode:worker',
+        state: 'idle',
+        observedAt: '2026-08-23T01:30:00.000Z',
+      });
+    }
+
+    registry.clearTeam('Alpha');
+
+    expect(registry.get('alpha', 'worker')).toBeNull();
+    expect(registry.get('beta', 'worker')).not.toBeNull();
   });
 });

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.leadTurnActivity.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.leadTurnActivity.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { openCodeLaneTurnActivityRegistry } from '../OpenCodeLaneTurnActivityRegistry';
 import {
   type OpenCodeLeadTurnActivityNotification,
   type OpenCodeMemberLaneIdentity,
@@ -155,6 +156,7 @@ describe('OpenCodeMemberMessageDeliveryService lead turn activity', () => {
 
   beforeEach(async () => {
     ledgerDir = await mkdtemp(join(tmpdir(), 'opencode-lead-turn-activity-'));
+    openCodeLaneTurnActivityRegistry.clear();
   });
 
   afterEach(async () => {
@@ -246,6 +248,11 @@ describe('OpenCodeMemberMessageDeliveryService lead turn activity', () => {
 
     expect(delivery.accepted).toBe(true);
     expect(notify).not.toHaveBeenCalled();
+    // The turn is still recorded: nothing else in the app sees a secondary lane settle.
+    expect(openCodeLaneTurnActivityRegistry.get('team-a', 'Muse')).toMatchObject({
+      laneId: SECONDARY_LANE.laneId,
+      state: 'idle',
+    });
   });
 
   it('never reports lead activity for a same-model primary teammate', async () => {
@@ -265,6 +272,11 @@ describe('OpenCodeMemberMessageDeliveryService lead turn activity', () => {
 
     expect(delivery.accepted).toBe(true);
     expect(notify).not.toHaveBeenCalled();
+    // Lane membership is not lead identity, but the turn still belongs in the registry.
+    expect(openCodeLaneTurnActivityRegistry.get('team-a', 'Muse')).toMatchObject({
+      laneId: 'primary',
+      state: 'idle',
+    });
   });
 
   it('swallows notification failures without affecting the delivery result', async () => {

--- a/src/main/services/team/provisioning/TeamProvisioningLiveInboxRelayRouting.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLiveInboxRelayRouting.ts
@@ -70,7 +70,11 @@ export async function relayInboxFileToLiveRecipientWithPorts(
   const { teamName, inboxName } = input;
   const options = input.options ?? {};
 
-  if (isCrossTeamPseudoRecipientName(inboxName) || isCrossTeamToolRecipientName(inboxName)) {
+  if (
+    isTerminalInboxRecipientName(inboxName) ||
+    isCrossTeamPseudoRecipientName(inboxName) ||
+    isCrossTeamToolRecipientName(inboxName)
+  ) {
     return { kind: LiveInboxRelayKind.Ignored, relayed: 0 };
   }
 
@@ -211,6 +215,19 @@ function isExactDurableCrossTeamInboxMessage(
     typeof message.timestamp === 'string' &&
     Number.isFinite(Date.parse(message.timestamp))
   );
+}
+
+/**
+ * `user` and `system` are app-owned terminal inboxes: the UI reads user.json
+ * through TeamInboxReader and no runtime ever receives it. Both names are
+ * reserved for app-owned writes, so no agent identity can claim them.
+ *
+ * The match is exact after trimming and lowercasing - a member legitimately
+ * named `users` or `system-notices` still routes normally.
+ */
+function isTerminalInboxRecipientName(name: string): boolean {
+  const normalized = name.trim().toLowerCase();
+  return normalized === 'user' || normalized === 'system';
 }
 
 function isSameInboxRecipient(inboxName: string, recipientName: string | null): boolean {

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateRunModel.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateRunModel.ts
@@ -116,7 +116,10 @@ export function createOpenCodeAggregateProvisioningRun(
     lastProvisioningTraceKey: null,
     provisioningOutputIndexByMessageId: new Map(),
     detectedSessionId: null,
-    leadActivityState: 'active' as const,
+    // Seed idle: the aggregate run has no stream turn loop, so lead activity is
+    // driven by prompt-delivery events; seeding 'active' would swallow the first
+    // 'active' transition (setLeadActivity is a pure state-change emitter).
+    leadActivityState: 'idle' as const,
     authFailureRetried: false,
     authRetryInProgress: false,
     leadContextUsage: null,

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.ts
@@ -50,6 +50,9 @@ type OpenCodeMemberMessageDeliveryHostRun = NonNullable<
   ReturnType<TeamProvisioningOpenCodeMemberMessageDeliveryHost['runs']['get']>
 >;
 
+/** A lead turn reported 'active' without a settle signal falls back to 'idle' after this long. */
+export const OPENCODE_LEAD_ACTIVE_FALLBACK_MS = 4 * 60_000;
+
 export interface TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityServiceDeps<
   TRun extends TeamProvisioningSendMessageToRunRun,
 > {
@@ -110,6 +113,8 @@ export class TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService<
 
   private openCodeMemberInboxRelayBoundaryValue: TeamProvisioningOpenCodeMemberInboxRelayBoundary | null =
     null;
+
+  private readonly openCodeLeadActiveFallbackTimers = new Map<string, NodeJS.Timeout>();
 
   constructor(
     private readonly deps: TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityServiceDeps<TRun>
@@ -205,11 +210,56 @@ export class TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService<
       )
         return;
       this.deps.setLeadActivity(run, input.state);
+      this.armOpenCodeLeadActiveFallback(input.teamName, input.runId, input.state);
     } catch (error) {
       this.deps.logger.warn(
         `OpenCode lead activity notification failed: ${this.deps.getErrorMessage(error)}`
       );
     }
+  }
+
+  /**
+   * The OpenCode lead has no stdin stream, so 'idle' can only arrive from a
+   * prompt-delivery settle. A runtime that keeps its session marked busy after a
+   * plain-text turn end never produces that settle, and the lead card would stay
+   * "processing" forever. A lead turn realistically finishes within minutes, so
+   * fall back to 'idle' when no newer signal arrives within the bound.
+   *
+   * Armed only past the guards above, so a notification that was dropped (wrong
+   * lane, not the lead recipient, a run that was replaced or stopped) neither
+   * arms a fallback nor disarms the one the live turn is relying on. Every
+   * accepted notification cancels the pending fallback first, so an 'idle' that
+   * does arrive disarms it (no late write over a newer real state), and repeated
+   * 'active' reports restart one timer rather than accumulating several. The
+   * fallback re-checks the same run identity when it fires, so a run that was
+   * replaced or stopped meanwhile is never written to.
+   */
+  private armOpenCodeLeadActiveFallback(
+    teamName: string,
+    runId: string,
+    state: OpenCodeLeadTurnActivityNotification['state']
+  ): void {
+    const existing = this.openCodeLeadActiveFallbackTimers.get(teamName);
+    if (existing) {
+      clearTimeout(existing);
+      this.openCodeLeadActiveFallbackTimers.delete(teamName);
+    }
+    if (state !== 'active') return;
+    const timer = setTimeout(() => {
+      this.openCodeLeadActiveFallbackTimers.delete(teamName);
+      const fallbackRun = this.deps.resolveLeadActivityRun(teamName);
+      if (
+        !fallbackRun ||
+        fallbackRun.runId !== runId ||
+        fallbackRun.processKilled ||
+        fallbackRun.cancelRequested ||
+        !this.deps.isCurrentTrackedRun(fallbackRun)
+      )
+        return;
+      this.deps.setLeadActivity(fallbackRun, 'idle');
+    }, OPENCODE_LEAD_ACTIVE_FALLBACK_MS);
+    timer.unref?.();
+    this.openCodeLeadActiveFallbackTimers.set(teamName, timer);
   }
 
   async deliverOpenCodeMemberMessage(

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLiveInboxRelayRouting.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLiveInboxRelayRouting.test.ts
@@ -59,6 +59,93 @@ describe('TeamProvisioningLiveInboxRelayRouting', () => {
     expect(ports.readMetaMembers).not.toHaveBeenCalled();
   });
 
+  it.each(['user', 'User', ' user ', 'system', 'SYSTEM', ' System '])(
+    'ignores the app-owned %j inbox without reading team state',
+    async (inboxName) => {
+      const readConfigSnapshot = vi.fn().mockResolvedValue(config([{ name: 'team-lead' }]));
+      const readMetaMembers = vi.fn().mockResolvedValue([]);
+      const readInboxMessages = vi.fn().mockResolvedValue([]);
+      const relayOpenCodeMemberInboxMessages = vi.fn().mockResolvedValue({
+        relayed: 0,
+        attempted: 0,
+        delivered: 0,
+        failed: 0,
+      });
+      const relayLeadInboxMessages = vi.fn().mockResolvedValue(0);
+      const ports = createPorts({
+        readConfigSnapshot,
+        readMetaMembers,
+        readInboxMessages,
+        relayOpenCodeMemberInboxMessages,
+        relayLeadInboxMessages,
+      });
+
+      await expect(
+        relayInboxFileToLiveRecipientWithPorts({ teamName: 'team-a', inboxName }, ports)
+      ).resolves.toEqual({
+        kind: LiveInboxRelayKind.Ignored,
+        relayed: 0,
+      });
+
+      // No diagnostics: the file watcher escalates a non-empty diagnostics array
+      // to a warn line, which is the whole defect here.
+      expect(readConfigSnapshot).not.toHaveBeenCalled();
+      expect(readMetaMembers).not.toHaveBeenCalled();
+      expect(relayOpenCodeMemberInboxMessages).not.toHaveBeenCalled();
+      expect(relayLeadInboxMessages).not.toHaveBeenCalled();
+      expect(readInboxMessages).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['users', 'system-notices', 'userland'])(
+    'still routes the member named %j: the terminal names match exactly, not by prefix',
+    async (memberName) => {
+      const readConfigSnapshot = vi
+        .fn()
+        .mockResolvedValue(config([{ name: 'team-lead' }, { name: memberName }]));
+      const readMetaMembers = vi.fn().mockResolvedValue([]);
+      const ports = createPorts({ readConfigSnapshot, readMetaMembers });
+
+      await expect(
+        relayInboxFileToLiveRecipientWithPorts({ teamName: 'team-a', inboxName: memberName }, ports)
+      ).resolves.toEqual({
+        kind: LiveInboxRelayKind.NativeMemberNoop,
+        relayed: 0,
+      });
+
+      expect(readConfigSnapshot).toHaveBeenCalledWith('team-a');
+      expect(readMetaMembers).toHaveBeenCalledWith('team-a');
+    }
+  );
+
+  it('still routes a real OpenCode member inbox after the terminal-inbox guard', async () => {
+    const relayOpenCodeMemberInboxMessages = vi.fn().mockResolvedValue({
+      relayed: 1,
+      attempted: 1,
+      delivered: 1,
+      failed: 0,
+    });
+    const ports = createPorts({
+      readConfigSnapshot: vi
+        .fn()
+        .mockResolvedValue(
+          config([{ name: 'team-lead' }, { name: 'Scout', providerId: 'opencode' }])
+        ),
+      isOpenCodeRuntimeRecipientFromSources,
+      relayOpenCodeMemberInboxMessages,
+    });
+
+    await expect(
+      relayInboxFileToLiveRecipientWithPorts({ teamName: 'team-a', inboxName: 'Scout' }, ports)
+    ).resolves.toMatchObject({
+      kind: LiveInboxRelayKind.OpenCodeMember,
+      relayed: 1,
+    });
+    expect(relayOpenCodeMemberInboxMessages).toHaveBeenCalledWith('team-a', 'Scout', {
+      source: 'watcher',
+    });
+  });
+
   it('routes native lead inbox files through the lead relay only when the team is alive', async () => {
     const relayLeadInboxMessages = vi.fn().mockResolvedValue(2);
     const ports = createPorts({ relayLeadInboxMessages });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateRun.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateRun.test.ts
@@ -3,6 +3,10 @@ import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  injectPostCompactReminder,
+  type TeamProvisioningIdlePromptInjectionPorts,
+} from '../TeamProvisioningIdlePromptInjection';
+import {
   buildOpenCodeAggregateFailureProgress,
   buildOpenCodeAggregateFinalProgress,
   createOpenCodeAggregateProvisioningRun,
@@ -144,6 +148,47 @@ function lanePlan(input: {
   };
 }
 
+function freshAggregateRun(): OpenCodeAggregateProvisioningRun {
+  const alice = member('alice', { cwd: '/fake/project' });
+  return createOpenCodeAggregateProvisioningRun({
+    runId: 'run-open-code',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    progress: progress(),
+    request: {
+      teamName: 'open-code-team',
+      cwd: '/fake/project',
+      providerId: 'opencode',
+      members: [alice],
+      description: 'fake launch request',
+    } as unknown as TeamCreateRequest,
+    members: [alice],
+    lanePlan: lanePlan({ primaryMembers: [alice] }),
+    onProgress: vi.fn(),
+  });
+}
+
+type AggregateIdlePromptInjectionPorts =
+  TeamProvisioningIdlePromptInjectionPorts<OpenCodeAggregateProvisioningRun>;
+
+function idlePromptInjectionPorts(
+  writeLeadStdin: AggregateIdlePromptInjectionPorts['writeLeadStdin']
+): AggregateIdlePromptInjectionPorts {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn() },
+    readConfigForObservation: async () => ({ members: [{ name: 'alice', role: 'Lead' }] }),
+    readTasks: async () => [],
+    isLeadMember: (configMember) => configMember.role?.toLowerCase().includes('lead') === true,
+    buildPersistentLeadContext: () => 'persistent context',
+    buildTaskBoardSnapshot: () => 'task board snapshot',
+    buildGeminiPostLaunchHydrationPrompt: () => 'hydration prompt',
+    getPromptSizeSummary: () => ({ chars: 23, lines: 1 }),
+    writeLeadStdin,
+    setLeadActivity: () => undefined,
+    resetRuntimeToolActivity: () => undefined,
+    getRunLeadName: () => 'alice',
+  };
+}
+
 describe('TeamProvisioningOpenCodeAggregateRun', () => {
   it('builds aggregate defaults with expected members scoped to the primary lane', () => {
     const alice = member('alice', { cwd: PROJECT_CWD });
@@ -240,7 +285,7 @@ describe('TeamProvisioningOpenCodeAggregateRun', () => {
       provisioningTraceLines: [],
       lastProvisioningTraceKey: null,
       detectedSessionId: null,
-      leadActivityState: 'active',
+      leadActivityState: 'idle',
       authFailureRetried: false,
       authRetryInProgress: false,
       leadContextUsage: null,
@@ -281,6 +326,31 @@ describe('TeamProvisioningOpenCodeAggregateRun', () => {
     expect(run.pendingMemberRestarts).toBeInstanceOf(Map);
     expect(run.memberSpawnLeadInboxCursorByMember).toBeInstanceOf(Map);
     expect(run.lastMemberSpawnAuditMissingWarningAt).toBeInstanceOf(Map);
+  });
+
+  it('delivers the post-compact reminder on a fresh run and defers it once a turn goes active', async () => {
+    const run = freshAggregateRun();
+    run.child = {
+      stdin: { writable: true },
+    } as unknown as OpenCodeAggregateProvisioningRun['child'];
+    run.pendingPostCompactReminder = true;
+    const writeLeadStdin = vi.fn(async () => undefined);
+    const ports = idlePromptInjectionPorts(writeLeadStdin);
+
+    await injectPostCompactReminder(run, ports);
+
+    expect(writeLeadStdin).toHaveBeenCalledTimes(1);
+    expect(run.pendingPostCompactReminder).toBe(false);
+
+    // The first prompt-delivery turn flips the seeded 'idle' to 'active'; the
+    // reminder must now be deferred and re-armed instead of injected mid-turn.
+    run.leadActivityState = 'active';
+    run.pendingPostCompactReminder = true;
+
+    await injectPostCompactReminder(run, ports);
+
+    expect(writeLeadStdin).toHaveBeenCalledTimes(1);
+    expect(run.pendingPostCompactReminder).toBe(true);
   });
 
   it('projects aggregate final progress for ready, pending, failed, and missing diagnostics', () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.test.ts
@@ -1,14 +1,16 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   type OpenCodeMemberInboxRelayResult,
   relayOpenCodeMemberInboxMessagesWithPorts,
 } from '../TeamProvisioningOpenCodeMemberInboxRelay';
 import {
+  OPENCODE_LEAD_ACTIVE_FALLBACK_MS,
   TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService,
   type TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityServiceDeps,
 } from '../TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade';
 
+import type { OpenCodeLeadTurnActivityNotification } from '../../opencode/delivery/OpenCodeMemberMessageDeliveryPorts';
 import type { OpenCodeTeamRuntimeMessageResult } from '../../runtime';
 import type { TeamProvisioningOpenCodeMemberMessageDeliveryHost } from '../TeamProvisioningOpenCodeMemberMessageDeliveryServiceFactory';
 import type { TeamProvisioningSendMessageToRunRun } from '../TeamProvisioningSendMessageToRunBoundaryFactory';
@@ -173,14 +175,7 @@ describe('TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService', ()
   });
 
   it('forwards OpenCode lead turn activity to setLeadActivity for the tracked run only', async () => {
-    const run = {
-      teamName: 'team-a',
-      runId: 'run-1',
-      processKilled: false,
-      cancelRequested: false,
-      request: {},
-      child: null,
-    } satisfies TestSendRun;
+    const run = trackedRun();
     const setLeadActivity = vi.fn();
     const resolveLeadActivityRun = vi.fn((teamName: string) =>
       teamName === 'team-a' ? run : null
@@ -221,7 +216,188 @@ describe('TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService', ()
       [run, 'idle'],
     ]);
   });
+
+  describe('lead active fallback', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('drops a lead turn back to idle when no settle signal ever arrives', async () => {
+      const run = trackedRun();
+      const setLeadActivity = vi.fn();
+      const service = createService({
+        setLeadActivity,
+        resolveLeadActivityRun: () => run,
+      });
+
+      await service.notifyOpenCodeLeadTurnActivity(leadTurnActivity('active'));
+      vi.advanceTimersByTime(OPENCODE_LEAD_ACTIVE_FALLBACK_MS - 1);
+      expect(setLeadActivity.mock.calls).toEqual([[run, 'active']]);
+
+      vi.advanceTimersByTime(1);
+      expect(setLeadActivity.mock.calls).toEqual([
+        [run, 'active'],
+        [run, 'idle'],
+      ]);
+    });
+
+    it('unrefs the fallback timer so it cannot hold the process open', async () => {
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+      const service = createService({ resolveLeadActivityRun: () => trackedRun() });
+
+      await service.notifyOpenCodeLeadTurnActivity(leadTurnActivity('active'));
+
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+      const timer = setTimeoutSpy.mock.results[0]?.value as { hasRef(): boolean };
+      expect(timer.hasRef()).toBe(false);
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('restarts a single fallback timer instead of accumulating one per active report', async () => {
+      const run = trackedRun();
+      const setLeadActivity = vi.fn();
+      const service = createService({
+        setLeadActivity,
+        resolveLeadActivityRun: () => run,
+      });
+
+      await service.notifyOpenCodeLeadTurnActivity(leadTurnActivity('active'));
+      vi.advanceTimersByTime(OPENCODE_LEAD_ACTIVE_FALLBACK_MS - 1);
+      await service.notifyOpenCodeLeadTurnActivity(leadTurnActivity('active'));
+      expect(vi.getTimerCount()).toBe(1);
+
+      // The first timer would have fired here if it had not been cleared.
+      vi.advanceTimersByTime(1);
+      expect(setLeadActivity.mock.calls).toEqual([
+        [run, 'active'],
+        [run, 'active'],
+      ]);
+
+      vi.advanceTimersByTime(OPENCODE_LEAD_ACTIVE_FALLBACK_MS);
+      expect(setLeadActivity.mock.calls).toEqual([
+        [run, 'active'],
+        [run, 'active'],
+        [run, 'idle'],
+      ]);
+    });
+
+    it('never writes idle twice when a real settle signal beats the fallback', async () => {
+      const run = trackedRun();
+      const setLeadActivity = vi.fn();
+      const service = createService({
+        setLeadActivity,
+        resolveLeadActivityRun: () => run,
+      });
+
+      await service.notifyOpenCodeLeadTurnActivity(leadTurnActivity('active'));
+      await service.notifyOpenCodeLeadTurnActivity(leadTurnActivity('idle'));
+      expect(vi.getTimerCount()).toBe(0);
+
+      vi.advanceTimersByTime(OPENCODE_LEAD_ACTIVE_FALLBACK_MS * 2);
+
+      expect(setLeadActivity.mock.calls).toEqual([
+        [run, 'active'],
+        [run, 'idle'],
+      ]);
+      expect(setLeadActivity.mock.calls.filter(([, state]) => state === 'idle')).toHaveLength(1);
+    });
+
+    it('arms nothing for a team with no tracked run, and no-ops when the run disappears', async () => {
+      const setLeadActivity = vi.fn();
+      const serviceWithoutRun = createService({
+        setLeadActivity,
+        resolveLeadActivityRun: () => null,
+      });
+
+      await expect(
+        serviceWithoutRun.notifyOpenCodeLeadTurnActivity(leadTurnActivity('active'))
+      ).resolves.toBeUndefined();
+      expect(vi.getTimerCount()).toBe(0);
+      expect(setLeadActivity).not.toHaveBeenCalled();
+
+      let trackedRunOrNull: TestSendRun | null = trackedRun();
+      const serviceLosingRun = createService({
+        setLeadActivity,
+        resolveLeadActivityRun: () => trackedRunOrNull,
+      });
+
+      await serviceLosingRun.notifyOpenCodeLeadTurnActivity(leadTurnActivity('active'));
+      trackedRunOrNull = null;
+
+      expect(() => vi.advanceTimersByTime(OPENCODE_LEAD_ACTIVE_FALLBACK_MS)).not.toThrow();
+      expect(setLeadActivity.mock.calls).toEqual([[expect.anything(), 'active']]);
+    });
+
+    it('never arms the fallback for a notification the lead activity guards drop', async () => {
+      const run = trackedRun();
+      const setLeadActivity = vi.fn();
+      const service = createService({
+        setLeadActivity,
+        resolveLeadActivityRun: () => run,
+      });
+
+      for (const dropped of [
+        { ...leadTurnActivity('active'), laneId: 'secondary:opencode:builder' },
+        { ...leadTurnActivity('active'), runId: null },
+        { ...leadTurnActivity('active'), memberName: 'builder' },
+        { ...leadTurnActivity('active'), runId: 'replacement-run' },
+      ]) {
+        await service.notifyOpenCodeLeadTurnActivity(dropped);
+        expect(vi.getTimerCount()).toBe(0);
+      }
+
+      vi.advanceTimersByTime(OPENCODE_LEAD_ACTIVE_FALLBACK_MS * 2);
+      expect(setLeadActivity).not.toHaveBeenCalled();
+    });
+
+    it('keeps a live turn fallback armed when a dropped notification arrives behind it', async () => {
+      const run = trackedRun();
+      const setLeadActivity = vi.fn();
+      const service = createService({
+        setLeadActivity,
+        resolveLeadActivityRun: () => run,
+      });
+
+      await service.notifyOpenCodeLeadTurnActivity(leadTurnActivity('active'));
+      await service.notifyOpenCodeLeadTurnActivity({
+        ...leadTurnActivity('idle'),
+        runId: 'replacement-run',
+      });
+      expect(vi.getTimerCount()).toBe(1);
+
+      vi.advanceTimersByTime(OPENCODE_LEAD_ACTIVE_FALLBACK_MS);
+      expect(setLeadActivity.mock.calls).toEqual([
+        [run, 'active'],
+        [run, 'idle'],
+      ]);
+    });
+  });
 });
+
+function trackedRun(): TestSendRun {
+  return {
+    teamName: 'team-a',
+    runId: 'run-1',
+    processKilled: false,
+    cancelRequested: false,
+    request: {},
+    child: null,
+  } satisfies TestSendRun;
+}
+
+function leadTurnActivity(state: 'active' | 'idle'): OpenCodeLeadTurnActivityNotification {
+  return {
+    teamName: 'team-a',
+    memberName: 'team-lead',
+    laneId: 'primary',
+    runId: 'run-1',
+    state,
+  };
+}
 
 function createService(
   overrides: Partial<TestDeps> = {}

--- a/src/main/services/team/stallMonitor/TaskStallJournalStore.ts
+++ b/src/main/services/team/stallMonitor/TaskStallJournalStore.ts
@@ -1,4 +1,8 @@
-import type { TaskStallJournalEntry, TaskStallJournalState } from './TeamTaskStallTypes';
+import type {
+  TaskStallJournalEntry,
+  TaskStallJournalState,
+  TaskStallSignal,
+} from './TeamTaskStallTypes';
 
 export interface TaskStallJournalMutation<T> {
   entries: TaskStallJournalEntry[];
@@ -26,6 +30,19 @@ function isValidState(value: unknown): value is TaskStallJournalState {
   return value === 'suspected' || value === 'alert_ready' || value === 'alerted';
 }
 
+// Every signal the journal may round-trip. A signal missing here is dropped on
+// read, which silently resets the two-scan counter for that branch.
+const VALID_SIGNALS = new Set<TaskStallSignal>([
+  'turn_ended_after_touch',
+  'mid_turn_after_touch',
+  'touch_then_other_turns',
+  'pending_pickup_after_unblock',
+]);
+
+function isValidSignal(value: unknown): value is TaskStallSignal {
+  return typeof value === 'string' && VALID_SIGNALS.has(value as TaskStallSignal);
+}
+
 /**
  * Validates untrusted journal data (legacy JSON files, worker round-trips) and
  * drops malformed entries instead of failing the whole journal.
@@ -45,9 +62,7 @@ export function sanitizeTaskStallJournalEntries(value: unknown): TaskStallJourna
         typeof (item as TaskStallJournalEntry).taskId === 'string' &&
         ((item as TaskStallJournalEntry).branch === 'work' ||
           (item as TaskStallJournalEntry).branch === 'review') &&
-        ((item as TaskStallJournalEntry).signal === 'turn_ended_after_touch' ||
-          (item as TaskStallJournalEntry).signal === 'mid_turn_after_touch' ||
-          (item as TaskStallJournalEntry).signal === 'touch_then_other_turns') &&
+        isValidSignal((item as TaskStallJournalEntry).signal) &&
         isValidState((item as TaskStallJournalEntry).state) &&
         typeof (item as TaskStallJournalEntry).consecutiveScans === 'number' &&
         typeof (item as TaskStallJournalEntry).createdAt === 'string' &&
@@ -68,6 +83,9 @@ export function sanitizeTaskStallJournalEntries(value: unknown): TaskStallJourna
         : {}),
       ...(typeof entry.alertedAt === 'string' && entry.alertedAt
         ? { alertedAt: entry.alertedAt }
+        : {}),
+      ...(typeof entry.alertCount === 'number' && Number.isFinite(entry.alertCount)
+        ? { alertCount: Math.max(0, Math.trunc(entry.alertCount)) }
         : {}),
     }));
 }

--- a/src/main/services/team/stallMonitor/TaskStallJournalStore.ts
+++ b/src/main/services/team/stallMonitor/TaskStallJournalStore.ts
@@ -31,16 +31,20 @@ function isValidState(value: unknown): value is TaskStallJournalState {
 }
 
 // Every signal the journal may round-trip. A signal missing here is dropped on
-// read, which silently resets the two-scan counter for that branch.
-const VALID_SIGNALS = new Set<TaskStallSignal>([
-  'turn_ended_after_touch',
-  'mid_turn_after_touch',
-  'touch_then_other_turns',
-  'pending_pickup_after_unblock',
-]);
+// read, which silently resets the two-scan counter for that branch: that is the
+// bug the pickup signal hit. The mapping is a Record over the union rather than
+// a list, so adding a TaskStallSignal without listing it here fails typecheck
+// instead of failing a branch at runtime.
+const VALID_SIGNAL_BY_NAME: Record<TaskStallSignal, true> = {
+  turn_ended_after_touch: true,
+  mid_turn_after_touch: true,
+  touch_then_other_turns: true,
+  pending_pickup_after_unblock: true,
+};
+const VALID_SIGNALS = new Set<string>(Object.keys(VALID_SIGNAL_BY_NAME));
 
 function isValidSignal(value: unknown): value is TaskStallSignal {
-  return typeof value === 'string' && VALID_SIGNALS.has(value as TaskStallSignal);
+  return typeof value === 'string' && VALID_SIGNALS.has(value);
 }
 
 /**

--- a/src/main/services/team/stallMonitor/TeamTaskStallJournal.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallJournal.ts
@@ -12,6 +12,18 @@ function parseTime(value: string | undefined): number | null {
   return Number.isFinite(time) ? time : null;
 }
 
+/**
+ * Stamps how many alerts the epoch already produced so the caller can bound its
+ * escalation. Left off a first alert to keep the evaluation identical to the one
+ * the policy produced.
+ */
+function withPriorAlertCount(
+  evaluation: TaskStallEvaluation,
+  alertCount: number | undefined
+): TaskStallEvaluation {
+  return alertCount && alertCount > 0 ? { ...evaluation, priorAlertCount: alertCount } : evaluation;
+}
+
 export interface TeamTaskStallJournalOptions {
   alertCooldownMs?: number;
   /** Persistence backend. Defaults to the legacy per-team JSON file store. */
@@ -102,14 +114,14 @@ export class TeamTaskStallJournal {
 
           existing.state = 'alert_ready';
           existing.consecutiveScans += 1;
-          readyEvaluations.push(evaluation);
+          readyEvaluations.push(withPriorAlertCount(evaluation, existing.alertCount));
           continue;
         }
 
         existing.consecutiveScans += 1;
         if (existing.consecutiveScans >= 2) {
           existing.state = 'alert_ready';
-          readyEvaluations.push(evaluation);
+          readyEvaluations.push(withPriorAlertCount(evaluation, existing.alertCount));
         }
       }
 
@@ -126,6 +138,7 @@ export class TeamTaskStallJournal {
       target.state = 'alerted';
       target.updatedAt = now;
       target.alertedAt = now;
+      target.alertCount = (target.alertCount ?? 0) + 1;
       return { entries, result: undefined };
     });
   }

--- a/src/main/services/team/stallMonitor/TeamTaskStallMonitor.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallMonitor.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@shared/utils/logger';
 import { getTaskDisplayId } from '@shared/utils/taskIdentity';
 
 import {
+  getOpenCodeWeakStartStallThresholdMs,
   getTeamTaskStallActivationGraceMs,
   getTeamTaskStallScanIntervalMs,
   getTeamTaskStallStartupGraceMs,
@@ -10,6 +11,7 @@ import {
   isTeamTaskStallMonitorEnabled,
   isTeamTaskStallScannerEnabled,
 } from './featureGates';
+import { getOpenWorkInterval } from './TeamTaskStallPolicy';
 
 import type { ActiveTeamRegistry } from './ActiveTeamRegistry';
 import type { TeamTaskStallJournal } from './TeamTaskStallJournal';
@@ -35,6 +37,8 @@ interface TeamTaskStallScanRun {
 }
 
 const DEFAULT_TEAM_TASK_STALL_SCAN_TIMEOUT_MS = 2 * 60_000;
+const OPENCODE_SKIP_LOG_INTERVAL_MS = 10 * 60_000;
+const OPENCODE_HELD_ALERT_LOG_DELAY_MS = 2 * 60_000;
 
 function unrefBackgroundTimer(timer: ReturnType<typeof setTimeout>): void {
   const maybeTimer = timer as { unref?: () => void };
@@ -286,6 +290,7 @@ export class TeamTaskStallMonitor {
     for (const task of snapshot.inProgressTasks) {
       evaluations.push(this.policy.evaluateWork({ now, task, snapshot }));
     }
+    this.logOpenCodeOwnerSkips(snapshot, evaluations, now);
     for (const task of snapshot.reviewOpenTasks) {
       evaluations.push(this.policy.evaluateReview({ now, task, snapshot }));
     }
@@ -310,6 +315,7 @@ export class TeamTaskStallMonitor {
     if (!this.shouldContinueScan(scanRun)) {
       return;
     }
+    this.logOpenCodeOwnerAlertsHeldByJournal(snapshot, journalEvaluations, readyEvaluations, now);
 
     const alerts = readyEvaluations
       .map((evaluation) => this.buildAlert(snapshot, evaluation))
@@ -398,6 +404,87 @@ export class TeamTaskStallMonitor {
         teamName: snapshot.teamName,
       },
     };
+  }
+
+  /**
+   * Diagnosability: an OpenCode owner whose task has been in progress longer
+   * than the OpenCode stall threshold but was not alerted is logged at warn
+   * level (once per task and reason per cooldown) so the next "the monitor
+   * never fired" report can be read out of the error log instead of guessed at.
+   */
+  private readonly openCodeSkipLogAtByKey = new Map<string, number>();
+  private readonly heldAlertFirstSeenAtByKey = new Map<string, number>();
+
+  private shouldLogOpenCodeSkip(key: string, nowMs: number): boolean {
+    const last = this.openCodeSkipLogAtByKey.get(key);
+    if (last !== undefined && nowMs - last < OPENCODE_SKIP_LOG_INTERVAL_MS) {
+      return false;
+    }
+    this.openCodeSkipLogAtByKey.set(key, nowMs);
+    return true;
+  }
+
+  private describeOpenCodeLane(
+    snapshot: NonNullable<Awaited<ReturnType<TeamTaskStallSnapshotSource['getSnapshot']>>>,
+    owner: string | undefined
+  ): string {
+    const key = owner?.trim().toLowerCase() ?? '';
+    const idleSince = snapshot.openCodeLaneIdleSinceByMemberName?.get(key);
+    if (idleSince) return `lane idle since ${idleSince}`;
+    if (snapshot.openCodeLaneActiveMemberNames?.has(key)) return 'lane active';
+    return 'lane state unknown';
+  }
+
+  private logOpenCodeOwnerSkips(
+    snapshot: NonNullable<Awaited<ReturnType<TeamTaskStallSnapshotSource['getSnapshot']>>>,
+    evaluations: TaskStallEvaluation[],
+    now: Date
+  ): void {
+    const thresholdMs = getOpenCodeWeakStartStallThresholdMs();
+    for (const evaluation of evaluations) {
+      if (evaluation.status !== 'skip' || !evaluation.taskId) continue;
+      const task = snapshot.allTasksById.get(evaluation.taskId);
+      if (!task?.owner || task.status !== 'in_progress') continue;
+      const ownerProviderId = snapshot.providerByMemberName.get(task.owner.trim().toLowerCase());
+      if (ownerProviderId !== 'opencode') continue;
+      const startedAt = getOpenWorkInterval(task)?.startedAt;
+      const inProgressMs = startedAt ? now.getTime() - Date.parse(startedAt) : Number.NaN;
+      if (!Number.isFinite(inProgressMs) || inProgressMs < thresholdMs) continue;
+      const key = `${snapshot.teamName}:${task.id}:${evaluation.skipReason ?? 'skip'}`;
+      if (!this.shouldLogOpenCodeSkip(key, now.getTime())) continue;
+      logger.warn(
+        `[${snapshot.teamName}] Stall monitor did not alert OpenCode task #${getTaskDisplayId(task)} (owner ${task.owner}, in progress ${Math.round(inProgressMs / 60_000)} min): ${evaluation.skipReason ?? 'skip'} - ${evaluation.reason}; ${this.describeOpenCodeLane(snapshot, task.owner)}`
+      );
+    }
+  }
+
+  private logOpenCodeOwnerAlertsHeldByJournal(
+    snapshot: NonNullable<Awaited<ReturnType<TeamTaskStallSnapshotSource['getSnapshot']>>>,
+    evaluations: TaskStallEvaluation[],
+    readyEvaluations: TaskStallEvaluation[],
+    now: Date
+  ): void {
+    const readyKeys = new Set(readyEvaluations.map((evaluation) => evaluation.epochKey));
+    for (const evaluation of evaluations) {
+      if (evaluation.status !== 'alert' || !evaluation.taskId || !evaluation.epochKey) continue;
+      const heldKey = `${snapshot.teamName}:${evaluation.epochKey}`;
+      if (readyKeys.has(evaluation.epochKey)) {
+        this.heldAlertFirstSeenAtByKey.delete(heldKey);
+        continue;
+      }
+      if (!this.isOpenCodeOwnerWorkEvaluation(snapshot, evaluation)) continue;
+      // The journal holds every alert on the scan that first sees it; only a
+      // hold that outlives that rule is worth a log line.
+      const firstSeenAt = this.heldAlertFirstSeenAtByKey.get(heldKey) ?? now.getTime();
+      this.heldAlertFirstSeenAtByKey.set(heldKey, firstSeenAt);
+      if (now.getTime() - firstSeenAt < OPENCODE_HELD_ALERT_LOG_DELAY_MS) continue;
+      const task = snapshot.allTasksById.get(evaluation.taskId);
+      const key = `${heldKey}:journal_hold`;
+      if (!this.shouldLogOpenCodeSkip(key, now.getTime())) continue;
+      logger.warn(
+        `[${snapshot.teamName}] Stall alert for OpenCode task #${task ? getTaskDisplayId(task) : evaluation.taskId} (owner ${evaluation.memberName ?? task?.owner ?? 'unknown'}) is held by the stall journal (cooldown or first-scan rule): ${evaluation.reason}`
+      );
+    }
   }
 
   private isOpenCodeOwnerWorkEvaluation(

--- a/src/main/services/team/stallMonitor/TeamTaskStallMonitor.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallMonitor.ts
@@ -561,9 +561,18 @@ export class TeamTaskStallMonitor {
     owner: string | undefined
   ): string {
     const key = owner?.trim().toLowerCase() ?? '';
+    // Timestamp first, always: a bare "lane active" is what made the original
+    // suppression unreadable after the fact.
+    const staleActiveSince = snapshot.openCodeLaneStaleActiveSinceByMemberName?.get(key);
+    if (staleActiveSince) {
+      return `lane turn sample stale-active since ${staleActiveSince} (demoted to idle)`;
+    }
     const idleSince = snapshot.openCodeLaneIdleSinceByMemberName?.get(key);
     if (idleSince) return `lane idle since ${idleSince}`;
-    if (snapshot.openCodeLaneActiveMemberNames?.has(key)) return 'lane active';
+    if (snapshot.openCodeLaneActiveMemberNames?.has(key)) {
+      const activeSince = snapshot.openCodeLaneActiveSinceByMemberName?.get(key);
+      return activeSince ? `lane active since ${activeSince}` : 'lane active';
+    }
     return 'lane state unknown';
   }
 

--- a/src/main/services/team/stallMonitor/TeamTaskStallMonitor.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallMonitor.ts
@@ -40,6 +40,28 @@ const DEFAULT_TEAM_TASK_STALL_SCAN_TIMEOUT_MS = 2 * 60_000;
 const OPENCODE_SKIP_LOG_INTERVAL_MS = 10 * 60_000;
 const OPENCODE_HELD_ALERT_LOG_DELAY_MS = 2 * 60_000;
 
+/** Rungs of the pickup ladder: nudge the owner once, tell the lead once, then stop. */
+const PICKUP_ESCALATION_RUNGS = 2;
+
+interface PickupEscalationState {
+  priorAlertCount: number;
+  clockMs: number;
+}
+
+interface PickupEscalationPlan {
+  ownerAlerts: TaskStallAlert[];
+  leadOnlyAlerts: TaskStallAlert[];
+  silencedAlerts: TaskStallAlert[];
+  /** The subset of silenced alerts whose ladder ran out on this scan; logged once. */
+  newlyExhaustedAlerts: TaskStallAlert[];
+}
+
+/** Missing or unparsable clocks sort last so a known-oldest task wins the scan. */
+function parsePickupClockMs(readyAt: string | undefined): number {
+  const parsed = readyAt ? Date.parse(readyAt) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
+}
+
 function unrefBackgroundTimer(timer: ReturnType<typeof setTimeout>): void {
   const maybeTimer = timer as { unref?: () => void };
   maybeTimer.unref?.();
@@ -291,6 +313,9 @@ export class TeamTaskStallMonitor {
       evaluations.push(this.policy.evaluateWork({ now, task, snapshot }));
     }
     this.logOpenCodeOwnerSkips(snapshot, evaluations, now);
+    for (const task of snapshot.pendingPickupTasks ?? []) {
+      evaluations.push(this.policy.evaluatePendingPickup({ now, task, snapshot }));
+    }
     for (const task of snapshot.reviewOpenTasks) {
       evaluations.push(this.policy.evaluateReview({ now, task, snapshot }));
     }
@@ -302,8 +327,17 @@ export class TeamTaskStallMonitor {
     const journalEvaluations = openCodeOnlyMode
       ? evaluations.filter((evaluation) => this.isOpenCodeOwnerWorkEvaluation(snapshot, evaluation))
       : evaluations;
+    // Pickup candidates must be in this set: the journal prunes any entry whose
+    // task is not active, so leaving them out would reset the two-scan counter
+    // on every scan and the pickup branch would never alert.
     const activeTaskIds = [
-      ...new Set([...snapshot.inProgressTasks, ...snapshot.reviewOpenTasks].map((task) => task.id)),
+      ...new Set(
+        [
+          ...snapshot.inProgressTasks,
+          ...snapshot.reviewOpenTasks,
+          ...(snapshot.pendingPickupTasks ?? []),
+        ].map((task) => task.id)
+      ),
     ];
     const readyEvaluations = await this.journal.reconcileScan({
       teamName,
@@ -325,9 +359,14 @@ export class TeamTaskStallMonitor {
       return;
     }
 
+    const { ownerAlerts, leadOnlyAlerts, silencedAlerts, newlyExhaustedAlerts } =
+      this.planPickupEscalation(alerts, readyEvaluations);
+    this.logExhaustedPickupEscalations(teamName, newlyExhaustedAlerts);
+    const routableAlerts = [...ownerAlerts, ...leadOnlyAlerts];
+
     const alertedEpochKeys = new Set<string>();
-    if (openCodeRemediationEnabled) {
-      const remediatedAlerts = await this.notifier.notifyOpenCodeOwners(teamName, alerts);
+    if (openCodeRemediationEnabled && ownerAlerts.length > 0) {
+      const remediatedAlerts = await this.notifier.notifyOpenCodeOwners(teamName, ownerAlerts);
       if (!this.shouldContinueScan(scanRun)) {
         return;
       }
@@ -336,7 +375,9 @@ export class TeamTaskStallMonitor {
       }
     }
 
-    const leadFallbackAlerts = alerts.filter((alert) => !alertedEpochKeys.has(alert.epochKey));
+    const leadFallbackAlerts = routableAlerts.filter(
+      (alert) => !alertedEpochKeys.has(alert.epochKey)
+    );
     if (leadFallbackAlerts.length > 0 && isTeamTaskStallAlertsEnabled()) {
       await this.notifier.notifyLead(teamName, leadFallbackAlerts);
       if (!this.shouldContinueScan(scanRun)) {
@@ -347,7 +388,13 @@ export class TeamTaskStallMonitor {
       }
     }
 
-    if (alertedEpochKeys.size === 0) {
+    // A silenced rung is journaled too: the cooldown is what keeps an abandoned
+    // task from being re-evaluated on every scan.
+    const journaledAlerts = [
+      ...routableAlerts.filter((alert) => alertedEpochKeys.has(alert.epochKey)),
+      ...silencedAlerts,
+    ];
+    if (journaledAlerts.length === 0) {
       logger.debug(`Task stall monitor shadow-ready alerts for ${teamName}: ${alerts.length}`);
       return;
     }
@@ -356,10 +403,94 @@ export class TeamTaskStallMonitor {
       return;
     }
     await Promise.all(
-      alerts
-        .filter((alert) => alertedEpochKeys.has(alert.epochKey))
-        .map((alert) => this.journal.markAlerted(teamName, alert.epochKey, now.toISOString()))
+      journaledAlerts.map((alert) =>
+        this.journal.markAlerted(teamName, alert.epochKey, now.toISOString())
+      )
     );
+  }
+
+  /**
+   * Pickup alerts climb a bounded ladder - owner nudge, then lead alert, then
+   * silence - and only the oldest pending task per member reaches that member's
+   * lane in one scan. Alerts held back by the per-member cap are left
+   * unjournaled so the next scan reconsiders them instead of burning a rung.
+   */
+  private planPickupEscalation(
+    alerts: TaskStallAlert[],
+    readyEvaluations: TaskStallEvaluation[]
+  ): PickupEscalationPlan {
+    const stateByEpochKey = new Map<string, PickupEscalationState>();
+    for (const evaluation of readyEvaluations) {
+      if (!evaluation.epochKey) continue;
+      stateByEpochKey.set(evaluation.epochKey, {
+        priorAlertCount: evaluation.priorAlertCount ?? 0,
+        clockMs: parsePickupClockMs(evaluation.readyAt),
+      });
+    }
+
+    const plan: PickupEscalationPlan = {
+      ownerAlerts: [],
+      leadOnlyAlerts: [],
+      silencedAlerts: [],
+      newlyExhaustedAlerts: [],
+    };
+    const pickupAlertsByMember = new Map<string, TaskStallAlert[]>();
+    for (const alert of alerts) {
+      if (alert.remediationKind !== 'pending_pickup') {
+        plan.ownerAlerts.push(alert);
+        continue;
+      }
+      const priorAlertCount = stateByEpochKey.get(alert.epochKey)?.priorAlertCount ?? 0;
+      if (priorAlertCount >= PICKUP_ESCALATION_RUNGS) {
+        plan.silencedAlerts.push(alert);
+        if (priorAlertCount === PICKUP_ESCALATION_RUNGS) {
+          plan.newlyExhaustedAlerts.push(alert);
+        }
+        continue;
+      }
+      const memberKey = alert.owner?.trim().toLowerCase() ?? '';
+      const memberAlerts = pickupAlertsByMember.get(memberKey);
+      if (memberAlerts) {
+        memberAlerts.push(alert);
+      } else {
+        pickupAlertsByMember.set(memberKey, [alert]);
+      }
+    }
+
+    for (const memberAlerts of pickupAlertsByMember.values()) {
+      const oldest = [...memberAlerts].sort((left, right) => {
+        const leftMs = stateByEpochKey.get(left.epochKey)?.clockMs ?? Number.POSITIVE_INFINITY;
+        const rightMs = stateByEpochKey.get(right.epochKey)?.clockMs ?? Number.POSITIVE_INFINITY;
+        if (leftMs !== rightMs) {
+          return leftMs < rightMs ? -1 : 1;
+        }
+        return left.taskId.localeCompare(right.taskId);
+      })[0];
+      if (!oldest) continue;
+      if ((stateByEpochKey.get(oldest.epochKey)?.priorAlertCount ?? 0) === 0) {
+        plan.ownerAlerts.push(oldest);
+      } else {
+        plan.leadOnlyAlerts.push(oldest);
+      }
+    }
+
+    return plan;
+  }
+
+  /**
+   * Logged once per epoch, on the scan the ladder runs out. Later scans keep
+   * silencing the same alert but say nothing, so an abandoned task does not
+   * repeat a warn line for the rest of the run.
+   */
+  private logExhaustedPickupEscalations(
+    teamName: string,
+    newlyExhaustedAlerts: TaskStallAlert[]
+  ): void {
+    for (const alert of newlyExhaustedAlerts) {
+      logger.warn(
+        `[${teamName}] Stall monitor stopped escalating task #${alert.displayId} (owner ${alert.owner ?? 'unknown'}): pickup_escalation_exhausted - the owner nudge and the lead alert are spent and the task is still pending.`
+      );
+    }
   }
 
   private buildAlert(
@@ -394,6 +525,7 @@ export class TeamTaskStallMonitor {
       branch: evaluation.branch,
       signal: evaluation.signal,
       ...(evaluation.progressSignal ? { progressSignal: evaluation.progressSignal } : {}),
+      ...(evaluation.remediationKind ? { remediationKind: evaluation.remediationKind } : {}),
       reason: evaluation.reason,
       epochKey: evaluation.epochKey,
       ...(task.owner ? { owner: task.owner } : {}),

--- a/src/main/services/team/stallMonitor/TeamTaskStallMonitor.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallMonitor.ts
@@ -250,6 +250,8 @@ export class TeamTaskStallMonitor {
     }
 
     const now = new Date();
+    this.pruneDiagnosticState(activeSet, now.getTime());
+
     const eligibleTeamNames: string[] = [];
     for (const teamName of activeTeams) {
       const observation = this.getOrCreateObservation(teamName, now.getTime());
@@ -545,7 +547,7 @@ export class TeamTaskStallMonitor {
    * never fired" report can be read out of the error log instead of guessed at.
    */
   private readonly openCodeSkipLogAtByKey = new Map<string, number>();
-  private readonly heldAlertFirstSeenAtByKey = new Map<string, number>();
+  private readonly heldAlertFirstSeenAtByTeam = new Map<string, Map<string, number>>();
 
   private shouldLogOpenCodeSkip(key: string, nowMs: number): boolean {
     const last = this.openCodeSkipLogAtByKey.get(key);
@@ -554,6 +556,31 @@ export class TeamTaskStallMonitor {
     }
     this.openCodeSkipLogAtByKey.set(key, nowMs);
     return true;
+  }
+
+  /**
+   * Both diagnostic maps are keyed by data that turns over inside a live team -
+   * task ids, and epoch keys that carry a touch timestamp - so the monitor,
+   * which runs for the whole main-process lifetime, would otherwise keep one
+   * dead entry per task and per epoch forever. Neither bound is an arbitrary
+   * cap: each entry is dropped when it can no longer affect a decision.
+   */
+  private pruneDiagnosticState(activeTeamNames: Set<string>, nowMs: number): void {
+    // A rate-limit stamp older than its own interval cannot suppress anything:
+    // shouldLogOpenCodeSkip would return true for that key either way, so
+    // dropping it is exactly equivalent to keeping it.
+    for (const [key, loggedAtMs] of this.openCodeSkipLogAtByKey) {
+      if (nowMs - loggedAtMs >= OPENCODE_SKIP_LOG_INTERVAL_MS) {
+        this.openCodeSkipLogAtByKey.delete(key);
+      }
+    }
+    // Held-alert clocks belong to a team's live scan. A team that is no longer
+    // running has no held alerts, and its next launch starts a fresh journal.
+    for (const teamName of this.heldAlertFirstSeenAtByTeam.keys()) {
+      if (!activeTeamNames.has(teamName)) {
+        this.heldAlertFirstSeenAtByTeam.delete(teamName);
+      }
+    }
   }
 
   private describeOpenCodeLane(
@@ -606,25 +633,32 @@ export class TeamTaskStallMonitor {
     now: Date
   ): void {
     const readyKeys = new Set(readyEvaluations.map((evaluation) => evaluation.epochKey));
+    const previousFirstSeenAt = this.heldAlertFirstSeenAtByTeam.get(snapshot.teamName);
+    // Rebuilt from this scan rather than mutated: an epoch that became ready,
+    // stopped being an OpenCode work alert or left the board entirely is not
+    // carried over, so the map holds only the alerts still being held.
+    const stillHeldFirstSeenAt = new Map<string, number>();
     for (const evaluation of evaluations) {
       if (evaluation.status !== 'alert' || !evaluation.taskId || !evaluation.epochKey) continue;
-      const heldKey = `${snapshot.teamName}:${evaluation.epochKey}`;
-      if (readyKeys.has(evaluation.epochKey)) {
-        this.heldAlertFirstSeenAtByKey.delete(heldKey);
-        continue;
-      }
+      if (readyKeys.has(evaluation.epochKey)) continue;
       if (!this.isOpenCodeOwnerWorkEvaluation(snapshot, evaluation)) continue;
       // The journal holds every alert on the scan that first sees it; only a
       // hold that outlives that rule is worth a log line.
-      const firstSeenAt = this.heldAlertFirstSeenAtByKey.get(heldKey) ?? now.getTime();
-      this.heldAlertFirstSeenAtByKey.set(heldKey, firstSeenAt);
+      const firstSeenAt = previousFirstSeenAt?.get(evaluation.epochKey) ?? now.getTime();
+      stillHeldFirstSeenAt.set(evaluation.epochKey, firstSeenAt);
       if (now.getTime() - firstSeenAt < OPENCODE_HELD_ALERT_LOG_DELAY_MS) continue;
       const task = snapshot.allTasksById.get(evaluation.taskId);
-      const key = `${heldKey}:journal_hold`;
+      const key = `${snapshot.teamName}:${evaluation.epochKey}:journal_hold`;
       if (!this.shouldLogOpenCodeSkip(key, now.getTime())) continue;
       logger.warn(
         `[${snapshot.teamName}] Stall alert for OpenCode task #${task ? getTaskDisplayId(task) : evaluation.taskId} (owner ${evaluation.memberName ?? task?.owner ?? 'unknown'}) is held by the stall journal (cooldown or first-scan rule): ${evaluation.reason}`
       );
+    }
+
+    if (stillHeldFirstSeenAt.size > 0) {
+      this.heldAlertFirstSeenAtByTeam.set(snapshot.teamName, stillHeldFirstSeenAt);
+    } else {
+      this.heldAlertFirstSeenAtByTeam.delete(snapshot.teamName);
     }
   }
 

--- a/src/main/services/team/stallMonitor/TeamTaskStallMonitor.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallMonitor.ts
@@ -380,10 +380,17 @@ export class TeamTaskStallMonitor {
     const leadFallbackAlerts = routableAlerts.filter(
       (alert) => !alertedEpochKeys.has(alert.epochKey)
     );
-    if (leadFallbackAlerts.length > 0 && isTeamTaskStallAlertsEnabled()) {
-      await this.notifier.notifyLead(teamName, leadFallbackAlerts);
-      if (!this.shouldContinueScan(scanRun)) {
-        return;
+    if (leadFallbackAlerts.length > 0) {
+      // A rung is consumed by REACHING it, not by the notification landing.
+      // With lead alerts switched off, journaling these anyway is what lets the
+      // pickup ladder climb to `silenced`: an unjournaled rung keeps
+      // `priorAlertCount` at the same value, so the same alert would be rebuilt
+      // on every scan for the rest of the run and the ladder would never end.
+      if (isTeamTaskStallAlertsEnabled()) {
+        await this.notifier.notifyLead(teamName, leadFallbackAlerts);
+        if (!this.shouldContinueScan(scanRun)) {
+          return;
+        }
       }
       for (const alert of leadFallbackAlerts) {
         alertedEpochKeys.add(alert.epochKey);

--- a/src/main/services/team/stallMonitor/TeamTaskStallNotifier.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallNotifier.ts
@@ -55,6 +55,15 @@ function buildOpenCodeOwnerNudgeText(alert: TaskStallAlert): string {
     id: alert.taskId,
     displayId: alert.displayId,
   });
+  if (alert.remediationKind === 'pending_pickup') {
+    return [
+      `Task ${taskLabel} is assigned to you and nothing is blocking it, but it is still pending on the board - you never started it.`,
+      'Start it now: call task_start for this task, do the work, post the result as a task comment ON THIS TASK, then call task_complete.',
+      'A direct message to the user does not move the board and does not count as doing the task.',
+      'If you cannot start, add a task comment naming the concrete blocker and what you need. Do not reply with an acknowledgement only.',
+      'If prefixed Agent Teams MCP tool names are exposed, use mcp__agent-teams__task_start, mcp__agent-teams__task_add_comment and mcp__agent-teams__task_complete.',
+    ].join('\n');
+  }
   return [
     `Task ${taskLabel} may be stalled after a low-signal progress update.`,
     'Continue the task now. If blocked, add a concrete task comment explaining the blocker and needed input. If done, add a final task comment with the result and complete the task.',
@@ -62,8 +71,21 @@ function buildOpenCodeOwnerNudgeText(alert: TaskStallAlert): string {
   ].join('\n');
 }
 
+/**
+ * Relay outcomes that report `delivered: true` for a message the member already
+ * read, i.e. nothing was sent this time. Treating them as accepted would retire
+ * the alert against a no-op and strand the escalation.
+ */
+const NO_OP_DELIVERY_REASONS = new Set([
+  'opencode_inbox_message_already_read',
+  'opencode_inbox_read_already_committed',
+]);
+
 function isOpenCodeDeliveryAccepted(delivery: OpenCodeTaskStallDelivery): boolean {
   if (delivery.queuedBehindMessageId) {
+    return false;
+  }
+  if (delivery.reason && NO_OP_DELIVERY_REASONS.has(delivery.reason)) {
     return false;
   }
   if (delivery.accepted === true) {
@@ -123,7 +145,10 @@ export class TeamTaskStallNotifier {
         to: owner,
         messageId: args.messageId,
         timestamp: args.timestamp,
-        summary: 'Potential stalled task',
+        summary:
+          args.alert.remediationKind === 'pending_pickup'
+            ? 'Assigned task not started'
+            : 'Potential stalled task',
         text: args.text,
         taskRefs: [args.alert.taskRef],
         actionMode: 'do',

--- a/src/main/services/team/stallMonitor/TeamTaskStallPendingPickup.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallPendingPickup.ts
@@ -129,9 +129,17 @@ function buildPendingPickupEpochKey(args: {
 
 /**
  * "Pickup stall": a pending task has nothing left to wait for - every blocker is
- * resolved, or it never had one - and its owner is not busy on another task.
- * Needs no transcript evidence, which is what makes it work on OpenCode/ACP-lead
- * teams where the lead transcript carries no per-member turn rows.
+ * resolved, or it never had one - its owner is not busy on another task, and its
+ * OpenCode lane is not mid-turn. Needs no transcript evidence, which is what
+ * makes it work on OpenCode/ACP-lead teams where the lead transcript carries no
+ * per-member turn rows.
+ *
+ * `lane_active` below means a *fresh* delivery-turn sample. TeamTaskStallSnapshotSource
+ * demotes an 'active' sample older than getOpenCodeLaneTurnActivityMaxAgeMs (see
+ * openCodeLaneTurnFreshness); without that bound a jammed delivery lane silences the
+ * branch that exists to catch the jam. The gate order and resolvePendingPickupReadyAt
+ * are correct as they stand, so the freshness rule deliberately lives upstream of this
+ * function rather than inside it.
  */
 export function evaluatePendingPickupTask(args: {
   now: Date;
@@ -178,7 +186,24 @@ export function evaluatePendingPickupTask(args: {
     );
   }
 
-  if (args.now.getTime() - Date.parse(readyAt) < getPendingPickupStallThresholdMs()) {
+  if (snapshot.openCodeLaneActiveMemberNames?.has(ownerKey)) {
+    // The lane is still generating its turn; a nudge now would only queue
+    // behind - or derail - work that is already running.
+    return skip(task.id, 'OpenCode lane turn is still active', 'lane_active');
+  }
+
+  // An idle sample is ordinary evidence, not a precondition: it can push the
+  // clock later but never starts it, so a team whose lane was never sampled is
+  // judged exactly as it was before this branch learned to read lanes at all. A
+  // sample demoted for age publishes its ORIGINAL observation time, so the age
+  // bound cannot restart the clock either.
+  const laneIdleSince = snapshot.openCodeLaneIdleSinceByMemberName?.get(ownerKey);
+  const laneIdleSinceMs = laneIdleSince ? Date.parse(laneIdleSince) : Number.NaN;
+  const clockStartMs = Number.isFinite(laneIdleSinceMs)
+    ? Math.max(Date.parse(readyAt), laneIdleSinceMs)
+    : Date.parse(readyAt);
+
+  if (args.now.getTime() - clockStartMs < getPendingPickupStallThresholdMs()) {
     return skip(
       task.id,
       'Pending pickup is still below the configured stall threshold',
@@ -189,6 +214,9 @@ export function evaluatePendingPickupTask(args: {
   const clockLabel = (task.blockedBy ?? []).length
     ? `all blockers resolved at ${readyAt}`
     : `owner has had it since ${readyAt}`;
+  const laneLabel = laneIdleSince
+    ? ` and its OpenCode lane has been idle since ${laneIdleSince}`
+    : '';
   return {
     status: 'alert',
     taskId: task.id,
@@ -198,6 +226,6 @@ export function evaluatePendingPickupTask(args: {
     remediationKind: 'pending_pickup',
     epochKey: buildPendingPickupEpochKey({ task, owner: task.owner, readyAt }),
     readyAt,
-    reason: `Potential pickup stall: ${clockLabel} but the task is still pending and its owner is not working anything else.`,
+    reason: `Potential pickup stall: ${clockLabel} but the task is still pending, its owner is not working anything else${laneLabel}.`,
   };
 }

--- a/src/main/services/team/stallMonitor/TeamTaskStallPendingPickup.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallPendingPickup.ts
@@ -1,0 +1,203 @@
+import { isTeamTaskBlockedByUnfinishedDependency } from '@shared/utils/teamTaskState';
+
+import {
+  getPendingPickupStallThresholdMs,
+  isPendingPickupStallRemediationEnabled,
+} from './featureGates';
+
+import type { TaskStallEvaluation, TeamTaskStallSnapshot } from './TeamTaskStallTypes';
+import type { TeamTask } from '@shared/types';
+
+/**
+ * Comment id written by the controller when a blocker completes:
+ * `dep-resolved-<completedTaskId>-<blockedTaskId>` (agent-teams-controller
+ * notifyUnblockedOwners). The comment is the artifact the owner was notified
+ * with, so it is also the pickup clock.
+ */
+const DEPENDENCY_RESOLVED_COMMENT_ID_PREFIX = 'dep-resolved-';
+
+function normalizeMemberKey(name: string | undefined): string {
+  return name?.trim().toLowerCase() ?? '';
+}
+
+function skip(
+  taskId: string,
+  reason: string,
+  skipReason: TaskStallEvaluation['skipReason']
+): TaskStallEvaluation {
+  return {
+    status: 'skip',
+    taskId,
+    reason,
+    skipReason,
+  };
+}
+
+function laterIsoTimestamp(left: string, right: string | null): string {
+  if (!right) {
+    return left;
+  }
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  if (!Number.isFinite(rightMs)) {
+    return left;
+  }
+  return Number.isFinite(leftMs) && leftMs >= rightMs ? left : right;
+}
+
+/**
+ * ISO time at which the app told the owner a dependency was resolved, or null.
+ * Only `system`-authored comments count: `resolveTaskCommentAuthorName` rejects
+ * `from: 'system'` for agent tool calls, so an agent cannot forge this clock.
+ */
+function resolveDependencyUnblockedAt(task: TeamTask): string | null {
+  const idSuffix = `-${task.id}`;
+  let latest: string | null = null;
+  let latestMs = Number.NEGATIVE_INFINITY;
+  for (const comment of task.comments ?? []) {
+    if (normalizeMemberKey(comment.author) !== 'system') {
+      continue;
+    }
+    if (
+      !comment.id.startsWith(DEPENDENCY_RESOLVED_COMMENT_ID_PREFIX) ||
+      !comment.id.endsWith(idSuffix)
+    ) {
+      continue;
+    }
+    const createdAtMs = Date.parse(comment.createdAt);
+    if (!Number.isFinite(createdAtMs) || createdAtMs <= latestMs) {
+      continue;
+    }
+    latestMs = createdAtMs;
+    latest = comment.createdAt;
+  }
+  return latest;
+}
+
+/** ISO time the task was last handed to `owner`, so a reassignment restarts the clock. */
+function resolveOwnerAssignedAt(task: TeamTask, owner: string): string | null {
+  const events = task.historyEvents ?? [];
+  const ownerKey = normalizeMemberKey(owner);
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const event = events[i];
+    if (event.type === 'owner_changed' && normalizeMemberKey(event.to) === ownerKey) {
+      return event.timestamp;
+    }
+  }
+  return null;
+}
+
+/**
+ * Start of the pickup clock. A task that had blockers uses the resolved notice
+ * the owner was sent; a task that never had one - the launch shape, and anything
+ * the lead creates mid-run - uses the moment it became this owner's to start.
+ * Null only when blockers exist and the resolved notice was never written, which
+ * is the one shape with no trustworthy clock.
+ */
+export function resolvePendingPickupReadyAt(task: TeamTask, owner: string): string | null {
+  const ownerAssignedAt = resolveOwnerAssignedAt(task, owner);
+  const unblockedAt = resolveDependencyUnblockedAt(task);
+  if (unblockedAt) {
+    return laterIsoTimestamp(unblockedAt, ownerAssignedAt);
+  }
+  if ((task.blockedBy ?? []).length > 0) {
+    return null;
+  }
+  return task.createdAt ? laterIsoTimestamp(task.createdAt, ownerAssignedAt) : ownerAssignedAt;
+}
+
+/** Sequential work is the legitimate reason a pending task sits untouched. */
+function ownerIsBusyOnAnotherTask(
+  snapshot: TeamTaskStallSnapshot,
+  ownerKey: string,
+  taskId: string
+): boolean {
+  return snapshot.inProgressTasks.some(
+    (other) => other.id !== taskId && normalizeMemberKey(other.owner) === ownerKey
+  );
+}
+
+function buildPendingPickupEpochKey(args: {
+  task: TeamTask;
+  owner: string;
+  readyAt: string;
+}): string {
+  // Deliberately omits task.updatedAt: a stray comment must not rotate the key,
+  // reset the journal's two-scan counter, or slip past the alert cooldown.
+  return [args.task.id, 'work', 'pending_pickup_after_unblock', args.owner, args.readyAt].join(':');
+}
+
+/**
+ * "Pickup stall": a pending task has nothing left to wait for - every blocker is
+ * resolved, or it never had one - and its owner is not busy on another task.
+ * Needs no transcript evidence, which is what makes it work on OpenCode/ACP-lead
+ * teams where the lead transcript carries no per-member turn rows.
+ */
+export function evaluatePendingPickupTask(args: {
+  now: Date;
+  task: TeamTask;
+  snapshot: TeamTaskStallSnapshot;
+}): TaskStallEvaluation {
+  const { task, snapshot } = args;
+
+  if (!isPendingPickupStallRemediationEnabled()) {
+    return skip(task.id, 'Pending pickup remediation is disabled', 'pickup_remediation_disabled');
+  }
+  if (task.status !== 'pending') {
+    return skip(task.id, 'Task is not pending', 'task_not_pending');
+  }
+  if (!task.owner?.trim()) {
+    return skip(task.id, 'Task has no owner', 'owner_missing');
+  }
+  if (task.owner === snapshot.leadName) {
+    return skip(task.id, 'Task owner is the lead', 'owner_is_lead');
+  }
+  if (task.needsClarification) {
+    return skip(task.id, 'Task is waiting for clarification', 'needs_clarification');
+  }
+  if (isTeamTaskBlockedByUnfinishedDependency(task, snapshot.allTasksById)) {
+    return skip(task.id, 'Task is blocked', 'task_blocked');
+  }
+
+  const ownerKey = normalizeMemberKey(task.owner);
+  if (snapshot.providerByMemberName.get(ownerKey) !== 'opencode') {
+    // Native owners are covered by member-work-sync's stale-assigned-work
+    // activation, which already accepts owned pending tasks.
+    return skip(task.id, 'Task owner is not an OpenCode member', 'owner_not_opencode');
+  }
+  if (ownerIsBusyOnAnotherTask(snapshot, ownerKey, task.id)) {
+    return skip(task.id, 'Task owner is already working another task', 'owner_busy_on_other_task');
+  }
+
+  const readyAt = resolvePendingPickupReadyAt(task, task.owner);
+  if (!readyAt) {
+    return skip(
+      task.id,
+      'Task has no creation, assignment or dependency-resolved evidence to start the pickup clock',
+      'no_unblock_evidence'
+    );
+  }
+
+  if (args.now.getTime() - Date.parse(readyAt) < getPendingPickupStallThresholdMs()) {
+    return skip(
+      task.id,
+      'Pending pickup is still below the configured stall threshold',
+      'below_threshold'
+    );
+  }
+
+  const clockLabel = (task.blockedBy ?? []).length
+    ? `all blockers resolved at ${readyAt}`
+    : `owner has had it since ${readyAt}`;
+  return {
+    status: 'alert',
+    taskId: task.id,
+    memberName: task.owner,
+    branch: 'work',
+    signal: 'pending_pickup_after_unblock',
+    remediationKind: 'pending_pickup',
+    epochKey: buildPendingPickupEpochKey({ task, owner: task.owner, readyAt }),
+    readyAt,
+    reason: `Potential pickup stall: ${clockLabel} but the task is still pending and its owner is not working anything else.`,
+  };
+}

--- a/src/main/services/team/stallMonitor/TeamTaskStallPendingPickup.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallPendingPickup.ts
@@ -157,7 +157,10 @@ export function evaluatePendingPickupTask(args: {
   if (!task.owner?.trim()) {
     return skip(task.id, 'Task has no owner', 'owner_missing');
   }
-  if (task.owner === snapshot.leadName) {
+  // Normalized, like every other member comparison in this file: an agent that
+  // wrote the owner as "Team-Lead" while the config says "team-lead" would
+  // otherwise take a pickup nudge meant for teammates.
+  if (normalizeMemberKey(task.owner) === normalizeMemberKey(snapshot.leadName)) {
     return skip(task.id, 'Task owner is the lead', 'owner_is_lead');
   }
   if (task.needsClarification) {

--- a/src/main/services/team/stallMonitor/TeamTaskStallPolicy.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallPolicy.ts
@@ -47,7 +47,7 @@ function isAfterOrEqual(timestamp: string, lowerBound: string): boolean {
   return Date.parse(timestamp) >= Date.parse(lowerBound);
 }
 
-function getOpenWorkInterval(task: TeamTask): TaskWorkInterval | null {
+export function getOpenWorkInterval(task: TeamTask): TaskWorkInterval | null {
   const intervals = task.workIntervals ?? [];
   for (let i = intervals.length - 1; i >= 0; i -= 1) {
     const interval = intervals[i];
@@ -230,6 +230,28 @@ function findAnchorRowIndex(
   return candidates.at(-1)!.index;
 }
 
+function normalizeMemberKey(name: string | undefined): string {
+  return name?.trim().toLowerCase() ?? '';
+}
+
+/** ISO idle-since of the owner's lane when it settled at/after the touch; else null. */
+function resolveOpenCodeLaneIdleSince(
+  snapshot: TeamTaskStallSnapshot,
+  owner: string | undefined,
+  touchAt: string
+): string | null {
+  const idleSince = snapshot.openCodeLaneIdleSinceByMemberName?.get(normalizeMemberKey(owner));
+  if (!idleSince) return null;
+  const idleMs = Date.parse(idleSince);
+  const touchMs = Date.parse(touchAt);
+  if (!Number.isFinite(idleMs) || !Number.isFinite(touchMs)) return null;
+  return idleMs >= touchMs ? idleSince : null;
+}
+
+function isOpenCodeLaneActive(snapshot: TeamTaskStallSnapshot, owner: string | undefined): boolean {
+  return snapshot.openCodeLaneActiveMemberNames?.has(normalizeMemberKey(owner)) ?? false;
+}
+
 function classifyPostTouchState(args: {
   rows: TeamTaskStallExactRow[];
   anchorMessageUuid: string;
@@ -398,6 +420,9 @@ export class TeamTaskStallPolicy {
       if (isOpenCodeOwner) {
         const elapsedMs = args.now.getTime() - Date.parse(openWorkInterval.startedAt);
         if (elapsedMs >= getOpenCodeWeakStartStallThresholdMs()) {
+          if (isOpenCodeLaneActive(snapshot, task.owner)) {
+            return skip(task.id, 'OpenCode lane turn is still active', 'lane_active');
+          }
           return buildOpenCodeNoProgressAlertEvaluation({
             task,
             owner: task.owner,
@@ -435,6 +460,9 @@ export class TeamTaskStallPolicy {
       if (isOpenCodeOwner) {
         const elapsedMs = args.now.getTime() - Date.parse(openWorkInterval.startedAt);
         if (elapsedMs >= getOpenCodeWeakStartStallThresholdMs()) {
+          if (isOpenCodeLaneActive(snapshot, task.owner)) {
+            return skip(task.id, 'OpenCode lane turn is still active', 'lane_active');
+          }
           return buildOpenCodeNoProgressAlertEvaluation({
             task,
             owner: task.owner,
@@ -462,11 +490,24 @@ export class TeamTaskStallPolicy {
       return skip(task.id, 'Post-touch exact rows are unavailable', 'ambiguous_state');
     }
 
-    const signal = classifyPostTouchState({
+    const classifiedSignal = classifyPostTouchState({
       rows: exactRows,
       anchorMessageUuid: workContext.lastMeaningfulTouch.source.messageUuid,
       anchorToolUseId: workContext.lastMeaningfulTouch.source.toolUseId,
     });
+    // The orchestrator transcript carries no turn-end row for OpenCode lanes,
+    // so a member that went silent after its touch classifies as "mid turn"
+    // (10-minute threshold). The delivery service knows when the lane's turn
+    // settled; a lane idle since the touch is a turn that ended.
+    const laneIdleSince =
+      ownerProviderId === 'opencode'
+        ? resolveOpenCodeLaneIdleSince(snapshot, task.owner, workContext.lastMeaningfulTouchAt)
+        : null;
+    const signal: TaskStallSignal | 'ambiguous' =
+      laneIdleSince &&
+      (classifiedSignal === 'ambiguous' || classifiedSignal === 'mid_turn_after_touch')
+        ? 'turn_ended_after_touch'
+        : classifiedSignal;
     if (signal === 'ambiguous') {
       return skip(task.id, 'Post-touch state is ambiguous', 'ambiguous_state');
     }
@@ -488,6 +529,15 @@ export class TeamTaskStallPolicy {
         'below_threshold'
       );
     }
+    if (
+      ownerProviderId === 'opencode' &&
+      !laneIdleSince &&
+      isOpenCodeLaneActive(snapshot, task.owner)
+    ) {
+      // The lane is still generating its turn; a nudge now would only queue
+      // behind (or derail) work that is already in progress.
+      return skip(task.id, 'OpenCode lane turn is still active', 'lane_active');
+    }
 
     return buildAlertEvaluation({
       task,
@@ -498,7 +548,9 @@ export class TeamTaskStallPolicy {
       touch: workContext.lastMeaningfulTouch,
       reason: isOpenCodeWeakStartOnly
         ? 'Potential work stall after weak start-only task comment.'
-        : `Potential work stall after ${signal.replaceAll('_', ' ')}.`,
+        : laneIdleSince
+          ? `Potential work stall: OpenCode lane idle since ${laneIdleSince} after the last task touch.`
+          : `Potential work stall after ${signal.replaceAll('_', ' ')}.`,
     });
   }
 

--- a/src/main/services/team/stallMonitor/TeamTaskStallPolicy.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallPolicy.ts
@@ -2,9 +2,11 @@ import { isTeamTaskBlockedByUnfinishedDependency } from '@shared/utils/teamTaskS
 
 import { getOpenCodeWeakStartStallThresholdMs } from './featureGates';
 import { classifyTaskProgressTouch, type TaskProgressSignal } from './TaskProgressSignalClassifier';
+import { evaluatePendingPickupTask } from './TeamTaskStallPendingPickup';
 
 import type { BoardTaskActivityRecord } from '../taskLogs/activity/BoardTaskActivityRecord';
 import type {
+  PostTouchStallSignal,
   ReviewTaskContext,
   TaskStallBranch,
   TaskStallEvaluation,
@@ -19,12 +21,12 @@ const WORK_TOUCH_TOOLS = new Set(['task_start', 'task_add_comment', 'task_set_st
 const REVIEW_TOUCH_TOOLS = new Set(['review_start', 'task_add_comment']);
 
 const ONE_MINUTE_MS = 60_000;
-const WORK_THRESHOLDS_MS: Record<TaskStallSignal, number> = {
+const WORK_THRESHOLDS_MS: Record<PostTouchStallSignal, number> = {
   turn_ended_after_touch: 4 * ONE_MINUTE_MS,
   touch_then_other_turns: 5 * ONE_MINUTE_MS,
   mid_turn_after_touch: 10 * ONE_MINUTE_MS,
 };
-const REVIEW_THRESHOLDS_MS: Record<TaskStallSignal, number> = {
+const REVIEW_THRESHOLDS_MS: Record<PostTouchStallSignal, number> = {
   turn_ended_after_touch: 5 * ONE_MINUTE_MS,
   touch_then_other_turns: 6 * ONE_MINUTE_MS,
   mid_turn_after_touch: 12 * ONE_MINUTE_MS,
@@ -256,7 +258,7 @@ function classifyPostTouchState(args: {
   rows: TeamTaskStallExactRow[];
   anchorMessageUuid: string;
   anchorToolUseId?: string;
-}): TaskStallSignal | 'ambiguous' {
+}): PostTouchStallSignal | 'ambiguous' {
   const normalizedRows = deduplicateAssistantRowsByRequestId(args.rows, args.anchorToolUseId);
   const anchorIndex = findAnchorRowIndex(
     normalizedRows,
@@ -552,6 +554,14 @@ export class TeamTaskStallPolicy {
           ? `Potential work stall: OpenCode lane idle since ${laneIdleSince} after the last task touch.`
           : `Potential work stall after ${signal.replaceAll('_', ' ')}.`,
     });
+  }
+
+  evaluatePendingPickup(args: {
+    now: Date;
+    task: TeamTask;
+    snapshot: TeamTaskStallSnapshot;
+  }): TaskStallEvaluation {
+    return evaluatePendingPickupTask(args);
   }
 
   evaluateReview(args: {

--- a/src/main/services/team/stallMonitor/TeamTaskStallPolicy.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallPolicy.ts
@@ -21,7 +21,14 @@ const WORK_TOUCH_TOOLS = new Set(['task_start', 'task_add_comment', 'task_set_st
 const REVIEW_TOUCH_TOOLS = new Set(['review_start', 'task_add_comment']);
 
 const ONE_MINUTE_MS = 60_000;
-const WORK_THRESHOLDS_MS: Record<PostTouchStallSignal, number> = {
+/**
+ * Exported because `getOpenCodeLaneTurnActivityMaxAgeMs` has to stay at or above
+ * every threshold in here: the lane-freshness bound demotes a stale 'active'
+ * sample to a backdated idle time, which is what turns `mid_turn_after_touch`
+ * into `turn_ended_after_touch`. The ordering is checked against these numbers
+ * in openCodeLaneTurnFreshness.test.ts instead of being restated in a comment.
+ */
+export const WORK_THRESHOLDS_MS: Record<PostTouchStallSignal, number> = {
   turn_ended_after_touch: 4 * ONE_MINUTE_MS,
   touch_then_other_turns: 5 * ONE_MINUTE_MS,
   mid_turn_after_touch: 10 * ONE_MINUTE_MS,

--- a/src/main/services/team/stallMonitor/TeamTaskStallPolicy.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallPolicy.ts
@@ -404,7 +404,10 @@ export class TeamTaskStallPolicy {
     if (!task.owner) {
       return skip(task.id, 'Task has no owner', 'owner_missing');
     }
-    if (task.owner === snapshot.leadName) {
+    // Normalized for the same reason the pickup branch normalizes it: an owner
+    // an agent spelled "Team-Lead" is still the lead, and skipping is the safe
+    // direction (one fewer alert, never one more).
+    if (normalizeMemberKey(task.owner) === normalizeMemberKey(snapshot.leadName)) {
       return skip(task.id, 'Task owner is the lead', 'owner_is_lead');
     }
     if (task.reviewState === 'review') {

--- a/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
@@ -67,19 +67,50 @@ function buildProviderByMemberName(args: {
   return providerByMemberName;
 }
 
+/**
+ * Collaborators of the snapshot source. Every one has a production default, so
+ * a caller overrides only what it already owns; the object shape keeps that
+ * possible without spelling out the collaborators in front of it positionally.
+ */
+export interface TeamTaskStallSnapshotSourceDeps {
+  transcriptSourceLocator?: TeamTranscriptSourceLocator;
+  taskReader?: TeamTaskReader;
+  kanbanManager?: TeamKanbanManager;
+  transcriptReader?: BoardTaskActivityTranscriptReader;
+  activityBatchIndexer?: BoardTaskActivityBatchIndexer;
+  freshnessReader?: TeamTaskLogFreshnessReader;
+  exactRowReader?: TeamTaskStallExactRowReader;
+  membersMetaStore?: TeamMembersMetaStore;
+  openCodeEvidenceSource?: OpenCodeTaskStallEvidenceSource;
+  laneTurnActivity?: OpenCodeLaneTurnActivityRegistry;
+}
+
 export class TeamTaskStallSnapshotSource {
-  constructor(
-    private readonly transcriptSourceLocator: TeamTranscriptSourceLocator = new TeamTranscriptSourceLocator(),
-    private readonly taskReader: TeamTaskReader = new TeamTaskReader(),
-    private readonly kanbanManager: TeamKanbanManager = new TeamKanbanManager(),
-    private readonly transcriptReader: BoardTaskActivityTranscriptReader = new BoardTaskActivityTranscriptReader(),
-    private readonly activityBatchIndexer: BoardTaskActivityBatchIndexer = new BoardTaskActivityBatchIndexer(),
-    private readonly freshnessReader: TeamTaskLogFreshnessReader = new TeamTaskLogFreshnessReader(),
-    private readonly exactRowReader: TeamTaskStallExactRowReader = new TeamTaskStallExactRowReader(),
-    private readonly membersMetaStore: TeamMembersMetaStore = new TeamMembersMetaStore(),
-    private readonly openCodeEvidenceSource: OpenCodeTaskStallEvidenceSource = new OpenCodeTaskStallEvidenceSource(),
-    private readonly laneTurnActivity: OpenCodeLaneTurnActivityRegistry = openCodeLaneTurnActivityRegistry
-  ) {}
+  private readonly transcriptSourceLocator: TeamTranscriptSourceLocator;
+  private readonly taskReader: TeamTaskReader;
+  private readonly kanbanManager: TeamKanbanManager;
+  private readonly transcriptReader: BoardTaskActivityTranscriptReader;
+  private readonly activityBatchIndexer: BoardTaskActivityBatchIndexer;
+  private readonly freshnessReader: TeamTaskLogFreshnessReader;
+  private readonly exactRowReader: TeamTaskStallExactRowReader;
+  private readonly membersMetaStore: TeamMembersMetaStore;
+  private readonly openCodeEvidenceSource: OpenCodeTaskStallEvidenceSource;
+  private readonly laneTurnActivity: OpenCodeLaneTurnActivityRegistry;
+
+  constructor(deps: TeamTaskStallSnapshotSourceDeps = {}) {
+    this.transcriptSourceLocator =
+      deps.transcriptSourceLocator ?? new TeamTranscriptSourceLocator();
+    this.taskReader = deps.taskReader ?? new TeamTaskReader();
+    this.kanbanManager = deps.kanbanManager ?? new TeamKanbanManager();
+    this.transcriptReader = deps.transcriptReader ?? new BoardTaskActivityTranscriptReader();
+    this.activityBatchIndexer = deps.activityBatchIndexer ?? new BoardTaskActivityBatchIndexer();
+    this.freshnessReader = deps.freshnessReader ?? new TeamTaskLogFreshnessReader();
+    this.exactRowReader = deps.exactRowReader ?? new TeamTaskStallExactRowReader();
+    this.membersMetaStore = deps.membersMetaStore ?? new TeamMembersMetaStore();
+    this.openCodeEvidenceSource =
+      deps.openCodeEvidenceSource ?? new OpenCodeTaskStallEvidenceSource();
+    this.laneTurnActivity = deps.laneTurnActivity ?? openCodeLaneTurnActivityRegistry;
+  }
 
   async getSnapshot(teamName: string): Promise<TeamTaskStallSnapshot | null> {
     const transcriptContext = await this.transcriptSourceLocator.getContext(teamName);

--- a/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
@@ -17,8 +17,10 @@ import { getTeamTaskWorkflowColumn, isTeamTaskActivelyWorked } from '../teamTask
 import { TeamTaskReader } from '../TeamTaskReader';
 
 import { BoardTaskActivityBatchIndexer } from './BoardTaskActivityBatchIndexer';
-import { getOpenCodeLaneTurnActivityMaxAgeMs } from './featureGates';
-import { classifyOpenCodeLaneTurnSample } from './openCodeLaneTurnFreshness';
+import {
+  classifyOpenCodeLaneTurnSample,
+  resolveOpenCodeLaneTurnActivityMaxAgeMs,
+} from './openCodeLaneTurnFreshness';
 import { OpenCodeTaskStallEvidenceSource } from './OpenCodeTaskStallEvidenceSource';
 import { buildResolvedReviewerIndex } from './reviewerResolution';
 import { TeamTaskLogFreshnessReader } from './TeamTaskLogFreshnessReader';
@@ -278,7 +280,7 @@ export class TeamTaskStallSnapshotSource {
     const openCodeLaneActiveMemberNames = new Set<string>();
     const openCodeLaneActiveSinceByMemberName = new Map<string, string>();
     const openCodeLaneStaleActiveSinceByMemberName = new Map<string, string>();
-    const maxAgeMs = getOpenCodeLaneTurnActivityMaxAgeMs();
+    const maxAgeMs = resolveOpenCodeLaneTurnActivityMaxAgeMs();
 
     for (const [memberName, sample] of this.laneTurnActivity.listTeam(teamName)) {
       const verdict = classifyOpenCodeLaneTurnSample({ sample, nowMs, maxAgeMs });

--- a/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
@@ -134,6 +134,9 @@ export class TeamTaskStallSnapshotSource {
         }) === 'review'
       );
     });
+    const pendingPickupTasks = workflowActiveTasks.filter(
+      (task) => task.status === 'pending' && Boolean(task.owner?.trim()) && !task.deletedAt
+    );
     const resolvedReviewersByTaskId = buildResolvedReviewerIndex(activeTasks, kanbanState);
     const activityReadsEnabled = isBoardTaskActivityReadEnabled();
     const exactReadsEnabled = isBoardTaskExactLogsReadEnabled();
@@ -204,6 +207,7 @@ export class TeamTaskStallSnapshotSource {
       allTasksById,
       inProgressTasks,
       reviewOpenTasks,
+      pendingPickupTasks,
       resolvedReviewersByTaskId,
       recordsByTaskId: mergedRecordsByTaskId,
       freshnessByTaskId,

--- a/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
@@ -3,6 +3,10 @@ import {
   normalizeOptionalTeamProviderId,
 } from '@shared/utils/teamProvider';
 
+import {
+  type OpenCodeLaneTurnActivityRegistry,
+  openCodeLaneTurnActivityRegistry,
+} from '../opencode/delivery/OpenCodeLaneTurnActivityRegistry';
 import { BoardTaskActivityTranscriptReader } from '../taskLogs/activity/BoardTaskActivityTranscriptReader';
 import { isBoardTaskActivityReadEnabled } from '../taskLogs/activity/featureGates';
 import { TeamTranscriptSourceLocator } from '../taskLogs/discovery/TeamTranscriptSourceLocator';
@@ -73,7 +77,8 @@ export class TeamTaskStallSnapshotSource {
     private readonly freshnessReader: TeamTaskLogFreshnessReader = new TeamTaskLogFreshnessReader(),
     private readonly exactRowReader: TeamTaskStallExactRowReader = new TeamTaskStallExactRowReader(),
     private readonly membersMetaStore: TeamMembersMetaStore = new TeamMembersMetaStore(),
-    private readonly openCodeEvidenceSource: OpenCodeTaskStallEvidenceSource = new OpenCodeTaskStallEvidenceSource()
+    private readonly openCodeEvidenceSource: OpenCodeTaskStallEvidenceSource = new OpenCodeTaskStallEvidenceSource(),
+    private readonly laneTurnActivity: OpenCodeLaneTurnActivityRegistry = openCodeLaneTurnActivityRegistry
   ) {}
 
   async getSnapshot(teamName: string): Promise<TeamTaskStallSnapshot | null> {
@@ -204,7 +209,24 @@ export class TeamTaskStallSnapshotSource {
       freshnessByTaskId,
       exactRowsByFilePath: mergedExactRowsByFilePath,
       providerByMemberName,
+      ...this.collectOpenCodeLaneTurnActivity(teamName),
     };
+  }
+
+  private collectOpenCodeLaneTurnActivity(teamName: string): {
+    openCodeLaneIdleSinceByMemberName: Map<string, string>;
+    openCodeLaneActiveMemberNames: Set<string>;
+  } {
+    const openCodeLaneIdleSinceByMemberName = new Map<string, string>();
+    const openCodeLaneActiveMemberNames = new Set<string>();
+    for (const [memberName, sample] of this.laneTurnActivity.listTeam(teamName)) {
+      if (sample.state === 'idle') {
+        openCodeLaneIdleSinceByMemberName.set(memberName, sample.observedAt);
+      } else {
+        openCodeLaneActiveMemberNames.add(memberName);
+      }
+    }
+    return { openCodeLaneIdleSinceByMemberName, openCodeLaneActiveMemberNames };
   }
 
   private mergeActivityRecords(

--- a/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.ts
@@ -17,6 +17,8 @@ import { getTeamTaskWorkflowColumn, isTeamTaskActivelyWorked } from '../teamTask
 import { TeamTaskReader } from '../TeamTaskReader';
 
 import { BoardTaskActivityBatchIndexer } from './BoardTaskActivityBatchIndexer';
+import { getOpenCodeLaneTurnActivityMaxAgeMs } from './featureGates';
+import { classifyOpenCodeLaneTurnSample } from './openCodeLaneTurnFreshness';
 import { OpenCodeTaskStallEvidenceSource } from './OpenCodeTaskStallEvidenceSource';
 import { buildResolvedReviewerIndex } from './reviewerResolution';
 import { TeamTaskLogFreshnessReader } from './TeamTaskLogFreshnessReader';
@@ -113,6 +115,11 @@ export class TeamTaskStallSnapshotSource {
   }
 
   async getSnapshot(teamName: string): Promise<TeamTaskStallSnapshot | null> {
+    // One clock reading for the whole scan: the lane-freshness bound below and
+    // the `scannedAt` the alerts are stamped with must not drift apart across
+    // the awaits in between, or a sample can read fresh against one and stale
+    // against the other.
+    const scannedAtMs = Date.now();
     const transcriptContext = await this.transcriptSourceLocator.getContext(teamName);
     if (!transcriptContext) {
       return null;
@@ -226,7 +233,7 @@ export class TeamTaskStallSnapshotSource {
 
     return {
       teamName,
-      scannedAt: new Date().toISOString(),
+      scannedAt: new Date(scannedAtMs).toISOString(),
       projectDir: transcriptContext.projectDir,
       projectId: transcriptContext.projectId,
       leadName: resolveLeadNameFromConfig(transcriptContext.config),
@@ -244,24 +251,56 @@ export class TeamTaskStallSnapshotSource {
       freshnessByTaskId,
       exactRowsByFilePath: mergedExactRowsByFilePath,
       providerByMemberName,
-      ...this.collectOpenCodeLaneTurnActivity(teamName),
+      ...this.collectOpenCodeLaneTurnActivity(teamName, scannedAtMs),
     };
   }
 
-  private collectOpenCodeLaneTurnActivity(teamName: string): {
+  /**
+   * Turn the delivery service's lane-turn samples into the snapshot's owner
+   * liveness evidence, with a staleness bound.
+   *
+   * The registry never expires an 'active' sample on its own, so an unbounded
+   * read lets a jammed delivery lane silence every OpenCode stall branch - the
+   * pickup branch and the in-progress work branch both read the same two
+   * collections. Bounding it here rather than inside either branch fixes both
+   * at once and leaves the evaluation logic untouched.
+   */
+  private collectOpenCodeLaneTurnActivity(
+    teamName: string,
+    nowMs: number
+  ): {
     openCodeLaneIdleSinceByMemberName: Map<string, string>;
     openCodeLaneActiveMemberNames: Set<string>;
+    openCodeLaneActiveSinceByMemberName: Map<string, string>;
+    openCodeLaneStaleActiveSinceByMemberName: Map<string, string>;
   } {
     const openCodeLaneIdleSinceByMemberName = new Map<string, string>();
     const openCodeLaneActiveMemberNames = new Set<string>();
+    const openCodeLaneActiveSinceByMemberName = new Map<string, string>();
+    const openCodeLaneStaleActiveSinceByMemberName = new Map<string, string>();
+    const maxAgeMs = getOpenCodeLaneTurnActivityMaxAgeMs();
+
     for (const [memberName, sample] of this.laneTurnActivity.listTeam(teamName)) {
-      if (sample.state === 'idle') {
-        openCodeLaneIdleSinceByMemberName.set(memberName, sample.observedAt);
-      } else {
+      const verdict = classifyOpenCodeLaneTurnSample({ sample, nowMs, maxAgeMs });
+      if (verdict.treatAsActive) {
         openCodeLaneActiveMemberNames.add(memberName);
       }
+      if (verdict.idleSince) {
+        openCodeLaneIdleSinceByMemberName.set(memberName, verdict.idleSince);
+      }
+      if (verdict.activeSince) {
+        openCodeLaneActiveSinceByMemberName.set(memberName, verdict.activeSince);
+      }
+      if (verdict.staleActiveSince) {
+        openCodeLaneStaleActiveSinceByMemberName.set(memberName, verdict.staleActiveSince);
+      }
     }
-    return { openCodeLaneIdleSinceByMemberName, openCodeLaneActiveMemberNames };
+    return {
+      openCodeLaneIdleSinceByMemberName,
+      openCodeLaneActiveMemberNames,
+      openCodeLaneActiveSinceByMemberName,
+      openCodeLaneStaleActiveSinceByMemberName,
+    };
   }
 
   private mergeActivityRecords(

--- a/src/main/services/team/stallMonitor/TeamTaskStallTypes.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallTypes.ts
@@ -133,6 +133,18 @@ export interface TeamTaskStallSnapshot {
   openCodeLaneIdleSinceByMemberName?: Map<string, string>;
   /** Lower-case member names whose OpenCode lane currently runs a prompt-delivery turn. */
   openCodeLaneActiveMemberNames?: Set<string>;
+  /**
+   * Lower-case member name -> ISO time the still-trusted active turn started.
+   * Diagnostics only: without it a suppressed alert logs a bare "lane active"
+   * and leaves no way to tell a live turn from a frozen flag.
+   */
+  openCodeLaneActiveSinceByMemberName?: Map<string, string>;
+  /**
+   * Lower-case member name -> ISO time of an 'active' sample that was demoted
+   * as stale (see openCodeLaneTurnFreshness). Diagnostics only; the demotion
+   * itself is already reflected in the idle/active collections above.
+   */
+  openCodeLaneStaleActiveSinceByMemberName?: Map<string, string>;
 }
 
 export interface WorkTaskContext {

--- a/src/main/services/team/stallMonitor/TeamTaskStallTypes.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallTypes.ts
@@ -8,7 +8,15 @@ export type TaskStallBranch = 'work' | 'review';
 export type TaskStallSignal =
   | 'turn_ended_after_touch'
   | 'mid_turn_after_touch'
-  | 'touch_then_other_turns';
+  | 'touch_then_other_turns'
+  | 'pending_pickup_after_unblock';
+
+/**
+ * Signals `classifyPostTouchState` can emit. The pickup signal is produced only
+ * by the pending-pickup branch, which reads no transcript, so the post-touch
+ * threshold maps stay exhaustive without an unreachable entry.
+ */
+export type PostTouchStallSignal = Exclude<TaskStallSignal, 'pending_pickup_after_unblock'>;
 
 export type TaskStallEvaluationStatus = 'skip' | 'suspected' | 'alert';
 
@@ -30,7 +38,13 @@ export type TaskStallSkipReason =
   | 'ambiguous_state'
   | 'below_threshold'
   | 'first_scan_only'
-  | 'lane_active';
+  | 'lane_active'
+  | 'pickup_remediation_disabled'
+  | 'task_not_pending'
+  | 'owner_not_opencode'
+  | 'owner_busy_on_other_task'
+  | 'no_unblock_evidence'
+  | 'pickup_escalation_exhausted';
 
 export type ResolvedReviewerSource =
   | 'kanban_state'
@@ -51,7 +65,16 @@ export interface TaskStallEvaluation {
   branch?: TaskStallBranch;
   signal?: TaskStallSignal;
   progressSignal?: TaskProgressSignal;
+  remediationKind?: 'pending_pickup';
   epochKey?: string;
+  /** Pickup-branch clock start; orders the per-member pickup alert cap. */
+  readyAt?: string;
+  /**
+   * Alerts already dispatched for this epoch, stamped by the journal when it
+   * promotes an entry (absent for a first alert). Bounds the pickup escalation
+   * ladder so an abandoned task cannot nudge forever.
+   */
+  priorAlertCount?: number;
   reason: string;
   skipReason?: TaskStallSkipReason;
 }
@@ -91,6 +114,12 @@ export interface TeamTaskStallSnapshot {
   allTasksById: Map<string, TeamTask>;
   inProgressTasks: TeamTask[];
   reviewOpenTasks: TeamTask[];
+  /**
+   * Pending tasks with an owner, candidates for the pickup-stall branch.
+   * Excluded from transcript/exact-row reads on purpose: the branch needs no
+   * transcript evidence, so widening those reads would cost IO per backlog task.
+   */
+  pendingPickupTasks?: TeamTask[];
   resolvedReviewersByTaskId: Map<string, ResolvedReviewer>;
   recordsByTaskId: Map<string, BoardTaskActivityRecord[]>;
   freshnessByTaskId: Map<string, TaskLogFreshnessSignal>;
@@ -128,6 +157,7 @@ export interface TaskStallAlert {
   branch: TaskStallBranch;
   signal: TaskStallSignal;
   progressSignal?: TaskProgressSignal;
+  remediationKind?: 'pending_pickup';
   reason: string;
   epochKey: string;
   owner?: string;
@@ -153,4 +183,6 @@ export interface TaskStallJournalEntry {
   createdAt: string;
   updatedAt: string;
   alertedAt?: string;
+  /** How many alerts this epoch already produced; drives the pickup escalation ladder. */
+  alertCount?: number;
 }

--- a/src/main/services/team/stallMonitor/TeamTaskStallTypes.ts
+++ b/src/main/services/team/stallMonitor/TeamTaskStallTypes.ts
@@ -29,7 +29,8 @@ export type TaskStallSkipReason =
   | 'no_open_review_window'
   | 'ambiguous_state'
   | 'below_threshold'
-  | 'first_scan_only';
+  | 'first_scan_only'
+  | 'lane_active';
 
 export type ResolvedReviewerSource =
   | 'kanban_state'
@@ -95,6 +96,14 @@ export interface TeamTaskStallSnapshot {
   freshnessByTaskId: Map<string, TaskLogFreshnessSignal>;
   exactRowsByFilePath: Map<string, TeamTaskStallExactRow[]>;
   providerByMemberName: Map<string, TeamProviderId>;
+  /**
+   * Lower-case member name -> ISO time since which the member's OpenCode lane
+   * has been idle (its last prompt-delivery turn settled). Absent while the
+   * lane is active or was never observed.
+   */
+  openCodeLaneIdleSinceByMemberName?: Map<string, string>;
+  /** Lower-case member names whose OpenCode lane currently runs a prompt-delivery turn. */
+  openCodeLaneActiveMemberNames?: Set<string>;
 }
 
 export interface WorkTaskContext {

--- a/src/main/services/team/stallMonitor/featureGates.ts
+++ b/src/main/services/team/stallMonitor/featureGates.ts
@@ -102,6 +102,10 @@ export function getOpenCodeLaneTurnActivityMaxAgeMs(): number {
   // starts at the demotion instead of at the five-minute mark.
   //
   // openCodeLaneTurnFreshness.test.ts holds this ordering as a test, so
-  // lowering the default below any of those thresholds fails the build.
+  // lowering the default below any of those thresholds fails the build. This is
+  // the raw reader: an environment override is not a default and no test can
+  // pin it, so `resolveOpenCodeLaneTurnActivityMaxAgeMs` (openCodeLaneTurnFreshness)
+  // raises an under-floor override back to the floor before the snapshot
+  // applies it. Read that resolver, not this gate, to get the effective bound.
   return readInt(process.env.CLAUDE_TEAM_OPENCODE_LANE_TURN_ACTIVITY_MAX_AGE_MS, 10 * 60_000);
 }

--- a/src/main/services/team/stallMonitor/featureGates.ts
+++ b/src/main/services/team/stallMonitor/featureGates.ts
@@ -63,3 +63,16 @@ export function getOpenCodeWeakStartStallThresholdMs(): number {
   // Shorter OpenCode threshold for "started work" comments that do not contain concrete progress.
   return readInt(process.env.CLAUDE_TEAM_OPENCODE_WEAK_START_STALL_THRESHOLD_MS, 100_000);
 }
+
+export function getPendingPickupStallThresholdMs(): number {
+  // A task with nothing left to wait for is still only pending: the owner already
+  // received the "Dependency resolved" notice and its delivery retries, so this is
+  // a missed pickup, not missing information. 5 minutes is longer than one slow
+  // model turn, and the journal's two-scan rule adds one more scan interval on top.
+  return readInt(process.env.CLAUDE_TEAM_PENDING_PICKUP_STALL_THRESHOLD_MS, 5 * 60_000);
+}
+
+export function isPendingPickupStallRemediationEnabled(): boolean {
+  // Pickup-stall branch for pending tasks whose blockers are all resolved.
+  return readEnabledFlag(process.env.CLAUDE_TEAM_PENDING_PICKUP_STALL_REMEDIATION_ENABLED, true);
+}

--- a/src/main/services/team/stallMonitor/featureGates.ts
+++ b/src/main/services/team/stallMonitor/featureGates.ts
@@ -60,8 +60,11 @@ export function getTeamTaskStallAlertCooldownMs(): number {
 }
 
 export function getOpenCodeWeakStartStallThresholdMs(): number {
-  // Shorter OpenCode threshold for "started work" comments that do not contain concrete progress.
-  return readInt(process.env.CLAUDE_TEAM_OPENCODE_WEAK_START_STALL_THRESHOLD_MS, 100_000);
+  // OpenCode threshold for "started work" comments that do not contain concrete
+  // progress. An OpenCode member routinely needs several minutes for one turn,
+  // and every remediation nudge costs it a full model turn and can derail the
+  // work in progress, so this sits at 5 minutes (previous default was 100 s).
+  return readInt(process.env.CLAUDE_TEAM_OPENCODE_WEAK_START_STALL_THRESHOLD_MS, 5 * 60_000);
 }
 
 export function getPendingPickupStallThresholdMs(): number {

--- a/src/main/services/team/stallMonitor/featureGates.ts
+++ b/src/main/services/team/stallMonitor/featureGates.ts
@@ -79,3 +79,29 @@ export function isPendingPickupStallRemediationEnabled(): boolean {
   // Pickup-stall branch for pending tasks whose blockers are all resolved.
   return readEnabledFlag(process.env.CLAUDE_TEAM_PENDING_PICKUP_STALL_REMEDIATION_ENABLED, true);
 }
+
+export function getOpenCodeLaneTurnActivityMaxAgeMs(): number {
+  // A delivery-turn 'active' sample is evidence only while it is fresh. The
+  // registry is written by the delivery service and never expires a sample on
+  // its own, so a lane whose settle path never runs - an accepted prompt whose
+  // retry stays deferred - suppresses every OpenCode stall branch for that
+  // member for as long as the jam lasts.
+  //
+  // ORDERING INVARIANT: this must sit at or above every OpenCode stall
+  // threshold whose `lane_active` guard it can unlock, or the guard becomes
+  // unreachable for exactly the turns it exists to protect. The registry stamps
+  // 'active' once, at prompt acceptance, and never refreshes it during a turn,
+  // so a four-minute bound would demote every OpenCode turn longer than four
+  // minutes: a member five minutes into a legitimate turn would be nudged
+  // mid-generation by the weak-start branch, and the backdated idle time would
+  // rewrite its ten-minute mid-turn signal into the four-minute turn-ended one.
+  // Ten minutes is the largest of those thresholds
+  // (WORK_THRESHOLDS_MS.mid_turn_after_touch in TeamTaskStallPolicy), so a
+  // demoted sample can never make a work branch fire earlier than that branch's
+  // own threshold. The cost is paid by the pickup branch, whose clock then
+  // starts at the demotion instead of at the five-minute mark.
+  //
+  // openCodeLaneTurnFreshness.test.ts holds this ordering as a test, so
+  // lowering the default below any of those thresholds fails the build.
+  return readInt(process.env.CLAUDE_TEAM_OPENCODE_LANE_TURN_ACTIVITY_MAX_AGE_MS, 10 * 60_000);
+}

--- a/src/main/services/team/stallMonitor/featureGates.ts
+++ b/src/main/services/team/stallMonitor/featureGates.ts
@@ -98,8 +98,17 @@ export function getOpenCodeLaneTurnActivityMaxAgeMs(): number {
   // Ten minutes is the largest of those thresholds
   // (WORK_THRESHOLDS_MS.mid_turn_after_touch in TeamTaskStallPolicy), so a
   // demoted sample can never make a work branch fire earlier than that branch's
-  // own threshold. The cost is paid by the pickup branch, whose clock then
-  // starts at the demotion instead of at the five-minute mark.
+  // own threshold.
+  //
+  // The pickup branch pays the cost, and pays it in full: a demotion publishes
+  // the ORIGINAL observation time as `idleSince` (classifyOpenCodeLaneTurnSample
+  // keeps it there on purpose, so the bound cannot restart the clock), and that
+  // time is already older than the five-minute pickup threshold at the moment
+  // of demotion. A member honestly ten minutes into one turn therefore takes a
+  // pickup nudge for a task still sitting in `pending`. That is the deliberate
+  // trade: the nudge queues behind the turn in flight rather than interrupting
+  // it, while the alternative - trusting the flag indefinitely - is a jammed
+  // lane switching the detector off for as long as the jam lasts.
   //
   // openCodeLaneTurnFreshness.test.ts holds this ordering as a test, so
   // lowering the default below any of those thresholds fails the build. This is

--- a/src/main/services/team/stallMonitor/openCodeLaneTurnFreshness.ts
+++ b/src/main/services/team/stallMonitor/openCodeLaneTurnFreshness.ts
@@ -1,3 +1,12 @@
+import { createLogger } from '@shared/utils/logger';
+
+import {
+  getOpenCodeLaneTurnActivityMaxAgeMs,
+  getOpenCodeWeakStartStallThresholdMs,
+  getPendingPickupStallThresholdMs,
+} from './featureGates';
+import { WORK_THRESHOLDS_MS } from './TeamTaskStallPolicy';
+
 import type { OpenCodeLaneTurnActivitySample } from '../opencode/delivery/OpenCodeLaneTurnActivityRegistry';
 
 /**
@@ -27,6 +36,58 @@ import type { OpenCodeLaneTurnActivitySample } from '../opencode/delivery/OpenCo
  * makes a stale flag from any future cause - including a lane nothing tries to
  * dispatch to - unable to silence pickup detection.
  */
+
+const logger = createLogger('Service:OpenCodeLaneTurnFreshness');
+
+/** Remembers the last override reported as out of range so a misconfigured
+ * install gets one warn line, not one per scan. */
+let lastReportedUnderfloorMaxAgeMs: number | null = null;
+
+/**
+ * The smallest age bound that still satisfies the ordering invariant: every
+ * OpenCode stall threshold whose `lane_active` guard a demotion can unlock.
+ * Read live, because the weak-start and pickup thresholds are themselves
+ * overridable and raising either raises this floor with it.
+ */
+function getOpenCodeLaneTurnActivityMaxAgeFloorMs(): number {
+  return Math.max(
+    ...Object.values(WORK_THRESHOLDS_MS),
+    getOpenCodeWeakStartStallThresholdMs(),
+    getPendingPickupStallThresholdMs()
+  );
+}
+
+/**
+ * The age bound the snapshot actually applies.
+ *
+ * `getOpenCodeLaneTurnActivityMaxAgeMs` reads a positive integer from the
+ * environment and nothing more, so an override below the floor above would
+ * demote a lane in the middle of a legitimate turn: at
+ * CLAUDE_TEAM_OPENCODE_LANE_TURN_ACTIVITY_MAX_AGE_MS=60000 a member one minute
+ * into a five-minute turn is published as idle, the `lane_active` guard the
+ * weak-start branch relies on never fires, and the nudge lands mid-generation -
+ * the exact failure the guard exists to prevent. The invariant is only tested
+ * against the default, and a default is not a bound.
+ *
+ * An under-floor override is therefore raised to the floor rather than
+ * accepted: it can still be set higher, which is always safe (a lane stays
+ * trusted for longer), but it cannot be set to a value that switches the guard
+ * off.
+ */
+export function resolveOpenCodeLaneTurnActivityMaxAgeMs(): number {
+  const configuredMs = getOpenCodeLaneTurnActivityMaxAgeMs();
+  const floorMs = getOpenCodeLaneTurnActivityMaxAgeFloorMs();
+  if (configuredMs >= floorMs) {
+    return configuredMs;
+  }
+  if (lastReportedUnderfloorMaxAgeMs !== configuredMs) {
+    lastReportedUnderfloorMaxAgeMs = configuredMs;
+    logger.warn(
+      `CLAUDE_TEAM_OPENCODE_LANE_TURN_ACTIVITY_MAX_AGE_MS=${configuredMs} is below the ${floorMs}ms OpenCode stall floor and would demote a lane mid-turn; using ${floorMs}ms`
+    );
+  }
+  return floorMs;
+}
 
 export interface OpenCodeLaneTurnVerdict {
   /** Whether the pickup and work branches should treat the owner as mid-turn. */

--- a/src/main/services/team/stallMonitor/openCodeLaneTurnFreshness.ts
+++ b/src/main/services/team/stallMonitor/openCodeLaneTurnFreshness.ts
@@ -1,0 +1,109 @@
+import type { OpenCodeLaneTurnActivitySample } from '../opencode/delivery/OpenCodeLaneTurnActivityRegistry';
+
+/**
+ * Freshness rule for one OpenCode lane turn sample.
+ *
+ * INVARIANT: the stall monitor's "is this owner actually busy?" signal must
+ * never be silenceable indefinitely by the subsystem the monitor supervises.
+ * `OpenCodeLaneTurnActivityRegistry` is a last-write-wins in-memory map fed by
+ * the delivery service's own settle paths, so a lane whose settle never runs
+ * stays advertised as mid-turn for as long as the jam lasts - and every
+ * OpenCode stall branch reads that flag as "the owner is working, stay quiet".
+ * A jammed delivery lane therefore switches off the detector for the jam.
+ *
+ * The shape this exists for was recorded in a multi-hour mixed-provider run
+ * (2026-08-28). A user-DM delivery record on one member's lane was accepted at
+ * 08:09:43.105Z and then sat at `status: retry_scheduled`, `responseState:
+ * not_observed`, `lastTurnProgressAt: null` until 08:19:41.340Z. Nothing moved
+ * in the ledger for ten minutes, yet the registry sample stayed
+ * `active @ 08:09:43.105Z`, so a pending task owned by that member - every
+ * blocker resolved at 08:09:55.325Z, owner working nothing else - was skipped
+ * with `lane_active` on every scan, and the stall journal was still empty at
+ * 08:17:30.325Z.
+ *
+ * Defense in depth, deliberately. The individual deadlock that froze that
+ * sample is fixed on the delivery side, but that repair depends on a dispatch
+ * actually happening and covers that one cause only. The age bound is what
+ * makes a stale flag from any future cause - including a lane nothing tries to
+ * dispatch to - unable to silence pickup detection.
+ */
+
+export interface OpenCodeLaneTurnVerdict {
+  /** Whether the pickup and work branches should treat the owner as mid-turn. */
+  treatAsActive: boolean;
+  /** ISO time the lane has been idle since, or null when there is no evidence. */
+  idleSince: string | null;
+  /** Set only on a demotion: the ISO time of the sample that went stale. */
+  staleActiveSince?: string;
+  /** Set only while the sample is trusted as active: when that turn started. */
+  activeSince?: string;
+}
+
+/** Whether an 'active' sample has outlived the window in which it is evidence. */
+function isActiveSampleExpired(args: {
+  observedAt: string;
+  nowMs: number;
+  maxAgeMs: number;
+}): boolean {
+  const observedAtMs = Date.parse(args.observedAt);
+  if (!Number.isFinite(observedAtMs)) {
+    // Fail-safe direction is "do not stay silent": a sample whose clock cannot
+    // be read is exactly the sample that could otherwise suppress alerts
+    // forever, so it is treated as expired rather than as fresh evidence.
+    return true;
+  }
+  return args.nowMs - observedAtMs >= args.maxAgeMs;
+}
+
+/**
+ * Classify one lane sample into the snapshot's active/idle evidence.
+ *
+ * `maxAgeMs` carries an ordering invariant rather than being a free knob: a
+ * demotion publishes a backdated `idleSince` that the work branches read as
+ * "the turn ENDED at that moment", so the bound must sit at or above the
+ * largest stall threshold that evidence can unlock.
+ * `getOpenCodeLaneTurnActivityMaxAgeMs` documents the arithmetic; below it, a
+ * legitimately long turn is demoted mid-generation and the `lane_active` guard
+ * that protects it can never fire.
+ */
+export function classifyOpenCodeLaneTurnSample(args: {
+  sample: OpenCodeLaneTurnActivitySample;
+  nowMs: number;
+  maxAgeMs: number;
+}): OpenCodeLaneTurnVerdict {
+  const { sample } = args;
+  if (sample.state === 'idle') {
+    // An idle sample states that a turn ENDED, and that fact does not decay:
+    // the lane cannot become busy again without the delivery service writing a
+    // new 'active' sample over it. Age is irrelevant here, and the bound below
+    // never sees an idle sample.
+    return { treatAsActive: false, idleSince: sample.observedAt };
+  }
+
+  if (
+    !isActiveSampleExpired({
+      observedAt: sample.observedAt,
+      nowMs: args.nowMs,
+      maxAgeMs: args.maxAgeMs,
+    })
+  ) {
+    return { treatAsActive: true, idleSince: null, activeSince: sample.observedAt };
+  }
+
+  if (!Number.isFinite(Date.parse(sample.observedAt))) {
+    // No usable clock at all: demote, but publish no idle time either. The
+    // pickup branch then falls back to its own readiness clock instead of
+    // quietly starting from a timestamp nobody can read.
+    return { treatAsActive: false, idleSince: null, staleActiveSince: sample.observedAt };
+  }
+  // `idleSince` is the ORIGINAL observation, never `now`. The pickup branch
+  // starts its clock at the later of its own readiness time and this one, so
+  // demoting to `now` would restart that clock and re-hide the stall for
+  // another threshold window - exactly the outcome this bound exists to
+  // prevent.
+  return {
+    treatAsActive: false,
+    idleSince: sample.observedAt,
+    staleActiveSince: sample.observedAt,
+  };
+}

--- a/test/features/member-work-sync/core/application/MemberWorkSyncNudgeActivationPolicy.test.ts
+++ b/test/features/member-work-sync/core/application/MemberWorkSyncNudgeActivationPolicy.test.ts
@@ -151,6 +151,78 @@ describe('MemberWorkSyncNudgeActivationPolicy', () => {
     ).toEqual({ active: true, reason: 'opencode_targeted_shadow_collecting' });
   });
 
+  it('holds OpenCode targeted nudges inside the quiet window after the agenda changed', () => {
+    // A nudge 20 s after the agenda changed lands mid-turn and derails the work
+    // the change just started.
+    expect(
+      decideMemberWorkSyncNudgeActivation({
+        status: nativeStaleInProgressStatus({ providerId: 'opencode' }),
+        metrics: staleMetrics({ generatedAt: '2026-05-06T00:00:20.000Z' }),
+      })
+    ).toEqual({ active: false, reason: 'opencode_quiet_window' });
+    expect(
+      decideMemberWorkSyncNudgeActivation({
+        status: nativeStaleInProgressStatus({ providerId: 'opencode' }),
+        metrics: staleMetrics({ generatedAt: '2026-05-06T00:09:59.000Z' }),
+      })
+    ).toEqual({ active: false, reason: 'opencode_quiet_window' });
+    expect(
+      decideMemberWorkSyncNudgeActivation({
+        status: nativeStaleInProgressStatus({ providerId: 'opencode' }),
+        metrics: staleMetrics({ generatedAt: '2026-05-06T00:10:00.000Z' }),
+      })
+    ).toEqual({ active: true, reason: 'opencode_targeted_shadow_collecting' });
+    // Native providers keep their own 6-minute stale window.
+    expect(
+      decideMemberWorkSyncNudgeActivation({
+        status: nativeStaleInProgressStatus(),
+        metrics: staleMetrics(),
+      })
+    ).toEqual({ active: true, reason: 'native_stale_in_progress' });
+  });
+
+  it('holds only a member that is visibly working: unstarted and unobserved still get nudged', () => {
+    const openCodeWorking = nativeStaleInProgressStatus({ providerId: 'opencode' });
+    const justChangedAgenda = staleMetrics({ generatedAt: '2026-05-06T00:00:20.000Z' });
+
+    expect(
+      decideMemberWorkSyncNudgeActivation({
+        status: openCodeWorking,
+        metrics: justChangedAgenda,
+      })
+    ).toEqual({ active: false, reason: 'opencode_quiet_window' });
+
+    // Same member, same 20-second-old agenda, but the task is assigned and not
+    // started: there is no turn in flight to interrupt, so the nudge goes out.
+    const openCodeNotStarted: MemberWorkSyncStatus = {
+      ...openCodeWorking,
+      agenda: {
+        ...openCodeWorking.agenda,
+        items: openCodeWorking.agenda.items.map((item) => ({
+          ...item,
+          reason: 'owned_pending_task' as const,
+          evidence: { status: 'pending' as const, owner: 'alice' },
+        })),
+      },
+    };
+    expect(
+      decideMemberWorkSyncNudgeActivation({
+        status: openCodeNotStarted,
+        metrics: justChangedAgenda,
+      })
+    ).toEqual({ active: true, reason: 'opencode_targeted_shadow_collecting' });
+
+    // And an unobserved member is not a working member: with no needs_sync
+    // sample recorded there is no quiet window to be inside of, so the nudge
+    // goes out rather than being held on a guess.
+    expect(
+      decideMemberWorkSyncNudgeActivation({
+        status: openCodeWorking,
+        metrics: staleMetrics({ generatedAt: '2026-05-06T00:00:20.000Z', recentEvents: [] }),
+      })
+    ).toEqual({ active: true, reason: 'opencode_targeted_shadow_collecting' });
+  });
+
   it('activates native inbox-watch nudges while shadow data is still collecting', () => {
     for (const providerId of ['anthropic', 'codex', 'gemini'] as const) {
       expect(
@@ -503,10 +575,18 @@ describe('MemberWorkSyncNudgeActivationPolicy', () => {
       })
     ).toEqual({ active: true, reason: 'lead_targeted_shadow_collecting' });
 
+    // OpenCode stays on targeted recovery (no Codex repair); the 1-minute-old
+    // agenda is inside the OpenCode quiet window, so it is held rather than sent.
     expect(
       decideMemberWorkSyncNudgeActivation({
         status: { ...repairReady, providerId: 'opencode' },
         metrics: earlyBlockingMetrics,
+      })
+    ).toEqual({ active: false, reason: 'opencode_quiet_window' });
+    expect(
+      decideMemberWorkSyncNudgeActivation({
+        status: { ...repairReady, providerId: 'opencode' },
+        metrics: staleMetrics({ generatedAt: '2026-05-06T00:11:00.000Z' }),
       })
     ).toEqual({ active: true, reason: 'opencode_targeted_shadow_collecting' });
 
@@ -856,7 +936,7 @@ describe('MemberWorkSyncNudgeActivationPolicy', () => {
     expect(
       decideMemberWorkSyncNudgeActivation({
         status: nativeStaleInProgressStatus({ providerId: 'opencode' }),
-        metrics: staleMetrics(),
+        metrics: staleMetrics({ generatedAt: '2026-05-06T00:10:00.000Z' }),
       })
     ).toEqual({ active: true, reason: 'opencode_targeted_shadow_collecting' });
 

--- a/test/main/services/team/stallMonitor/TeamTaskStallJournal.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallJournal.test.ts
@@ -49,6 +49,42 @@ describe('TeamTaskStallJournal', () => {
     expect(secondReady).toEqual([evaluation]);
   });
 
+  it('persists a pending pickup epoch across scans instead of dropping it on read', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stall-journal-'));
+    setClaudeBasePathOverride(tmpDir);
+    await fs.mkdir(path.join(tmpDir, 'teams', 'demo'), { recursive: true });
+
+    const journal = new TeamTaskStallJournal();
+    const evaluation = {
+      status: 'alert',
+      taskId: 'task-pickup',
+      memberName: 'Scout',
+      branch: 'work',
+      signal: 'pending_pickup_after_unblock',
+      epochKey: 'task-pickup:work:pending_pickup_after_unblock:Scout:2026-04-19T12:00:00.000Z',
+      reason: 'Potential pickup stall',
+    } as const;
+
+    // A signal the journal sanitizer does not know is dropped on every read, so
+    // consecutiveScans would never reach 2 and the branch would never alert.
+    await expect(
+      journal.reconcileScan({
+        teamName: 'demo',
+        evaluations: [evaluation],
+        activeTaskIds: ['task-pickup'],
+        now: '2026-04-19T12:10:00.000Z',
+      })
+    ).resolves.toEqual([]);
+    await expect(
+      journal.reconcileScan({
+        teamName: 'demo',
+        evaluations: [evaluation],
+        activeTaskIds: ['task-pickup'],
+        now: '2026-04-19T12:10:30.000Z',
+      })
+    ).resolves.toEqual([evaluation]);
+  });
+
   it('allows the same stalled epoch to alert again after the cooldown expires', async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stall-journal-'));
     setClaudeBasePathOverride(tmpDir);
@@ -95,7 +131,87 @@ describe('TeamTaskStallJournal', () => {
         activeTaskIds: ['task-a'],
         now: '2026-04-19T12:12:00.000Z',
       })
-    ).resolves.toEqual([evaluation]);
+    ).resolves.toEqual([{ ...evaluation, priorAlertCount: 1 }]);
+  });
+
+  it('counts every dispatched alert for an epoch so an escalation ladder can be bounded', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stall-journal-'));
+    setClaudeBasePathOverride(tmpDir);
+    await fs.mkdir(path.join(tmpDir, 'teams', 'demo'), { recursive: true });
+
+    const journal = new TeamTaskStallJournal({ alertCooldownMs: 1 });
+    const evaluation = {
+      status: 'alert',
+      taskId: 'task-pickup',
+      memberName: 'Scout',
+      branch: 'work',
+      signal: 'pending_pickup_after_unblock',
+      epochKey: 'task-pickup:work:pending_pickup_after_unblock:Scout:2026-04-19T12:00:00.000Z',
+      reason: 'Potential pickup stall',
+    } as const;
+    const reconcile = (now: string) =>
+      journal.reconcileScan({
+        teamName: 'demo',
+        evaluations: [evaluation],
+        activeTaskIds: ['task-pickup'],
+        now,
+      });
+
+    await reconcile('2026-04-19T12:10:00.000Z');
+    await expect(reconcile('2026-04-19T12:10:30.000Z')).resolves.toEqual([evaluation]);
+    await journal.markAlerted('demo', evaluation.epochKey, '2026-04-19T12:10:30.000Z');
+    await expect(reconcile('2026-04-19T12:11:00.000Z')).resolves.toEqual([
+      { ...evaluation, priorAlertCount: 1 },
+    ]);
+    await journal.markAlerted('demo', evaluation.epochKey, '2026-04-19T12:11:00.000Z');
+    await expect(reconcile('2026-04-19T12:11:30.000Z')).resolves.toEqual([
+      { ...evaluation, priorAlertCount: 2 },
+    ]);
+  });
+
+  it('keeps a persisted alert count across a journal reload', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stall-journal-'));
+    setClaudeBasePathOverride(tmpDir);
+    const teamDir = path.join(tmpDir, 'teams', 'demo');
+    await fs.mkdir(teamDir, { recursive: true });
+    await fs.writeFile(
+      path.join(teamDir, 'stall-monitor-journal.json'),
+      JSON.stringify([
+        {
+          epochKey: 'task-a:epoch-1',
+          teamName: 'demo',
+          taskId: 'task-a',
+          branch: 'work',
+          signal: 'turn_ended_after_touch',
+          state: 'alerted',
+          consecutiveScans: 3,
+          createdAt: '2026-04-19T12:00:00.000Z',
+          updatedAt: '2026-04-19T12:01:00.000Z',
+          alertedAt: '2026-04-19T12:01:00.000Z',
+          alertCount: 2,
+        },
+      ]),
+      'utf8'
+    );
+
+    const journal = new TeamTaskStallJournal({ alertCooldownMs: 10 * 60_000 });
+    const evaluation = {
+      status: 'alert',
+      taskId: 'task-a',
+      branch: 'work',
+      signal: 'turn_ended_after_touch',
+      epochKey: 'task-a:epoch-1',
+      reason: 'Potential work stall',
+    } as const;
+
+    await expect(
+      journal.reconcileScan({
+        teamName: 'demo',
+        evaluations: [evaluation],
+        activeTaskIds: ['task-a'],
+        now: '2026-04-19T12:20:00.000Z',
+      })
+    ).resolves.toEqual([{ ...evaluation, priorAlertCount: 2 }]);
   });
 
   it('does not suppress a stalled epoch forever when alertedAt is in the future', async () => {

--- a/test/main/services/team/stallMonitor/TeamTaskStallMonitor.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallMonitor.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { TeamTaskStallJournal } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallJournal';
 import { TeamTaskStallMonitor } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallMonitor';
+
+import type {
+  TaskStallJournalMutation,
+  TaskStallJournalStore,
+} from '../../../../../src/main/services/team/stallMonitor/TaskStallJournalStore';
+import type { TaskStallJournalEntry } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallTypes';
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -674,5 +681,434 @@ describe('TeamTaskStallMonitor', () => {
     await vi.advanceTimersByTimeAsync(2_100);
 
     expect(notifier.notifyLead).toHaveBeenCalledTimes(1);
+  });
+
+  describe('pending pickup escalation', () => {
+    const pickupTask = {
+      id: 'task-pickup',
+      displayId: 'feed9999',
+      subject: 'Summarize the top-3 risks',
+      owner: 'Scout',
+      status: 'pending',
+    };
+    const startedTask = { ...pickupTask, status: 'in_progress' };
+    const pickupEvaluation = {
+      status: 'alert',
+      taskId: 'task-pickup',
+      memberName: 'Scout',
+      branch: 'work',
+      signal: 'pending_pickup_after_unblock',
+      remediationKind: 'pending_pickup',
+      epochKey: 'task-pickup:work:pending_pickup_after_unblock:Scout:2026-04-19T12:00:00.000Z',
+      reason: 'Potential pickup stall.',
+    } as const;
+
+    /** One completed scan per advance after the initial 2 s start delay. */
+    const SCAN_ADVANCE_MS = 1_100;
+
+    function createMemoryJournalStore(): TaskStallJournalStore & {
+      readEntries: () => TaskStallJournalEntry[];
+    } {
+      let stored: TaskStallJournalEntry[] = [];
+      return {
+        readEntries: () => stored,
+        async update<T>(
+          _teamName: string,
+          mutate: (entries: TaskStallJournalEntry[]) => TaskStallJournalMutation<T>
+        ): Promise<T> {
+          const mutation = mutate(stored.map((entry) => ({ ...entry })));
+          stored = mutation.entries;
+          return mutation.result;
+        },
+      };
+    }
+
+    function stubScanEnv(): void {
+      vi.stubEnv('CLAUDE_TEAM_TASK_STALL_SCAN_INTERVAL_MS', '1000');
+      vi.stubEnv('CLAUDE_TEAM_TASK_STALL_STARTUP_GRACE_MS', '1');
+      vi.stubEnv('CLAUDE_TEAM_TASK_STALL_ACTIVATION_GRACE_MS', '1');
+    }
+
+    function createRegistry() {
+      return {
+        start: vi.fn(),
+        stop: vi.fn(async () => undefined),
+        noteTeamChange: vi.fn(),
+        listActiveTeams: vi.fn(async () => ['demo']),
+      };
+    }
+
+    function createSnapshot(task: typeof pickupTask) {
+      const isPending = task.status === 'pending';
+      return {
+        teamName: 'demo',
+        inProgressTasks: isPending ? [] : [task],
+        reviewOpenTasks: [],
+        pendingPickupTasks: isPending ? [task] : [],
+        allTasksById: new Map([[task.id, task]]),
+        providerByMemberName: new Map([['scout', 'opencode']]),
+      };
+    }
+
+    it('nudges the OpenCode owner exactly once, only after the second scan', async () => {
+      vi.useFakeTimers();
+      stubScanEnv();
+
+      const store = createMemoryJournalStore();
+      const journal = new TeamTaskStallJournal({ store });
+      const notifier = {
+        notifyLead: vi.fn(async () => undefined),
+        notifyOpenCodeOwners: vi.fn(async (_teamName: string, alerts: unknown[]) => alerts),
+      };
+      const monitor = new TeamTaskStallMonitor(
+        createRegistry() as never,
+        { getSnapshot: vi.fn(async () => createSnapshot(pickupTask)) } as never,
+        {
+          evaluateWork: vi.fn(),
+          evaluatePendingPickup: vi.fn(() => pickupEvaluation),
+          evaluateReview: vi.fn(),
+        } as never,
+        journal as never,
+        notifier as never
+      );
+
+      monitor.start();
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+
+      // The two-scan rule holds the first alert, and the pending task id must be
+      // in activeTaskIds or the journal would prune the entry on every scan.
+      expect(notifier.notifyOpenCodeOwners).not.toHaveBeenCalled();
+      expect(store.readEntries()).toEqual([
+        expect.objectContaining({
+          taskId: 'task-pickup',
+          memberName: 'Scout',
+          signal: 'pending_pickup_after_unblock',
+          state: 'suspected',
+          consecutiveScans: 1,
+        }),
+      ]);
+
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+
+      expect(notifier.notifyOpenCodeOwners).toHaveBeenCalledTimes(1);
+      expect(notifier.notifyOpenCodeOwners).toHaveBeenCalledWith('demo', [
+        expect.objectContaining({
+          taskId: 'task-pickup',
+          owner: 'Scout',
+          ownerProviderId: 'opencode',
+          branch: 'work',
+          signal: 'pending_pickup_after_unblock',
+          remediationKind: 'pending_pickup',
+        }),
+      ]);
+      expect(notifier.notifyLead).not.toHaveBeenCalled();
+      expect(store.readEntries()).toEqual([
+        expect.objectContaining({ state: 'alerted', consecutiveScans: 2 }),
+      ]);
+
+      // A third scan stays inside the alert cooldown: still exactly one nudge.
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+      expect(notifier.notifyOpenCodeOwners).toHaveBeenCalledTimes(1);
+      expect(notifier.notifyLead).not.toHaveBeenCalled();
+
+      await monitor.stop();
+    });
+
+    it('sends nothing when the owner starts the task between the two scans', async () => {
+      vi.useFakeTimers();
+      stubScanEnv();
+
+      const store = createMemoryJournalStore();
+      const journal = new TeamTaskStallJournal({ store });
+      const notifier = {
+        notifyLead: vi.fn(async () => undefined),
+        notifyOpenCodeOwners: vi.fn(async (_teamName: string, alerts: unknown[]) => alerts),
+      };
+      const monitor = new TeamTaskStallMonitor(
+        createRegistry() as never,
+        {
+          getSnapshot: vi
+            .fn()
+            .mockResolvedValueOnce(createSnapshot(pickupTask))
+            .mockResolvedValue(createSnapshot(startedTask)),
+        } as never,
+        {
+          evaluateWork: vi.fn(() => ({
+            status: 'skip',
+            taskId: 'task-pickup',
+            reason: 'Work touch is still below the configured stall threshold',
+            skipReason: 'below_threshold',
+          })),
+          evaluatePendingPickup: vi.fn(() => pickupEvaluation),
+          evaluateReview: vi.fn(),
+        } as never,
+        journal as never,
+        notifier as never
+      );
+
+      monitor.start();
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+      expect(store.readEntries()).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+
+      expect(notifier.notifyOpenCodeOwners).not.toHaveBeenCalled();
+      expect(notifier.notifyLead).not.toHaveBeenCalled();
+      expect(store.readEntries()).toEqual([]);
+
+      await monitor.stop();
+    });
+
+    it('falls back to the lead when the pickup nudge is not accepted', async () => {
+      vi.useFakeTimers();
+      stubScanEnv();
+
+      const notifier = {
+        notifyLead: vi.fn(async () => undefined),
+        notifyOpenCodeOwners: vi.fn(async () => []),
+      };
+      const monitor = new TeamTaskStallMonitor(
+        createRegistry() as never,
+        { getSnapshot: vi.fn(async () => createSnapshot(pickupTask)) } as never,
+        {
+          evaluateWork: vi.fn(),
+          evaluatePendingPickup: vi.fn(() => pickupEvaluation),
+          evaluateReview: vi.fn(),
+        } as never,
+        new TeamTaskStallJournal({ store: createMemoryJournalStore() }) as never,
+        notifier as never
+      );
+
+      monitor.start();
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+
+      expect(notifier.notifyLead).toHaveBeenCalledWith('demo', [
+        expect.objectContaining({ taskId: 'task-pickup', remediationKind: 'pending_pickup' }),
+      ]);
+
+      await monitor.stop();
+    });
+
+    it('escalates the pickup alert from the owner to the lead and then goes silent', async () => {
+      vi.useFakeTimers();
+      stubScanEnv();
+
+      const store = createMemoryJournalStore();
+      // A 1 ms cooldown makes every later scan a fresh escalation attempt.
+      const journal = new TeamTaskStallJournal({ store, alertCooldownMs: 1 });
+      const notifier = {
+        notifyLead: vi.fn(async () => undefined),
+        notifyOpenCodeOwners: vi.fn(async (_teamName: string, alerts: unknown[]) => alerts),
+      };
+      const monitor = new TeamTaskStallMonitor(
+        createRegistry() as never,
+        { getSnapshot: vi.fn(async () => createSnapshot(pickupTask)) } as never,
+        {
+          evaluateWork: vi.fn(),
+          evaluatePendingPickup: vi.fn(() => pickupEvaluation),
+          evaluateReview: vi.fn(),
+        } as never,
+        journal as never,
+        notifier as never
+      );
+
+      monitor.start();
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+
+      expect(notifier.notifyOpenCodeOwners).toHaveBeenCalledTimes(1);
+      expect(notifier.notifyLead).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+
+      // Second rung: the owner was already nudged for this epoch, so the lead
+      // takes over instead of the owner being nudged again.
+      expect(notifier.notifyOpenCodeOwners).toHaveBeenCalledTimes(1);
+      expect(notifier.notifyLead).toHaveBeenCalledTimes(1);
+      expect(notifier.notifyLead).toHaveBeenCalledWith('demo', [
+        expect.objectContaining({ taskId: 'task-pickup', remediationKind: 'pending_pickup' }),
+      ]);
+
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+
+      // Third rung and beyond: nobody is told again, and the ladder announces
+      // itself spent exactly once rather than on every later scan.
+      expect(notifier.notifyOpenCodeOwners).toHaveBeenCalledTimes(1);
+      expect(notifier.notifyLead).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(console.warn).mock.calls.map((call) => call.join(' '))).toEqual([
+        expect.stringContaining('pickup_escalation_exhausted'),
+      ]);
+      vi.mocked(console.warn).mockClear();
+      // The cooldown keeps running so the silenced epoch is not re-examined on
+      // every scan.
+      expect(store.readEntries()).toEqual([
+        expect.objectContaining({ state: 'alerted', alertCount: 4 }),
+      ]);
+
+      await monitor.stop();
+    });
+
+    it('respects the alert cooldown between escalation rungs', async () => {
+      vi.useFakeTimers();
+      stubScanEnv();
+
+      const notifier = {
+        notifyLead: vi.fn(async () => undefined),
+        notifyOpenCodeOwners: vi.fn(async (_teamName: string, alerts: unknown[]) => alerts),
+      };
+      const monitor = new TeamTaskStallMonitor(
+        createRegistry() as never,
+        { getSnapshot: vi.fn(async () => createSnapshot(pickupTask)) } as never,
+        {
+          evaluateWork: vi.fn(),
+          evaluatePendingPickup: vi.fn(() => pickupEvaluation),
+          evaluateReview: vi.fn(),
+        } as never,
+        new TeamTaskStallJournal({
+          store: createMemoryJournalStore(),
+          alertCooldownMs: 10 * 60_000,
+        }) as never,
+        notifier as never
+      );
+
+      monitor.start();
+      await vi.advanceTimersByTimeAsync(2_100);
+      for (let scan = 0; scan < 8; scan += 1) {
+        await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+      }
+
+      // Nine scans inside one 10-minute cooldown: the owner is nudged once and
+      // the lead is never reached, because the second rung is not yet due.
+      expect(notifier.notifyOpenCodeOwners).toHaveBeenCalledTimes(1);
+      expect(notifier.notifyLead).not.toHaveBeenCalled();
+
+      await monitor.stop();
+    });
+
+    it('nudges only the oldest pending task per member and keeps the rest for a later scan', async () => {
+      vi.useFakeTimers();
+      stubScanEnv();
+
+      const olderTask = { ...pickupTask };
+      const newerTask = {
+        ...pickupTask,
+        id: 'task-pickup-newer',
+        displayId: 'feed8888',
+        subject: 'Second unblocked task',
+      };
+      const evaluationByTaskId = {
+        [olderTask.id]: { ...pickupEvaluation, readyAt: '2026-04-19T12:00:00.000Z' },
+        [newerTask.id]: {
+          ...pickupEvaluation,
+          taskId: newerTask.id,
+          readyAt: '2026-04-19T12:03:00.000Z',
+          epochKey:
+            'task-pickup-newer:work:pending_pickup_after_unblock:Scout:2026-04-19T12:03:00.000Z',
+        },
+      };
+      const notifier = {
+        notifyLead: vi.fn(async () => undefined),
+        notifyOpenCodeOwners: vi.fn(async (_teamName: string, alerts: unknown[]) => alerts),
+      };
+      const monitor = new TeamTaskStallMonitor(
+        createRegistry() as never,
+        {
+          getSnapshot: vi.fn(async () => ({
+            teamName: 'demo',
+            inProgressTasks: [],
+            reviewOpenTasks: [],
+            // Newest first: the cap must order by the pickup clock, not by the
+            // order the snapshot happens to list the tasks in.
+            pendingPickupTasks: [newerTask, olderTask],
+            allTasksById: new Map([
+              [olderTask.id, olderTask],
+              [newerTask.id, newerTask],
+            ]),
+            providerByMemberName: new Map([['scout', 'opencode']]),
+          })),
+        } as never,
+        {
+          evaluateWork: vi.fn(),
+          evaluatePendingPickup: vi.fn(
+            ({ task }: { task: { id: keyof typeof evaluationByTaskId } }) =>
+              evaluationByTaskId[task.id]
+          ),
+          evaluateReview: vi.fn(),
+        } as never,
+        new TeamTaskStallJournal({ store: createMemoryJournalStore() }) as never,
+        notifier as never
+      );
+
+      monitor.start();
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+
+      expect(notifier.notifyOpenCodeOwners).toHaveBeenCalledTimes(1);
+      expect(notifier.notifyOpenCodeOwners).toHaveBeenCalledWith('demo', [
+        expect.objectContaining({ taskId: olderTask.id }),
+      ]);
+      // The held-back task must not leak to the lead either.
+      expect(notifier.notifyLead).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+
+      expect(notifier.notifyOpenCodeOwners).toHaveBeenCalledTimes(2);
+      expect(notifier.notifyOpenCodeOwners).toHaveBeenLastCalledWith('demo', [
+        expect.objectContaining({ taskId: newerTask.id }),
+      ]);
+      expect(notifier.notifyLead).not.toHaveBeenCalled();
+
+      await monitor.stop();
+    });
+
+    it('leaves snapshots without pending pickup candidates untouched', async () => {
+      vi.useFakeTimers();
+      stubScanEnv();
+
+      const evaluatePendingPickup = vi.fn();
+      const reconcileScan = vi.fn(async () => []);
+      const task = { id: 'task-a', displayId: 'abcd1234', subject: 'Task A' };
+      const monitor = new TeamTaskStallMonitor(
+        createRegistry() as never,
+        {
+          getSnapshot: vi.fn(async () => ({
+            teamName: 'demo',
+            inProgressTasks: [task],
+            reviewOpenTasks: [],
+            allTasksById: new Map([['task-a', task]]),
+          })),
+        } as never,
+        {
+          evaluateWork: vi.fn(() => ({
+            status: 'skip',
+            taskId: 'task-a',
+            reason: 'Task has no open work interval',
+            skipReason: 'no_open_work_interval',
+          })),
+          evaluatePendingPickup,
+          evaluateReview: vi.fn(),
+        } as never,
+        { reconcileScan, markAlerted: vi.fn(async () => undefined) } as never,
+        { notifyLead: vi.fn(), notifyOpenCodeOwners: vi.fn() } as never
+      );
+
+      monitor.start();
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(SCAN_ADVANCE_MS);
+
+      expect(evaluatePendingPickup).not.toHaveBeenCalled();
+      expect(reconcileScan).toHaveBeenCalledWith(
+        expect.objectContaining({ activeTaskIds: ['task-a'] })
+      );
+
+      await monitor.stop();
+    });
   });
 });

--- a/test/main/services/team/stallMonitor/TeamTaskStallMonitor.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallMonitor.test.ts
@@ -1111,4 +1111,197 @@ describe('TeamTaskStallMonitor', () => {
       await monitor.stop();
     });
   });
+
+  describe('diagnostic state', () => {
+    /**
+     * The monitor lives as long as the main process, so both diagnostic maps
+     * are read directly: their size is the whole behaviour under test and it
+     * has no other observable effect.
+     */
+    function diagnosticState(monitor: TeamTaskStallMonitor): {
+      openCodeSkipLogAtByKey: Map<string, number>;
+      heldAlertFirstSeenAtByTeam: Map<string, Map<string, number>>;
+    } {
+      return monitor as unknown as {
+        openCodeSkipLogAtByKey: Map<string, number>;
+        heldAlertFirstSeenAtByTeam: Map<string, Map<string, number>>;
+      };
+    }
+
+    function stubFastScanEnv(): void {
+      vi.stubEnv('CLAUDE_TEAM_TASK_STALL_SCAN_INTERVAL_MS', '1000');
+      vi.stubEnv('CLAUDE_TEAM_TASK_STALL_STARTUP_GRACE_MS', '1');
+      vi.stubEnv('CLAUDE_TEAM_TASK_STALL_ACTIVATION_GRACE_MS', '1');
+    }
+
+    const heldTask = {
+      id: 'task-held',
+      displayId: 'abcd1234',
+      subject: 'Held task',
+      owner: 'Scout',
+      status: 'in_progress',
+    };
+
+    function heldAlertMonitor(listActiveTeams: () => Promise<string[]>): {
+      monitor: TeamTaskStallMonitor;
+      evaluateWork: ReturnType<typeof vi.fn>;
+    } {
+      let touch = 0;
+      // A live member touches its task between scans, and the epoch key carries
+      // the touch that produced it, so every scan mints a new key.
+      const evaluateWork = vi.fn(() => {
+        touch += 1;
+        return {
+          status: 'alert',
+          taskId: heldTask.id,
+          branch: 'work',
+          signal: 'turn_ended_after_touch',
+          epochKey: `work-held:touch-${touch}`,
+          reason: 'Potential work stall.',
+        };
+      });
+      const monitor = new TeamTaskStallMonitor(
+        {
+          start: vi.fn(),
+          stop: vi.fn(async () => undefined),
+          noteTeamChange: vi.fn(),
+          listActiveTeams: vi.fn(listActiveTeams),
+        } as never,
+        {
+          getSnapshot: vi.fn(async () => ({
+            teamName: 'demo',
+            inProgressTasks: [heldTask],
+            reviewOpenTasks: [],
+            allTasksById: new Map([[heldTask.id, heldTask]]),
+            providerByMemberName: new Map([['scout', 'opencode']]),
+          })),
+        } as never,
+        { evaluateWork, evaluateReview: vi.fn(), evaluatePendingPickup: vi.fn() } as never,
+        {
+          reconcileScan: vi.fn(async () => []),
+          markAlerted: vi.fn(async () => undefined),
+        } as never,
+        { notifyLead: vi.fn(), notifyOpenCodeOwners: vi.fn(async () => []) } as never
+      );
+      return { monitor, evaluateWork };
+    }
+
+    it('keeps only the held alert clocks the current scan is still holding', async () => {
+      vi.useFakeTimers();
+      stubFastScanEnv();
+      const { monitor, evaluateWork } = heldAlertMonitor(async () => ['demo']);
+
+      monitor.start();
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(1_100);
+      await vi.advanceTimersByTimeAsync(1_100);
+      await vi.advanceTimersByTimeAsync(1_100);
+
+      expect(evaluateWork).toHaveBeenCalledTimes(3);
+      // Three epochs were held, one at a time. Carrying the retired two would
+      // leak one entry per touch for the life of the process.
+      expect([...(diagnosticState(monitor).heldAlertFirstSeenAtByTeam.get('demo') ?? [])]).toEqual([
+        ['work-held:touch-3', expect.any(Number)],
+      ]);
+
+      await monitor.stop();
+    });
+
+    it('drops the held alert clocks of a team that is no longer running', async () => {
+      vi.useFakeTimers();
+      stubFastScanEnv();
+      let activeTeams = ['demo'];
+      const { monitor } = heldAlertMonitor(async () => activeTeams);
+
+      monitor.start();
+      // The first scan only starts the startup-grace clock; the second one holds.
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(1_100);
+      expect(diagnosticState(monitor).heldAlertFirstSeenAtByTeam.has('demo')).toBe(true);
+
+      activeTeams = [];
+      await vi.advanceTimersByTimeAsync(1_100);
+
+      expect(diagnosticState(monitor).heldAlertFirstSeenAtByTeam.size).toBe(0);
+
+      await monitor.stop();
+    });
+
+    it('expires an OpenCode skip rate limit once it can no longer suppress a log line', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-04-19T12:00:00.000Z'));
+      // Longer than the 10 minute skip-log interval, so one scan interval is
+      // enough for a stamp from the previous scan to go dead.
+      vi.stubEnv('CLAUDE_TEAM_TASK_STALL_SCAN_INTERVAL_MS', '700000');
+      vi.stubEnv('CLAUDE_TEAM_TASK_STALL_STARTUP_GRACE_MS', '1');
+      vi.stubEnv('CLAUDE_TEAM_TASK_STALL_ACTIVATION_GRACE_MS', '1');
+
+      const skippedTask = (id: string) => ({
+        id,
+        displayId: `disp-${id}`,
+        subject: 'Long running task',
+        owner: 'Scout',
+        status: 'in_progress',
+        workIntervals: [{ startedAt: '2026-04-19T11:50:00.000Z' }],
+      });
+      const firstTask = skippedTask('task-first');
+      const secondTask = skippedTask('task-second');
+      let currentTask = firstTask;
+      const monitor = new TeamTaskStallMonitor(
+        {
+          start: vi.fn(),
+          stop: vi.fn(async () => undefined),
+          noteTeamChange: vi.fn(),
+          listActiveTeams: vi.fn(async () => ['demo']),
+        } as never,
+        {
+          getSnapshot: vi.fn(async () => ({
+            teamName: 'demo',
+            inProgressTasks: [currentTask],
+            reviewOpenTasks: [],
+            allTasksById: new Map([[currentTask.id, currentTask]]),
+            providerByMemberName: new Map([['scout', 'opencode']]),
+            openCodeLaneActiveMemberNames: new Set(['scout']),
+          })),
+        } as never,
+        {
+          evaluateWork: vi.fn(() => ({
+            status: 'skip',
+            taskId: currentTask.id,
+            reason: 'Owner lane is mid-turn',
+            skipReason: 'lane_active',
+          })),
+          evaluateReview: vi.fn(),
+          evaluatePendingPickup: vi.fn(),
+        } as never,
+        {
+          reconcileScan: vi.fn(async () => []),
+          markAlerted: vi.fn(async () => undefined),
+        } as never,
+        { notifyLead: vi.fn(), notifyOpenCodeOwners: vi.fn(async () => []) } as never
+      );
+
+      monitor.start();
+      // The first scan only starts the startup-grace clock; the second one skips
+      // and stamps the first task's rate limit.
+      await vi.advanceTimersByTimeAsync(2_100);
+      await vi.advanceTimersByTimeAsync(700_100);
+      expect([...diagnosticState(monitor).openCodeSkipLogAtByKey.keys()]).toEqual([
+        'demo:task-first:lane_active',
+      ]);
+
+      // The first task leaves the board. Its stamp is now older than the
+      // interval it rate limits, so it cannot suppress anything again.
+      currentTask = secondTask;
+      await vi.advanceTimersByTimeAsync(700_100);
+
+      expect([...diagnosticState(monitor).openCodeSkipLogAtByKey.keys()]).toEqual([
+        'demo:task-second:lane_active',
+      ]);
+
+      expect(vi.mocked(console.warn).mock.calls).toHaveLength(2);
+      vi.mocked(console.warn).mockClear();
+      await monitor.stop();
+    });
+  });
 });

--- a/test/main/services/team/stallMonitor/TeamTaskStallMonitor.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallMonitor.test.ts
@@ -138,6 +138,70 @@ describe('TeamTaskStallMonitor', () => {
     expect(journal.markAlerted).toHaveBeenCalledWith('demo', 'work-a:epoch', expect.any(String));
   });
 
+  it('journals a lead rung it could not send because lead alerts are disabled', async () => {
+    // Without this, `priorAlertCount` never moves: the pickup ladder stays on
+    // the lead rung for the rest of the run, rebuilding the same alert on every
+    // scan and never reaching `silenced`.
+    vi.useFakeTimers();
+    vi.stubEnv('CLAUDE_TEAM_TASK_STALL_SCAN_INTERVAL_MS', '1000');
+    vi.stubEnv('CLAUDE_TEAM_TASK_STALL_STARTUP_GRACE_MS', '1');
+    vi.stubEnv('CLAUDE_TEAM_TASK_STALL_ACTIVATION_GRACE_MS', '1');
+    vi.stubEnv('CLAUDE_TEAM_TASK_STALL_ALERTS_ENABLED', '0');
+
+    const registry = {
+      start: vi.fn(),
+      stop: vi.fn(async () => undefined),
+      noteTeamChange: vi.fn(),
+      listActiveTeams: vi.fn(async () => ['demo']),
+    };
+    const snapshot = {
+      teamName: 'demo',
+      inProgressTasks: [{ id: 'task-a', displayId: 'abcd1234', subject: 'Task A' }],
+      reviewOpenTasks: [],
+      allTasksById: new Map([
+        ['task-a', { id: 'task-a', displayId: 'abcd1234', subject: 'Task A' }],
+      ]),
+    };
+    const alert = {
+      status: 'alert',
+      taskId: 'task-a',
+      branch: 'work',
+      signal: 'turn_ended_after_touch',
+      epochKey: 'work-a:epoch',
+      reason: 'Potential work stall.',
+    };
+    const snapshotSource = { getSnapshot: vi.fn(async () => snapshot) };
+    const policy = {
+      evaluateWork: vi.fn(() => alert),
+      evaluateReview: vi.fn(),
+    };
+    const journal = {
+      reconcileScan: vi.fn(async () => [alert]),
+      markAlerted: vi.fn(async () => undefined),
+    };
+    const notifier = {
+      notifyLead: vi.fn(async () => undefined),
+      notifyOpenCodeOwners: vi.fn(async () => []),
+    };
+
+    const monitor = new TeamTaskStallMonitor(
+      registry as never,
+      snapshotSource as never,
+      policy as never,
+      journal as never,
+      notifier as never
+    );
+
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(2_100);
+    await vi.advanceTimersByTimeAsync(2_100);
+
+    expect(snapshotSource.getSnapshot).toHaveBeenCalled();
+    expect(notifier.notifyOpenCodeOwners).toHaveBeenCalled();
+    expect(notifier.notifyLead).not.toHaveBeenCalled();
+    expect(journal.markAlerted).toHaveBeenCalledWith('demo', 'work-a:epoch', expect.any(String));
+  });
+
   it('times out a hung scan so later stall scans continue', async () => {
     vi.useFakeTimers();
     vi.stubEnv('CLAUDE_TEAM_TASK_STALL_SCAN_INTERVAL_MS', '1000');

--- a/test/main/services/team/stallMonitor/TeamTaskStallNotifier.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallNotifier.test.ts
@@ -145,6 +145,110 @@ describe('TeamTaskStallNotifier', () => {
     await expect(notifier.notifyOpenCodeOwners('demo', [createAlert()])).resolves.toEqual([]);
   });
 
+  it('sends a start-the-task nudge for pending pickup alerts', async () => {
+    const relay = vi.fn(async () => ({ lastDelivery: { delivered: true, accepted: true } }));
+    const inboxWriter = {
+      sendMessage: vi.fn(async () => ({ deliveredToInbox: true, messageId: 'msg' })),
+    };
+    const notifier = new TeamTaskStallNotifier(
+      { sendSystemNotificationToLead: vi.fn(async () => undefined) } as never,
+      { relayOpenCodeMemberInboxMessages: relay } as never,
+      { getMessagesFor: vi.fn(async () => []) } as never,
+      inboxWriter as never
+    );
+    const alert = createAlert({
+      signal: 'pending_pickup_after_unblock',
+      remediationKind: 'pending_pickup',
+      epochKey: 'task-a:work:pending_pickup_after_unblock:alice:2026-04-19T12:00:00.000Z',
+      reason: 'Potential pickup stall.',
+    });
+    const messageId = `task-stall:demo:task-a:${alert.epochKey}`;
+
+    await expect(notifier.notifyOpenCodeOwners('demo', [alert])).resolves.toEqual([alert]);
+
+    const request = (inboxWriter.sendMessage.mock.calls as unknown as unknown[][])[0]?.[1] as {
+      messageId: string;
+      messageKind: string;
+      summary: string;
+      actionMode: string;
+      text: string;
+    };
+    expect(request.text).toContain('still pending on the board');
+    expect(request.text).toContain('A direct message to the user does not move the board');
+    expect(request.text).toContain('task_start');
+    expect(request.summary).toBe('Assigned task not started');
+    // Only text and summary change: id, kind and relay metadata stay on the proven path.
+    expect(request.messageId).toBe(messageId);
+    expect(request.messageKind).toBe('task_stall_remediation');
+    expect(request.actionMode).toBe('do');
+    expect(relay).toHaveBeenCalledWith('demo', 'alice', {
+      onlyMessageId: messageId,
+      source: 'watchdog',
+      deliveryMetadata: {
+        replyRecipient: 'user',
+        actionMode: 'do',
+        taskRefs: [alert.taskRef],
+      },
+    });
+  });
+
+  it('does not write a second inbox row for a repeated pending pickup alert', async () => {
+    const alert = createAlert({
+      signal: 'pending_pickup_after_unblock',
+      remediationKind: 'pending_pickup',
+      epochKey: 'task-a:work:pending_pickup_after_unblock:alice:2026-04-19T12:00:00.000Z',
+    });
+    const messageId = `task-stall:demo:task-a:${alert.epochKey}`;
+    const inboxWriter = {
+      sendMessage: vi.fn(async () => ({ deliveredToInbox: true, messageId })),
+    };
+    const notifier = new TeamTaskStallNotifier(
+      { sendSystemNotificationToLead: vi.fn(async () => undefined) } as never,
+      {
+        relayOpenCodeMemberInboxMessages: vi.fn(async () => ({
+          lastDelivery: { delivered: true, accepted: true },
+        })),
+      } as never,
+      { getMessagesFor: vi.fn(async () => [{ messageId }]) } as never,
+      inboxWriter as never
+    );
+
+    await expect(notifier.notifyOpenCodeOwners('demo', [alert])).resolves.toEqual([alert]);
+    expect(inboxWriter.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['opencode_inbox_message_already_read', { delivered: true }],
+    ['opencode_inbox_read_already_committed', { delivered: true, accepted: true }],
+  ])(
+    'does not count a %s no-op redelivery as remediated so the alert can escalate',
+    async (reason, deliveryShape) => {
+      const notifier = new TeamTaskStallNotifier(
+        { sendSystemNotificationToLead: vi.fn(async () => undefined) } as never,
+        {
+          relayOpenCodeMemberInboxMessages: vi.fn(async () => ({
+            attempted: 1,
+            delivered: 1,
+            lastDelivery: { ...deliveryShape, reason, diagnostics: [reason] },
+            diagnostics: [reason],
+          })),
+        } as never,
+        { getMessagesFor: vi.fn(async () => []) } as never,
+        { sendMessage: vi.fn(async () => ({ deliveredToInbox: true, messageId: 'msg' })) } as never
+      );
+
+      await expect(
+        notifier.notifyOpenCodeOwners('demo', [
+          createAlert({
+            signal: 'pending_pickup_after_unblock',
+            remediationKind: 'pending_pickup',
+            epochKey: 'task-a:work:pending_pickup_after_unblock:alice:2026-04-19T12:00:00.000Z',
+          }),
+        ])
+      ).resolves.toEqual([]);
+    }
+  );
+
   it('does not mark queued-behind delivery as remediated even when active ledger exists', async () => {
     const notifier = new TeamTaskStallNotifier(
       { sendSystemNotificationToLead: vi.fn(async () => undefined) } as never,
@@ -203,7 +307,11 @@ describe('TeamTaskStallNotifier', () => {
       { sendSystemNotificationToLead: vi.fn(async () => undefined) } as never,
       { relayOpenCodeMemberInboxMessages: relay } as never,
       { getMessagesFor: vi.fn(async () => []) } as never,
-      { sendMessage: vi.fn(async () => { throw new Error('disk full'); }) } as never
+      {
+        sendMessage: vi.fn(async () => {
+          throw new Error('disk full');
+        }),
+      } as never
     );
 
     await expect(notifier.notifyOpenCodeOwners('demo', [createAlert()])).resolves.toEqual([]);
@@ -220,7 +328,11 @@ describe('TeamTaskStallNotifier', () => {
     const notifier = new TeamTaskStallNotifier(
       { sendSystemNotificationToLead: vi.fn(async () => undefined) } as never,
       { relayOpenCodeMemberInboxMessages: relay } as never,
-      { getMessagesFor: vi.fn(async () => { throw new Error('read failed'); }) } as never,
+      {
+        getMessagesFor: vi.fn(async () => {
+          throw new Error('read failed');
+        }),
+      } as never,
       { sendMessage: inboxWrite } as never
     );
 

--- a/test/main/services/team/stallMonitor/TeamTaskStallPendingPickup.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallPendingPickup.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { OpenCodeLaneTurnActivityRegistry } from '../../../../../src/main/services/team/opencode/delivery/OpenCodeLaneTurnActivityRegistry';
+import { getOpenCodeLaneTurnActivityMaxAgeMs } from '../../../../../src/main/services/team/stallMonitor/featureGates';
 import { TeamTaskStallPolicy } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallPolicy';
+import { TeamTaskStallSnapshotSource } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource';
 
-import type { TeamTaskStallSnapshot } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallTypes';
+import type {
+  TaskStallEvaluation,
+  TeamTaskStallSnapshot,
+} from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallTypes';
 import type { TeamTask } from '../../../../../src/shared/types';
 
 const UNBLOCKED_AT = '2026-04-19T12:00:00.000Z';
@@ -431,5 +437,166 @@ describe('TeamTaskStallPolicy.evaluatePendingPickup', () => {
 
     expect(first.status).toBe('alert');
     expect(second.epochKey).toBe(first.epochKey);
+  });
+
+  it('stays quiet while the owner lane is mid-turn but not once that sample goes stale', () => {
+    const task = createPendingTask();
+    const activeAt = '2026-04-19T12:00:30.000Z';
+
+    // A fresh sample reaches the branch through openCodeLaneActiveMemberNames.
+    expect(
+      policy.evaluatePendingPickup({
+        now: new Date(PAST_THRESHOLD_AT),
+        task,
+        snapshot: snapshotFor(task, {
+          openCodeLaneActiveMemberNames: new Set(['scout']),
+          openCodeLaneActiveSinceByMemberName: new Map([['scout', activeAt]]),
+        }),
+      })
+    ).toMatchObject({ status: 'skip', skipReason: 'lane_active' });
+
+    // The same sample, once the snapshot source has demoted it for age, is
+    // published as a backdated idle time and stops silencing the branch.
+    expect(
+      policy.evaluatePendingPickup({
+        now: new Date(PAST_THRESHOLD_AT),
+        task,
+        snapshot: snapshotFor(task, {
+          openCodeLaneIdleSinceByMemberName: new Map([['scout', activeAt]]),
+          openCodeLaneStaleActiveSinceByMemberName: new Map([['scout', activeAt]]),
+        }),
+      })
+    ).toMatchObject({ status: 'alert', signal: 'pending_pickup_after_unblock' });
+  });
+
+  it('treats a lane idle time as ordinary evidence: it can delay the alert, never block it', () => {
+    const task = createPendingTask();
+
+    // Later than the unblock, so it moves the clock and holds the alert back.
+    expect(
+      policy.evaluatePendingPickup({
+        now: new Date(PAST_THRESHOLD_AT),
+        task,
+        snapshot: snapshotFor(task, {
+          openCodeLaneIdleSinceByMemberName: new Map([['scout', '2026-04-19T12:06:00.000Z']]),
+        }),
+      })
+    ).toMatchObject({ status: 'skip', skipReason: 'below_threshold' });
+
+    // Absent altogether, the branch judges the task exactly as it did before it
+    // learned to read lanes at all: an unobserved lane is not an active one.
+    const withoutLaneEvidence = policy.evaluatePendingPickup({
+      now: new Date(PAST_THRESHOLD_AT),
+      task,
+      snapshot: snapshotFor(task),
+    });
+    expect(withoutLaneEvidence.status).toBe('alert');
+    expect(withoutLaneEvidence.reason).not.toContain('lane has been idle');
+  });
+});
+
+/**
+ * The end-to-end shape the age bound exists for: a delivery lane accepted a
+ * prompt, never settled, and so keeps advertising the same 'active' sample.
+ * Nothing else in the app will ever contradict that sample, so the bound alone
+ * has to be what lets the pickup alert through.
+ */
+describe('pending pickup behind a delivery lane that never settled', () => {
+  const policy = new TeamTaskStallPolicy();
+
+  function isoAgo(nowMs: number, ageMs: number): string {
+    return new Date(nowMs - ageMs).toISOString();
+  }
+
+  function snapshotSourceFor(
+    task: TeamTask,
+    laneTurnActivity: OpenCodeLaneTurnActivityRegistry
+  ): TeamTaskStallSnapshotSource {
+    return new TeamTaskStallSnapshotSource({
+      transcriptSourceLocator: {
+        getContext: vi.fn(() =>
+          Promise.resolve({
+            projectDir: '/repo/project',
+            projectId: 'project-id',
+            config: {
+              members: [
+                { name: 'team-lead', role: 'team lead', providerId: 'codex' },
+                { name: 'Scout', role: 'Developer', providerId: 'opencode' },
+              ],
+            },
+            sessionIds: [],
+            transcriptFiles: [],
+          })
+        ),
+      } as never,
+      taskReader: {
+        getTasks: vi.fn(() => Promise.resolve([task])),
+        getDeletedTasks: vi.fn(() => Promise.resolve([])),
+      } as never,
+      kanbanManager: {
+        getState: vi.fn(() => Promise.resolve({ teamName: 'demo', tasks: {} })),
+      } as never,
+      transcriptReader: { readFiles: vi.fn(() => Promise.resolve([])) } as never,
+      activityBatchIndexer: { buildIndex: vi.fn(() => new Map()) } as never,
+      freshnessReader: { readSignals: vi.fn(() => Promise.resolve(new Map())) } as never,
+      exactRowReader: { parseFiles: vi.fn(() => Promise.resolve(new Map())) } as never,
+      membersMetaStore: { getMembers: vi.fn(() => Promise.resolve([])) } as never,
+      openCodeEvidenceSource: {
+        readEvidence: vi.fn(() =>
+          Promise.resolve({ recordsByTaskId: new Map(), exactRowsByFilePath: new Map() })
+        ),
+      } as never,
+      laneTurnActivity,
+    });
+  }
+
+  async function evaluateWithUnsettledLaneOfAge(ageMs: number): Promise<TaskStallEvaluation> {
+    const nowMs = Date.now();
+    const task: TeamTask = {
+      id: 'task-pickup',
+      displayId: 'feed9999',
+      subject: 'Summarize the top-3 risks',
+      owner: 'Scout',
+      status: 'pending',
+      createdAt: isoAgo(nowMs, ageMs),
+    };
+    const laneTurnActivity = new OpenCodeLaneTurnActivityRegistry();
+    laneTurnActivity.note({
+      teamName: 'demo',
+      memberName: 'Scout',
+      laneId: 'secondary:opencode:scout',
+      state: 'active',
+      observedAt: isoAgo(nowMs, ageMs),
+    });
+
+    const snapshot = await snapshotSourceFor(task, laneTurnActivity).getSnapshot('demo');
+    if (!snapshot) {
+      throw new Error('the snapshot source produced no snapshot');
+    }
+    expect(snapshot.pendingPickupTasks?.map((pending) => pending.id)).toEqual(['task-pickup']);
+    return policy.evaluatePendingPickup({ now: new Date(), task, snapshot });
+  }
+
+  it('stays silent while the unsettled sample is still inside the max age', async () => {
+    const maxAgeMs = getOpenCodeLaneTurnActivityMaxAgeMs();
+
+    // Already well past the pickup threshold, so only the lane flag is holding
+    // the alert back - which is the correct call while the turn may be live.
+    await expect(evaluateWithUnsettledLaneOfAge(maxAgeMs - 60_000)).resolves.toMatchObject({
+      status: 'skip',
+      skipReason: 'lane_active',
+    });
+  });
+
+  it('alerts once the unsettled sample outlives the max age, with no probe involved', async () => {
+    const maxAgeMs = getOpenCodeLaneTurnActivityMaxAgeMs();
+
+    // Nothing wrote a settle sample and nothing asked the lane host anything.
+    // The age bound on its own is what ends the silence.
+    await expect(evaluateWithUnsettledLaneOfAge(maxAgeMs + 60_000)).resolves.toMatchObject({
+      status: 'alert',
+      signal: 'pending_pickup_after_unblock',
+      memberName: 'Scout',
+    });
   });
 });

--- a/test/main/services/team/stallMonitor/TeamTaskStallPendingPickup.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallPendingPickup.test.ts
@@ -1,0 +1,435 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TeamTaskStallPolicy } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallPolicy';
+
+import type { TeamTaskStallSnapshot } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallTypes';
+import type { TeamTask } from '../../../../../src/shared/types';
+
+const UNBLOCKED_AT = '2026-04-19T12:00:00.000Z';
+const PAST_THRESHOLD_AT = '2026-04-19T12:08:00.000Z';
+
+const BLOCKER: TeamTask = {
+  id: 'task-blocker',
+  displayId: 'b10c1234',
+  subject: 'Resolved dependency',
+  status: 'completed',
+};
+
+function createSnapshot(overrides: Partial<TeamTaskStallSnapshot> = {}): TeamTaskStallSnapshot {
+  return {
+    teamName: 'demo',
+    scannedAt: PAST_THRESHOLD_AT,
+    projectDir: 'projects/demo',
+    projectId: 'project-id',
+    leadName: 'team-lead',
+    transcriptFiles: [],
+    activityReadsEnabled: true,
+    exactReadsEnabled: true,
+    activeTasks: [],
+    deletedTasks: [],
+    allTasksById: new Map(),
+    inProgressTasks: [],
+    reviewOpenTasks: [],
+    pendingPickupTasks: [],
+    resolvedReviewersByTaskId: new Map(),
+    recordsByTaskId: new Map(),
+    freshnessByTaskId: new Map(),
+    exactRowsByFilePath: new Map(),
+    providerByMemberName: new Map([['scout', 'opencode' as const]]),
+    ...overrides,
+  };
+}
+
+function createPendingTask(overrides: Partial<TeamTask> = {}): TeamTask {
+  return {
+    id: 'task-pickup',
+    displayId: 'feed9999',
+    subject: 'Summarize the top-3 risks',
+    owner: 'Scout',
+    status: 'pending',
+    blockedBy: ['task-blocker'],
+    comments: [
+      {
+        id: 'dep-resolved-task-blocker-task-pickup',
+        author: 'system',
+        text: 'Dependency resolved - all blockers for #feed9999 are resolved.',
+        createdAt: UNBLOCKED_AT,
+        type: 'regular',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function snapshotFor(task: TeamTask, overrides: Partial<TeamTaskStallSnapshot> = {}) {
+  return createSnapshot({
+    activeTasks: [task],
+    pendingPickupTasks: [task],
+    allTasksById: new Map([
+      [task.id, task],
+      [BLOCKER.id, BLOCKER],
+    ]),
+    ...overrides,
+  });
+}
+
+describe('TeamTaskStallPolicy.evaluatePendingPickup', () => {
+  const policy = new TeamTaskStallPolicy();
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('alerts once an idle OpenCode owner leaves an unblocked task pending past the threshold', () => {
+    const task = createPendingTask();
+
+    const evaluation = policy.evaluatePendingPickup({
+      now: new Date(PAST_THRESHOLD_AT),
+      task,
+      snapshot: snapshotFor(task),
+    });
+
+    expect(evaluation).toMatchObject({
+      status: 'alert',
+      taskId: 'task-pickup',
+      memberName: 'Scout',
+      branch: 'work',
+      signal: 'pending_pickup_after_unblock',
+      remediationKind: 'pending_pickup',
+      readyAt: UNBLOCKED_AT,
+      epochKey: `task-pickup:work:pending_pickup_after_unblock:Scout:${UNBLOCKED_AT}`,
+    });
+    expect(evaluation.reason).toContain(`all blockers resolved at ${UNBLOCKED_AT}`);
+  });
+
+  it('holds the alert until the threshold elapses, to the millisecond', () => {
+    const task = createPendingTask();
+    const snapshot = snapshotFor(task);
+
+    expect(
+      policy.evaluatePendingPickup({
+        now: new Date('2026-04-19T12:04:59.999Z'),
+        task,
+        snapshot,
+      })
+    ).toMatchObject({ status: 'skip', skipReason: 'below_threshold' });
+    expect(
+      policy.evaluatePendingPickup({
+        now: new Date('2026-04-19T12:05:00.000Z'),
+        task,
+        snapshot,
+      })
+    ).toMatchObject({
+      status: 'alert',
+      signal: 'pending_pickup_after_unblock',
+      remediationKind: 'pending_pickup',
+    });
+  });
+
+  it('restarts the clock when the task was reassigned after the unblock', () => {
+    const task = createPendingTask({
+      historyEvents: [
+        {
+          id: 'evt-owner',
+          type: 'owner_changed',
+          timestamp: '2026-04-19T12:05:00.000Z',
+          from: 'Builder',
+          to: 'Scout',
+        },
+      ],
+    });
+
+    expect(
+      policy.evaluatePendingPickup({
+        now: new Date(PAST_THRESHOLD_AT),
+        task,
+        snapshot: snapshotFor(task),
+      })
+    ).toMatchObject({ status: 'skip', skipReason: 'below_threshold' });
+  });
+
+  it('produces no evaluation traffic when the owner starts the task in time', () => {
+    const task = createPendingTask({ status: 'in_progress' });
+
+    expect(
+      policy.evaluatePendingPickup({
+        now: new Date(PAST_THRESHOLD_AT),
+        task,
+        snapshot: snapshotFor(task),
+      })
+    ).toMatchObject({ status: 'skip', taskId: 'task-pickup', skipReason: 'task_not_pending' });
+  });
+
+  it('never escalates while a blocker is unfinished, no matter how long it waits', () => {
+    const secondBlocker: TeamTask = {
+      id: 'task-blocker-2',
+      displayId: 'b10c5678',
+      subject: 'Still running',
+      status: 'in_progress',
+    };
+    const task = createPendingTask({ blockedBy: ['task-blocker', 'b10c5678'] });
+    const snapshot = snapshotFor(task, {
+      allTasksById: new Map([
+        [task.id, task],
+        [BLOCKER.id, BLOCKER],
+        [secondBlocker.id, secondBlocker],
+      ]),
+    });
+
+    // An hour past the threshold, and a day past it: the unfinished blocker is
+    // not a timeout, it is a hard gate.
+    for (const now of ['2026-04-19T13:08:00.000Z', '2026-04-20T12:08:00.000Z']) {
+      expect(policy.evaluatePendingPickup({ now: new Date(now), task, snapshot })).toMatchObject({
+        status: 'skip',
+        skipReason: 'task_blocked',
+      });
+    }
+  });
+
+  it('resumes escalating once that same blocker completes', () => {
+    const secondBlocker: TeamTask = {
+      id: 'task-blocker-2',
+      displayId: 'b10c5678',
+      subject: 'Now finished',
+      status: 'completed',
+    };
+    const task = createPendingTask({ blockedBy: ['task-blocker', 'b10c5678'] });
+
+    expect(
+      policy.evaluatePendingPickup({
+        now: new Date(PAST_THRESHOLD_AT),
+        task,
+        snapshot: snapshotFor(task, {
+          allTasksById: new Map([
+            [task.id, task],
+            [BLOCKER.id, BLOCKER],
+            [secondBlocker.id, secondBlocker],
+          ]),
+        }),
+      })
+    ).toMatchObject({ status: 'alert', signal: 'pending_pickup_after_unblock' });
+  });
+
+  describe('tasks that never had a blocker', () => {
+    function createNeverBlockedTask(overrides: Partial<TeamTask> = {}): TeamTask {
+      return createPendingTask({ blockedBy: [], comments: [], ...overrides });
+    }
+
+    it('starts the pickup clock at creation, so the launch shape is covered too', () => {
+      const task = createNeverBlockedTask({ createdAt: UNBLOCKED_AT });
+
+      const evaluation = policy.evaluatePendingPickup({
+        now: new Date(PAST_THRESHOLD_AT),
+        task,
+        snapshot: snapshotFor(task),
+      });
+
+      expect(evaluation).toMatchObject({
+        status: 'alert',
+        taskId: 'task-pickup',
+        signal: 'pending_pickup_after_unblock',
+        remediationKind: 'pending_pickup',
+        readyAt: UNBLOCKED_AT,
+        epochKey: `task-pickup:work:pending_pickup_after_unblock:Scout:${UNBLOCKED_AT}`,
+      });
+      expect(evaluation.reason).toContain(`owner has had it since ${UNBLOCKED_AT}`);
+    });
+
+    it('does not alert a board created seconds ago', () => {
+      const task = createNeverBlockedTask({ createdAt: '2026-04-19T12:07:30.000Z' });
+
+      expect(
+        policy.evaluatePendingPickup({
+          now: new Date(PAST_THRESHOLD_AT),
+          task,
+          snapshot: snapshotFor(task),
+        })
+      ).toMatchObject({ status: 'skip', skipReason: 'below_threshold' });
+    });
+
+    it('restarts the clock at the assignment that handed the task to this owner', () => {
+      const task = createNeverBlockedTask({
+        createdAt: '2026-04-19T11:00:00.000Z',
+        historyEvents: [
+          {
+            id: 'evt-owner',
+            type: 'owner_changed',
+            timestamp: '2026-04-19T12:05:00.000Z',
+            from: 'Builder',
+            to: 'Scout',
+          },
+        ],
+      });
+
+      expect(
+        policy.evaluatePendingPickup({
+          now: new Date(PAST_THRESHOLD_AT),
+          task,
+          snapshot: snapshotFor(task),
+        })
+      ).toMatchObject({ status: 'skip', skipReason: 'below_threshold' });
+    });
+
+    it('still refuses a clock for a task whose listed blocker never reported resolved', () => {
+      const task = createPendingTask({ comments: [], createdAt: '2026-04-19T11:00:00.000Z' });
+
+      expect(
+        policy.evaluatePendingPickup({
+          now: new Date(PAST_THRESHOLD_AT),
+          task,
+          snapshot: snapshotFor(task),
+        })
+      ).toMatchObject({ status: 'skip', skipReason: 'no_unblock_evidence' });
+    });
+  });
+
+  describe('owner already working', () => {
+    const otherTask: TeamTask = {
+      id: 'task-other',
+      displayId: 'a11ce123',
+      subject: 'Already running',
+      owner: 'Scout',
+      status: 'in_progress',
+    };
+
+    it('suppresses the pickup alert while the owner runs another task', () => {
+      const task = createPendingTask();
+
+      expect(
+        policy.evaluatePendingPickup({
+          now: new Date(PAST_THRESHOLD_AT),
+          task,
+          snapshot: snapshotFor(task, { inProgressTasks: [otherTask] }),
+        })
+      ).toMatchObject({ status: 'skip', skipReason: 'owner_busy_on_other_task' });
+    });
+
+    it('still alerts when the running task belongs to a different member', () => {
+      const task = createPendingTask();
+
+      expect(
+        policy.evaluatePendingPickup({
+          now: new Date(PAST_THRESHOLD_AT),
+          task,
+          snapshot: snapshotFor(task, {
+            inProgressTasks: [{ ...otherTask, owner: 'Builder' }],
+          }),
+        })
+      ).toMatchObject({ status: 'alert', signal: 'pending_pickup_after_unblock' });
+    });
+  });
+
+  it.each([
+    [
+      'no dependency-resolved comment at all',
+      [
+        {
+          id: 'comment-owner',
+          author: 'Scout',
+          text: 'Looking into it.',
+          createdAt: UNBLOCKED_AT,
+          type: 'regular' as const,
+        },
+      ],
+    ],
+    [
+      'a dependency-resolved id forged by the owner',
+      [
+        {
+          id: 'dep-resolved-task-blocker-task-pickup',
+          author: 'Scout',
+          text: 'Dependency resolved.',
+          createdAt: UNBLOCKED_AT,
+          type: 'regular' as const,
+        },
+      ],
+    ],
+    [
+      'a dependency-resolved comment for a different task',
+      [
+        {
+          id: 'dep-resolved-task-blocker-task-other',
+          author: 'system',
+          text: 'Dependency resolved.',
+          createdAt: UNBLOCKED_AT,
+          type: 'regular' as const,
+        },
+      ],
+    ],
+  ])('has no unblock evidence with %s', (_label, comments) => {
+    const task = createPendingTask({ comments });
+
+    expect(
+      policy.evaluatePendingPickup({
+        now: new Date(PAST_THRESHOLD_AT),
+        task,
+        snapshot: snapshotFor(task),
+      })
+    ).toMatchObject({ status: 'skip', skipReason: 'no_unblock_evidence' });
+  });
+
+  it.each([
+    [
+      'owner_not_opencode',
+      { owner: 'Worker' },
+      { providerByMemberName: new Map([['worker', 'anthropic' as const]]) },
+    ],
+    ['owner_is_lead', { owner: 'team-lead' }, {}],
+    ['owner_missing', { owner: '  ' }, {}],
+    ['needs_clarification', { needsClarification: 'lead' }, {}],
+  ] as const)('skips with %s', (skipReason, taskOverrides, snapshotOverrides) => {
+    const task = createPendingTask(taskOverrides);
+
+    expect(
+      policy.evaluatePendingPickup({
+        now: new Date(PAST_THRESHOLD_AT),
+        task,
+        snapshot: snapshotFor(task, snapshotOverrides),
+      })
+    ).toMatchObject({ status: 'skip', skipReason });
+  });
+
+  it('is disabled by its env gate', () => {
+    vi.stubEnv('CLAUDE_TEAM_PENDING_PICKUP_STALL_REMEDIATION_ENABLED', '0');
+    const task = createPendingTask();
+
+    expect(
+      policy.evaluatePendingPickup({
+        now: new Date(PAST_THRESHOLD_AT),
+        task,
+        snapshot: snapshotFor(task),
+      })
+    ).toMatchObject({ status: 'skip', skipReason: 'pickup_remediation_disabled' });
+  });
+
+  it('keeps the epoch key stable across unrelated task churn', () => {
+    const task = createPendingTask({ updatedAt: '2026-04-19T12:03:00.000Z' });
+    const first = policy.evaluatePendingPickup({
+      now: new Date(PAST_THRESHOLD_AT),
+      task,
+      snapshot: snapshotFor(task),
+    });
+
+    const churned = createPendingTask({
+      updatedAt: '2026-04-19T12:07:30.000Z',
+      comments: [
+        ...(task.comments ?? []),
+        {
+          id: 'comment-noise',
+          author: 'Builder',
+          text: 'FYI I touched a neighbouring file.',
+          createdAt: '2026-04-19T12:07:30.000Z',
+          type: 'regular',
+        },
+      ],
+    });
+    const second = policy.evaluatePendingPickup({
+      now: new Date(PAST_THRESHOLD_AT),
+      task: churned,
+      snapshot: snapshotFor(churned),
+    });
+
+    expect(first.status).toBe('alert');
+    expect(second.epochKey).toBe(first.epochKey);
+  });
+});

--- a/test/main/services/team/stallMonitor/TeamTaskStallPendingPickup.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallPendingPickup.test.ts
@@ -381,6 +381,8 @@ describe('TeamTaskStallPolicy.evaluatePendingPickup', () => {
       { providerByMemberName: new Map([['worker', 'anthropic' as const]]) },
     ],
     ['owner_is_lead', { owner: 'team-lead' }, {}],
+    // The lead is still the lead when an agent capitalised the owner field.
+    ['owner_is_lead', { owner: 'Team-Lead ' }, {}],
     ['owner_missing', { owner: '  ' }, {}],
     ['needs_clarification', { needsClarification: 'lead' }, {}],
   ] as const)('skips with %s', (skipReason, taskOverrides, snapshotOverrides) => {

--- a/test/main/services/team/stallMonitor/TeamTaskStallPolicy.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallPolicy.test.ts
@@ -668,6 +668,191 @@ describe('TeamTaskStallPolicy', () => {
     });
   });
 
+  it('treats an OpenCode lane that settled after the touch as a turn end (4 min, not 10)', () => {
+    const task: TeamTask = {
+      id: 'task-open-settled',
+      displayId: 'feed4444',
+      subject: 'OpenCode silent after concrete progress',
+      owner: 'Worker',
+      status: 'in_progress',
+      workIntervals: [{ startedAt: '2026-04-19T11:50:00.000Z' }],
+      comments: [
+        {
+          id: 'comment-strong',
+          author: 'Worker',
+          text: 'Found the failing test in src/app.ts and reproduced it with pnpm test.',
+          createdAt: '2026-04-19T12:00:00.000Z',
+          type: 'regular',
+        },
+      ],
+    };
+    const record = createRecord({
+      task: {
+        locator: {
+          ref: 'task-open-settled',
+          refKind: 'canonical',
+          canonicalId: 'task-open-settled',
+        },
+        resolution: 'resolved',
+        taskRef: {
+          taskId: 'task-open-settled',
+          displayId: 'feed4444',
+          teamName: 'demo',
+        },
+      },
+      actor: { memberName: 'Worker', role: 'member', sessionId: 'session-1', isSidechain: true },
+      action: {
+        canonicalToolName: 'task_add_comment',
+        category: 'comment',
+        toolUseId: 'tool-strong',
+        details: { commentId: 'comment-strong' },
+      },
+      source: {
+        messageUuid: 'msg-touch',
+        filePath: 'opencode-runtime:demo:worker',
+        toolUseId: 'tool-strong',
+        sourceOrder: 1,
+      },
+    });
+    // The orchestrator projection has no turn-end row: only the touch and an
+    // empty assistant message after it.
+    const exactRowsByFilePath = new Map([
+      [
+        'opencode-runtime:demo:worker',
+        [
+          createExactRow({
+            messageUuid: 'msg-touch',
+            toolUseIds: ['tool-strong'],
+          }),
+          createExactRow({
+            sourceOrder: 2,
+            messageUuid: 'msg-empty-assistant',
+            parsedMessage: createParsedMessage({ uuid: 'msg-empty-assistant' }),
+          }),
+        ],
+      ],
+    ]);
+    const baseSnapshot = {
+      activeTasks: [task],
+      allTasksById: new Map([[task.id, task]]),
+      inProgressTasks: [task],
+      providerByMemberName: new Map([['worker', 'opencode' as const]]),
+      recordsByTaskId: new Map([[task.id, [record]]]),
+      exactRowsByFilePath,
+    };
+
+    // Without lane state the classifier sees a mid-turn touch: 10-minute threshold.
+    const withoutLaneState = policy.evaluateWork({
+      now: new Date('2026-04-19T12:05:00.000Z'),
+      task,
+      snapshot: createSnapshot(baseSnapshot),
+    });
+    expect(withoutLaneState).toMatchObject({ status: 'skip', skipReason: 'below_threshold' });
+
+    // The lane settled after the touch: the turn ended, 4-minute threshold applies.
+    const settled = policy.evaluateWork({
+      now: new Date('2026-04-19T12:05:00.000Z'),
+      task,
+      snapshot: createSnapshot({
+        ...baseSnapshot,
+        openCodeLaneIdleSinceByMemberName: new Map([['worker', '2026-04-19T12:00:30.000Z']]),
+      }),
+    });
+    expect(settled).toMatchObject({
+      status: 'alert',
+      branch: 'work',
+      signal: 'turn_ended_after_touch',
+      memberName: 'Worker',
+    });
+    expect(settled.reason).toContain('OpenCode lane idle since 2026-04-19T12:00:30.000Z');
+
+    // A lane that went idle BEFORE the touch says nothing about this turn.
+    const staleIdle = policy.evaluateWork({
+      now: new Date('2026-04-19T12:05:00.000Z'),
+      task,
+      snapshot: createSnapshot({
+        ...baseSnapshot,
+        openCodeLaneIdleSinceByMemberName: new Map([['worker', '2026-04-19T11:59:00.000Z']]),
+      }),
+    });
+    expect(staleIdle).toMatchObject({ status: 'skip', skipReason: 'below_threshold' });
+
+    // A non-OpenCode owner is not reclassified by lane state at all: the very
+    // same settle sample must leave the 10-minute mid-turn threshold in place.
+    const nonOpenCodeOwner = policy.evaluateWork({
+      now: new Date('2026-04-19T12:05:00.000Z'),
+      task,
+      snapshot: createSnapshot({
+        ...baseSnapshot,
+        providerByMemberName: new Map([['worker', 'anthropic' as const]]),
+        openCodeLaneIdleSinceByMemberName: new Map([['worker', '2026-04-19T12:00:30.000Z']]),
+      }),
+    });
+    expect(nonOpenCodeOwner).toMatchObject({ status: 'skip', skipReason: 'below_threshold' });
+
+    // A lane still generating is never nudged, even past the 10-minute threshold.
+    const active = policy.evaluateWork({
+      now: new Date('2026-04-19T12:11:00.000Z'),
+      task,
+      snapshot: createSnapshot({
+        ...baseSnapshot,
+        openCodeLaneIdleSinceByMemberName: new Map(),
+        openCodeLaneActiveMemberNames: new Set(['worker']),
+      }),
+    });
+    expect(active).toMatchObject({ status: 'skip', skipReason: 'lane_active' });
+  });
+
+  it('leaves a non-OpenCode owner untouched by lane turn state', () => {
+    const task: TeamTask = {
+      id: 'task-anthropic-lane-noise',
+      displayId: 'feed6666',
+      subject: 'Anthropic owner with a same-named OpenCode lane sample',
+      owner: 'worker',
+      status: 'in_progress',
+      workIntervals: [{ startedAt: '2026-04-19T11:50:00.000Z' }],
+    };
+    const evaluation = policy.evaluateWork({
+      now: new Date('2026-04-19T12:11:00.000Z'),
+      task,
+      snapshot: createSnapshot({
+        activeTasks: [task],
+        allTasksById: new Map([[task.id, task]]),
+        inProgressTasks: [task],
+        providerByMemberName: new Map([['worker', 'anthropic']]),
+        openCodeLaneActiveMemberNames: new Set(['worker']),
+      }),
+    });
+    // The OpenCode-only guards must not swallow a non-OpenCode owner's stall.
+    expect(evaluation).toMatchObject({
+      status: 'skip',
+      skipReason: 'non_instrumented_run',
+    });
+  });
+
+  it('does not nudge an OpenCode owner without progress evidence while its lane is active', () => {
+    const task: TeamTask = {
+      id: 'task-open-active',
+      displayId: 'feed5555',
+      subject: 'OpenCode no evidence, lane busy',
+      owner: 'alice',
+      status: 'in_progress',
+      workIntervals: [{ startedAt: '2026-04-19T11:50:00.000Z' }],
+    };
+    const evaluation = policy.evaluateWork({
+      now: new Date('2026-04-19T12:00:00.000Z'),
+      task,
+      snapshot: createSnapshot({
+        activeTasks: [task],
+        allTasksById: new Map([[task.id, task]]),
+        inProgressTasks: [task],
+        providerByMemberName: new Map([['alice', 'opencode']]),
+        openCodeLaneActiveMemberNames: new Set(['alice']),
+      }),
+    });
+    expect(evaluation).toMatchObject({ status: 'skip', skipReason: 'lane_active' });
+  });
+
   it('alerts OpenCode-owned tasks with no instrumented owner progress after threshold', () => {
     const task: TeamTask = {
       id: 'task-open-no-progress',

--- a/test/main/services/team/stallMonitor/TeamTaskStallPolicy.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallPolicy.test.ts
@@ -886,6 +886,51 @@ describe('TeamTaskStallPolicy', () => {
     expect(evaluation.epochKey).toContain('opencode_no_owner_progress');
   });
 
+  it('lets the work branch keep alerting while the pickup gate is off', () => {
+    vi.stubEnv('CLAUDE_TEAM_PENDING_PICKUP_STALL_REMEDIATION_ENABLED', '0');
+
+    const inProgress: TeamTask = {
+      id: 'task-open-no-progress',
+      displayId: 'feed4444',
+      subject: 'OpenCode no progress',
+      owner: 'alice',
+      status: 'in_progress',
+      workIntervals: [{ startedAt: '2026-04-19T12:00:00.000Z' }],
+    };
+    const pending: TeamTask = {
+      id: 'task-pending',
+      displayId: 'feed5555',
+      subject: 'Never started',
+      owner: 'alice',
+      status: 'pending',
+      createdAt: '2026-04-19T12:00:00.000Z',
+    };
+    const snapshot = createSnapshot({
+      activeTasks: [inProgress, pending],
+      allTasksById: new Map([
+        [inProgress.id, inProgress],
+        [pending.id, pending],
+      ]),
+      inProgressTasks: [inProgress],
+      pendingPickupTasks: [pending],
+      providerByMemberName: new Map([['alice', 'opencode']]),
+    });
+    const now = new Date('2026-04-19T12:07:00.000Z');
+
+    expect(policy.evaluatePendingPickup({ now, task: pending, snapshot })).toMatchObject({
+      status: 'skip',
+      skipReason: 'pickup_remediation_disabled',
+    });
+    expect(policy.evaluateWork({ now, task: inProgress, snapshot })).toMatchObject({
+      status: 'alert',
+      taskId: 'task-open-no-progress',
+      branch: 'work',
+      signal: 'mid_turn_after_touch',
+    });
+
+    vi.unstubAllEnvs();
+  });
+
   it('keeps non-OpenCode no-progress tasks on the existing non-instrumented skip path', () => {
     const task: TeamTask = {
       id: 'task-codex-no-progress',

--- a/test/main/services/team/stallMonitor/TeamTaskStallPolicy.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallPolicy.test.ts
@@ -473,7 +473,7 @@ describe('TeamTaskStallPolicy', () => {
 
     expect(
       policy.evaluateWork({
-        now: new Date(touchAtMs + 100_000 - 1),
+        now: new Date(touchAtMs + 300_000 - 1),
         task,
         snapshot,
       })
@@ -484,7 +484,7 @@ describe('TeamTaskStallPolicy', () => {
     });
     expect(
       policy.evaluateWork({
-        now: new Date(touchAtMs + 100_000),
+        now: new Date(touchAtMs + 300_000),
         task,
         snapshot,
       })

--- a/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { OpenCodeLaneTurnActivityRegistry } from '../../../../../src/main/services/team/opencode/delivery/OpenCodeLaneTurnActivityRegistry';
+import { getOpenCodeLaneTurnActivityMaxAgeMs } from '../../../../../src/main/services/team/stallMonitor/featureGates';
 import { TeamTaskStallSnapshotSource } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource';
 
 describe('TeamTaskStallSnapshotSource', () => {
@@ -378,36 +379,72 @@ describe('TeamTaskStallSnapshotSource', () => {
 
   it('splits the recorded OpenCode lane turn samples into idle-since and active sets', async () => {
     const laneTurnActivity = new OpenCodeLaneTurnActivityRegistry();
+    // An idle sample never expires, so it can be as old as the run itself; an
+    // active one is evidence only while it is inside the max age.
+    const bobIdleSince = isoAgo(6 * ONE_HOUR_MS);
+    const carolActiveSince = isoAgo(ONE_MINUTE_MS);
     laneTurnActivity.note({
       teamName: 'demo',
       memberName: 'Bob',
       laneId: 'secondary:opencode:bob',
       state: 'idle',
-      observedAt: '2026-04-19T12:00:30.000Z',
+      observedAt: bobIdleSince,
     });
     laneTurnActivity.note({
       teamName: 'demo',
       memberName: 'Carol',
       laneId: 'secondary:opencode:carol',
       state: 'active',
-      observedAt: '2026-04-19T12:01:00.000Z',
+      observedAt: carolActiveSince,
     });
     laneTurnActivity.note({
       teamName: 'other-team',
       memberName: 'Dave',
       laneId: 'secondary:opencode:dave',
       state: 'active',
-      observedAt: '2026-04-19T12:02:00.000Z',
+      observedAt: isoAgo(ONE_MINUTE_MS),
     });
 
     const snapshot = await snapshotSourceWithLaneTurnActivity(laneTurnActivity).getSnapshot('demo');
 
     expect([...(snapshot?.openCodeLaneIdleSinceByMemberName ?? new Map())]).toEqual([
-      ['bob', '2026-04-19T12:00:30.000Z'],
+      ['bob', bobIdleSince],
     ]);
     expect([...(snapshot?.openCodeLaneActiveMemberNames ?? new Set())]).toEqual(['carol']);
+    expect([...(snapshot?.openCodeLaneActiveSinceByMemberName ?? new Map())]).toEqual([
+      ['carol', carolActiveSince],
+    ]);
+    expect(snapshot?.openCodeLaneStaleActiveSinceByMemberName?.size).toBe(0);
+  });
+
+  it('demotes an active lane sample that has outlived the turn-activity max age', async () => {
+    const staleActiveSince = isoAgo(getOpenCodeLaneTurnActivityMaxAgeMs() + ONE_MINUTE_MS);
+    const laneTurnActivity = new OpenCodeLaneTurnActivityRegistry();
+    laneTurnActivity.note({
+      teamName: 'demo',
+      memberName: 'Carol',
+      laneId: 'secondary:opencode:carol',
+      state: 'active',
+      observedAt: staleActiveSince,
+    });
+
+    const snapshot = await snapshotSourceWithLaneTurnActivity(laneTurnActivity).getSnapshot('demo');
+
+    expect([...(snapshot?.openCodeLaneActiveMemberNames ?? new Set())]).toEqual([]);
+    // Backdated to the original observation, never to the scan time: demoting
+    // to now would restart the pickup clock on every scan.
+    expect(snapshot?.openCodeLaneIdleSinceByMemberName?.get('carol')).toBe(staleActiveSince);
+    expect(snapshot?.openCodeLaneStaleActiveSinceByMemberName?.get('carol')).toBe(staleActiveSince);
+    expect(snapshot?.openCodeLaneActiveSinceByMemberName?.get('carol')).toBeUndefined();
   });
 });
+
+const ONE_MINUTE_MS = 60_000;
+const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+
+function isoAgo(ageMs: number): string {
+  return new Date(Date.now() - ageMs).toISOString();
+}
 
 function snapshotSourceWithLaneTurnActivity(
   laneTurnActivity: OpenCodeLaneTurnActivityRegistry

--- a/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
@@ -191,6 +191,104 @@ describe('TeamTaskStallSnapshotSource', () => {
     expect(snapshot?.recordsByTaskId).toBe(recordsByTaskId);
   });
 
+  it('collects owned pending tasks without widening any evidence read', async () => {
+    const activeTasks = [
+      { id: 'task-owned-pending', subject: 'Owned pending', status: 'pending', owner: 'Scout' },
+      { id: 'task-unowned-pending', subject: 'Unowned pending', status: 'pending' },
+      {
+        id: 'task-deleted-pending',
+        subject: 'Deleted pending',
+        status: 'pending',
+        owner: 'Scout',
+        deletedAt: '2026-04-19T12:00:00.000Z',
+      },
+      { id: 'task-active', subject: 'Active', status: 'in_progress', owner: 'Scout' },
+    ];
+    const freshnessReader = { readSignals: vi.fn(async () => new Map()) };
+    const exactRowReader = { parseFiles: vi.fn(async () => new Map()) };
+    const openCodeEvidenceSource = {
+      readEvidence: vi.fn(async () => ({
+        recordsByTaskId: new Map(),
+        exactRowsByFilePath: new Map(),
+      })),
+    };
+    const source = new TeamTaskStallSnapshotSource(
+      {
+        getContext: vi.fn(async () => ({
+          projectDir: '/tmp/project',
+          projectId: 'project-id',
+          config: {
+            members: [
+              { name: 'team-lead', role: 'team lead', providerId: 'codex' },
+              { name: 'Scout', role: 'Developer', providerId: 'opencode' },
+            ],
+          },
+          sessionIds: [],
+          transcriptFiles: [],
+        })),
+      } as never,
+      {
+        getTasks: vi.fn(async () => activeTasks),
+        getDeletedTasks: vi.fn(async () => []),
+      } as never,
+      { getState: vi.fn(async () => ({ teamName: 'demo', tasks: {} })) } as never,
+      { readFiles: vi.fn(async () => []) } as never,
+      { buildIndex: vi.fn(() => new Map()) } as never,
+      freshnessReader as never,
+      exactRowReader as never,
+      { getMembers: vi.fn(async () => []) } as never,
+      openCodeEvidenceSource as never
+    );
+
+    const snapshot = await source.getSnapshot('demo');
+
+    expect(snapshot?.pendingPickupTasks?.map((task) => task.id)).toEqual(['task-owned-pending']);
+    // Pickup candidates need no transcript evidence, so the per-scan IO stays
+    // scoped to in-progress and started-review tasks.
+    expect(freshnessReader.readSignals).toHaveBeenCalledWith('/tmp/project', ['task-active'], {
+      teamName: 'demo',
+    });
+    expect(exactRowReader.parseFiles).toHaveBeenCalledWith([]);
+    expect(openCodeEvidenceSource.readEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tasks: [expect.objectContaining({ id: 'task-active' })],
+      })
+    );
+  });
+
+  it('still yields a snapshot for a team with no session ids or transcripts', async () => {
+    const source = new TeamTaskStallSnapshotSource(
+      {
+        getContext: vi.fn(async () => ({
+          projectDir: '/tmp/project',
+          projectId: 'project-id',
+          config: { members: [{ name: 'acp-lead', role: 'team lead', providerId: 'opencode' }] },
+          sessionIds: [],
+          transcriptFiles: [],
+        })),
+      } as never,
+      { getTasks: vi.fn(async () => []), getDeletedTasks: vi.fn(async () => []) } as never,
+      { getState: vi.fn(async () => ({ teamName: 'demo', tasks: {} })) } as never,
+      { readFiles: vi.fn(async () => []) } as never,
+      { buildIndex: vi.fn(() => new Map()) } as never,
+      { readSignals: vi.fn(async () => new Map()) } as never,
+      { parseFiles: vi.fn(async () => new Map()) } as never,
+      { getMembers: vi.fn(async () => []) } as never,
+      {
+        readEvidence: vi.fn(async () => ({
+          recordsByTaskId: new Map(),
+          exactRowsByFilePath: new Map(),
+        })),
+      } as never
+    );
+
+    const snapshot = await source.getSnapshot('demo');
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.transcriptFiles).toEqual([]);
+    expect(snapshot?.pendingPickupTasks).toEqual([]);
+  });
+
   it('merges OpenCode runtime evidence even when no Claude transcript files are available', async () => {
     const task = {
       id: 'task-open',

--- a/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
@@ -1,4 +1,15 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// The under-floor override below is reported through the shared logger, and the
+// suite fails any test that reaches console.warn.
+vi.mock('@shared/utils/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
 
 import { OpenCodeLaneTurnActivityRegistry } from '../../../../../src/main/services/team/opencode/delivery/OpenCodeLaneTurnActivityRegistry';
 import { getOpenCodeLaneTurnActivityMaxAgeMs } from '../../../../../src/main/services/team/stallMonitor/featureGates';
@@ -437,6 +448,31 @@ describe('TeamTaskStallSnapshotSource', () => {
     expect(snapshot?.openCodeLaneStaleActiveSinceByMemberName?.get('carol')).toBe(staleActiveSince);
     expect(snapshot?.openCodeLaneActiveSinceByMemberName?.get('carol')).toBeUndefined();
   });
+
+  it('keeps a live lane active when the max-age override is below the ordering floor', async () => {
+    // 60 s is a positive integer, so the gate reader accepts it. Applied
+    // literally it would publish a member six minutes into an ordinary turn as
+    // idle, and the weak-start branch would nudge mid-generation.
+    vi.stubEnv('CLAUDE_TEAM_OPENCODE_LANE_TURN_ACTIVITY_MAX_AGE_MS', '60000');
+    const activeSince = isoAgo(6 * ONE_MINUTE_MS);
+    const laneTurnActivity = new OpenCodeLaneTurnActivityRegistry();
+    laneTurnActivity.note({
+      teamName: 'demo',
+      memberName: 'Carol',
+      laneId: 'secondary:opencode:carol',
+      state: 'active',
+      observedAt: activeSince,
+    });
+
+    const snapshot = await snapshotSourceWithLaneTurnActivity(laneTurnActivity).getSnapshot('demo');
+
+    expect([...(snapshot?.openCodeLaneActiveMemberNames ?? new Set())]).toEqual(['carol']);
+    expect(snapshot?.openCodeLaneStaleActiveSinceByMemberName?.size).toBe(0);
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 const ONE_MINUTE_MS = 60_000;

--- a/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
@@ -5,16 +5,9 @@ import { TeamTaskStallSnapshotSource } from '../../../../../src/main/services/te
 
 describe('TeamTaskStallSnapshotSource', () => {
   it('returns null when transcript context is unavailable', async () => {
-    const source = new TeamTaskStallSnapshotSource(
-      { getContext: vi.fn(async () => null) } as never,
-      {} as never,
-      {} as never,
-      {} as never,
-      {} as never,
-      {} as never,
-      {} as never,
-      {} as never
-    );
+    const source = new TeamTaskStallSnapshotSource({
+      transcriptSourceLocator: { getContext: vi.fn(async () => null) } as never,
+    });
 
     await expect(source.getSnapshot('demo')).resolves.toBeNull();
   });
@@ -133,17 +126,17 @@ describe('TeamTaskStallSnapshotSource', () => {
       })),
     };
 
-    const source = new TeamTaskStallSnapshotSource(
-      locator as never,
-      taskReader as never,
-      kanbanManager as never,
-      transcriptReader as never,
-      batchIndexer as never,
-      freshnessReader as never,
-      exactRowReader as never,
-      membersMetaStore as never,
-      openCodeEvidenceSource as never
-    );
+    const source = new TeamTaskStallSnapshotSource({
+      transcriptSourceLocator: locator as never,
+      taskReader: taskReader as never,
+      kanbanManager: kanbanManager as never,
+      transcriptReader: transcriptReader as never,
+      activityBatchIndexer: batchIndexer as never,
+      freshnessReader: freshnessReader as never,
+      exactRowReader: exactRowReader as never,
+      membersMetaStore: membersMetaStore as never,
+      openCodeEvidenceSource: openCodeEvidenceSource as never,
+    });
 
     const snapshot = await source.getSnapshot('demo');
     const expectedWorkflowActiveTasks = [
@@ -212,8 +205,8 @@ describe('TeamTaskStallSnapshotSource', () => {
         exactRowsByFilePath: new Map(),
       })),
     };
-    const source = new TeamTaskStallSnapshotSource(
-      {
+    const source = new TeamTaskStallSnapshotSource({
+      transcriptSourceLocator: {
         getContext: vi.fn(async () => ({
           projectDir: '/tmp/project',
           projectId: 'project-id',
@@ -227,18 +220,18 @@ describe('TeamTaskStallSnapshotSource', () => {
           transcriptFiles: [],
         })),
       } as never,
-      {
+      taskReader: {
         getTasks: vi.fn(async () => activeTasks),
         getDeletedTasks: vi.fn(async () => []),
       } as never,
-      { getState: vi.fn(async () => ({ teamName: 'demo', tasks: {} })) } as never,
-      { readFiles: vi.fn(async () => []) } as never,
-      { buildIndex: vi.fn(() => new Map()) } as never,
-      freshnessReader as never,
-      exactRowReader as never,
-      { getMembers: vi.fn(async () => []) } as never,
-      openCodeEvidenceSource as never
-    );
+      kanbanManager: { getState: vi.fn(async () => ({ teamName: 'demo', tasks: {} })) } as never,
+      transcriptReader: { readFiles: vi.fn(async () => []) } as never,
+      activityBatchIndexer: { buildIndex: vi.fn(() => new Map()) } as never,
+      freshnessReader: freshnessReader as never,
+      exactRowReader: exactRowReader as never,
+      membersMetaStore: { getMembers: vi.fn(async () => []) } as never,
+      openCodeEvidenceSource: openCodeEvidenceSource as never,
+    });
 
     const snapshot = await source.getSnapshot('demo');
 
@@ -257,8 +250,8 @@ describe('TeamTaskStallSnapshotSource', () => {
   });
 
   it('still yields a snapshot for a team with no session ids or transcripts', async () => {
-    const source = new TeamTaskStallSnapshotSource(
-      {
+    const source = new TeamTaskStallSnapshotSource({
+      transcriptSourceLocator: {
         getContext: vi.fn(async () => ({
           projectDir: '/tmp/project',
           projectId: 'project-id',
@@ -267,20 +260,23 @@ describe('TeamTaskStallSnapshotSource', () => {
           transcriptFiles: [],
         })),
       } as never,
-      { getTasks: vi.fn(async () => []), getDeletedTasks: vi.fn(async () => []) } as never,
-      { getState: vi.fn(async () => ({ teamName: 'demo', tasks: {} })) } as never,
-      { readFiles: vi.fn(async () => []) } as never,
-      { buildIndex: vi.fn(() => new Map()) } as never,
-      { readSignals: vi.fn(async () => new Map()) } as never,
-      { parseFiles: vi.fn(async () => new Map()) } as never,
-      { getMembers: vi.fn(async () => []) } as never,
-      {
+      taskReader: {
+        getTasks: vi.fn(async () => []),
+        getDeletedTasks: vi.fn(async () => []),
+      } as never,
+      kanbanManager: { getState: vi.fn(async () => ({ teamName: 'demo', tasks: {} })) } as never,
+      transcriptReader: { readFiles: vi.fn(async () => []) } as never,
+      activityBatchIndexer: { buildIndex: vi.fn(() => new Map()) } as never,
+      freshnessReader: { readSignals: vi.fn(async () => new Map()) } as never,
+      exactRowReader: { parseFiles: vi.fn(async () => new Map()) } as never,
+      membersMetaStore: { getMembers: vi.fn(async () => []) } as never,
+      openCodeEvidenceSource: {
         readEvidence: vi.fn(async () => ({
           recordsByTaskId: new Map(),
           exactRowsByFilePath: new Map(),
         })),
-      } as never
-    );
+      } as never,
+    });
 
     const snapshot = await source.getSnapshot('demo');
 
@@ -326,8 +322,8 @@ describe('TeamTaskStallSnapshotSource', () => {
         toolResultIds: [],
       },
     ];
-    const source = new TeamTaskStallSnapshotSource(
-      {
+    const source = new TeamTaskStallSnapshotSource({
+      transcriptSourceLocator: {
         getContext: vi.fn(async () => ({
           projectDir: '/tmp/project',
           projectId: 'project-id',
@@ -341,37 +337,37 @@ describe('TeamTaskStallSnapshotSource', () => {
           transcriptFiles: [],
         })),
       } as never,
-      {
+      taskReader: {
         getTasks: vi.fn(async () => [task]),
         getDeletedTasks: vi.fn(async () => []),
       } as never,
-      {
+      kanbanManager: {
         getState: vi.fn(async () => ({ teamName: 'demo', tasks: {} })),
       } as never,
-      {
+      transcriptReader: {
         readFiles: vi.fn(async () => {
           throw new Error('transcript reader should not be called');
         }),
       } as never,
-      {
+      activityBatchIndexer: {
         buildIndex: vi.fn(() => new Map()),
       } as never,
-      {
+      freshnessReader: {
         readSignals: vi.fn(async () => new Map()),
       } as never,
-      {
+      exactRowReader: {
         parseFiles: vi.fn(async () => new Map()),
       } as never,
-      {
+      membersMetaStore: {
         getMembers: vi.fn(async () => []),
       } as never,
-      {
+      openCodeEvidenceSource: {
         readEvidence: vi.fn(async () => ({
           recordsByTaskId: new Map([['task-open', [openCodeRecord]]]),
           exactRowsByFilePath: new Map([['opencode-runtime:demo:bob', openCodeRows]]),
         })),
-      } as never
-    );
+      } as never,
+    });
 
     const snapshot = await source.getSnapshot('demo');
 
@@ -416,8 +412,8 @@ describe('TeamTaskStallSnapshotSource', () => {
 function snapshotSourceWithLaneTurnActivity(
   laneTurnActivity: OpenCodeLaneTurnActivityRegistry
 ): TeamTaskStallSnapshotSource {
-  return new TeamTaskStallSnapshotSource(
-    {
+  return new TeamTaskStallSnapshotSource({
+    transcriptSourceLocator: {
       getContext: vi.fn(() =>
         Promise.resolve({
           projectDir: '/repo/project',
@@ -428,17 +424,19 @@ function snapshotSourceWithLaneTurnActivity(
         })
       ),
     } as never,
-    {
+    taskReader: {
       getTasks: vi.fn(() => Promise.resolve([])),
       getDeletedTasks: vi.fn(() => Promise.resolve([])),
     } as never,
-    { getState: vi.fn(() => Promise.resolve({ teamName: 'demo', tasks: {} })) } as never,
-    { readFiles: vi.fn(() => Promise.resolve(new Map())) } as never,
-    { buildIndex: vi.fn(() => new Map()) } as never,
-    { readSignals: vi.fn(() => Promise.resolve(new Map())) } as never,
-    { parseFiles: vi.fn(() => Promise.resolve(new Map())) } as never,
-    { getMembers: vi.fn(() => Promise.resolve([])) } as never,
-    {
+    kanbanManager: {
+      getState: vi.fn(() => Promise.resolve({ teamName: 'demo', tasks: {} })),
+    } as never,
+    transcriptReader: { readFiles: vi.fn(() => Promise.resolve(new Map())) } as never,
+    activityBatchIndexer: { buildIndex: vi.fn(() => new Map()) } as never,
+    freshnessReader: { readSignals: vi.fn(() => Promise.resolve(new Map())) } as never,
+    exactRowReader: { parseFiles: vi.fn(() => Promise.resolve(new Map())) } as never,
+    membersMetaStore: { getMembers: vi.fn(() => Promise.resolve([])) } as never,
+    openCodeEvidenceSource: {
       readEvidence: vi.fn(() =>
         Promise.resolve({
           recordsByTaskId: new Map(),
@@ -446,6 +444,6 @@ function snapshotSourceWithLaneTurnActivity(
         })
       ),
     } as never,
-    laneTurnActivity
-  );
+    laneTurnActivity,
+  });
 }

--- a/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
+++ b/test/main/services/team/stallMonitor/TeamTaskStallSnapshotSource.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { OpenCodeLaneTurnActivityRegistry } from '../../../../../src/main/services/team/opencode/delivery/OpenCodeLaneTurnActivityRegistry';
 import { TeamTaskStallSnapshotSource } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallSnapshotSource';
 
 describe('TeamTaskStallSnapshotSource', () => {
@@ -79,7 +80,10 @@ describe('TeamTaskStallSnapshotSource', () => {
       ],
     ]);
     const freshnessByTaskId = new Map([
-      ['task-a', { taskId: 'task-a', updatedAt: '2026-04-19T12:00:00.000Z', filePath: '/tmp/fresh.json' }],
+      [
+        'task-a',
+        { taskId: 'task-a', updatedAt: '2026-04-19T12:00:00.000Z', filePath: '/tmp/fresh.json' },
+      ],
     ]);
     const exactRowsByFilePath = new Map([['/tmp/project/session-b.jsonl', []]]);
 
@@ -158,7 +162,10 @@ describe('TeamTaskStallSnapshotSource', () => {
     expect(freshnessReader.readSignals).toHaveBeenCalledWith('/tmp/project', ['task-a', 'task-b'], {
       teamName: 'demo',
     });
-    expect(exactRowReader.parseFiles).toHaveBeenCalledWith(['/tmp/project/session-a.jsonl', '/tmp/project/session-b.jsonl']);
+    expect(exactRowReader.parseFiles).toHaveBeenCalledWith([
+      '/tmp/project/session-a.jsonl',
+      '/tmp/project/session-b.jsonl',
+    ]);
     expect(openCodeEvidenceSource.readEvidence).toHaveBeenCalledWith({
       teamName: 'demo',
       tasks: [expectedWorkflowActiveTasks[0], expectedWorkflowActiveTasks[1]],
@@ -274,4 +281,73 @@ describe('TeamTaskStallSnapshotSource', () => {
     expect(snapshot?.exactRowsByFilePath.get('opencode-runtime:demo:bob')).toEqual(openCodeRows);
     expect(snapshot?.transcriptFiles).toEqual([]);
   });
+
+  it('splits the recorded OpenCode lane turn samples into idle-since and active sets', async () => {
+    const laneTurnActivity = new OpenCodeLaneTurnActivityRegistry();
+    laneTurnActivity.note({
+      teamName: 'demo',
+      memberName: 'Bob',
+      laneId: 'secondary:opencode:bob',
+      state: 'idle',
+      observedAt: '2026-04-19T12:00:30.000Z',
+    });
+    laneTurnActivity.note({
+      teamName: 'demo',
+      memberName: 'Carol',
+      laneId: 'secondary:opencode:carol',
+      state: 'active',
+      observedAt: '2026-04-19T12:01:00.000Z',
+    });
+    laneTurnActivity.note({
+      teamName: 'other-team',
+      memberName: 'Dave',
+      laneId: 'secondary:opencode:dave',
+      state: 'active',
+      observedAt: '2026-04-19T12:02:00.000Z',
+    });
+
+    const snapshot = await snapshotSourceWithLaneTurnActivity(laneTurnActivity).getSnapshot('demo');
+
+    expect([...(snapshot?.openCodeLaneIdleSinceByMemberName ?? new Map())]).toEqual([
+      ['bob', '2026-04-19T12:00:30.000Z'],
+    ]);
+    expect([...(snapshot?.openCodeLaneActiveMemberNames ?? new Set())]).toEqual(['carol']);
+  });
 });
+
+function snapshotSourceWithLaneTurnActivity(
+  laneTurnActivity: OpenCodeLaneTurnActivityRegistry
+): TeamTaskStallSnapshotSource {
+  return new TeamTaskStallSnapshotSource(
+    {
+      getContext: vi.fn(() =>
+        Promise.resolve({
+          projectDir: '/repo/project',
+          projectId: 'project-id',
+          config: { members: [] },
+          sessionIds: [],
+          transcriptFiles: [],
+        })
+      ),
+    } as never,
+    {
+      getTasks: vi.fn(() => Promise.resolve([])),
+      getDeletedTasks: vi.fn(() => Promise.resolve([])),
+    } as never,
+    { getState: vi.fn(() => Promise.resolve({ teamName: 'demo', tasks: {} })) } as never,
+    { readFiles: vi.fn(() => Promise.resolve(new Map())) } as never,
+    { buildIndex: vi.fn(() => new Map()) } as never,
+    { readSignals: vi.fn(() => Promise.resolve(new Map())) } as never,
+    { parseFiles: vi.fn(() => Promise.resolve(new Map())) } as never,
+    { getMembers: vi.fn(() => Promise.resolve([])) } as never,
+    {
+      readEvidence: vi.fn(() =>
+        Promise.resolve({
+          recordsByTaskId: new Map(),
+          exactRowsByFilePath: new Map(),
+        })
+      ),
+    } as never,
+    laneTurnActivity
+  );
+}

--- a/test/main/services/team/stallMonitor/featureGates.test.ts
+++ b/test/main/services/team/stallMonitor/featureGates.test.ts
@@ -2,10 +2,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   getOpenCodeWeakStartStallThresholdMs,
+  getPendingPickupStallThresholdMs,
   getTeamTaskStallActivationGraceMs,
   getTeamTaskStallScanIntervalMs,
   getTeamTaskStallStartupGraceMs,
   isOpenCodeTaskStallRemediationEnabled,
+  isPendingPickupStallRemediationEnabled,
   isTeamTaskStallAlertsEnabled,
   isTeamTaskStallMonitorEnabled,
   isTeamTaskStallScannerEnabled,
@@ -25,6 +27,44 @@ describe('stallMonitor feature gates', () => {
     expect(getTeamTaskStallStartupGraceMs()).toBe(180_000);
     expect(getTeamTaskStallActivationGraceMs()).toBe(60_000);
     expect(getOpenCodeWeakStartStallThresholdMs()).toBe(100_000);
+    expect(getPendingPickupStallThresholdMs()).toBe(300_000);
+    expect(isPendingPickupStallRemediationEnabled()).toBe(true);
+  });
+
+  it('reads the pending pickup gates from the environment', () => {
+    vi.stubEnv('CLAUDE_TEAM_PENDING_PICKUP_STALL_THRESHOLD_MS', '120000');
+    vi.stubEnv('CLAUDE_TEAM_PENDING_PICKUP_STALL_REMEDIATION_ENABLED', '0');
+
+    expect(getPendingPickupStallThresholdMs()).toBe(120_000);
+    expect(isPendingPickupStallRemediationEnabled()).toBe(false);
+  });
+
+  it.each(['0', '-1', 'soon', ''])(
+    'keeps the default pending pickup threshold for the invalid value %j',
+    (value) => {
+      vi.stubEnv('CLAUDE_TEAM_PENDING_PICKUP_STALL_THRESHOLD_MS', value);
+
+      expect(getPendingPickupStallThresholdMs()).toBe(300_000);
+    }
+  );
+
+  it('scopes the pickup gate to the pickup branch alone', () => {
+    vi.stubEnv('CLAUDE_TEAM_PENDING_PICKUP_STALL_REMEDIATION_ENABLED', '0');
+
+    expect(isPendingPickupStallRemediationEnabled()).toBe(false);
+    // Everything the other stall branches read is untouched: the pickup flag is
+    // not a master switch for the monitor.
+    expect(isTeamTaskStallMonitorEnabled()).toBe(true);
+    expect(isOpenCodeTaskStallRemediationEnabled()).toBe(true);
+    expect(isTeamTaskStallScannerEnabled()).toBe(true);
+    expect(isTeamTaskStallAlertsEnabled()).toBe(true);
+    expect(getOpenCodeWeakStartStallThresholdMs()).toBe(100_000);
+  });
+
+  it('keeps pending pickup remediation enabled for an unparseable flag', () => {
+    vi.stubEnv('CLAUDE_TEAM_PENDING_PICKUP_STALL_REMEDIATION_ENABLED', 'maybe');
+
+    expect(isPendingPickupStallRemediationEnabled()).toBe(true);
   });
 
   it('parses truthy and falsy environment values', () => {

--- a/test/main/services/team/stallMonitor/featureGates.test.ts
+++ b/test/main/services/team/stallMonitor/featureGates.test.ts
@@ -26,7 +26,7 @@ describe('stallMonitor feature gates', () => {
     expect(getTeamTaskStallScanIntervalMs()).toBe(30_000);
     expect(getTeamTaskStallStartupGraceMs()).toBe(180_000);
     expect(getTeamTaskStallActivationGraceMs()).toBe(60_000);
-    expect(getOpenCodeWeakStartStallThresholdMs()).toBe(100_000);
+    expect(getOpenCodeWeakStartStallThresholdMs()).toBe(300_000);
     expect(getPendingPickupStallThresholdMs()).toBe(300_000);
     expect(isPendingPickupStallRemediationEnabled()).toBe(true);
   });
@@ -58,7 +58,7 @@ describe('stallMonitor feature gates', () => {
     expect(isOpenCodeTaskStallRemediationEnabled()).toBe(true);
     expect(isTeamTaskStallScannerEnabled()).toBe(true);
     expect(isTeamTaskStallAlertsEnabled()).toBe(true);
-    expect(getOpenCodeWeakStartStallThresholdMs()).toBe(100_000);
+    expect(getOpenCodeWeakStartStallThresholdMs()).toBe(300_000);
   });
 
   it('keeps pending pickup remediation enabled for an unparseable flag', () => {
@@ -115,6 +115,6 @@ describe('stallMonitor feature gates', () => {
     expect(isOpenCodeTaskStallRemediationEnabled()).toBe(true);
     expect(isTeamTaskStallScannerEnabled()).toBe(true);
     expect(isTeamTaskStallAlertsEnabled()).toBe(true);
-    expect(getOpenCodeWeakStartStallThresholdMs()).toBe(100_000);
+    expect(getOpenCodeWeakStartStallThresholdMs()).toBe(300_000);
   });
 });

--- a/test/main/services/team/stallMonitor/openCodeLaneTurnFreshness.test.ts
+++ b/test/main/services/team/stallMonitor/openCodeLaneTurnFreshness.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getOpenCodeLaneTurnActivityMaxAgeMs,
+  getOpenCodeWeakStartStallThresholdMs,
+  getPendingPickupStallThresholdMs,
+} from '../../../../../src/main/services/team/stallMonitor/featureGates';
+import { classifyOpenCodeLaneTurnSample } from '../../../../../src/main/services/team/stallMonitor/openCodeLaneTurnFreshness';
+import { WORK_THRESHOLDS_MS } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallPolicy';
+
+const OBSERVED_AT = '2026-04-19T12:00:00.000Z';
+const OBSERVED_AT_MS = Date.parse(OBSERVED_AT);
+const MAX_AGE_MS = 10 * 60_000;
+
+function classifyActiveAtAge(ageMs: number) {
+  return classifyOpenCodeLaneTurnSample({
+    sample: { laneId: 'secondary:opencode:scout', state: 'active', observedAt: OBSERVED_AT },
+    nowMs: OBSERVED_AT_MS + ageMs,
+    maxAgeMs: MAX_AGE_MS,
+  });
+}
+
+describe('getOpenCodeLaneTurnActivityMaxAgeMs ordering invariant', () => {
+  it('stays at or above every OpenCode stall threshold the lane_active guard can unlock', () => {
+    const maxAgeMs = getOpenCodeLaneTurnActivityMaxAgeMs();
+
+    // A demotion publishes a backdated idle time that the work branch reads as
+    // "the turn ended at that moment". Below any of these thresholds a
+    // legitimately long turn is demoted mid-generation and the `lane_active`
+    // guard becomes unreachable for exactly the turns it exists to protect.
+    expect(maxAgeMs).toBeGreaterThanOrEqual(WORK_THRESHOLDS_MS.mid_turn_after_touch);
+    expect(maxAgeMs).toBeGreaterThanOrEqual(WORK_THRESHOLDS_MS.touch_then_other_turns);
+    expect(maxAgeMs).toBeGreaterThanOrEqual(WORK_THRESHOLDS_MS.turn_ended_after_touch);
+    expect(maxAgeMs).toBeGreaterThanOrEqual(getOpenCodeWeakStartStallThresholdMs());
+    expect(maxAgeMs).toBeGreaterThanOrEqual(getPendingPickupStallThresholdMs());
+  });
+});
+
+describe('classifyOpenCodeLaneTurnSample', () => {
+  it('never treats an idle sample as stale, however old it is', () => {
+    const verdict = classifyOpenCodeLaneTurnSample({
+      sample: { laneId: 'secondary:opencode:scout', state: 'idle', observedAt: OBSERVED_AT },
+      nowMs: OBSERVED_AT_MS + 1000 * MAX_AGE_MS,
+      maxAgeMs: MAX_AGE_MS,
+    });
+
+    // "The turn ended" does not decay: only a new 'active' sample can undo it.
+    expect(verdict).toEqual({ treatAsActive: false, idleSince: OBSERVED_AT });
+    expect(verdict.staleActiveSince).toBeUndefined();
+  });
+
+  it('treats an active sample with an unparsable observation time as stale', () => {
+    const verdict = classifyOpenCodeLaneTurnSample({
+      sample: { laneId: 'secondary:opencode:scout', state: 'active', observedAt: 'not-a-date' },
+      nowMs: OBSERVED_AT_MS,
+      maxAgeMs: MAX_AGE_MS,
+    });
+
+    // Fail-safe direction is "do not stay silent". No idle time is published
+    // either, so the pickup branch falls back to its own readiness clock rather
+    // than starting from a timestamp nobody can read.
+    expect(verdict).toEqual({
+      treatAsActive: false,
+      idleSince: null,
+      staleActiveSince: 'not-a-date',
+    });
+  });
+
+  it('expires an active sample exactly at the max age and not one millisecond earlier', () => {
+    expect(classifyActiveAtAge(MAX_AGE_MS - 1)).toEqual({
+      treatAsActive: true,
+      idleSince: null,
+      activeSince: OBSERVED_AT,
+    });
+    expect(classifyActiveAtAge(MAX_AGE_MS)).toEqual({
+      treatAsActive: false,
+      idleSince: OBSERVED_AT,
+      staleActiveSince: OBSERVED_AT,
+    });
+  });
+
+  it('backdates a demoted sample to its original observation instead of to now', () => {
+    // Demoting to `now` would restart the pickup clock on every scan and
+    // re-hide the stall for another threshold window.
+    expect(classifyActiveAtAge(50 * MAX_AGE_MS).idleSince).toBe(OBSERVED_AT);
+  });
+});

--- a/test/main/services/team/stallMonitor/openCodeLaneTurnFreshness.test.ts
+++ b/test/main/services/team/stallMonitor/openCodeLaneTurnFreshness.test.ts
@@ -1,12 +1,31 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { laneFreshnessWarn } = vi.hoisted(() => ({ laneFreshnessWarn: vi.fn() }));
+
+vi.mock('@shared/utils/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: laneFreshnessWarn,
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
 
 import {
   getOpenCodeLaneTurnActivityMaxAgeMs,
   getOpenCodeWeakStartStallThresholdMs,
   getPendingPickupStallThresholdMs,
 } from '../../../../../src/main/services/team/stallMonitor/featureGates';
-import { classifyOpenCodeLaneTurnSample } from '../../../../../src/main/services/team/stallMonitor/openCodeLaneTurnFreshness';
+import {
+  classifyOpenCodeLaneTurnSample,
+  resolveOpenCodeLaneTurnActivityMaxAgeMs,
+} from '../../../../../src/main/services/team/stallMonitor/openCodeLaneTurnFreshness';
 import { WORK_THRESHOLDS_MS } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallPolicy';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  laneFreshnessWarn.mockClear();
+});
 
 const OBSERVED_AT = '2026-04-19T12:00:00.000Z';
 const OBSERVED_AT_MS = Date.parse(OBSERVED_AT);
@@ -20,19 +39,73 @@ function classifyActiveAtAge(ageMs: number) {
   });
 }
 
+function expectOrderingInvariant(maxAgeMs: number): void {
+  // A demotion publishes a backdated idle time that the work branch reads as
+  // "the turn ended at that moment". Below any of these thresholds a
+  // legitimately long turn is demoted mid-generation and the `lane_active`
+  // guard becomes unreachable for exactly the turns it exists to protect.
+  expect(maxAgeMs).toBeGreaterThanOrEqual(WORK_THRESHOLDS_MS.mid_turn_after_touch);
+  expect(maxAgeMs).toBeGreaterThanOrEqual(WORK_THRESHOLDS_MS.touch_then_other_turns);
+  expect(maxAgeMs).toBeGreaterThanOrEqual(WORK_THRESHOLDS_MS.turn_ended_after_touch);
+  expect(maxAgeMs).toBeGreaterThanOrEqual(getOpenCodeWeakStartStallThresholdMs());
+  expect(maxAgeMs).toBeGreaterThanOrEqual(getPendingPickupStallThresholdMs());
+}
+
 describe('getOpenCodeLaneTurnActivityMaxAgeMs ordering invariant', () => {
   it('stays at or above every OpenCode stall threshold the lane_active guard can unlock', () => {
-    const maxAgeMs = getOpenCodeLaneTurnActivityMaxAgeMs();
+    expectOrderingInvariant(getOpenCodeLaneTurnActivityMaxAgeMs());
+  });
+});
 
-    // A demotion publishes a backdated idle time that the work branch reads as
-    // "the turn ended at that moment". Below any of these thresholds a
-    // legitimately long turn is demoted mid-generation and the `lane_active`
-    // guard becomes unreachable for exactly the turns it exists to protect.
-    expect(maxAgeMs).toBeGreaterThanOrEqual(WORK_THRESHOLDS_MS.mid_turn_after_touch);
-    expect(maxAgeMs).toBeGreaterThanOrEqual(WORK_THRESHOLDS_MS.touch_then_other_turns);
-    expect(maxAgeMs).toBeGreaterThanOrEqual(WORK_THRESHOLDS_MS.turn_ended_after_touch);
-    expect(maxAgeMs).toBeGreaterThanOrEqual(getOpenCodeWeakStartStallThresholdMs());
-    expect(maxAgeMs).toBeGreaterThanOrEqual(getPendingPickupStallThresholdMs());
+describe('resolveOpenCodeLaneTurnActivityMaxAgeMs', () => {
+  it('holds the ordering invariant against an environment override, not only the default', () => {
+    // The default satisfies the invariant, but a default is not a bound: this
+    // override would demote a lane one minute into a five-minute turn and take
+    // the `lane_active` guard off exactly the turns it protects.
+    vi.stubEnv('CLAUDE_TEAM_OPENCODE_LANE_TURN_ACTIVITY_MAX_AGE_MS', '60000');
+
+    const resolvedMs = resolveOpenCodeLaneTurnActivityMaxAgeMs();
+
+    expect(resolvedMs).toBe(WORK_THRESHOLDS_MS.mid_turn_after_touch);
+    expectOrderingInvariant(resolvedMs);
+  });
+
+  it('raises the floor with the thresholds it protects', () => {
+    // The weak-start threshold is itself overridable, and a lane bound below it
+    // is under-floor however large it looks on its own.
+    vi.stubEnv('CLAUDE_TEAM_OPENCODE_WEAK_START_STALL_THRESHOLD_MS', '1800000');
+    vi.stubEnv('CLAUDE_TEAM_OPENCODE_LANE_TURN_ACTIVITY_MAX_AGE_MS', '900000');
+
+    const resolvedMs = resolveOpenCodeLaneTurnActivityMaxAgeMs();
+
+    expect(resolvedMs).toBe(1_800_000);
+    expectOrderingInvariant(resolvedMs);
+  });
+
+  it('passes through the default and any override at or above the floor', () => {
+    expect(resolveOpenCodeLaneTurnActivityMaxAgeMs()).toBe(getOpenCodeLaneTurnActivityMaxAgeMs());
+
+    // Longer is always safe: a lane stays trusted as mid-turn for longer, which
+    // can only delay an alert, never fire one inside a live turn.
+    vi.stubEnv('CLAUDE_TEAM_OPENCODE_LANE_TURN_ACTIVITY_MAX_AGE_MS', '1200000');
+    expect(resolveOpenCodeLaneTurnActivityMaxAgeMs()).toBe(1_200_000);
+    expect(laneFreshnessWarn).not.toHaveBeenCalled();
+  });
+
+  it('reports an out-of-range override once instead of on every scan', () => {
+    vi.stubEnv('CLAUDE_TEAM_OPENCODE_LANE_TURN_ACTIVITY_MAX_AGE_MS', '61000');
+
+    resolveOpenCodeLaneTurnActivityMaxAgeMs();
+    resolveOpenCodeLaneTurnActivityMaxAgeMs();
+    resolveOpenCodeLaneTurnActivityMaxAgeMs();
+
+    // The scan runs every 30 s, so a warn per read would be a log flood for a
+    // setting that is wrong exactly once, at startup.
+    expect(laneFreshnessWarn).toHaveBeenCalledTimes(1);
+    expect(laneFreshnessWarn.mock.calls[0][0]).toContain('61000');
+    expect(laneFreshnessWarn.mock.calls[0][0]).toContain(
+      String(WORK_THRESHOLDS_MS.mid_turn_after_touch)
+    );
   });
 });
 

--- a/test/main/services/team/stallMonitor/openCodeLaneTurnFreshness.test.ts
+++ b/test/main/services/team/stallMonitor/openCodeLaneTurnFreshness.test.ts
@@ -15,12 +15,12 @@ import {
   getOpenCodeLaneTurnActivityMaxAgeMs,
   getOpenCodeWeakStartStallThresholdMs,
   getPendingPickupStallThresholdMs,
-} from '../../../../../src/main/services/team/stallMonitor/featureGates';
+} from '@main/services/team/stallMonitor/featureGates';
 import {
   classifyOpenCodeLaneTurnSample,
   resolveOpenCodeLaneTurnActivityMaxAgeMs,
-} from '../../../../../src/main/services/team/stallMonitor/openCodeLaneTurnFreshness';
-import { WORK_THRESHOLDS_MS } from '../../../../../src/main/services/team/stallMonitor/TeamTaskStallPolicy';
+} from '@main/services/team/stallMonitor/openCodeLaneTurnFreshness';
+import { WORK_THRESHOLDS_MS } from '@main/services/team/stallMonitor/TeamTaskStallPolicy';
 
 afterEach(() => {
   vi.unstubAllEnvs();

--- a/test/main/sourceControlCharacters.test.ts
+++ b/test/main/sourceControlCharacters.test.ts
@@ -1,0 +1,64 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * A raw control character in a source file makes git treat it as binary: the
+ * diff reports `Bin 2671 -> 3600 bytes` instead of lines, review sees nothing,
+ * and the source-size guard cannot count it. This has happened twice in this
+ * repository, both times because a NUL byte was written where the escape
+ * sequence was meant, in a map-key separator. Control characters belong in
+ * string escapes, never in the bytes of a source file.
+ */
+const ALLOWED_CONTROL_CHARACTERS = new Set(['\t', '\n', '\r']);
+const SOURCE_EXTENSIONS = ['.ts', '.tsx'];
+
+const sourceRoot = path.resolve(__dirname, '..', '..', 'src');
+
+async function listSourceFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listSourceFiles(entryPath)));
+    } else if (SOURCE_EXTENSIONS.includes(path.extname(entry.name))) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+function findControlCharacter(contents: string): { line: number; codePoint: number } | null {
+  const lines = contents.split('\n');
+  for (const [index, line] of lines.entries()) {
+    for (const character of line) {
+      const codePoint = character.codePointAt(0) ?? 0;
+      if (codePoint < 0x20 && !ALLOWED_CONTROL_CHARACTERS.has(character)) {
+        return { line: index + 1, codePoint };
+      }
+    }
+  }
+  return null;
+}
+
+describe('source control characters', () => {
+  it('has no raw control characters in any TypeScript source file', async () => {
+    const files = await listSourceFiles(sourceRoot);
+    expect(files.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const found = findControlCharacter(await readFile(file, 'utf8'));
+      if (!found) continue;
+      const relative = path.relative(sourceRoot, file).replaceAll('\\', '/');
+      const codePoint = found.codePoint.toString(16).padStart(4, '0').toUpperCase();
+      offenders.push(
+        `src/${relative}:${found.line} contains U+${codePoint} — use the escape sequence instead`
+      );
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
Builds on #565 (merged), which made the OpenCode lead report its turn activity and kept a stale pending lead delivery from blocking the lane. #568 (merged) then made that lead-activity path asynchronous, serialised it per team and put four guards in front of the `setLeadActivity` write: the lane must be primary, the notification must carry a run id, the recipient must pass `isOpenCodeLeadRecipient` against a freshly read member directory, and the run must still be the tracked one. This branch arms its fallback only past those guards.

## Problem

Seven defects. The first three are missing or wrong consumers of the turn-activity signal #565 introduced; the next three are stalls that signal makes it possible to see; the last is the hole the new signal opens if nothing bounds it. All were observed on live mixed-provider runs during an earlier campaign.

**1. An OpenCode aggregate run is born in a state it can never leave.** `createOpenCodeAggregateProvisioningRun` seeded `leadActivityState: 'active'`, and `setLeadActivity` is a pure state-change emitter, so the run's first genuine `active` was a no-op and the run stayed `active` until something reported `idle`. `TeamProvisioningIdlePromptInjection` defers both the post-compact reminder and the Gemini post-launch hydration while `run.leadActivityState !== 'idle'`, so an OpenCode aggregate run never received a post-compact reminder. This one is visible on `main` today, without any of the rest of this branch.

**2. A lead card stuck on "processing".** The OpenCode lead has no stdin stream, so `idle` can only arrive from a prompt-delivery settle. When a runtime keeps its session marked busy after a plain-text turn end, the settle path never runs, no `idle` is ever reported, and the lead card stays "processing" for the rest of the session while every consumer that gates on lead activity waits behind a turn that finished long ago.

**3. The stall monitor could not see a secondary lane's turn.** The delivery service is the only place that knows when an OpenCode lane's turn starts and ends, and it discarded that for every lane except the primary one. The orchestrator transcript projection carries no turn-end row for an OpenCode lane, so a member that finished its turn without writing a comment looked identical to one still generating: the policy classified it `mid_turn_after_touch` (ten minutes), the work-sync nudge fired first, and the monitor never recorded why it stayed silent. The mirror image is just as bad: a nudge could land in the middle of a live turn.

**4. A task nobody picks up is invisible.** The stall monitor watched in-progress and in-review tasks. A task that was never started sat outside its view, so the one failure the board cannot recover from on its own went unnoticed: a task is assigned, its blockers complete, the controller posts the "Dependency resolved" notice to the owner, and the owner never calls `task_start`. The board sits at pending with nothing in progress and nobody waiting on anything.

**5. A work-sync nudge landed inside the turn it complained about.** An OpenCode member runs one turn at a time and a turn can take minutes. Targeted work-sync recovery fired on the agenda change itself, so a member that had just moved a task to in_progress got an agenda-sync nudge about twenty seconds later, abandoned the work to answer it, and the remediation became the stall. The OpenCode weak-start threshold of 100 s was shorter than one ordinary turn for the same reason. On the controller side, a member that did answer frequently copied the `wrs:v1.<payload>.<signature>` report token but omitted `memberName`, and every report then failed with "Unknown member work sync report member: .", so the member looped on the tool for minutes instead of working.

**6. Every reply to the user produced a warning.** `inboxes/user.json` and `inboxes/system.json` are app-owned files that no runtime consumes, but the inbox file watcher re-entered `relayInboxFileToLiveRecipientWithPorts` for every write to them, read the team config and the members metadata, failed to canonicalise `user` to any member, and returned an `Ignored` result carrying a diagnostic. The watcher escalates a non-empty diagnostics array to a warn line, so a healthy conversation produced one warn and two avoidable file reads per message.

**7. A stale lane-active sample can silence the monitor.** Once the monitor reads the lane turn state (defect 3), the registry behind it is a last-write-wins in-memory map written by the delivery service's own settle paths, and nothing expires a sample. A lane whose settle never runs keeps advertising the same `active` reading for as long as the jam lasts, and every OpenCode stall branch reads that flag as "the owner is working, stay quiet". The subsystem the monitor supervises could therefore switch the monitor off, and the longer the fault lasted the longer the silence. It is not hypothetical: in a multi-hour run a delivery record accepted at 08:09:43.105Z sat at `status: retry_scheduled`, `responseState: not_observed`, `lastTurnProgressAt: null` until 08:19:41.340Z. For ten minutes nothing moved in the ledger, the sample stayed `active @ 08:09:43.105Z`, and a pending task whose blockers had all resolved at 08:09:55.325Z, owner working nothing else, was skipped on every scan while the stall journal stayed empty.

## Fix

**1. Seed the aggregate run idle.** `createOpenCodeAggregateProvisioningRun` in `TeamProvisioningOpenCodeAggregateRunModel.ts` seeds `leadActivityState: 'idle'`, the truthful state of a run that has not yet delivered a prompt. Making `setLeadActivity` re-emit equal states would fix the symptom and change every other caller, so it stays a pure state-change emitter.

**2. A lead turn without a settle signal falls back to idle.** `TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityService` arms a bounded fallback whenever it actually reports `active`: if no newer notification arrives within `OPENCODE_LEAD_ACTIVE_FALLBACK_MS` (four minutes) it re-resolves the tracked run through `resolveLeadActivityRun` and reports `idle`. The arming sits inside `applyOpenCodeLeadTurnActivity` and after every guard #568 added, so a notification that path drops neither arms a fallback nor disarms the one the live turn is relying on. Every accepted notification cancels the pending fallback first, so a real `idle` disarms it, repeated `active` reports restart one timer instead of accumulating several, a team with no tracked run arms nothing, and `unref()` keeps a pending fallback from holding the process open. It is a fallback, not a source of truth: when it fires it re-resolves the run and re-checks the same run identity, so it cannot write into a run that was replaced or stopped meanwhile.

**3. The lane turn registry records every lane.** `OpenCodeLaneTurnActivityRegistry.ts` keeps the last `OpenCodeLaneTurnActivitySample` per team member in memory, and `noteOpenCodeLaneTurnActivity` becomes the single entry point `OpenCodeMemberMessageDeliveryService` calls: it records every lane unconditionally, then mirrors the sample to the lead-activity notifier only for a recipient the caller resolved as the lead. That is #568's `isOpenCodeLeadRecipient`, which the delivery service already computes once per delivery, so its per-delivery `notifyActivity` closure keeps its signature and every call site and no delivery path had to learn about the registry. Lane membership stays out of the decision: same-model teammates share the primary lane, so a teammate's primary-lane turn is recorded without ever touching the lead card. The registry write comes first and outside the try/catch that guards the notifier: a secondary lane has no lead card to update but its turn state is exactly what the monitor needs, and a notifier that throws must not cost the caller the sample it just observed. The registry is deliberately in-memory and per-process; the policy treats an absent sample as unknown, never as active. Production readers are `note` (the delivery service) and `listTeam` (the snapshot source); `get`, `getIdleSince` and `clear` are read and reset helpers its own tests use. The map key folds team and member with a `\u0000` escape, and that separator has twice been committed to this repository as a raw NUL byte, which makes git treat the file as binary and hides the diff from review, so `test/main/sourceControlCharacters.test.ts` now fails the build if a control character other than tab, newline or carriage return appears in any TypeScript source.

**4. The stall monitor reads the lane turn state.** `TeamTaskStallSnapshot` gains `openCodeLaneIdleSinceByMemberName` and `openCodeLaneActiveMemberNames`, filled by `TeamTaskStallSnapshotSource.collectOpenCodeLaneTurnActivity`, and `TeamTaskStallPolicy` uses them for `ownerProviderId === 'opencode'` only. A lane that settled at or after the last task touch means the turn ended, so an `ambiguous` or `mid_turn_after_touch` classification becomes `turn_ended_after_touch` (four minutes) and the alert reason names the settle time. A lane still running a turn is never nudged, under the new `lane_active` skip reason, in the post-touch branch and in both weak-start branches. A settle recorded before the touch says nothing about the current turn and is ignored. The lane state is advisory and only ever sharpens a decision the policy already had to make; both fields are optional, so every existing caller keeps working. `TeamTaskStallMonitor` additionally logs, rate-limited per task and reason (`OPENCODE_SKIP_LOG_INTERVAL_MS`), every OpenCode-owned task past the weak-start threshold that was not alerted, with the skip reason and the lane state from `describeOpenCodeLane`, plus alerts the journal has been holding for longer than `OPENCODE_HELD_ALERT_LOG_DELAY_MS`. The previous incident of this class could only be diagnosed by reading the delivery ledger by hand.

**5. A pending task whose blockers are resolved gets a bounded pickup escalation.** `TeamTaskStallPendingPickup.ts` adds the branch and `TeamTaskStallPolicy.evaluatePendingPickup` exposes it; the snapshot collects `pendingPickupTasks` without widening any transcript or exact-log read, because the branch needs no transcript evidence. `resolvePendingPickupReadyAt` starts the clock at the `dep-resolved-<blocker>-<task>` comment the app itself wrote (system-authored only, since `resolveTaskCommentAuthorName` rejects `from: 'system'` for agent tool calls, so an agent cannot forge its own reprieve) or, for a task that never had a blocker, at creation or the assignment to this owner, whichever is later. A task whose blockers are listed but never reported resolved has no trustworthy clock and is skipped (`no_unblock_evidence`). An owner already running another task is not nudged about the queue behind it. The escalation is bounded, which is the part worth reviewing: the journal counts alerts per epoch (`alertCount`, stamped back as `priorAlertCount`), `TeamTaskStallMonitor.planPickupEscalation` spends it on a two-rung ladder (`PICKUP_ESCALATION_RUNGS` = 2, so nudge the owner once, tell the lead once, then stay silent) and `logExhaustedPickupEscalations` reports the ladder spent exactly once; within a scan only the oldest pending task per member is sent, and the rest are left unjournaled so the next scan reconsiders them. The existing two-scan confirmation and alert cooldown gate every rung. Three supporting changes: `TaskStallJournalStore` validated signals against an inline literal triple, so a `pending_pickup_after_unblock` entry would have been dropped on every read and the two-scan counter could never reach two (it now goes through one `VALID_SIGNALS` set); pickup task ids join `activeTaskIds` so the journal does not prune them; and `TeamTaskStallNotifier` no longer counts a relay that reports success for a message the member already read as remediation (`NO_OP_DELIVERY_REASONS`), because retiring an alert against a no-op strands the escalation on its first rung. Two gates in the existing `featureGates.ts` pattern: `CLAUDE_TEAM_PENDING_PICKUP_STALL_REMEDIATION_ENABLED` (default on) and `CLAUDE_TEAM_PENDING_PICKUP_STALL_THRESHOLD_MS` (default 5 min).

**6. A work-sync nudge never interrupts a member mid-turn.** In `MemberWorkSyncNudgeActivationPolicy`, targeted recovery with capability `opencode_runtime_delivery` for a member with an owned in-progress task waits until the current needs_sync agenda has been stable for `OPENCODE_TARGETED_RECOVERY_MIN_QUIET_MS` (ten minutes) and reports the new `opencode_quiet_window` reason. Only a member that is visibly working is held: assigned-but-never-started work keeps its nudge, and an unobserved member is not a working member, so with no sample recorded the nudge goes out rather than being withheld on a guess. `getOpenCodeWeakStartStallThresholdMs` moves from 100 s to 5 minutes for the same reason. On the controller side, `memberNameFromReportToken` in `agent-teams-controller/src/internal/workSync.js` reads the report token's own payload as a fallback identity when the caller supplies none. It is only a fallback: an explicit identity wins, the token's agenda fingerprint is never substituted, and an unknown prefix, an unparseable payload or a missing member yields no identity. The shape test is exactly the one the app's verifier applies, three non-empty dot-separated segments and no fourth, so a truncated or padded token names nobody rather than queueing a report the app could only reject. The app still verifies the signature and the member and agenda binding, and nothing added writes to stdout, which is the JSON-RPC stream. The controller half touches a file #546 (merged) did not; its test file is shared with #546.

**7. The user and system inboxes are terminal, not relay targets.** `relayInboxFileToLiveRecipientWithPorts` checks `isTerminalInboxRecipientName` first, before any team state is read, and returns the plain `Ignored` result with no diagnostics. The comparison is exact after trimming and lowercasing, not a prefix test: `users`, `userland` and `system-notices` are ordinary member names that keep routing.

**8. A stale lane-active sample can no longer silence pickup detection.** `openCodeLaneTurnFreshness.ts` classifies each sample with `classifyOpenCodeLaneTurnSample` before the snapshot publishes it. An `active` sample older than `getOpenCodeLaneTurnActivityMaxAgeMs()` (default 10 min) is demoted to idle, backdated to its original observation so the demotion cannot restart any downstream clock, and recorded in `openCodeLaneStaleActiveSinceByMemberName` so the monitor's diagnostic line says "lane turn sample stale-active since ..." instead of a bare "lane active". An `idle` sample never expires, because a turn that ended stays ended, and a sample whose timestamp cannot be parsed is treated as expired, because the fail-safe direction here is "do not stay silent". `getSnapshot` also takes one clock reading for the whole scan, so the freshness bound and the `scannedAt` the alerts are stamped with cannot drift apart across the awaits between them. Bounding the samples where the snapshot is assembled fixes the pickup branch and the in-progress work branch at once and leaves both evaluations untouched. The pickup branch then gains the lane guard it was missing: a fresh `active` sample skips with `lane_active`, and an idle time is ordinary evidence that can push the clock later but never starts it, so a team whose lane was never sampled is judged exactly as before. That last point is a product decision worth naming: an OpenCode owner with no observed lane can still get a pickup nudge, matching the "unknown is not active" rule the rest of the branch follows.

The max age carries an ordering invariant rather than being a free knob. The registry stamps `active` once, at prompt acceptance, and never refreshes it during a turn, so a bound below the largest stall threshold would demote every turn longer than the bound and make the `lane_active` guard unreachable for exactly the turns it protects. Ten minutes is the largest of those thresholds, and the test holds the ordering against `WORK_THRESHOLDS_MS` (exported from `TeamTaskStallPolicy.ts` for the floor computation in `openCodeLaneTurnFreshness.ts` and this test), the weak-start threshold and the pending-pickup threshold, so lowering the default below any of them fails the build. The environment override is held to the same invariant: `resolveOpenCodeLaneTurnActivityMaxAgeMs` computes that floor live, since the weak-start and pickup thresholds are themselves overridable, and raises an under-floor override back to it, reporting the value once. A larger override passes through, because a longer bound can only delay an alert, never fire one inside a live turn. The clamp sits at the read site rather than in `featureGates.ts` because reading `WORK_THRESHOLDS_MS` there would be an import cycle. The age bound ships alone on purpose: a live session-status probe could corroborate a demotion, but it needs a resolvable lane port, so it cannot answer on every host and cannot answer at all for a lane nothing tries to dispatch to, which is the shape that produced the silence.

## Tests

Negative controls, each its own test and each mutation-checked (the rule was broken, the named tests went red, the rule restored).

- `TeamProvisioningOpenCodeAggregateRun.test.ts`: "delivers the post-compact reminder on a fresh run and defers it once a turn goes active" drives the real `injectPostCompactReminder` against a real freshly created aggregate run. Reverting the seed to `active` fails it and the defaults assertion that pins the seed.
- `TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.test.ts`, seven new cases under "lead active fallback": the fallback firing, "unrefs the fallback timer so it cannot hold the process open" (asserted through a `setTimeout` spy and `hasRef()`), "restarts a single fallback timer instead of accumulating one per active report", "never writes idle twice when a real settle signal beats the fallback", "arms nothing for a team with no tracked run, and no-ops when the run disappears", and the two that pin the arming to the far side of #568's guards: "never arms the fallback for a notification the lead activity guards drop" (a secondary lane, a null run id, a member who is not the lead recipient, a replaced run) and "keeps a live turn fallback armed when a dropped notification arrives behind it". The behaviour had no coverage at all before. Dropping the `clearTimeout` fails two, arming on `idle` fails one, dropping `unref` fails one, never re-resolving the run fails one, never arming fails three, and moving the arming in front of the guards fails three.
- `OpenCodeLaneTurnActivityRegistry.test.ts`: "records a secondary lane without ever emitting lead activity for it", "keeps the recorded sample when the lead notifier throws", "records a primary lane even when no lead notifier is wired", "records a primary lane for a teammate the caller did not identify as the lead" (the same-model case `isOpenCodeLeadRecipient` exists for), and "separates members whose names would otherwise concatenate into the same key" (the `ab`/`c` versus `a`/`bc` collision that justifies the separator). The production caller is covered where #568 already tests it: `OpenCodeMemberMessageDeliveryService.leadTurnActivity.test.ts` now also asserts that the secondary lane and the same-model primary teammate, neither of which emits lead activity, are both recorded in the registry. Moving the registry write behind the lead-recipient return fails five across the two files.
- `sourceControlCharacters.test.ts`: "has no raw control characters in any TypeScript source file" fails with the file and line when a raw NUL is injected.
- `TeamTaskStallPolicy.test.ts`: "treats an OpenCode lane that settled after the touch as a turn end (4 min, not 10)", "leaves a non-OpenCode owner untouched by lane turn state", "does not nudge an OpenCode owner without progress evidence while its lane is active", and "lets the work branch keep alerting while the pickup gate is off". Making the snapshot classify every sample as active fails one case.
- `TeamTaskStallSnapshotSource.test.ts`: "splits the recorded OpenCode lane turn samples into idle-since and active sets", "demotes an active lane sample that has outlived the turn-activity max age" and "keeps a live lane active when the max-age override is below the ordering floor", which is the behaviour an unclamped override got wrong.
- `TeamTaskStallPendingPickup.test.ts`: the clock (the threshold to the millisecond, a reassignment restarts it, creation covers the launch shape, an unfinished blocker never escalates and resumes once it completes, a listed-but-unresolved blocker still gets no clock), sequential work ("suppresses the pickup alert while the owner runs another task", "still alerts when the running task belongs to a different member"), the env gate, epoch-key stability across unrelated task churn, and the lane rules: "stays quiet while the owner lane is mid-turn but not once that sample goes stale" and "treats a lane idle time as ordinary evidence: it can delay the alert, never block it". The end-to-end pair "pending pickup behind a delivery lane that never settled" proves the age bound alone breaks the deadlock: silent while the unsettled sample is inside the max age, alerting once it outlives it, with no probe involved.
- `TeamTaskStallMonitor.test.ts`, the escalation ladder: "nudges the OpenCode owner exactly once, only after the second scan", "sends nothing when the owner starts the task between the two scans", "falls back to the lead when the pickup nudge is not accepted", "escalates the pickup alert from the owner to the lead and then goes silent", "respects the alert cooldown between escalation rungs", "nudges only the oldest pending task per member and keeps the rest for a later scan", and "leaves snapshots without pending pickup candidates untouched". Raising the rung count or ignoring the journal count fails each. Under "diagnostic state": "keeps only the held alert clocks the current scan is still holding", "drops the held alert clocks of a team that is no longer running" and "expires an OpenCode skip rate limit once it can no longer suppress a log line". Dropping the per-scan prune fails the last two; carrying the previous scan's clocks forward fails the first.
- `TeamTaskStallJournal.test.ts`: "persists a pending pickup epoch across scans instead of dropping it on read", "counts every dispatched alert for an epoch so an escalation ladder can be bounded", "keeps a persisted alert count across a journal reload".
- `TeamTaskStallNotifier.test.ts`: "sends a start-the-task nudge for pending pickup alerts", "does not write a second inbox row for a repeated pending pickup alert".
- `MemberWorkSyncNudgeActivationPolicy.test.ts`: "holds OpenCode targeted nudges inside the quiet window after the agenda changed" and "holds only a member that is visibly working: unstarted and unobserved still get nudged".
- `controller.test.js`: "derives the report member from the report token when the caller omits memberName" and "never lets a report token stand in for another member or another agenda", which also refuses seven malformed tokens with the same error as before, including an unsigned two-segment token and one with a trailing extra segment, both carrying a payload that does name a configured member so that only the segment count can refuse them; the same cases assert that no pending report intent was written.
- `TeamProvisioningLiveInboxRelayRouting.test.ts`: `user` and `system` are terminal case- and whitespace-insensitively and no port is called at all; `users`, `system-notices` and `userland` still route; "still routes a real OpenCode member inbox after the terminal-inbox guard". A prefix comparison fails three cases, dropping the normalisation fails four.
- `openCodeLaneTurnFreshness.test.ts`: the ordering invariant ("stays at or above every OpenCode stall threshold the lane_active guard can unlock") plus "never treats an idle sample as stale, however old it is", "treats an active sample with an unparsable observation time as stale", "expires an active sample exactly at the max age and not one millisecond earlier" (`>=` versus `>`), and "backdates a demoted sample to its original observation instead of to now". Lowering the default max age to four minutes fails only the invariant test. The override clamp adds "holds the ordering invariant against an environment override, not only the default", "raises the floor with the thresholds it protects", "passes through the default and any override at or above the floor" and "reports an out-of-range override once instead of on every scan"; removing the clamp fails three of those and the snapshot case below.
- `featureGates.test.ts`: the pickup gates read from the environment, the pickup gate is scoped to the pickup branch alone, an unparseable flag keeps pickup remediation enabled, and the weak-start default is pinned at its new value.

Gates on the tip: `pnpm typecheck`, size guard, provisioning guard, the announcements content check, `eslint` (0 errors, and no warning this branch did not inherit) and `prettier --check` on every changed `src/` file, `src/main/index.ts` included, plus targeted vitest. On the tip the stall-monitor suite is 157 (90 on `main`) and the controller suite 316 (nine more cases than on `main`). Full suite on the tip: 16278 tests, 16171 passed, 106 skipped, 1 failed; an unmodified `origin/main @ 192560997` runs 16184 tests with none failed on the same machine. The one failure is in `TeamProvisioningMemberMcpConfig.safe-e2e.test.ts`, a file this branch does not touch: its temp-directory cleanup hook hits `EPERM` on `rmSync` under the parallel full-suite run on Windows, and the file passes both times it is run alone.

## Notes

`refactor(team): the stall snapshot source takes its collaborators as one deps object` is a size-guard and ergonomics extraction with no behaviour change, and it ships as its own commit so the diff that changes what the monitor does is not also the diff that moves ten parameters. `TeamTaskStallSnapshotSource` had grown to ten positional optional constructor parameters, each with a production default; the one production caller (`src/main/index.ts`) overrides the first and had to stay silent about the other nine, and a test that wanted the last had to write eight placeholders in front of it. The constructor now takes one `TeamTaskStallSnapshotSourceDeps` object with the same ten optional fields, the same defaults and the same construction order, assigned to readonly instance fields.

Sizes at the tip, all under the 800 default: `TeamTaskStallPolicy.ts` 678, `TeamTaskStallMonitor.ts` 697 (435 on `main`; the rate-limited diagnostics log is the natural extraction if you want it smaller), `TeamTaskStallSnapshotSource.ts` 382, `MemberWorkSyncNudgeActivationPolicy.ts` 364, `agent-teams-controller/src/internal/workSync.js` 343, `TeamProvisioningLiveInboxRelayRouting.ts` 269, `TeamTaskStallPendingPickup.ts` 231, `TeamTaskStallNotifier.ts` 231, `TeamTaskStallTypes.ts` 200, `openCodeLaneTurnFreshness.ts` 170, `OpenCodeLaneTurnActivityRegistry.ts` 131, `featureGates.ts` 111, `TaskStallJournalStore.ts` 95. `OpenCodeMemberMessageDeliveryService.ts` is 1456/1578 and `TeamProvisioningOpenCodeMemberMessageDeliveryCompatibilityFacade.ts` 395. `scripts/ci/source-file-size-baseline.json` is untouched.

Two things I would rather have your call on than mine. `OPENCODE_LEAD_ACTIVE_FALLBACK_MS` is a module constant while comparable stall timings live behind `featureGates.ts` env readers; say the word and it moves there. And none of the gates in `featureGates.ts` are documented outside that file, these two included, so a doc page for all of them is the obvious follow-up. The third question in the first round of this description, whether to clamp the lane max-age override to the ordering invariant, is answered above: it is clamped.

## Commits

**Turn activity reaches its consumers**

- `fec96ee` fix(team): an OpenCode aggregate run starts idle so the first active transition is observed
- `3e3ada7` fix(team): a lead turn without a settle signal falls back to idle
- `191df68` feat(opencode): the lane turn registry records every lane, not only the lead
- `b947fb2` feat(team): the stall monitor reads the OpenCode lane turn state instead of a transcript turn-end row

**Pickup escalation and nudge timing**

- `738390e` fix(team): the user and system inboxes are terminal, not relay targets
- `3c54b26` feat(team): a pending task whose blockers are resolved gets a bounded pickup escalation
- `16d5a78` fix(member-work-sync): a work-sync nudge never interrupts a member mid-turn

**Bounding the lane turn signal**

- `62d9d1f` refactor(team): the stall snapshot source takes its collaborators as one deps object
- `e42ff37` fix(team): a stale lane-active sample can no longer silence pickup detection

**Review round 1**

- `94a7945` fix(member-work-sync): a report token names a member only in the shape the app can verify
- `dbb190c` fix(team): an out-of-range lane turn max age is raised to the ordering floor instead of applied
- `4d2fb70` fix(team): the stall monitor's diagnostic maps drop entries that can no longer decide anything
- `d90d5b3` refactor(team): a stall signal missing from the journal's valid set is a compile error
- `7050b05` test(team): the lane turn freshness test imports through the @main alias

## Tested on

Windows 11 Pro, from source, against `origin/main @ 192560997`, which already contains #565 and #568. The stuck "processing" card, the nudge landing inside a live turn, a board parked at pending after a dependency resolved, a member looping on `member_work_sync_report` over a missing name, and the ten-minute lane silence above were all hit on live runs with OpenCode-hosted teammates during an earlier campaign. With these commits the lead card settles within the fallback window, the monitor holds its nudge while a lane is genuinely active, and the pickup nudge still arrives once a frozen sample outlives the max age. Not tested on macOS or Linux; nothing here is platform-specific.

**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.

Base: main @ 192560997


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pending-pickup stall detection with configurable alerts and escalation from task owners to team leads.
  - Added OpenCode lane activity tracking to improve stall detection and avoid interrupting active work.
  - Added a 10-minute quiet window for targeted OpenCode recovery nudges.
  - Added alert-count tracking for repeated stall notifications.

- **Bug Fixes**
  - Improved handling of report tokens when member details are omitted.
  - Prevented app-owned inboxes such as “user” and “system” from being routed as team members.
  - Added fallback handling when OpenCode activity signals are delayed or missing.
  - Improved filtering of duplicate or already-processed notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->