### PR TITLE
fix(team): a stop is final: the stop marker, run-scoped reconcile writes, and a Stop that finishes on evidence

### DIFF
--- a/src/main/http/teams/teamLifecycleRoutes.ts
+++ b/src/main/http/teams/teamLifecycleRoutes.ts
@@ -15,6 +15,7 @@ import {
   runTeamForceStopFlow,
 } from '@main/services/team/lifecycle/teamForceStopFlow';
 import { validateTeamName } from '@main/services/team/TeamIdentifierValidation';
+import { TeamLaunchStateStore } from '@main/services/team/TeamLaunchStateStore';
 import { getTeamsBasePath } from '@main/utils/pathDecoder';
 import { getErrorMessage } from '@shared/utils/errorHandling';
 
@@ -108,6 +109,7 @@ export function registerTeamLifecycleRoutes(
               requestedAtMs: context.requestedAtMs,
             }),
           logWarning: (message) => logger.warn(message),
+          markTeamStopped: (name) => new TeamLaunchStateStore().markStopped(name),
         });
         return reply.send(result);
       } catch (error) {

--- a/src/main/http/teams/teamLifecycleRoutes.ts
+++ b/src/main/http/teams/teamLifecycleRoutes.ts
@@ -9,6 +9,7 @@
  */
 import {
   clearPendingOpenCodePromptDeliveriesForTeam,
+  countLiveRecordedRuntimeHostsForTeam,
   killRetainedOpenCodeRuntimeProcessesForTeam,
   readOpenCodeRuntimeLaneIdsForTeam,
   readOwnedOpenCodeRuntimeRunIdsForTeam,
@@ -27,7 +28,11 @@ import type { FastifyInstance } from 'fastify';
 
 /** Error handling shared with the routes that stayed in `../teams`. */
 export interface TeamLifecycleRouteDeps {
-  logger: { error(message: string, detail: string): void; warn(message: string): void };
+  logger: {
+    error(message: string, detail: string): void;
+    warn(message: string): void;
+    info(message: string): void;
+  };
   shouldLogError: (error: unknown) => boolean;
   getStatusCode: (error: unknown) => number;
   getResponseErrorMessage: (error: unknown) => string;
@@ -86,9 +91,14 @@ export function registerTeamLifecycleRoutes(
             }),
           logWarning: (message) => logger.warn(message),
           stopTimeoutMs: STOP_ESCALATION_TIMEOUT_MS,
+          countLiveRuntimeHosts: (name) => countLiveRecordedRuntimeHostsForTeam({ teamName: name }),
           markTeamStopped: (name) => new TeamLaunchStateStore().markStopped(name),
         });
-        if (result.stopOutcome !== 'stopped') {
+        if (result.stopOutcome === 'runtime_already_down') {
+          logger.info(
+            `[${teamName}] Runtime hosts were already down; finished the stop without the orchestrator acknowledgement (killed ${result.killedRuntimePids.length} runtime pid(s), cancelled ${result.clearedPendingDeliveries} pending deliveries)`
+          );
+        } else if (result.stopOutcome !== 'stopped') {
           logger.warn(
             `[${teamName}] Regular stop ${result.stopOutcome}; escalated to force stop (killed ${result.killedRuntimePids.length} runtime pid(s), cancelled ${result.clearedPendingDeliveries} pending deliveries)`
           );

--- a/src/main/http/teams/teamLifecycleRoutes.ts
+++ b/src/main/http/teams/teamLifecycleRoutes.ts
@@ -13,6 +13,8 @@ import {
   readOpenCodeRuntimeLaneIdsForTeam,
   readOwnedOpenCodeRuntimeRunIdsForTeam,
   runTeamForceStopFlow,
+  STOP_ESCALATION_TIMEOUT_MS,
+  stopTeamWithEscalation,
 } from '@main/services/team/lifecycle/teamForceStopFlow';
 import { validateTeamName } from '@main/services/team/TeamIdentifierValidation';
 import { TeamLaunchStateStore } from '@main/services/team/TeamLaunchStateStore';
@@ -58,9 +60,40 @@ export function registerTeamLifecycleRoutes(
           return reply.status(400).send({ error: validatedTeamName.error });
         }
 
+        const teamName = validatedTeamName.value!;
         const teamRuntimeApi = getTeamRuntimeApi(services);
-        await teamRuntimeApi.stopTeam(validatedTeamName.value!);
-        return reply.send(await teamRuntimeApi.getRuntimeState(validatedTeamName.value!));
+        // Same semantics as the in-app Stop control: the regular stop gets a
+        // bounded budget, and only if it does not deliver does the force-stop
+        // cleanup guarantee the team is down.
+        const result = await stopTeamWithEscalation(teamName, {
+          stopTeam: (name) => teamRuntimeApi.stopTeam(name),
+          observeOwnedRuntimeRunIds: (name) =>
+            readOwnedOpenCodeRuntimeRunIdsForTeam({ teamName: name }),
+          observeOwnedRuntimeLaneIds: (name) =>
+            readOpenCodeRuntimeLaneIdsForTeam(getTeamsBasePath(), name),
+          killRetainedRuntimeProcesses: (name, context) =>
+            killRetainedOpenCodeRuntimeProcessesForTeam({
+              teamName: name,
+              requestedAtMs: context.requestedAtMs,
+              otherAliveTeams: teamRuntimeApi.getAliveTeams().filter((alive) => alive !== name),
+            }),
+          clearPendingPromptDeliveries: (name, context) =>
+            clearPendingOpenCodePromptDeliveriesForTeam({
+              teamName: name,
+              ownedRunIds: context.ownedRunIds,
+              ownedLaneIds: context.ownedLaneIds,
+              requestedAtMs: context.requestedAtMs,
+            }),
+          logWarning: (message) => logger.warn(message),
+          stopTimeoutMs: STOP_ESCALATION_TIMEOUT_MS,
+          markTeamStopped: (name) => new TeamLaunchStateStore().markStopped(name),
+        });
+        if (result.stopOutcome !== 'stopped') {
+          logger.warn(
+            `[${teamName}] Regular stop ${result.stopOutcome}; escalated to force stop (killed ${result.killedRuntimePids.length} runtime pid(s), cancelled ${result.clearedPendingDeliveries} pending deliveries)`
+          );
+        }
+        return reply.send(await teamRuntimeApi.getRuntimeState(teamName));
       } catch (error) {
         if (shouldLogError(error)) {
           logger.error(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -249,6 +249,7 @@ import {
   createOpenCodeBridgeClientIdentity,
   OpenCodeBridgeCommandHandshakePort,
 } from './services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
+import { startPeriodicOpenCodeHostStartupLockPurge } from './services/team/opencode/bridge/OpenCodeHostStartupLockCleanup';
 import { cleanupManagedOpenCodeServeProcesses } from './services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup';
 import { OpenCodeStateChangingBridgeCommandService } from './services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import { OpenCodeRuntimeLaunchAuthorityWriter } from './services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
@@ -679,6 +680,8 @@ async function createOpenCodeRuntimeAdapterRegistry(
     }),
   ]);
 }
+let stopPeriodicOpenCodeHostStartupLockPurge: (() => void) | null = null;
+
 async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'): Promise<void> {
   let registryHostPids = new Set<number>();
   let registryCleanupAvailable = false;
@@ -707,6 +710,11 @@ async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'):
     registryCleanupAvailable = !result.diagnostics.some((diagnostic) =>
       diagnostic.startsWith('OpenCode host cleanup bridge failed:')
     );
+  }
+
+  if (reason === 'shutdown') {
+    stopPeriodicOpenCodeHostStartupLockPurge?.();
+    stopPeriodicOpenCodeHostStartupLockPurge = null;
   }
 
   if (reason === 'startup' && !registryCleanupAvailable) {
@@ -2065,6 +2073,10 @@ async function initializeServices(): Promise<void> {
       logger.warn(`[OpenCode] Startup host cleanup failed: ${String(error)}`)
     );
   }, STARTUP_RECOVERY_DELAY_MS);
+  stopPeriodicOpenCodeHostStartupLockPurge = startPeriodicOpenCodeHostStartupLockPurge({
+    logInfo: (message) => logger.info(message),
+    logWarning: (message) => logger.warn(message),
+  });
   // Startup GC: remove stale MCP config files from previous sessions (best-effort)
   void new TeamMcpConfigBuilder().gcStaleConfigs();
   void teamDataService

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -712,11 +712,6 @@ async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'):
     );
   }
 
-  if (reason === 'shutdown') {
-    stopPeriodicOpenCodeHostStartupLockPurge?.();
-    stopPeriodicOpenCodeHostStartupLockPurge = null;
-  }
-
   if (reason === 'startup' && !registryCleanupAvailable) {
     logger.warn(
       '[OpenCode] Startup fallback cleanup skipped because host registry cleanup is unavailable'
@@ -3018,6 +3013,11 @@ async function shutdownServices(): Promise<void> {
 
     clearStartupTimers();
     clearInboxNotifyTimers();
+    // Ahead of the first awaited step: runShutdownStep stops waiting on a step
+    // that hangs, it does not cancel it, so no awaited step may decide whether
+    // the background lock purge is still running.
+    stopPeriodicOpenCodeHostStartupLockPurge?.();
+    stopPeriodicOpenCodeHostStartupLockPurge = null;
 
     await runShutdownStep('team runtime recovery scheduler cleanup', async () => {
       teamProvisioningService?.setRuntimeRecoveryFailureObserver(null);

--- a/src/main/ipc/teams.ts
+++ b/src/main/ipc/teams.ts
@@ -148,6 +148,8 @@ import {
   readOpenCodeRuntimeLaneIdsForTeam,
   readOwnedOpenCodeRuntimeRunIdsForTeam,
   runTeamForceStopFlow,
+  STOP_ESCALATION_TIMEOUT_MS,
+  stopTeamWithEscalation,
 } from '../services/team/lifecycle/teamForceStopFlow';
 import {
   buildReplaceMembersDiff,
@@ -4210,8 +4212,43 @@ async function handleStopTeam(
     return { success: false, error: validated.error ?? 'Invalid teamName' };
   }
   return wrapTeamHandler('stop', async () => {
-    addMainBreadcrumb('team', 'stop', { teamName: validated.value! });
-    await getTeamRuntimeApi().stopTeam(validated.value!);
+    const tn = validated.value!;
+    addMainBreadcrumb('team', 'stop', { teamName: tn });
+    // The regular stop can reject or hang: the orchestrator holds a per-team
+    // lock, and a stop command that exits non-zero or never returns leaves the
+    // host running with the run still tracked as alive. The user pressed Stop
+    // and expects the team to be stopped, so the force-stop cleanup takes over
+    // when the regular stop does not confirm within its budget.
+    const result = await stopTeamWithEscalation(tn, {
+      stopTeam: (name) => getTeamRuntimeApi().stopTeam(name),
+      observeOwnedRuntimeRunIds: (name) =>
+        readOwnedOpenCodeRuntimeRunIdsForTeam({ teamName: name }),
+      observeOwnedRuntimeLaneIds: (name) =>
+        readOpenCodeRuntimeLaneIdsForTeam(getTeamsBasePath(), name),
+      killRetainedRuntimeProcesses: (name, context) =>
+        killRetainedOpenCodeRuntimeProcessesForTeam({
+          teamName: name,
+          requestedAtMs: context.requestedAtMs,
+          otherAliveTeams: getTeamRuntimeApi()
+            .getAliveTeams()
+            .filter((alive) => alive !== name),
+        }),
+      clearPendingPromptDeliveries: (name, context) =>
+        clearPendingOpenCodePromptDeliveriesForTeam({
+          teamName: name,
+          ownedRunIds: context.ownedRunIds,
+          ownedLaneIds: context.ownedLaneIds,
+          requestedAtMs: context.requestedAtMs,
+        }),
+      logWarning: (message) => logger.warn(message),
+      stopTimeoutMs: STOP_ESCALATION_TIMEOUT_MS,
+      markTeamStopped: (name) => new TeamLaunchStateStore().markStopped(name),
+    });
+    if (result.stopOutcome !== 'stopped') {
+      logger.warn(
+        `[${tn}] Regular stop ${result.stopOutcome}; escalated to force stop (killed ${result.killedRuntimePids.length} runtime pid(s), cancelled ${result.clearedPendingDeliveries} pending deliveries)`
+      );
+    }
   });
 }
 

--- a/src/main/ipc/teams.ts
+++ b/src/main/ipc/teams.ts
@@ -162,6 +162,7 @@ import { TeamAttachmentStore } from '../services/team/TeamAttachmentStore';
 import { TeamConfigReader } from '../services/team/TeamConfigReader';
 import { capMessagesPageLiveOverlay } from '../services/team/teamInboxOrdering';
 import { readTeamLaunchFailureDiagnosticsBundle } from '../services/team/TeamLaunchFailureArtifactPack';
+import { TeamLaunchStateStore } from '../services/team/TeamLaunchStateStore';
 import { TeamMembersMetaStore } from '../services/team/TeamMembersMetaStore';
 import { TeamMetaStore } from '../services/team/TeamMetaStore';
 import { TeamTaskAttachmentStore } from '../services/team/TeamTaskAttachmentStore';
@@ -4247,6 +4248,7 @@ async function handleForceStopTeam(
           requestedAtMs: context.requestedAtMs,
         }),
       logWarning: (message) => logger.warn(message),
+      markTeamStopped: (name) => new TeamLaunchStateStore().markStopped(name),
     });
   });
 }

--- a/src/main/ipc/teams.ts
+++ b/src/main/ipc/teams.ts
@@ -144,6 +144,7 @@ import {
 } from '../services/team/LaunchIoGovernor';
 import {
   clearPendingOpenCodePromptDeliveriesForTeam,
+  countLiveRecordedRuntimeHostsForTeam,
   killRetainedOpenCodeRuntimeProcessesForTeam,
   readOpenCodeRuntimeLaneIdsForTeam,
   readOwnedOpenCodeRuntimeRunIdsForTeam,
@@ -4242,9 +4243,14 @@ async function handleStopTeam(
         }),
       logWarning: (message) => logger.warn(message),
       stopTimeoutMs: STOP_ESCALATION_TIMEOUT_MS,
+      countLiveRuntimeHosts: (name) => countLiveRecordedRuntimeHostsForTeam({ teamName: name }),
       markTeamStopped: (name) => new TeamLaunchStateStore().markStopped(name),
     });
-    if (result.stopOutcome !== 'stopped') {
+    if (result.stopOutcome === 'runtime_already_down') {
+      logger.info(
+        `[${tn}] Runtime hosts were already down; finished the stop without the orchestrator acknowledgement (killed ${result.killedRuntimePids.length} runtime pid(s), cancelled ${result.clearedPendingDeliveries} pending deliveries)`
+      );
+    } else if (result.stopOutcome !== 'stopped') {
       logger.warn(
         `[${tn}] Regular stop ${result.stopOutcome}; escalated to force stop (killed ${result.killedRuntimePids.length} runtime pid(s), cancelled ${result.clearedPendingDeliveries} pending deliveries)`
       );

--- a/src/main/services/team/TeamBackupRestoreService.ts
+++ b/src/main/services/team/TeamBackupRestoreService.ts
@@ -317,8 +317,18 @@ export class TeamBackupRestoreService {
     try {
       await fs.promises.access(liveMarker);
       return true;
-    } catch {
-      return false;
+    } catch (error) {
+      // Only ENOENT proves the marker is gone. A permission or I/O failure is
+      // not evidence that the team was never stopped, and answering "not
+      // stopped" republishes the pre-stop launch state and undoes the stop.
+      // Freezing instead costs the two derived files a reconcile re-derives.
+      if (isEnoent(error)) return false;
+      logger.warn(
+        `[Backup] Could not read the stop marker for ${teamName}; keeping launch state frozen: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return true;
     }
   }
 

--- a/src/main/services/team/TeamBackupRestoreService.ts
+++ b/src/main/services/team/TeamBackupRestoreService.ts
@@ -13,8 +13,10 @@ import { getTeamsBasePath } from '@main/utils/pathDecoder';
 import { createLogger } from '@shared/utils/logger';
 
 import { TeamConfigReader } from './TeamConfigReader';
+import { TEAM_LAUNCH_STOPPED_MARKER_FILE } from './TeamLaunchStateStore';
 
 const logger = createLogger('TeamBackupService');
+const LAUNCH_STATE_PUBLICATION_FILES = new Set(['launch-state.json', 'launch-summary.json']);
 const DRAFT_DELETION_IDENTITY_FILE = '.permanent-deletion-identity.json';
 
 interface BackupManifest {
@@ -162,8 +164,13 @@ export class TeamBackupRestoreService {
     }
 
     // Restore remaining files
+    const launchStateFrozen = await this.isLaunchStateFrozenByStop(teamName, backupFiles);
     for (const relPath of backupFiles) {
       if (relPath === 'config.json' || relPath === 'manifest.json') continue;
+      if (launchStateFrozen && LAUNCH_STATE_PUBLICATION_FILES.has(relPath)) {
+        logger.info(`[Backup] Skip restore ${teamName}/${relPath}: team is stopped`);
+        continue;
+      }
       try {
         const src = path.join(backupDir, relPath);
         const dest = this.ports.getSourcePathForRelPath(teamName, relPath);
@@ -229,10 +236,15 @@ export class TeamBackupRestoreService {
   ): Promise<number> {
     const backupDir = this.ports.getBackupDir(teamName);
     const backupFiles = await this.ports.enumerateBackupFiles(teamName);
+    const launchStateFrozen = await this.isLaunchStateFrozenByStop(teamName, backupFiles);
     let count = 0;
 
     for (const relPath of backupFiles) {
       if (relPath === 'manifest.json') continue;
+      if (launchStateFrozen && LAUNCH_STATE_PUBLICATION_FILES.has(relPath)) {
+        logger.info(`[Backup] Skip restore ${teamName}/${relPath}: team is stopped`);
+        continue;
+      }
       const dest = this.ports.getSourcePathForRelPath(teamName, relPath);
 
       try {
@@ -295,6 +307,30 @@ export class TeamBackupRestoreService {
 
     void manifest; // fileStats not checked during restore — mtime comparison happens in full restore
     return count;
+  }
+
+  /**
+   * A stopped team - the stop marker is in the live team directory, or it was
+   * already backed up - must not get its last launch-state / launch-summary
+   * back. The backup can still hold the snapshot from before the stop, and
+   * restoring it brings the phantom "launch failed partway / teammate never
+   * spawned" card back after the next app start.
+   */
+  private async isLaunchStateFrozenByStop(
+    teamName: string,
+    backupFiles: readonly string[]
+  ): Promise<boolean> {
+    if (backupFiles.includes(TEAM_LAUNCH_STOPPED_MARKER_FILE)) return true;
+    const liveMarker = this.ports.getSourcePathForRelPath(
+      teamName,
+      TEAM_LAUNCH_STOPPED_MARKER_FILE
+    );
+    try {
+      await fs.promises.access(liveMarker);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   private checkIdentityFromConfig(

--- a/src/main/services/team/TeamBackupRestoreService.ts
+++ b/src/main/services/team/TeamBackupRestoreService.ts
@@ -12,24 +12,13 @@ import {
 import { getTeamsBasePath } from '@main/utils/pathDecoder';
 import { createLogger } from '@shared/utils/logger';
 
+import { type BackupManifest } from './teamBackupManifest';
 import { TeamConfigReader } from './TeamConfigReader';
 import { TEAM_LAUNCH_STOPPED_MARKER_FILE } from './TeamLaunchStateStore';
 
 const logger = createLogger('TeamBackupService');
 const LAUNCH_STATE_PUBLICATION_FILES = new Set(['launch-state.json', 'launch-summary.json']);
 const DRAFT_DELETION_IDENTITY_FILE = '.permanent-deletion-identity.json';
-
-interface BackupManifest {
-  teamName: string;
-  identityId: string;
-  projectPath?: string;
-  displayName?: string;
-  status: 'active' | 'deleted_by_user';
-  deletedByUserAt?: string;
-  firstBackupAt: string;
-  lastBackupAt: string;
-  fileStats: Record<string, { mtime: number; size: number }>;
-}
 
 type SourceConfigObservation =
   | {

--- a/src/main/services/team/TeamBackupRestoreService.ts
+++ b/src/main/services/team/TeamBackupRestoreService.ts
@@ -14,7 +14,10 @@ import { createLogger } from '@shared/utils/logger';
 
 import { type BackupManifest } from './teamBackupManifest';
 import { TeamConfigReader } from './TeamConfigReader';
-import { TEAM_LAUNCH_STOPPED_MARKER_FILE } from './TeamLaunchStateStore';
+import {
+  TEAM_LAUNCH_STOPPED_MARKER_FILE,
+  withTeamLaunchStatePublicationLock,
+} from './TeamLaunchStateStore';
 
 const logger = createLogger('TeamBackupService');
 const LAUNCH_STATE_PUBLICATION_FILES = new Set(['launch-state.json', 'launch-summary.json']);
@@ -198,13 +201,15 @@ export class TeamBackupRestoreService {
         }
         await fs.promises.mkdir(path.dirname(dest), { recursive: true });
         if (
-          await this.commitRestoredFile(
-            dest,
-            content,
-            observedDestination,
-            configDest,
-            committedIdentity,
-            Buffer.from(backupConfigContent)
+          await this.commitRestoredFileFencedByStop(teamName, relPath, backupFiles, () =>
+            this.commitRestoredFile(
+              dest,
+              content,
+              observedDestination,
+              configDest,
+              committedIdentity,
+              Buffer.from(backupConfigContent)
+            )
           )
         ) {
           count++;
@@ -277,13 +282,15 @@ export class TeamBackupRestoreService {
         const src = path.join(backupDir, relPath);
         const content = await fs.promises.readFile(src);
         if (
-          await this.commitRestoredFile(
-            dest,
-            content,
-            destinationObservation,
-            path.join(getTeamsBasePath(), teamName, 'config.json'),
-            sourceConfig.identity,
-            Buffer.from(sourceConfig.raw)
+          await this.commitRestoredFileFencedByStop(teamName, relPath, backupFiles, () =>
+            this.commitRestoredFile(
+              dest,
+              content,
+              destinationObservation,
+              path.join(getTeamsBasePath(), teamName, 'config.json'),
+              sourceConfig.identity,
+              Buffer.from(sourceConfig.raw)
+            )
           )
         ) {
           count++;
@@ -305,6 +312,34 @@ export class TeamBackupRestoreService {
    * restoring it brings the phantom "launch failed partway / teammate never
    * spawned" card back after the next app start.
    */
+  /**
+   * Commits one restored file. The two launch-state publication files go
+   * through the store's publication queue with the stop fence read again: the
+   * fence read before the loop is only as fresh as the moment it ran, and a
+   * stop that lands while the loop works removes those files and writes its
+   * marker afterwards. A commit that slips between the two puts the pre-stop
+   * publication back with no marker left to hold it - the stop is undone and
+   * the phantom launch card returns. Holding the queue is what keeps the stop
+   * indivisible from here; the re-read alone would only narrow the window.
+   */
+  private async commitRestoredFileFencedByStop(
+    teamName: string,
+    relPath: string,
+    backupFiles: readonly string[],
+    commit: () => Promise<boolean>
+  ): Promise<boolean> {
+    if (!LAUNCH_STATE_PUBLICATION_FILES.has(relPath)) {
+      return commit();
+    }
+    return withTeamLaunchStatePublicationLock(teamName, async () => {
+      if (await this.isLaunchStateFrozenByStop(teamName, backupFiles)) {
+        logger.info(`[Backup] Skip restore ${teamName}/${relPath}: team stopped during restore`);
+        return false;
+      }
+      return commit();
+    });
+  }
+
   private async isLaunchStateFrozenByStop(
     teamName: string,
     backupFiles: readonly string[]

--- a/src/main/services/team/TeamBackupService.ts
+++ b/src/main/services/team/TeamBackupService.ts
@@ -27,6 +27,14 @@ import {
   collectRecursiveFiles,
   collectRecursiveFilesSync,
 } from './TeamBackupFileCollection';
+import {
+  type BackupManifest,
+  getBackupManifestPath,
+  readBackupManifest,
+  readBackupManifestSync,
+  writeBackupManifest,
+  writeBackupManifestSync,
+} from './teamBackupManifest';
 import { TeamBackupRestoreService } from './TeamBackupRestoreService';
 
 import type { PermanentDeletionLock } from './permanent-deletion/TeamPermanentDeletionLock';
@@ -41,18 +49,6 @@ const logger = createLogger('TeamBackupService');
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
-
-interface BackupManifest {
-  teamName: string;
-  identityId: string;
-  projectPath?: string;
-  displayName?: string;
-  status: 'active' | 'deleted_by_user';
-  deletedByUserAt?: string;
-  firstBackupAt: string;
-  lastBackupAt: string;
-  fileStats: Record<string, { mtime: number; size: number }>;
-}
 
 interface BackupRegistry {
   version: 1;
@@ -332,7 +328,7 @@ export class TeamBackupService {
           validateDetached: async (detachedPath) => {
             try {
               const manifest = JSON.parse(
-                await fs.promises.readFile(path.join(detachedPath, 'manifest.json'), 'utf8')
+                await fs.promises.readFile(getBackupManifestPath(detachedPath), 'utf8')
               ) as BackupManifest;
               return (
                 manifest.teamName === teamName &&
@@ -542,13 +538,8 @@ export class TeamBackupService {
     if (sourceFiles.length === 0) return;
 
     const backupDir = this.getBackupDir(teamName);
-    let manifest: BackupManifest | null = null;
-    try {
-      const raw = fs.readFileSync(path.join(backupDir, 'manifest.json'), 'utf8');
-      manifest = JSON.parse(raw) as BackupManifest;
-    } catch {
-      // A missing manifest is initialized below after source identity ownership is known.
-    }
+    // A missing manifest is initialized below after source identity ownership is known.
+    let manifest = readBackupManifestSync(backupDir);
 
     if (
       manifest?.status === 'deleted_by_user' ||
@@ -1081,15 +1072,7 @@ export class TeamBackupService {
   }
 
   private async loadManifest(teamName: string): Promise<BackupManifest | null> {
-    try {
-      const raw = await fs.promises.readFile(
-        path.join(this.getBackupDir(teamName), 'manifest.json'),
-        'utf8'
-      );
-      return JSON.parse(raw) as BackupManifest;
-    } catch {
-      return null;
-    }
+    return readBackupManifest(this.getBackupDir(teamName));
   }
 
   private async saveManifest(
@@ -1100,23 +1083,11 @@ export class TeamBackupService {
   ): Promise<void> {
     if (this.isShuttingDown) return;
     await beforeCommit?.();
-    await atomicWriteAsync(
-      path.join(this.getBackupDir(teamName), 'manifest.json'),
-      JSON.stringify(manifest, null, 2),
-      {
-        ...(strict ? { durability: 'strict' as const, syncDirectory: true } : {}),
-        ...(beforeCommit ? { beforeCommit } : {}),
-      }
-    );
+    await writeBackupManifest(this.getBackupDir(teamName), manifest, { strict, beforeCommit });
   }
 
   private saveManifestSync(teamName: string, manifest: BackupManifest): void {
-    try {
-      const manifestPath = path.join(this.getBackupDir(teamName), 'manifest.json');
-      atomicWriteSync(manifestPath, JSON.stringify(manifest, null, 2));
-    } catch {
-      // best-effort
-    }
+    writeBackupManifestSync(this.getBackupDir(teamName), manifest);
   }
 
   // ── Internal: validation ─────────────────────────────────────────────

--- a/src/main/services/team/TeamBackupService.ts
+++ b/src/main/services/team/TeamBackupService.ts
@@ -77,6 +77,7 @@ const TEAM_ROOT_FILES = [
   'team.meta.json',
   'launch-state.json',
   'launch-summary.json',
+  'launch-stopped.json',
   'kanban-state.json',
   'sentMessages.json',
   'sent-cross-team.json',

--- a/src/main/services/team/TeamBackupService.ts
+++ b/src/main/services/team/TeamBackupService.ts
@@ -36,6 +36,7 @@ import {
   writeBackupManifestSync,
 } from './teamBackupManifest';
 import { TeamBackupRestoreService } from './TeamBackupRestoreService';
+import { TEAM_LAUNCH_STOPPED_MARKER_FILE } from './TeamLaunchStateStore';
 
 import type { PermanentDeletionLock } from './permanent-deletion/TeamPermanentDeletionLock';
 
@@ -77,7 +78,7 @@ const TEAM_ROOT_FILES = [
   'team.meta.json',
   'launch-state.json',
   'launch-summary.json',
-  'launch-stopped.json',
+  TEAM_LAUNCH_STOPPED_MARKER_FILE,
   'kanban-state.json',
   'sentMessages.json',
   'sent-cross-team.json',
@@ -587,6 +588,7 @@ export class TeamBackupService {
     for (const descriptor of sourceFiles) {
       this.backupSingleFileSync(descriptor, backupDir, manifest);
     }
+    this.pruneStaleStopMarkerBackupSync(teamName, backupDir, manifest);
 
     manifest.lastBackupAt = nowIso();
     this.saveManifestSync(teamName, manifest);
@@ -598,6 +600,26 @@ export class TeamBackupService {
       deletedByUserAt: manifest.deletedByUserAt,
       lastBackupAt: manifest.lastBackupAt,
     };
+  }
+
+  /**
+   * The shutdown backup only adds files, so a stop marker the team no longer
+   * has would stay in the backup and freeze every later restore of its launch
+   * state. Only a proven ENOENT drops it: unreadable is not absent.
+   */
+  private pruneStaleStopMarkerBackupSync(
+    teamName: string,
+    backupDir: string,
+    manifest: BackupManifest
+  ): void {
+    try {
+      fs.statSync(path.join(getTeamsBasePath(), teamName, TEAM_LAUNCH_STOPPED_MARKER_FILE));
+      return;
+    } catch (err: unknown) {
+      if (!isEnoent(err)) return;
+    }
+    fs.rmSync(path.join(backupDir, TEAM_LAUNCH_STOPPED_MARKER_FILE), { force: true });
+    delete manifest.fileStats[TEAM_LAUNCH_STOPPED_MARKER_FILE];
   }
 
   private async backupSingleFile(

--- a/src/main/services/team/TeamLaunchStateStore.ts
+++ b/src/main/services/team/TeamLaunchStateStore.ts
@@ -15,7 +15,7 @@ import type { PersistedTeamLaunchSnapshot } from '@shared/types';
 const logger = createLogger('Service:TeamLaunchStateStore');
 const TEAM_LAUNCH_STATE_FILE = 'launch-state.json';
 const MAX_LAUNCH_STATE_BYTES = 256 * 1024;
-const publicationQueueByTeam = new Map<string, Promise<void>>();
+const publicationQueueByTeam = new Map<string, Promise<unknown>>();
 
 export function getTeamLaunchStatePath(teamName: string): string {
   return path.join(getTeamsBasePath(), teamName, TEAM_LAUNCH_STATE_FILE);
@@ -90,7 +90,7 @@ function throwPublicationRevocationFailure(
   }
 }
 
-function enqueuePublication(teamName: string, operation: () => Promise<void>): Promise<void> {
+function enqueuePublication<T>(teamName: string, operation: () => Promise<T>): Promise<T> {
   const previous = publicationQueueByTeam.get(teamName);
   const queued = (previous ?? Promise.resolve()).catch(() => undefined).then(operation);
   publicationQueueByTeam.set(teamName, queued);
@@ -99,6 +99,22 @@ function enqueuePublication(teamName: string, operation: () => Promise<void>): P
       publicationQueueByTeam.delete(teamName);
     }
   });
+}
+
+/**
+ * Runs `operation` in this team's launch-state publication queue - the same one
+ * `write` and `markStopped` use. A caller that publishes or withdraws these
+ * files from outside the store needs it, because a stop is not one instant:
+ * `markStopped` removes the publication files first and writes its marker
+ * afterwards, and only the queue makes those two steps indivisible from the
+ * outside. Checking the marker without holding the queue reads a stop that has
+ * begun as a stop that never happened.
+ */
+export function withTeamLaunchStatePublicationLock<T>(
+  teamName: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  return enqueuePublication(teamName, operation);
 }
 
 /**

--- a/src/main/services/team/TeamLaunchStateStore.ts
+++ b/src/main/services/team/TeamLaunchStateStore.ts
@@ -63,6 +63,22 @@ async function isMissingTeamDirectoryWriteRace(
   }
 }
 
+/** Reports the revocation failures the caller has to see; silent when there are none. */
+function throwPublicationRevocationFailure(
+  teamName: string,
+  results: PromiseSettledResult<void>[]
+): void {
+  const errors = results
+    .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+    .map((result) => result.reason);
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, `[${teamName}] Failed to clear launch-state publication`);
+  }
+}
+
 function enqueuePublication(teamName: string, operation: () => Promise<void>): Promise<void> {
   const previous = publicationQueueByTeam.get(teamName);
   const queued = (previous ?? Promise.resolve()).catch(() => undefined).then(operation);
@@ -140,7 +156,7 @@ export class TeamLaunchStateStore {
   /** Stopped team: no launch state, and reconciliation stays off until the next launch. */
   async markStopped(teamName: string): Promise<void> {
     await enqueuePublication(teamName, async () => {
-      await Promise.allSettled([
+      const revocations = await Promise.allSettled([
         fs.promises.rm(getTeamLaunchStatePath(teamName), { force: true }),
         fs.promises.rm(getTeamLaunchSummaryPath(teamName), { force: true }),
       ]);
@@ -156,6 +172,12 @@ export class TeamLaunchStateStore {
         }
         throw error;
       }
+      // The marker comes first even when a publication file survives, because
+      // a stop the user asked for must stay final for reconciliation. What
+      // must not stay silent is the survivor: read() answers from the launch
+      // state and not from the marker, so a snapshot that could not be removed
+      // is still served to the UI. The caller reports it as a stop diagnostic.
+      throwPublicationRevocationFailure(teamName, revocations);
     });
   }
 
@@ -171,19 +193,13 @@ export class TeamLaunchStateStore {
    */
   async clear(teamName: string): Promise<void> {
     await enqueuePublication(teamName, async () => {
-      const results = await Promise.allSettled([
-        fs.promises.rm(getTeamLaunchStatePath(teamName), { force: true }),
-        fs.promises.rm(getTeamLaunchSummaryPath(teamName), { force: true }),
-      ]);
-      const errors = results
-        .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
-        .map((result) => result.reason);
-      if (errors.length === 1) {
-        throw errors[0];
-      }
-      if (errors.length > 1) {
-        throw new AggregateError(errors, `[${teamName}] Failed to clear launch-state publication`);
-      }
+      throwPublicationRevocationFailure(
+        teamName,
+        await Promise.allSettled([
+          fs.promises.rm(getTeamLaunchStatePath(teamName), { force: true }),
+          fs.promises.rm(getTeamLaunchSummaryPath(teamName), { force: true }),
+        ])
+      );
     });
   }
 }

--- a/src/main/services/team/TeamLaunchStateStore.ts
+++ b/src/main/services/team/TeamLaunchStateStore.ts
@@ -101,29 +101,77 @@ function enqueuePublication(teamName: string, operation: () => Promise<void>): P
   });
 }
 
+/**
+ * What a launch-state read found. `absent` is an answer - this team published
+ * no launch state - while `unreadable` is the lack of one: something is on
+ * disk that the store could not turn into a snapshot, so nothing may be
+ * concluded about what the team has running.
+ */
+export type TeamLaunchStateReadResult =
+  | { status: 'snapshot'; snapshot: PersistedTeamLaunchSnapshot }
+  | { status: 'absent' }
+  | { status: 'unreadable'; reason: string };
+
+function describeReadFailure(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export class TeamLaunchStateStore {
+  /**
+   * The launch snapshot, or `null` when there is none to be had. It cannot say
+   * why: a team that never launched and a launch state this app could not read
+   * both answer `null`. Callers that draw a conclusion from the absence of
+   * recorded state - "nothing is running" - need `readResult` instead.
+   */
   async read(teamName: string): Promise<PersistedTeamLaunchSnapshot | null> {
+    const result = await this.readResult(teamName);
+    return result.status === 'snapshot' ? result.snapshot : null;
+  }
+
+  /**
+   * The same read, keeping "this team has no launch state" apart from "the
+   * launch state could not be read". Only the first is evidence about the team;
+   * the second is the absence of evidence, and a caller that counts it as an
+   * empty snapshot reports a probe that answered nothing as a definite zero.
+   */
+  async readResult(teamName: string): Promise<TeamLaunchStateReadResult> {
     const targetPath = getTeamLaunchStatePath(teamName);
+    let raw: string;
     try {
       const stat = await fs.promises.stat(targetPath);
-      if (!stat.isFile() || stat.size > MAX_LAUNCH_STATE_BYTES) {
-        return null;
+      if (!stat.isFile()) {
+        return { status: 'unreadable', reason: 'launch state path is not a file' };
       }
-      const raw = await fs.promises.readFile(targetPath, 'utf8');
-      const parsed = JSON.parse(raw) as unknown;
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        const record = parsed as Record<string, unknown>;
-        if (
-          record.version === 2 &&
-          (typeof record.teamName !== 'string' || record.teamName.trim() !== teamName)
-        ) {
-          return null;
-        }
+      if (stat.size > MAX_LAUNCH_STATE_BYTES) {
+        return { status: 'unreadable', reason: `launch state exceeds ${MAX_LAUNCH_STATE_BYTES}B` };
       }
-      return normalizePersistedLaunchSnapshot(teamName, parsed);
-    } catch {
-      return null;
+      raw = await fs.promises.readFile(targetPath, 'utf8');
+    } catch (error) {
+      // Only a missing file is an answer; every other failure leaves the
+      // question open.
+      return (error as NodeJS.ErrnoException).code === 'ENOENT'
+        ? { status: 'absent' }
+        : { status: 'unreadable', reason: describeReadFailure(error) };
     }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw) as unknown;
+    } catch (error) {
+      return { status: 'unreadable', reason: describeReadFailure(error) };
+    }
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const record = parsed as Record<string, unknown>;
+      if (
+        record.version === 2 &&
+        (typeof record.teamName !== 'string' || record.teamName.trim() !== teamName)
+      ) {
+        return { status: 'unreadable', reason: 'launch state names a different team' };
+      }
+    }
+    const snapshot = normalizePersistedLaunchSnapshot(teamName, parsed);
+    return snapshot
+      ? { status: 'snapshot', snapshot }
+      : { status: 'unreadable', reason: 'launch state did not describe a launch' };
   }
 
   async write(

--- a/src/main/services/team/TeamLaunchStateStore.ts
+++ b/src/main/services/team/TeamLaunchStateStore.ts
@@ -34,7 +34,7 @@ export function getTeamLaunchSummaryPath(teamName: string): string {
  * was still on disk. Any new active launch-state write (a real launch)
  * removes it.
  */
-const TEAM_LAUNCH_STOPPED_MARKER_FILE = 'launch-stopped.json';
+export const TEAM_LAUNCH_STOPPED_MARKER_FILE = 'launch-stopped.json';
 
 export function getTeamLaunchStoppedMarkerPath(teamName: string): string {
   return path.join(getTeamsBasePath(), teamName, TEAM_LAUNCH_STOPPED_MARKER_FILE);

--- a/src/main/services/team/TeamLaunchStateStore.ts
+++ b/src/main/services/team/TeamLaunchStateStore.ts
@@ -25,6 +25,27 @@ export function getTeamLaunchSummaryPath(teamName: string): string {
   return path.join(getTeamsBasePath(), teamName, TEAM_LAUNCH_SUMMARY_FILE);
 }
 
+/**
+ * Marker written when a team is stopped. While it exists, launch-state
+ * reconciliation must not re-derive a half-launched snapshot from leftover
+ * metadata: a stopped mixed OpenCode team used to come back as "Last launch
+ * failed partway - 2/3 teammates did not join", with members reported as
+ * never spawned, because the lane metadata of the run that was just stopped
+ * was still on disk. Any new active launch-state write (a real launch)
+ * removes it.
+ */
+const TEAM_LAUNCH_STOPPED_MARKER_FILE = 'launch-stopped.json';
+
+export function getTeamLaunchStoppedMarkerPath(teamName: string): string {
+  return path.join(getTeamsBasePath(), teamName, TEAM_LAUNCH_STOPPED_MARKER_FILE);
+}
+
+async function removeStoppedMarkerIfPresent(teamName: string): Promise<void> {
+  const markerPath = getTeamLaunchStoppedMarkerPath(teamName);
+  if (!fs.existsSync(markerPath)) return;
+  await fs.promises.rm(markerPath, { force: true });
+}
+
 async function isMissingTeamDirectoryWriteRace(
   targetPath: string,
   error: unknown
@@ -86,11 +107,23 @@ export class TeamLaunchStateStore {
     const launchStatePath = getTeamLaunchStatePath(teamName);
     const launchSummaryPath = getTeamLaunchSummaryPath(teamName);
     try {
+      if (snapshot.launchPhase !== 'active' && (await this.isStopped(teamName))) {
+        // Late reconcile/finish writes from an abandoned stop or a stale run
+        // must not resurrect launch state for a stopped team.
+        logger.debug(
+          `[${teamName}] Ignoring ${snapshot.launchPhase} launch-state write: team is stopped`
+        );
+        return;
+      }
       await atomicWriteAsync(launchStatePath, `${JSON.stringify(snapshot, null, 2)}\n`);
       await atomicWriteAsync(
         launchSummaryPath,
         `${JSON.stringify(createPersistedLaunchSummaryProjection(snapshot), null, 2)}\n`
       );
+      if (snapshot.launchPhase === 'active') {
+        // A real launch supersedes any earlier stop.
+        await removeStoppedMarkerIfPresent(teamName);
+      }
     } catch (error) {
       if (await isMissingTeamDirectoryWriteRace(launchStatePath, error)) {
         return;
@@ -104,6 +137,38 @@ export class TeamLaunchStateStore {
     }
   }
 
+  /** Stopped team: no launch state, and reconciliation stays off until the next launch. */
+  async markStopped(teamName: string): Promise<void> {
+    await enqueuePublication(teamName, async () => {
+      await Promise.allSettled([
+        fs.promises.rm(getTeamLaunchStatePath(teamName), { force: true }),
+        fs.promises.rm(getTeamLaunchSummaryPath(teamName), { force: true }),
+      ]);
+      const markerPath = getTeamLaunchStoppedMarkerPath(teamName);
+      try {
+        await atomicWriteAsync(
+          markerPath,
+          `${JSON.stringify({ version: 1, teamName, stoppedAt: new Date().toISOString() }, null, 2)}\n`
+        );
+      } catch (error) {
+        if (await isMissingTeamDirectoryWriteRace(markerPath, error)) {
+          return;
+        }
+        throw error;
+      }
+    });
+  }
+
+  async isStopped(teamName: string): Promise<boolean> {
+    return fs.existsSync(getTeamLaunchStoppedMarkerPath(teamName));
+  }
+
+  /**
+   * Removes the launch publication only. The stop marker survives a clear:
+   * stop flows and stale-write cleanups clear the publication after the team
+   * was marked stopped, and only a real launch (an 'active' write) may lift
+   * the marker again.
+   */
   async clear(teamName: string): Promise<void> {
     await enqueuePublication(teamName, async () => {
       const results = await Promise.allSettled([

--- a/src/main/services/team/TeamLaunchStateStore.ts
+++ b/src/main/services/team/TeamLaunchStateStore.ts
@@ -40,6 +40,17 @@ export function getTeamLaunchStoppedMarkerPath(teamName: string): string {
   return path.join(getTeamsBasePath(), teamName, TEAM_LAUNCH_STOPPED_MARKER_FILE);
 }
 
+export interface TeamLaunchStatePublicationOptions {
+  /**
+   * True when the write republishes launch truth that already existed instead
+   * of starting a launch: the rollback of a stale write restoring what it
+   * overwrote, or a recovery re-deriving the run that was just stopped. Only a
+   * launch may lift a stop, so a stop that landed meanwhile stays final over
+   * such a write - it is not published, and it never removes the marker.
+   */
+  republishesExistingLaunch?: boolean;
+}
+
 async function removeStoppedMarkerIfPresent(teamName: string): Promise<void> {
   const markerPath = getTeamLaunchStoppedMarkerPath(teamName);
   if (!fs.existsSync(markerPath)) return;
@@ -115,15 +126,28 @@ export class TeamLaunchStateStore {
     }
   }
 
-  async write(teamName: string, snapshot: PersistedTeamLaunchSnapshot): Promise<void> {
-    await enqueuePublication(teamName, () => this.writeNow(teamName, snapshot));
+  async write(
+    teamName: string,
+    snapshot: PersistedTeamLaunchSnapshot,
+    options?: TeamLaunchStatePublicationOptions
+  ): Promise<void> {
+    await enqueuePublication(teamName, () => this.writeNow(teamName, snapshot, options));
   }
 
-  private async writeNow(teamName: string, snapshot: PersistedTeamLaunchSnapshot): Promise<void> {
+  private async writeNow(
+    teamName: string,
+    snapshot: PersistedTeamLaunchSnapshot,
+    options?: TeamLaunchStatePublicationOptions
+  ): Promise<void> {
     const launchStatePath = getTeamLaunchStatePath(teamName);
     const launchSummaryPath = getTeamLaunchSummaryPath(teamName);
+    // Only a launch supersedes a stop. An active snapshot that merely
+    // republishes what was already on disk is not one, so it is fenced by the
+    // marker exactly like a reconcile write is.
+    const startsLaunch =
+      snapshot.launchPhase === 'active' && options?.republishesExistingLaunch !== true;
     try {
-      if (snapshot.launchPhase !== 'active' && (await this.isStopped(teamName))) {
+      if (!startsLaunch && (await this.isStopped(teamName))) {
         // Late reconcile/finish writes from an abandoned stop or a stale run
         // must not resurrect launch state for a stopped team.
         logger.debug(
@@ -136,7 +160,7 @@ export class TeamLaunchStateStore {
         launchSummaryPath,
         `${JSON.stringify(createPersistedLaunchSummaryProjection(snapshot), null, 2)}\n`
       );
-      if (snapshot.launchPhase === 'active') {
+      if (startsLaunch) {
         // A real launch supersedes any earlier stop.
         await removeStoppedMarkerIfPresent(teamName);
       }

--- a/src/main/services/team/lifecycle/teamForceStopFlow.ts
+++ b/src/main/services/team/lifecycle/teamForceStopFlow.ts
@@ -159,13 +159,32 @@ async function runTeamStopFlow(
   const timeoutMs = ports.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let stopOutcome: TeamForceStopResult['stopOutcome'];
+  let timedOut = false;
   try {
     const stopAttempt = ports.stopTeam(teamName).then(
-      () => 'stopped' as const,
+      () => {
+        if (timedOut) {
+          ports.logWarning(
+            `[${teamName}] Regular stop finished ${Date.now() - stopStartedAtMs}ms after it started, after the force stop cleanup had already run.`
+          );
+        }
+        return 'stopped' as const;
+      },
       (error: unknown) => {
         const message = error instanceof Error ? error.message : String(error);
-        ports.logWarning(`[${teamName}] Regular stop failed before force stop cleanup: ${message}`);
-        diagnostics.push(`Regular stop failed: ${message}`);
+        if (timedOut) {
+          // Expected once the hard kill already removed the hosts the
+          // orchestrator was still trying to stop: the failure describes a
+          // process that is gone, not a stop this flow still owes the user.
+          ports.logWarning(
+            `[${teamName}] Regular stop failed ${Date.now() - stopStartedAtMs}ms after it started, after the force stop cleanup had already run: ${message}`
+          );
+        } else {
+          ports.logWarning(
+            `[${teamName}] Regular stop failed before force stop cleanup: ${message}`
+          );
+          diagnostics.push(`Regular stop failed: ${message}`);
+        }
         return 'stop_failed' as const;
       }
     );
@@ -177,6 +196,7 @@ async function runTeamStopFlow(
       }),
     ]);
     if (stopOutcome === 'timed_out') {
+      timedOut = true;
       ports.logWarning(
         `[${teamName}] Regular stop did not finish within ${timeoutMs}ms; continuing with force stop cleanup.`
       );

--- a/src/main/services/team/lifecycle/teamForceStopFlow.ts
+++ b/src/main/services/team/lifecycle/teamForceStopFlow.ts
@@ -21,6 +21,12 @@ import {
 import type { TeamForceStopResult } from '@shared/types';
 
 const DEFAULT_STOP_TIMEOUT_MS = 15_000;
+/**
+ * How long the regular Stop waits for the orchestrator before the cleanup
+ * takes over. Longer than the force-stop default because the user pressed
+ * Stop, not Force stop: the orchestrator deserves the chance to finish first.
+ */
+export const STOP_ESCALATION_TIMEOUT_MS = 20_000;
 const FORCE_STOP_DELIVERY_CANCEL_REASON =
   'force_stop_requested: pending delivery cancelled by user force stop';
 
@@ -77,6 +83,36 @@ export async function runTeamForceStopFlow(
   teamName: string,
   ports: TeamForceStopFlowPorts
 ): Promise<TeamForceStopResult> {
+  return runTeamStopFlow(teamName, ports, { cleanup: 'always' });
+}
+
+/**
+ * The regular Stop, with an escape hatch. The orchestrator's stop gets a
+ * bounded budget and, only when it rejects or runs out of it, the force-stop
+ * cleanup runs: the same hard-cleanup attempt and the same run-fenced delivery
+ * cancellation. A stop that confirms cancels nothing and reaches nothing else -
+ * the user asked for a stop, not for a sweep, and the escalation exists because
+ * the stop sometimes cannot deliver what the user asked for.
+ *
+ * The force stop persists its cancellation before the stop, so a stop that
+ * removes the lane index cannot strand the ledger. A regular Stop cannot: it
+ * does not yet know whether it will have to escalate, so its cancellation runs
+ * after the stop, on the lane scope read before it, and under the same
+ * "the stop did not confirm" decision that gates the cleanup step.
+ */
+export async function stopTeamWithEscalation(
+  teamName: string,
+  ports: TeamForceStopFlowPorts
+): Promise<TeamForceStopResult> {
+  return runTeamStopFlow(teamName, ports, { cleanup: 'on_failure' });
+}
+
+async function runTeamStopFlow(
+  teamName: string,
+  ports: TeamForceStopFlowPorts,
+  options: { cleanup: 'always' | 'on_failure' }
+): Promise<TeamForceStopResult> {
+  const cleanupIsUnconditional = options.cleanup === 'always';
   const diagnostics: string[] = [];
   const stopStartedAtMs = Date.now();
   let ownedRunIds: readonly string[] = [];
@@ -114,7 +150,12 @@ export async function runTeamForceStopFlow(
     }
   };
   // Persist cancellation before stop can remove the lane index or runtime files.
-  await cancelOwnedDeliveries();
+  // A regular Stop has nothing to persist yet: it cancels only when the stop
+  // does not deliver, so its cancellation has to wait for the outcome and runs
+  // on the lane ids read above, which a removed lane index can no longer narrow.
+  if (cleanupIsUnconditional) {
+    await cancelOwnedDeliveries();
+  }
   const timeoutMs = ports.stopTimeoutMs ?? DEFAULT_STOP_TIMEOUT_MS;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let stopOutcome: TeamForceStopResult['stopOutcome'];
@@ -166,8 +207,13 @@ export async function runTeamForceStopFlow(
     }
   }
 
-  // Catch rows published by this run while its scoped stop was in flight.
-  if (ownedLaneIds?.length) await cancelOwnedDeliveries();
+  // Catch rows published by this run while its scoped stop was in flight. For a
+  // regular Stop this is instead the deferred cancellation, and it is the same
+  // decision the kill step just made: a stop that confirmed cancels nothing.
+  const cancelAfterStop = cleanupIsUnconditional
+    ? Boolean(ownedLaneIds?.length)
+    : stopOutcome !== 'stopped';
+  if (cancelAfterStop) await cancelOwnedDeliveries();
 
   await markStopped(teamName, ports, diagnostics);
   return {

--- a/src/main/services/team/lifecycle/teamForceStopFlow.ts
+++ b/src/main/services/team/lifecycle/teamForceStopFlow.ts
@@ -20,6 +20,7 @@ import {
 } from '../opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import { TeamLaunchStateStore } from '../TeamLaunchStateStore';
 
+import type { TeamLaunchStateReadResult } from '../TeamLaunchStateStore';
 import type { PersistedTeamLaunchSnapshot, TeamForceStopResult } from '@shared/types';
 
 const DEFAULT_STOP_TIMEOUT_MS = 15_000;
@@ -78,8 +79,11 @@ export interface TeamForceStopFlowPorts {
    * generous; this lets the flow finish as soon as the hosts are actually gone
    * instead of waiting the budget out. Omitted - or zero live hosts at the
    * first sample - and the flow waits for the stop or the timeout as before.
+   *
+   * `null` means the probe could not answer. It is not zero: only a count the
+   * probe actually established may end the stop early.
    */
-  countLiveRuntimeHosts?(teamName: string): Promise<number>;
+  countLiveRuntimeHosts?(teamName: string): Promise<number | null>;
   /**
    * Persist the stopped state: drop the launch publication and write the stop
    * marker that keeps reconciliation from re-deriving a launch snapshot for a
@@ -147,9 +151,11 @@ function watchRuntimeHostsGone(
     return { promise: new Promise<'runtime_already_down'>(() => {}), cancel };
   }
   const promise = new Promise<'runtime_already_down'>((resolve) => {
-    const onSample = (remaining: number): void => {
+    const onSample = (remaining: number | null): void => {
       sampling = false;
-      if (!cancelled && remaining <= 0) {
+      // `null` is a sample that could not answer. Ending the stop on it would
+      // report hosts as gone on evidence that never looked at one.
+      if (!cancelled && remaining !== null && remaining <= 0) {
         cancel();
         resolve('runtime_already_down');
       }
@@ -159,8 +165,8 @@ function watchRuntimeHostsGone(
       sampling = true;
       void countLiveRuntimeHostsSafely(teamName, ports).then(onSample);
     };
-    const startSampling = (liveHosts: number): void => {
-      if (cancelled || liveHosts <= 0) {
+    const startSampling = (liveHosts: number | null): void => {
+      if (cancelled || liveHosts === null || liveHosts <= 0) {
         return;
       }
       interval = setInterval(sample, RUNTIME_HOSTS_POLL_INTERVAL_MS);
@@ -172,17 +178,19 @@ function watchRuntimeHostsGone(
 }
 
 /**
- * A probe that cannot answer must not keep the stop waiting, so a failure
- * counts as "no live hosts" rather than propagating out of the poll.
+ * A probe that cannot answer must not propagate out of the poll - and must not
+ * be read as "no live hosts" either. A rejection, or a count the probe itself
+ * could not establish, becomes `null`: unknown, not zero. The stop then waits
+ * for the orchestrator or the timeout, the same as if nothing had been sampled.
  */
 async function countLiveRuntimeHostsSafely(
   teamName: string,
   ports: TeamForceStopFlowPorts
-): Promise<number> {
+): Promise<number | null> {
   try {
-    return (await ports.countLiveRuntimeHosts?.(teamName)) ?? 0;
+    return (await ports.countLiveRuntimeHosts?.(teamName)) ?? null;
   } catch {
-    return 0;
+    return null;
   }
 }
 
@@ -190,14 +198,28 @@ async function countLiveRuntimeHostsSafely(
  * How many of the team's recorded lane host processes are still running. Same
  * evidence the kill step uses: only pids the launch state recorded for this
  * team count, so an unrelated process can never keep the stop waiting.
+ *
+ * `null` when the launch state could not be read. A team that published no
+ * launch state has no recorded hosts and counts zero; a launch state this app
+ * failed to read names no host either, but that is the probe being blind, and
+ * the stop must not take it for a team that has finished exiting.
  */
 export async function countLiveRecordedRuntimeHostsForTeam(input: {
   teamName: string;
   launchStateStore?: TeamLaunchStateStore;
   isRuntimeProcessAlive?: (pid: number) => boolean;
-}): Promise<number> {
+}): Promise<number | null> {
   const launchStateStore = input.launchStateStore ?? new TeamLaunchStateStore();
-  const snapshot = await launchStateStore.read(input.teamName).catch(() => null);
+  const launchState = await launchStateStore.readResult(input.teamName).catch(
+    (error: unknown): TeamLaunchStateReadResult => ({
+      status: 'unreadable',
+      reason: error instanceof Error ? error.message : String(error),
+    })
+  );
+  if (launchState.status === 'unreadable') {
+    return null;
+  }
+  const snapshot = launchState.status === 'snapshot' ? launchState.snapshot : null;
   const isAlive = input.isRuntimeProcessAlive ?? isProcessAlive;
   const pids = collectRecordedOpenCodeRuntimePids(snapshot);
   let live = 0;

--- a/src/main/services/team/lifecycle/teamForceStopFlow.ts
+++ b/src/main/services/team/lifecycle/teamForceStopFlow.ts
@@ -9,6 +9,7 @@
  */
 
 import { getTeamsBasePath } from '@main/utils/pathDecoder';
+import { isProcessAlive } from '@main/utils/processHealth';
 import * as fs from 'fs';
 
 import { createOpenCodePromptDeliveryLedgerStore } from '../opencode/delivery/OpenCodePromptDeliveryLedger';
@@ -17,16 +18,23 @@ import {
   OpenCodeRuntimeManifestEvidenceReader,
   readOpenCodeRuntimeLaneIndex,
 } from '../opencode/store/OpenCodeRuntimeManifestEvidenceReader';
+import { TeamLaunchStateStore } from '../TeamLaunchStateStore';
 
-import type { TeamForceStopResult } from '@shared/types';
+import type { PersistedTeamLaunchSnapshot, TeamForceStopResult } from '@shared/types';
 
 const DEFAULT_STOP_TIMEOUT_MS = 15_000;
+/** How often the flow re-reads how many recorded runtime hosts are still alive. */
+export const RUNTIME_HOSTS_POLL_INTERVAL_MS = 1_000;
 /**
- * How long the regular Stop waits for the orchestrator before the cleanup
- * takes over. Longer than the force-stop default because the user pressed
- * Stop, not Force stop: the orchestrator deserves the chance to finish first.
+ * Budget for the regular stop before the force-stop cleanup takes over.
+ *
+ * Measured per-lane orchestrator stops run 17-48s - a full capability probe
+ * plus a registry lock per command - so any budget inside that range escalates
+ * a stop that was about to succeed: a 45s budget cut off a lane that confirmed
+ * at 47.6s. `countLiveRuntimeHosts` ends the wait the moment the hosts are
+ * gone, so a healthy stop never spends this budget and it only bounds a hang.
  */
-export const STOP_ESCALATION_TIMEOUT_MS = 20_000;
+export const STOP_ESCALATION_TIMEOUT_MS = 90_000;
 const FORCE_STOP_DELIVERY_CANCEL_REASON =
   'force_stop_requested: pending delivery cancelled by user force stop';
 
@@ -64,6 +72,14 @@ export interface TeamForceStopFlowPorts {
   ): Promise<{ cleared: number; diagnostics: string[] }>;
   logWarning(message: string): void;
   stopTimeoutMs?: number;
+  /**
+   * How many of the team's recorded runtime host processes are still running.
+   * The orchestrator's stop takes 17-48s per lane, so the stop budget has to be
+   * generous; this lets the flow finish as soon as the hosts are actually gone
+   * instead of waiting the budget out. Omitted - or zero live hosts at the
+   * first sample - and the flow waits for the stop or the timeout as before.
+   */
+  countLiveRuntimeHosts?(teamName: string): Promise<number>;
   /**
    * Persist the stopped state: drop the launch publication and write the stop
    * marker that keeps reconciliation from re-deriving a launch snapshot for a
@@ -105,6 +121,115 @@ export async function stopTeamWithEscalation(
   ports: TeamForceStopFlowPorts
 ): Promise<TeamForceStopResult> {
   return runTeamStopFlow(teamName, ports, { cleanup: 'on_failure' });
+}
+
+/**
+ * Resolves once the team's recorded runtime hosts are gone. It starts only
+ * when the first sample sees at least one live host: without that evidence an
+ * empty sample means "nothing was recorded", not "everything exited", and
+ * would end the stop before the orchestrator had done any work at all.
+ */
+function watchRuntimeHostsGone(
+  teamName: string,
+  ports: TeamForceStopFlowPorts
+): { promise: Promise<'runtime_already_down'>; cancel(): void } {
+  let interval: ReturnType<typeof setInterval> | null = null;
+  let cancelled = false;
+  let sampling = false;
+  const cancel = (): void => {
+    cancelled = true;
+    if (interval) {
+      clearInterval(interval);
+      interval = null;
+    }
+  };
+  if (!ports.countLiveRuntimeHosts) {
+    return { promise: new Promise<'runtime_already_down'>(() => {}), cancel };
+  }
+  const promise = new Promise<'runtime_already_down'>((resolve) => {
+    const onSample = (remaining: number): void => {
+      sampling = false;
+      if (!cancelled && remaining <= 0) {
+        cancel();
+        resolve('runtime_already_down');
+      }
+    };
+    const sample = (): void => {
+      if (sampling) return;
+      sampling = true;
+      void countLiveRuntimeHostsSafely(teamName, ports).then(onSample);
+    };
+    const startSampling = (liveHosts: number): void => {
+      if (cancelled || liveHosts <= 0) {
+        return;
+      }
+      interval = setInterval(sample, RUNTIME_HOSTS_POLL_INTERVAL_MS);
+      interval.unref?.();
+    };
+    void countLiveRuntimeHostsSafely(teamName, ports).then(startSampling);
+  });
+  return { promise, cancel };
+}
+
+/**
+ * A probe that cannot answer must not keep the stop waiting, so a failure
+ * counts as "no live hosts" rather than propagating out of the poll.
+ */
+async function countLiveRuntimeHostsSafely(
+  teamName: string,
+  ports: TeamForceStopFlowPorts
+): Promise<number> {
+  try {
+    return (await ports.countLiveRuntimeHosts?.(teamName)) ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * How many of the team's recorded lane host processes are still running. Same
+ * evidence the kill step uses: only pids the launch state recorded for this
+ * team count, so an unrelated process can never keep the stop waiting.
+ */
+export async function countLiveRecordedRuntimeHostsForTeam(input: {
+  teamName: string;
+  launchStateStore?: TeamLaunchStateStore;
+  isRuntimeProcessAlive?: (pid: number) => boolean;
+}): Promise<number> {
+  const launchStateStore = input.launchStateStore ?? new TeamLaunchStateStore();
+  const snapshot = await launchStateStore.read(input.teamName).catch(() => null);
+  const isAlive = input.isRuntimeProcessAlive ?? isProcessAlive;
+  const pids = collectRecordedOpenCodeRuntimePids(snapshot);
+  let live = 0;
+  for (const pid of pids) {
+    try {
+      if (isAlive(pid)) live += 1;
+    } catch {
+      // An unreadable process is not evidence of a live host.
+    }
+  }
+  return live;
+}
+
+/**
+ * The runtime host pids the launch snapshot recorded for this team's OpenCode
+ * lanes. Nothing else counts as evidence: a host this app never wrote down is
+ * not the team's to wait for.
+ */
+function collectRecordedOpenCodeRuntimePids(
+  snapshot: PersistedTeamLaunchSnapshot | null
+): Set<number> {
+  const pids = new Set<number>();
+  for (const member of Object.values(snapshot?.members ?? {})) {
+    if (member.providerId !== 'opencode' || !member.laneId?.trim()) {
+      continue;
+    }
+    const pid = member.runtimePid;
+    if (typeof pid === 'number' && Number.isFinite(pid) && pid > 0) {
+      pids.add(pid);
+    }
+  }
+  return pids;
 }
 
 async function runTeamStopFlow(
@@ -160,6 +285,7 @@ async function runTeamStopFlow(
   let timer: ReturnType<typeof setTimeout> | null = null;
   let stopOutcome: TeamForceStopResult['stopOutcome'];
   let timedOut = false;
+  let runtimeHostsGone: { promise: Promise<'runtime_already_down'>; cancel(): void } | null = null;
   try {
     const stopAttempt = ports.stopTeam(teamName).then(
       () => {
@@ -188,8 +314,10 @@ async function runTeamStopFlow(
         return 'stop_failed' as const;
       }
     );
+    runtimeHostsGone = watchRuntimeHostsGone(teamName, ports);
     stopOutcome = await Promise.race([
       stopAttempt,
+      runtimeHostsGone.promise,
       new Promise<'timed_out'>((resolve) => {
         timer = setTimeout(() => resolve('timed_out'), timeoutMs);
         timer.unref?.();
@@ -201,11 +329,19 @@ async function runTeamStopFlow(
         `[${teamName}] Regular stop did not finish within ${timeoutMs}ms; continuing with force stop cleanup.`
       );
       diagnostics.push(`Regular stop timed out after ${timeoutMs}ms`);
+    } else if (stopOutcome === 'runtime_already_down') {
+      timedOut = true;
+      diagnostics.push(
+        `Runtime hosts were gone ${Date.now() - stopStartedAtMs}ms into the stop; finished without waiting for the orchestrator acknowledgement`
+      );
     }
   } finally {
     if (timer) {
       clearTimeout(timer);
     }
+    // Cancelled here rather than after the race so a throw between them - or
+    // any later exit from this block - cannot leave the poller running.
+    runtimeHostsGone?.cancel();
   }
 
   let killedRuntimePids: number[] = [];

--- a/src/main/services/team/lifecycle/teamForceStopFlow.ts
+++ b/src/main/services/team/lifecycle/teamForceStopFlow.ts
@@ -58,6 +58,13 @@ export interface TeamForceStopFlowPorts {
   ): Promise<{ cleared: number; diagnostics: string[] }>;
   logWarning(message: string): void;
   stopTimeoutMs?: number;
+  /**
+   * Persist the stopped state: drop the launch publication and write the stop
+   * marker that keeps reconciliation from re-deriving a launch snapshot for a
+   * team the user stopped. Optional so a caller that only wants the process
+   * cleanup - a diagnostic sweep, say - leaves the publication alone.
+   */
+  markTeamStopped?(teamName: string): Promise<void>;
 }
 
 /**
@@ -162,6 +169,7 @@ export async function runTeamForceStopFlow(
   // Catch rows published by this run while its scoped stop was in flight.
   if (ownedLaneIds?.length) await cancelOwnedDeliveries();
 
+  await markStopped(teamName, ports, diagnostics);
   return {
     stopOutcome,
     cleanupOutcome: stopOutcome === 'stopped' && !cleanupIncomplete ? 'completed' : 'incomplete',
@@ -169,6 +177,23 @@ export async function runTeamForceStopFlow(
     clearedPendingDeliveries,
     diagnostics,
   };
+}
+
+async function markStopped(
+  teamName: string,
+  ports: TeamForceStopFlowPorts,
+  diagnostics: string[]
+): Promise<void> {
+  if (!ports.markTeamStopped) {
+    return;
+  }
+  try {
+    await ports.markTeamStopped(teamName);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    ports.logWarning(`[${teamName}] Could not persist stopped launch state: ${message}`);
+    diagnostics.push(`Stopped-state persistence failed: ${message}`);
+  }
 }
 
 /**

--- a/src/main/services/team/opencode/bridge/OpenCodeHostStartupLockCleanup.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeHostStartupLockCleanup.ts
@@ -1,0 +1,173 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * The claude-multimodel orchestrator serialises OpenCode host startups with
+ * lock files under `<data dir>/opencode/host-startup-locks/`. Hosts that are
+ * killed - by a force stop, an app shutdown, or a crash - never release their
+ * lock, and the orchestrator's next readiness probe waits on every stale lock
+ * in turn, so a launch can sit in "spawning" for many minutes after a few of
+ * them accumulate. Locks of live hosts are held open by the orchestrator, so
+ * an unlink that fails with EBUSY/EPERM is left alone.
+ */
+
+const CLAUDE_MULTIMODEL_DATA_DIR_NAME = 'claude-multimodel-nodejs';
+const HOST_STARTUP_LOCKS_RELATIVE = ['opencode', 'host-startup-locks'];
+const LOCK_ENTRY_PATTERN = /\.lock(?:\.lock)*$/i;
+
+export interface ResolveClaudeMultimodelDataDirOptions {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+}
+
+/** Mirrors claude-multimodel's env-paths data directory. */
+export function resolveClaudeMultimodelDataDir(
+  options: ResolveClaudeMultimodelDataDirOptions = {}
+): string {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const homeDir = options.homeDir ?? os.homedir();
+  const override = env.CLAUDE_MULTIMODEL_DATA_HOME?.trim();
+  if (override && path.isAbsolute(override)) {
+    return path.normalize(override);
+  }
+  if (platform === 'win32') {
+    const localAppData = env.LOCALAPPDATA?.trim() || path.join(homeDir, 'AppData', 'Local');
+    return path.join(localAppData, CLAUDE_MULTIMODEL_DATA_DIR_NAME, 'Data');
+  }
+  if (platform === 'darwin') {
+    return path.join(homeDir, 'Library', 'Application Support', CLAUDE_MULTIMODEL_DATA_DIR_NAME);
+  }
+  const xdgDataHome = env.XDG_DATA_HOME?.trim() || path.join(homeDir, '.local', 'share');
+  return path.join(xdgDataHome, CLAUDE_MULTIMODEL_DATA_DIR_NAME);
+}
+
+export function resolveOpenCodeHostStartupLocksDir(
+  options: ResolveClaudeMultimodelDataDirOptions = {}
+): string {
+  return path.join(resolveClaudeMultimodelDataDir(options), ...HOST_STARTUP_LOCKS_RELATIVE);
+}
+
+export interface PurgeOpenCodeHostStartupLocksOptions extends ResolveClaudeMultimodelDataDirOptions {
+  /** Lock directory to purge; resolved from the orchestrator data dir when absent. */
+  locksDir?: string;
+  /** Only remove entries whose mtime is at least this old (0 = everything). */
+  minAgeMs?: number;
+  now?: () => number;
+}
+
+export interface PurgeOpenCodeHostStartupLocksResult {
+  locksDir: string;
+  scanned: number;
+  removed: number;
+  kept: number;
+  diagnostics: string[];
+}
+
+function isHeldError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'EBUSY' || code === 'EPERM' || code === 'EACCES';
+}
+
+export async function purgeStaleOpenCodeHostStartupLocks(
+  options: PurgeOpenCodeHostStartupLocksOptions = {}
+): Promise<PurgeOpenCodeHostStartupLocksResult> {
+  const locksDir = options.locksDir ?? resolveOpenCodeHostStartupLocksDir(options);
+  const minAgeMs = Math.max(0, options.minAgeMs ?? 0);
+  const nowMs = (options.now ?? Date.now)();
+  const result: PurgeOpenCodeHostStartupLocksResult = {
+    locksDir,
+    scanned: 0,
+    removed: 0,
+    kept: 0,
+    diagnostics: [],
+  };
+
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(locksDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      result.diagnostics.push(`lock dir unreadable: ${String(error)}`);
+    }
+    return result;
+  }
+
+  for (const entry of entries) {
+    if (!LOCK_ENTRY_PATTERN.test(entry.name)) {
+      continue;
+    }
+    result.scanned += 1;
+    const entryPath = path.join(locksDir, entry.name);
+    try {
+      if (minAgeMs > 0) {
+        const stat = await fs.promises.stat(entryPath);
+        if (nowMs - stat.mtimeMs < minAgeMs) {
+          result.kept += 1;
+          continue;
+        }
+      }
+      if (entry.isDirectory()) {
+        await fs.promises.rm(entryPath, { recursive: true, force: false });
+      } else {
+        await fs.promises.unlink(entryPath);
+      }
+      result.removed += 1;
+    } catch (error) {
+      result.kept += 1;
+      if (!isHeldError(error) && (error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        result.diagnostics.push(`${entry.name}: ${String(error)}`);
+      }
+    }
+  }
+  return result;
+}
+
+/** A host finishes starting within a couple of minutes; older locks guard nothing. */
+export const PERIODIC_STALE_LOCK_MIN_AGE_MS = 10 * 60_000;
+export const PERIODIC_STALE_LOCK_INTERVAL_MS = 5 * 60_000;
+
+/**
+ * Background purge for long sessions. Every orchestrator invocation that
+ * touches a host - a launch, a transcript read, a provider status probe -
+ * leaves a startup lock behind, and launch readiness stalls once enough of
+ * them pile up. Locks older than ten minutes cannot belong to a host that is
+ * still starting, so they are removed regardless of which teams are alive.
+ *
+ * Returns the function that stops the purge; it never throws.
+ */
+export function startPeriodicOpenCodeHostStartupLockPurge(
+  input: PurgeOpenCodeHostStartupLocksOptions & {
+    logInfo?: (message: string) => void;
+    logWarning?: (message: string) => void;
+  } = {}
+): () => void {
+  const { logInfo, logWarning, ...purgeOptions } = input;
+  const run = async (): Promise<void> => {
+    try {
+      const result = await purgeStaleOpenCodeHostStartupLocks({
+        ...purgeOptions,
+        minAgeMs: PERIODIC_STALE_LOCK_MIN_AGE_MS,
+      });
+      if (result.removed > 0) {
+        logInfo?.(
+          `[OpenCode] periodic purge removed ${result.removed} stale host startup lock(s) (${result.kept} kept)`
+        );
+      }
+      for (const diagnostic of result.diagnostics) {
+        logWarning?.(`[OpenCode] periodic lock purge: ${diagnostic}`);
+      }
+    } catch (error) {
+      logWarning?.(
+        `[OpenCode] periodic lock purge failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  };
+  const timer = setInterval(() => {
+    void run();
+  }, PERIODIC_STALE_LOCK_INTERVAL_MS);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchStateStoreBoundary.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchStateStoreBoundary.ts
@@ -13,10 +13,19 @@ export interface LaunchStateWriteOptions {
   runId?: string;
 }
 
+/** Mirrors `TeamLaunchStatePublicationOptions` on the launch-state store. */
+export interface LaunchStatePublicationOptions {
+  republishesExistingLaunch?: boolean;
+}
+
 export interface TeamProvisioningLaunchStateStoreBoundaryPorts {
   launchStateStore: {
     read(teamName: string): Promise<PersistedTeamLaunchSnapshot | null>;
-    write(teamName: string, snapshot: PersistedTeamLaunchSnapshot): Promise<void>;
+    write(
+      teamName: string,
+      snapshot: PersistedTeamLaunchSnapshot,
+      options?: LaunchStatePublicationOptions
+    ): Promise<void>;
     clear(teamName: string): Promise<void>;
   };
   membersMetaStore: {
@@ -47,11 +56,19 @@ export interface TeamProvisioningLaunchStateStoreBoundaryPorts {
 export interface TeamProvisioningLaunchStateStoreBoundaryServiceHost {
   launchStateStore: {
     read(teamName: string): Promise<PersistedTeamLaunchSnapshot | null>;
-    write(teamName: string, snapshot: PersistedTeamLaunchSnapshot): Promise<void>;
+    write(
+      teamName: string,
+      snapshot: PersistedTeamLaunchSnapshot,
+      options?: LaunchStatePublicationOptions
+    ): Promise<void>;
     clear?(teamName: string): Promise<void>;
   };
   defaultLaunchStateStore: {
-    write(teamName: string, snapshot: PersistedTeamLaunchSnapshot): Promise<void>;
+    write(
+      teamName: string,
+      snapshot: PersistedTeamLaunchSnapshot,
+      options?: LaunchStatePublicationOptions
+    ): Promise<void>;
     clear(teamName: string): Promise<void>;
   };
   membersMetaStore: TeamProvisioningLaunchStateStoreBoundaryPorts['membersMetaStore'];
@@ -203,8 +220,12 @@ export class TeamProvisioningLaunchStateStoreBoundary {
       // over - and by then the launch truth on disk may belong to someone else.
       // Clearing would delete that newer truth along with the stale write, so
       // restore what this call overwrote and only clear when there was nothing.
+      // The restore is not a launch: a stop that settled while the write was in
+      // flight has to survive it, marker included.
       if (previousSnapshot) {
-        await this.ports.launchStateStore.write(teamName, previousSnapshot);
+        await this.ports.launchStateStore.write(teamName, previousSnapshot, {
+          republishesExistingLaunch: true,
+        });
       } else {
         await this.ports.launchStateStore.clear(teamName);
       }
@@ -251,10 +272,10 @@ export function createTeamProvisioningLaunchStateStoreBoundaryFromService(
   return new TeamProvisioningLaunchStateStoreBoundary({
     launchStateStore: {
       read: (teamName) => service.launchStateStore.read(teamName),
-      write: async (teamName, snapshot) => {
-        await service.launchStateStore.write(teamName, snapshot);
+      write: async (teamName, snapshot, publicationOptions) => {
+        await service.launchStateStore.write(teamName, snapshot, publicationOptions);
         if (service.launchStateStore !== service.defaultLaunchStateStore) {
-          await service.defaultLaunchStateStore.write(teamName, snapshot);
+          await service.defaultLaunchStateStore.write(teamName, snapshot, publicationOptions);
         }
       },
       clear: async (teamName) => {

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchStateStoreBoundary.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchStateStoreBoundary.ts
@@ -198,7 +198,16 @@ export class TeamProvisioningLaunchStateStoreBoundary {
           (options.requireTrackedRun === true ||
             this.observedTrackedRunIdByTeam.get(teamName) === options.runId)))
     ) {
-      await this.ports.launchStateStore.clear(teamName);
+      // Undo this write; do not erase the publication. Tracking can drop while
+      // the write is in flight - a stop settling, or a successor run taking
+      // over - and by then the launch truth on disk may belong to someone else.
+      // Clearing would delete that newer truth along with the stale write, so
+      // restore what this call overwrote and only clear when there was nothing.
+      if (previousSnapshot) {
+        await this.ports.launchStateStore.write(teamName, previousSnapshot);
+      } else {
+        await this.ports.launchStateStore.clear(teamName);
+      }
       if (this.writtenRunIdByTeam.get(teamName) === writtenRunIdBeforeWrite) {
         this.writtenRunIdByTeam.delete(teamName);
       }
@@ -206,7 +215,7 @@ export class TeamProvisioningLaunchStateStoreBoundary {
       this.ports.logDebug(
         `[${teamName}] Removed stale launch-state write for run ${options.runId}`
       );
-      return { snapshot: normalizedSnapshot, wrote: false };
+      return { snapshot: previousSnapshot ?? normalizedSnapshot, wrote: false };
     }
     if (typeof options?.runId === 'string') {
       this.writtenRunIdByTeam.set(teamName, options.runId);

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchStateStoreBoundary.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchStateStoreBoundary.ts
@@ -11,6 +11,12 @@ export interface LaunchStateWriteOptions {
   allowNoopSkip?: boolean;
   requireTrackedRun?: boolean;
   runId?: string;
+  /**
+   * True when the snapshot republishes launch truth that already existed
+   * instead of starting a launch. Forwarded to the store, where it keeps a stop
+   * that settled during the write final over this publication.
+   */
+  republishesExistingLaunch?: boolean;
 }
 
 /** Mirrors `TeamLaunchStatePublicationOptions` on the launch-state store. */
@@ -202,7 +208,11 @@ export class TeamProvisioningLaunchStateStoreBoundary {
       return { snapshot: previousSnapshot, wrote: false };
     }
     const writtenRunIdBeforeWrite = this.writtenRunIdByTeam.get(teamName);
-    await this.ports.launchStateStore.write(teamName, normalizedSnapshot);
+    await this.ports.launchStateStore.write(
+      teamName,
+      normalizedSnapshot,
+      options?.republishesExistingLaunch === true ? { republishesExistingLaunch: true } : undefined
+    );
     const trackedRunIdAfterWrite =
       typeof options?.runId === 'string' ? this.ports.getTrackedRunId(teamName) : undefined;
     if (typeof options?.runId === 'string' && trackedRunIdAfterWrite === options.runId) {

--- a/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaneWiring.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaneWiring.ts
@@ -16,6 +16,7 @@ import {
   upsertOpenCodeRuntimeLaneIndexEntry,
 } from '../opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 import { snapshotToMemberSpawnStatuses } from '../TeamLaunchStateEvaluator';
+import { TeamLaunchStateStore } from '../TeamLaunchStateStore';
 
 import { createInitialMemberSpawnStatusEntry } from './TeamProvisioningMemberSpawnStatusPolicy';
 import {
@@ -283,6 +284,7 @@ export function createStaleMixedSecondaryRecoveryPorts<
   TRun extends TeamProvisioningMixedSecondaryLaneWiringRun,
 >(deps: TeamProvisioningMixedSecondaryLaneWiringDeps<TRun>): StaleMixedSecondaryRecoveryPorts {
   return {
+    isTeamLaunchStopped: (teamName) => new TeamLaunchStateStore().isStopped(teamName),
     hasMixedSecondaryLaunchMetadata: (snapshot) =>
       deps.service.hasMixedSecondaryLaunchMetadata(snapshot),
     shouldRecoverStalePersistedMixedLaunchSnapshot: (snapshot) =>

--- a/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaneWiring.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaneWiring.ts
@@ -310,8 +310,8 @@ export function createStaleMixedSecondaryRecoveryPorts<
     nowIso,
     getTeamsBasePath,
     buildAggregateLaunchSnapshot: (input) => deps.service.buildAggregateLaunchSnapshot(input),
-    writeLaunchStateSnapshot: (teamName, snapshot) =>
-      deps.service.writeLaunchStateSnapshot(teamName, snapshot),
+    writeLaunchStateSnapshot: (teamName, snapshot, options) =>
+      deps.service.writeLaunchStateSnapshot(teamName, snapshot, options),
   };
 }
 
@@ -367,8 +367,8 @@ export function createTeamProvisioningMixedSecondaryLaneWiringDepsFromService<
         ),
       buildAggregateLaunchSnapshot: (input) =>
         service.runtimeLaneCoordinator.buildAggregateLaunchSnapshot(input),
-      writeLaunchStateSnapshot: (teamName, snapshot) =>
-        service.writeLaunchStateSnapshot(teamName, snapshot),
+      writeLaunchStateSnapshot: (teamName, snapshot, writeOptions) =>
+        service.writeLaunchStateSnapshot(teamName, snapshot, writeOptions),
     },
     logger: options.logger,
   };

--- a/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaneWiring.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaneWiring.ts
@@ -4,6 +4,7 @@ import {
   type TeamRuntimeLanePlan,
 } from '@features/team-runtime-lanes';
 import { getTeamsBasePath } from '@main/utils/pathDecoder';
+import { isProcessAlive } from '@main/utils/processHealth';
 import { isLeadMember } from '@shared/utils/leadDetection';
 import { randomUUID } from 'crypto';
 
@@ -244,6 +245,7 @@ export function createSingleMixedSecondaryRuntimeLaneStopPorts<
     teamsBasePath: getTeamsBasePath(),
     getOpenCodeRuntimeAdapter: () => deps.service.getOpenCodeRuntimeAdapter(),
     readLaunchState: (teamName) => deps.service.readLaunchState(teamName),
+    isRuntimeProcessAlive: isProcessAlive,
     upsertOpenCodeRuntimeLaneIndexEntry,
     clearOpenCodeRuntimeLaneStorage,
     deleteSecondaryRuntimeRun: (teamName, laneId) =>

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeStopFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeStopFlow.ts
@@ -19,6 +19,7 @@ import type {
 
 interface StopLogger {
   warn(message: string): void;
+  info(message: string): void;
 }
 
 interface RuntimeAdapterRunEntry {
@@ -203,6 +204,9 @@ export async function stopSingleMixedSecondaryRuntimeLane(
   }
 }
 
+/** Lane stops slower than this are logged at warn level: a stop this slow is a problem, not a timing. */
+export const SLOW_SECONDARY_LANE_STOP_WARN_MS = 10_000;
+
 export async function stopMixedSecondaryRuntimeLanes(
   teamName: string,
   ports: OpenCodeRuntimeStopFlowPorts
@@ -223,7 +227,16 @@ export async function stopMixedSecondaryRuntimeLanes(
       throw new Error('OpenCode runtime adapter is unavailable');
     }
     const stopFailures: Error[] = [];
-    for (const secondaryRun of secondaryRuns) {
+    const laneTimings: string[] = [];
+    const startedAtMs = Date.now();
+    // Every lane owns its own host and its own bridge lease, so the lanes stop
+    // concurrently. A sequential walk cost one orchestrator round trip per
+    // lane, which pushed a three-member team past the Stop budget every time
+    // and made the escalation the normal path instead of the exception.
+    const stopSecondaryLane = async (
+      secondaryRun: (typeof secondaryRuns)[number]
+    ): Promise<void> => {
+      const laneStartedAtMs = Date.now();
       try {
         const result = await adapter.stop({
           runId: secondaryRun.runId,
@@ -247,8 +260,10 @@ export async function stopMixedSecondaryRuntimeLanes(
             stopError.message
           }`
         );
-        continue;
+        laneTimings.push(`${secondaryRun.laneId}=${Date.now() - laneStartedAtMs}ms(failed)`);
+        return;
       }
+      laneTimings.push(`${secondaryRun.laneId}=${Date.now() - laneStartedAtMs}ms`);
 
       // adapter.stop is an ownership handoff point. A relaunch may replace
       // the same lane object while it is awaited, so both storage and map
@@ -263,7 +278,7 @@ export async function stopMixedSecondaryRuntimeLanes(
           );
           if (!cleared) {
             if (!isCurrentSecondaryRuntimeRun(teamName, secondaryRun, ports)) {
-              continue;
+              return;
             }
             throw new Error(
               `OpenCode secondary lane ${secondaryRun.laneId} ownership changed before stopped storage cleanup`
@@ -280,6 +295,14 @@ export async function stopMixedSecondaryRuntimeLanes(
           `[${teamName}] Failed to clean stopped OpenCode secondary lane ${secondaryRun.laneId}: ${cleanupError.message}`
         );
       }
+    };
+    await Promise.all(secondaryRuns.map((secondaryRun) => stopSecondaryLane(secondaryRun)));
+    const totalMs = Date.now() - startedAtMs;
+    const timingSummary = `${secondaryRuns.length} secondary lane(s) stopped in ${totalMs}ms [${laneTimings.join(', ')}]`;
+    if (totalMs >= SLOW_SECONDARY_LANE_STOP_WARN_MS) {
+      ports.logger.warn(`[${teamName}] Slow OpenCode stop: ${timingSummary}`);
+    } else {
+      ports.logger.info(`[${teamName}] ${timingSummary}`);
     }
     if (stopFailures.length > 0) {
       throw stopFailures[0];
@@ -316,6 +339,7 @@ export async function stopOpenCodeRuntimeAdapterTeam(
   ports.invalidateRuntimeSnapshotCaches(teamName);
   try {
     const previousLaunchState = await ports.readLaunchState(teamName);
+    const stopStartedAtMs = Date.now();
     const result = await adapter.stop({
       runId,
       laneId: 'primary',
@@ -326,6 +350,14 @@ export async function stopOpenCodeRuntimeAdapterTeam(
       previousLaunchState,
       force: true,
     });
+    const stopMs = Date.now() - stopStartedAtMs;
+    if (stopMs >= SLOW_SECONDARY_LANE_STOP_WARN_MS) {
+      ports.logger.warn(
+        `[${teamName}] Slow OpenCode stop: primary lane stop took ${stopMs}ms (stopped=${String(result.stopped)})`
+      );
+    } else {
+      ports.logger.info(`[${teamName}] OpenCode primary lane stop took ${stopMs}ms`);
+    }
     assertOpenCodeRuntimeStopSucceeded(result, 'OpenCode team did not confirm stop');
 
     if (!ownsPrimaryRuntimeLane(teamName, runId, ports)) {

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeStopFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeStopFlow.ts
@@ -1,3 +1,4 @@
+import { assertOpenCodeRuntimeStopEffective } from './TeamProvisioningOpenCodeRuntimeStopOutcome';
 import { ownsOpenCodeRuntimeAdapterPrimaryLane } from './TeamProvisioningRuntimeAdapterCancellation';
 
 import type {
@@ -21,6 +22,9 @@ interface StopLogger {
   warn(message: string): void;
   info(message: string): void;
 }
+
+/** Process existence probe, so the stop flow does not reach for the OS itself. */
+type RuntimeProcessAliveProbe = (pid: number) => boolean;
 
 interface RuntimeAdapterRunEntry {
   runId: string;
@@ -62,6 +66,7 @@ export interface OpenCodeRuntimeStopFlowPorts {
   emitTeamChange(event: TeamChangeEvent): void;
   logger: StopLogger;
   nowIso(): string;
+  isRuntimeProcessAlive: RuntimeProcessAliveProbe;
 }
 
 export interface SingleMixedSecondaryRuntimeLaneStopRun {
@@ -76,6 +81,7 @@ export interface SingleMixedSecondaryRuntimeLaneStopPorts {
   teamsBasePath: string;
   getOpenCodeRuntimeAdapter(): TeamLaunchRuntimeAdapter | null;
   readLaunchState(teamName: string): Promise<PersistedTeamLaunchSnapshot | null>;
+  isRuntimeProcessAlive: RuntimeProcessAliveProbe;
   upsertOpenCodeRuntimeLaneIndexEntry(input: {
     teamsBasePath: string;
     teamName: string;
@@ -142,7 +148,14 @@ export async function stopSingleMixedSecondaryRuntimeLane(
       previousLaunchState,
       force: true,
     });
-    assertOpenCodeRuntimeStopSucceeded(result, `OpenCode lane ${lane.laneId} did not confirm stop`);
+    assertOpenCodeRuntimeStopEffective({
+      result,
+      laneId: lane.laneId,
+      previousLaunchState,
+      message: `OpenCode lane ${lane.laneId} did not confirm stop`,
+      logWarning: (message) => ports.logger.warn(`[${run.teamName}] ${message}`),
+      isRuntimeProcessAlive: ports.isRuntimeProcessAlive,
+    });
     keepStopFence = true;
     const cleared = await ports.clearOpenCodeRuntimeLaneStorage({
       teamsBasePath: ports.teamsBasePath,
@@ -248,10 +261,14 @@ export async function stopMixedSecondaryRuntimeLanes(
           previousLaunchState,
           force: true,
         });
-        assertOpenCodeRuntimeStopSucceeded(
+        assertOpenCodeRuntimeStopEffective({
           result,
-          `OpenCode secondary lane ${secondaryRun.laneId} did not confirm stop`
-        );
+          laneId: secondaryRun.laneId,
+          previousLaunchState,
+          message: `OpenCode secondary lane ${secondaryRun.laneId} did not confirm stop`,
+          logWarning: (message) => ports.logger.warn(`[${teamName}] ${message}`),
+          isRuntimeProcessAlive: ports.isRuntimeProcessAlive,
+        });
       } catch (error) {
         const stopError = asError(error);
         stopFailures.push(stopError);
@@ -358,7 +375,14 @@ export async function stopOpenCodeRuntimeAdapterTeam(
     } else {
       ports.logger.info(`[${teamName}] OpenCode primary lane stop took ${stopMs}ms`);
     }
-    assertOpenCodeRuntimeStopSucceeded(result, 'OpenCode team did not confirm stop');
+    assertOpenCodeRuntimeStopEffective({
+      result,
+      laneId: 'primary',
+      previousLaunchState,
+      message: 'OpenCode team did not confirm stop',
+      logWarning: (message) => ports.logger.warn(`[${teamName}] ${message}`),
+      isRuntimeProcessAlive: ports.isRuntimeProcessAlive,
+    });
 
     if (!ownsPrimaryRuntimeLane(teamName, runId, ports)) {
       return;
@@ -419,27 +443,6 @@ export async function stopOpenCodeRuntimeAdapterTeam(
     });
     throw error;
   }
-}
-
-function assertOpenCodeRuntimeStopSucceeded(
-  result: unknown,
-  message: string
-): asserts result is { stopped: true; diagnostics: string[]; warnings: string[] } {
-  if (result && typeof result === 'object' && (result as { stopped?: unknown }).stopped === true) {
-    return;
-  }
-  const stopResult = result as { diagnostics?: unknown; warnings?: unknown } | null;
-  const diagnostics = Array.isArray(stopResult?.diagnostics)
-    ? stopResult.diagnostics.filter((entry): entry is string => typeof entry === 'string')
-    : [];
-  const warnings = Array.isArray(stopResult?.warnings)
-    ? stopResult.warnings.filter((entry): entry is string => typeof entry === 'string')
-    : [];
-  const detail = [...diagnostics, ...warnings]
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .join('; ');
-  throw new Error(detail ? `${message}: ${detail}` : message);
 }
 
 function asError(error: unknown): Error {

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeStopOutcome.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeStopOutcome.ts
@@ -1,0 +1,119 @@
+import { isProcessAlive } from '@main/utils/processHealth';
+
+import type { PersistedTeamLaunchSnapshot } from '@shared/types';
+
+/**
+ * Idempotent OpenCode lane stop.
+ *
+ * The orchestrator's `opencode.stopTeam` reports `stopped: false` whenever a
+ * session abort does not confirm - which is exactly what happens when the
+ * runtime is already gone: the host crashed, was killed by a force stop, or
+ * exited after a previous stop. Treating that as a failed stop left the run
+ * tracked as alive, so every later Stop hit the same rejection - the HTTP
+ * `/stop` route answered 500 in a loop and the team never left the alive list.
+ *
+ * A stop whose lane has no live host process any more is a completed stop:
+ * there is nothing left to stop. Only a lane whose recorded host is still
+ * running turns an unconfirmed stop into a failure.
+ */
+
+export interface OpenCodeRuntimeStopResultLike {
+  stopped?: unknown;
+  diagnostics?: unknown;
+  warnings?: unknown;
+}
+
+export type OpenCodeRuntimeStopOutcome =
+  | { kind: 'stopped' }
+  | { kind: 'already_stopped'; detail: string; checkedPids: number[] }
+  | { kind: 'failed'; detail: string; alivePids: number[] };
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === 'string')
+    : [];
+}
+
+export function describeOpenCodeRuntimeStopResult(
+  result: OpenCodeRuntimeStopResultLike | null
+): string {
+  return [...stringList(result?.diagnostics), ...stringList(result?.warnings)]
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .join('; ');
+}
+
+/** Recorded host pids of the members that belong to `laneId` in the launch snapshot. */
+export function collectOpenCodeLaneRuntimePids(
+  snapshot: PersistedTeamLaunchSnapshot | null | undefined,
+  laneId: string
+): number[] {
+  const pids = new Set<number>();
+  for (const member of Object.values(snapshot?.members ?? {})) {
+    if (!member) continue;
+    const memberLaneId = member.laneId ?? (member.laneKind === 'secondary' ? undefined : 'primary');
+    if (memberLaneId !== laneId) continue;
+    const pid = member.runtimePid;
+    if (typeof pid === 'number' && Number.isFinite(pid) && pid > 0) {
+      pids.add(pid);
+    }
+  }
+  return [...pids];
+}
+
+export function resolveOpenCodeRuntimeStopOutcome(input: {
+  result: OpenCodeRuntimeStopResultLike | null | undefined;
+  laneId: string;
+  previousLaunchState: PersistedTeamLaunchSnapshot | null | undefined;
+  isRuntimeProcessAlive?: (pid: number) => boolean;
+}): OpenCodeRuntimeStopOutcome {
+  const result = input.result ?? null;
+  if (result && typeof result === 'object' && result.stopped === true) {
+    return { kind: 'stopped' };
+  }
+  const detail = describeOpenCodeRuntimeStopResult(result);
+  const isAlive = input.isRuntimeProcessAlive ?? isProcessAlive;
+  const pids = collectOpenCodeLaneRuntimePids(input.previousLaunchState, input.laneId);
+  const alivePids = pids.filter((pid) => {
+    try {
+      return isAlive(pid);
+    } catch {
+      return false;
+    }
+  });
+  if (pids.length > 0 && alivePids.length === 0) {
+    return { kind: 'already_stopped', detail, checkedPids: pids };
+  }
+  return { kind: 'failed', detail, alivePids };
+}
+
+/**
+ * Throws for a genuinely failed stop; returns normally - after logging - when
+ * the stop is confirmed or the runtime had already stopped.
+ */
+export function assertOpenCodeRuntimeStopEffective(input: {
+  result: OpenCodeRuntimeStopResultLike | null | undefined;
+  laneId: string;
+  previousLaunchState: PersistedTeamLaunchSnapshot | null | undefined;
+  message: string;
+  logWarning: (message: string) => void;
+  isRuntimeProcessAlive?: (pid: number) => boolean;
+}): OpenCodeRuntimeStopOutcome {
+  const outcome = resolveOpenCodeRuntimeStopOutcome(input);
+  if (outcome.kind === 'failed') {
+    const suffix = outcome.detail ? `: ${outcome.detail}` : '';
+    const alive =
+      outcome.alivePids.length > 0
+        ? ` (host process still alive: pid ${outcome.alivePids.join(', ')})`
+        : ' (no recorded host pid to verify)';
+    throw new Error(`${input.message}${suffix}${alive}`);
+  }
+  if (outcome.kind === 'already_stopped') {
+    input.logWarning(
+      `${input.message}, but no recorded host process is alive (checked pid ${outcome.checkedPids.join(', ')}); treating the runtime as already stopped${
+        outcome.detail ? `: ${outcome.detail}` : ''
+      }`
+    );
+  }
+  return outcome;
+}

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeStopOutcome.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeRuntimeStopOutcome.ts
@@ -15,7 +15,31 @@ import type { PersistedTeamLaunchSnapshot } from '@shared/types';
  * A stop whose lane has no live host process any more is a completed stop:
  * there is nothing left to stop. Only a lane whose recorded host is still
  * running turns an unconfirmed stop into a failure.
+ *
+ * A capability snapshot mismatch is the same trap one step earlier. The stop
+ * is rejected before the bridge handshake even runs - the persisted lane
+ * manifest no longer matches, which happens when the OpenCode user config
+ * changes while lanes are running - so the failure carries no host evidence
+ * at all. When the lane also has no recorded host pid there is nothing
+ * verifiable left to protect, and failing forever kept the team wedged in
+ * memory until the app was restarted. Only that no-evidence mismatch settles
+ * as already stopped; a recorded live host still fails the stop.
  */
+
+const OPEN_CODE_STOP_CAPABILITY_SNAPSHOT_MISMATCH_MARKERS = [
+  'bridge server capability snapshot mismatch',
+  'opencode bridge capability snapshot mismatch',
+  // Rejected before the handshake, by the persisted-manifest precondition.
+  'requires the exact persisted lane run and capability snapshot',
+  'capability snapshot does not match the persisted lane manifest',
+];
+
+function isOpenCodeCapabilitySnapshotMismatchStopDetail(detail: string): boolean {
+  const normalized = detail.toLowerCase();
+  return OPEN_CODE_STOP_CAPABILITY_SNAPSHOT_MISMATCH_MARKERS.some((marker) =>
+    normalized.includes(marker)
+  );
+}
 
 export interface OpenCodeRuntimeStopResultLike {
   stopped?: unknown;
@@ -84,6 +108,9 @@ export function resolveOpenCodeRuntimeStopOutcome(input: {
   if (pids.length > 0 && alivePids.length === 0) {
     return { kind: 'already_stopped', detail, checkedPids: pids };
   }
+  if (pids.length === 0 && isOpenCodeCapabilitySnapshotMismatchStopDetail(detail)) {
+    return { kind: 'already_stopped', detail, checkedPids: [] };
+  }
   return { kind: 'failed', detail, alivePids };
 }
 
@@ -109,8 +136,12 @@ export function assertOpenCodeRuntimeStopEffective(input: {
     throw new Error(`${input.message}${suffix}${alive}`);
   }
   if (outcome.kind === 'already_stopped') {
+    const evidence =
+      outcome.checkedPids.length > 0
+        ? `no recorded host process is alive (checked pid ${outcome.checkedPids.join(', ')})`
+        : 'the capability snapshot mismatch left no recorded host pid to verify';
     input.logWarning(
-      `${input.message}, but no recorded host process is alive (checked pid ${outcome.checkedPids.join(', ')}); treating the runtime as already stopped${
+      `${input.message}, but ${evidence}; treating the runtime as already stopped${
         outcome.detail ? `: ${outcome.detail}` : ''
       }`
     );

--- a/src/main/services/team/provisioning/TeamProvisioningPersistedLaunchReconcilePorts.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningPersistedLaunchReconcilePorts.ts
@@ -51,6 +51,13 @@ export interface TeamProvisioningPersistedLaunchReconcilePortsInput extends Pick
   | 'clearPersistedLaunchState'
   | 'getLiveTeamAgentRuntimeMetadata'
 > {
+  /**
+   * Required here, unlike on the reconcile ports themselves: a reconcile that
+   * runs against the provisioning service always has a tracked run to answer
+   * with, and leaving it out would silently opt every write out of the
+   * stale-run guards.
+   */
+  getTrackedRunId(teamName: string): string | null | undefined;
   readLaunchState(teamName: string): Promise<PersistedTeamLaunchSnapshot | null>;
   readMembersMeta(teamName: string): Promise<readonly TeamMember[]>;
   readPersistedRuntimeMembers(teamName: string): readonly BootstrapRuntimeMemberLike[];
@@ -81,6 +88,9 @@ export interface TeamProvisioningPersistedLaunchReconcileServiceHost extends Pic
   membersMetaStore: {
     getMembers: TeamProvisioningPersistedLaunchReconcilePortsInput['readMembersMeta'];
   };
+  runTracking: {
+    getTrackedRunId: TeamProvisioningPersistedLaunchReconcilePortsInput['getTrackedRunId'];
+  };
 }
 
 function nowIso(): string {
@@ -99,6 +109,7 @@ export function createTeamProvisioningPersistedLaunchReconcilePorts(
     applyOpenCodeSecondaryBootstrapStallOverlay: input.applyOpenCodeSecondaryBootstrapStallOverlay,
     writeLaunchStateSnapshot: input.writeLaunchStateSnapshot,
     clearPersistedLaunchState: input.clearPersistedLaunchState,
+    getTrackedRunId: input.getTrackedRunId,
     applyBootstrapTranscriptEvidenceOverlay: (snapshot) =>
       applyBootstrapTranscriptEvidenceOverlay({
         snapshot,
@@ -221,9 +232,15 @@ export function createTeamProvisioningPersistedLaunchReconcilePortsFromService(
       service.applyOpenCodeSecondaryEvidenceOverlay(input),
     applyOpenCodeSecondaryBootstrapStallOverlay: (snapshot) =>
       service.applyOpenCodeSecondaryBootstrapStallOverlay(snapshot),
-    writeLaunchStateSnapshot: (teamName, snapshot) =>
-      service.writeLaunchStateSnapshot(teamName, snapshot),
-    clearPersistedLaunchState: (teamName) => service.clearPersistedLaunchState(teamName),
+    writeLaunchStateSnapshot: (teamName, snapshot, options) =>
+      options === undefined
+        ? service.writeLaunchStateSnapshot(teamName, snapshot)
+        : service.writeLaunchStateSnapshot(teamName, snapshot, options),
+    clearPersistedLaunchState: (teamName, options) =>
+      options === undefined
+        ? service.clearPersistedLaunchState(teamName)
+        : service.clearPersistedLaunchState(teamName, options),
+    getTrackedRunId: (teamName) => service.runTracking.getTrackedRunId(teamName),
     getLiveTeamAgentRuntimeMetadata: (teamName) =>
       service.getLiveTeamAgentRuntimeMetadata(teamName),
     resolveExpectedLaunchMemberName: (members, candidateName) =>

--- a/src/main/services/team/provisioning/TeamProvisioningPersistedLaunchReconciliation.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningPersistedLaunchReconciliation.ts
@@ -70,9 +70,12 @@ export interface ReconcilePersistedLaunchStatePorts {
   ): PersistedTeamLaunchSnapshot | null;
   writeLaunchStateSnapshot(
     teamName: string,
-    snapshot: PersistedTeamLaunchSnapshot
+    snapshot: PersistedTeamLaunchSnapshot,
+    options?: { runId?: string }
   ): Promise<PersistedTeamLaunchSnapshot>;
-  clearPersistedLaunchState(teamName: string): Promise<void>;
+  clearPersistedLaunchState(teamName: string, options?: { expectedRunId?: string }): Promise<void>;
+  /** Run this reconcile is scoped to; without one its writes skip every stale-run guard. */
+  getTrackedRunId?(teamName: string): string | null | undefined;
   applyBootstrapTranscriptEvidenceOverlay(
     snapshot: PersistedTeamLaunchSnapshot | null
   ): Promise<PersistedTeamLaunchSnapshot | null>;
@@ -122,10 +125,32 @@ export interface ReconcilePersistedLaunchStatePorts {
   nowMs(): number;
 }
 
+/**
+ * Reconcile the persisted launch state of a team.
+ *
+ * Every write and clear is scoped to `expectedRunId` - the caller's, or the
+ * tracked run when the port supplies one. Unscoped,
+ * `writeLaunchStateSnapshotNow` skips its stale-run guards and
+ * `clearPersistedLaunchStateNow` takes the branch that also wipes bootstrap
+ * state, which lets a reconcile started for one run delete the launch state a
+ * concurrent run is still writing.
+ */
 export async function reconcilePersistedLaunchStateWithPorts(
   teamName: string,
-  ports: ReconcilePersistedLaunchStatePorts
+  ports: ReconcilePersistedLaunchStatePorts,
+  options?: { expectedRunId?: string | null }
 ): Promise<PersistedLaunchReconciliationResult> {
+  const expectedRunId = options?.expectedRunId ?? ports.getTrackedRunId?.(teamName) ?? undefined;
+  const writeSnapshot = (
+    snapshot: PersistedTeamLaunchSnapshot
+  ): Promise<PersistedTeamLaunchSnapshot> =>
+    expectedRunId
+      ? ports.writeLaunchStateSnapshot(teamName, snapshot, { runId: expectedRunId })
+      : ports.writeLaunchStateSnapshot(teamName, snapshot);
+  const clearPersistedState = (): Promise<void> =>
+    expectedRunId
+      ? ports.clearPersistedLaunchState(teamName, { expectedRunId })
+      : ports.clearPersistedLaunchState(teamName);
   const bootstrapSnapshot = await ports.readBootstrapLaunchSnapshot(teamName);
   const persisted = await ports.readLaunchState(teamName);
   const metaMembers = await ports.readMembersMeta(teamName).catch(() => []);
@@ -154,15 +179,15 @@ export async function reconcilePersistedLaunchStateWithPorts(
     snapshotBeforeBootstrapStallOverlay: overlaidRecoveredMixedSnapshot,
   });
   const stableRecoveredMixedSnapshotWithCommittedEvidence =
-    recoveredMixedSnapshotWithBootstrapStall &&
-    recoveredCommittedEvidenceWriteDecision.shouldWrite
-      ? await ports.writeLaunchStateSnapshot(teamName, recoveredMixedSnapshotWithBootstrapStall)
+    recoveredMixedSnapshotWithBootstrapStall && recoveredCommittedEvidenceWriteDecision.shouldWrite
+      ? await writeSnapshot(recoveredMixedSnapshotWithBootstrapStall)
       : recoveredMixedSnapshotWithBootstrapStall;
   const promotedRecoveredMixedSnapshot = promoteOpenCodePersistedFailureReasonsFromDiagnostics(
     stableRecoveredMixedSnapshotWithCommittedEvidence
   );
-  const cleanedRecoveredMixedSnapshot =
-    ports.cleanConfirmedBootstrapRuntimeDiagnostics(promotedRecoveredMixedSnapshot);
+  const cleanedRecoveredMixedSnapshot = ports.cleanConfirmedBootstrapRuntimeDiagnostics(
+    promotedRecoveredMixedSnapshot
+  );
   const recoveredPromotionCleanupWriteDecision = getPromotionCleanupWriteDecision({
     baseSnapshot: stableRecoveredMixedSnapshotWithCommittedEvidence,
     promotedSnapshot: promotedRecoveredMixedSnapshot,
@@ -170,7 +195,7 @@ export async function reconcilePersistedLaunchStateWithPorts(
   });
   const stableRecoveredMixedSnapshot =
     cleanedRecoveredMixedSnapshot && recoveredPromotionCleanupWriteDecision.shouldWrite
-      ? await ports.writeLaunchStateSnapshot(teamName, cleanedRecoveredMixedSnapshot)
+      ? await writeSnapshot(cleanedRecoveredMixedSnapshot)
       : cleanedRecoveredMixedSnapshot;
   const filteredBootstrapSnapshot = filterOptionalRemovedMembersFromLaunchSnapshot(
     bootstrapSnapshot,
@@ -225,7 +250,7 @@ export async function reconcilePersistedLaunchStateWithPorts(
   );
   const persistedWithCommittedEvidence =
     cleanedPersisted && persistedWriteDecision.shouldWrite
-      ? await ports.writeLaunchStateSnapshot(teamName, cleanedPersisted)
+      ? await writeSnapshot(cleanedPersisted)
       : cleanedPersisted;
   const preferredSnapshot = ports.choosePreferredLaunchSnapshot(
     overlaidBootstrapSnapshot,
@@ -238,11 +263,11 @@ export async function reconcilePersistedLaunchStateWithPorts(
   });
   if (preferredSnapshot && preferredBootstrapDecision.kind !== 'ignore') {
     if (preferredBootstrapDecision.kind === 'clear_persisted_state') {
-      await ports.clearPersistedLaunchState(teamName);
+      await clearPersistedState();
       return projectPersistedLaunchReconciliationResult(preferredSnapshot);
     }
     if (preferredBootstrapDecision.kind === 'write_snapshot') {
-      const writtenSnapshot = await ports.writeLaunchStateSnapshot(teamName, preferredSnapshot);
+      const writtenSnapshot = await writeSnapshot(preferredSnapshot);
       return projectPersistedLaunchReconciliationResult(writtenSnapshot);
     }
     return projectPersistedLaunchReconciliationResult(preferredSnapshot);
@@ -330,11 +355,11 @@ export async function reconcilePersistedLaunchStateWithPorts(
 
   const finalSnapshotDecision = decideFinalReconciledSnapshotWrite(reconciled);
   if (finalSnapshotDecision.kind === 'clear_persisted_state') {
-    await ports.clearPersistedLaunchState(teamName);
+    await clearPersistedState();
     return projectEmptyPersistedLaunchReconciliationResult();
   }
 
-  const writtenSnapshot = await ports.writeLaunchStateSnapshot(teamName, reconciled);
+  const writtenSnapshot = await writeSnapshot(reconciled);
   return projectPersistedLaunchReconciliationResult(writtenSnapshot);
 }
 

--- a/src/main/services/team/provisioning/TeamProvisioningPersistenceReconcileFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningPersistenceReconcileFacade.ts
@@ -75,6 +75,7 @@ export interface TeamProvisioningPersistenceReconcileFacadeServiceHost<
     launchPhase: PersistedTeamLaunchPhase
   ): PersistedTeamLaunchSnapshot | null;
   invalidateRuntimeSnapshotCaches(teamName: string): void;
+  getTrackedRunId(teamName: string): string | null | undefined;
 }
 
 export class TeamProvisioningPersistenceReconcileFacade<
@@ -188,9 +189,10 @@ export class TeamProvisioningPersistenceReconcileFacade<
       ...this.ports.reconcile,
       readLaunchState: (targetTeamName) => this.ports.readLaunchState(targetTeamName),
       readMembersMeta: (targetTeamName) => this.ports.readMembersMeta(targetTeamName),
-      writeLaunchStateSnapshot: (targetTeamName, snapshot) =>
-        this.writeLaunchStateSnapshot(targetTeamName, snapshot),
-      clearPersistedLaunchState: (targetTeamName) => this.clearPersistedLaunchState(targetTeamName),
+      writeLaunchStateSnapshot: (targetTeamName, snapshot, options) =>
+        this.writeLaunchStateSnapshot(targetTeamName, snapshot, options),
+      clearPersistedLaunchState: (targetTeamName, options) =>
+        this.clearPersistedLaunchState(targetTeamName, options),
     });
   }
 }
@@ -213,6 +215,7 @@ export function createTeamProvisioningPersistenceReconcileFacadeFromService<
     invalidateRuntimeSnapshotCaches: (teamName) =>
       service.invalidateRuntimeSnapshotCaches(teamName),
     reconcile: {
+      getTrackedRunId: (teamName) => service.getTrackedRunId(teamName),
       recoverStaleMixedSecondaryLaunchSnapshot: (teamName, bootstrapSnapshot, persistedSnapshot) =>
         service.recoverStaleMixedSecondaryLaunchSnapshot(
           teamName,

--- a/src/main/services/team/provisioning/TeamProvisioningStaleMixedSecondaryRecovery.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStaleMixedSecondaryRecovery.ts
@@ -147,7 +147,8 @@ export interface StaleMixedSecondaryRecoveryPorts {
   }): PersistedTeamLaunchSnapshot;
   writeLaunchStateSnapshot(
     teamName: string,
-    snapshot: PersistedTeamLaunchSnapshot
+    snapshot: PersistedTeamLaunchSnapshot,
+    options?: { republishesExistingLaunch?: boolean }
   ): Promise<PersistedTeamLaunchSnapshot | null>;
 }
 
@@ -423,5 +424,14 @@ export async function recoverStaleMixedSecondaryLaunchSnapshotWithPorts(
     primaryStatuses,
     secondaryMembers,
   });
-  return ports.writeLaunchStateSnapshot(teamName, recoveredSnapshot);
+  // Re-deriving the lanes takes runtime probes, so a stop can settle between
+  // the check above and this write. The write declares that it starts no
+  // launch: the store fences it with the stop marker inside its publication
+  // queue, which no stop can slip through, and a stopped team keeps its stop.
+  const recovered = await ports.writeLaunchStateSnapshot(teamName, recoveredSnapshot, {
+    republishesExistingLaunch: true,
+  });
+  // Nothing was published for a team that was stopped meanwhile, so the caller
+  // must not be handed a recovered snapshot either.
+  return (await ports.isTeamLaunchStopped(teamName)) ? persistedSnapshot : recovered;
 }

--- a/src/main/services/team/provisioning/TeamProvisioningStaleMixedSecondaryRecovery.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStaleMixedSecondaryRecovery.ts
@@ -85,6 +85,8 @@ export interface StaleMixedSecondaryMemberInput {
 }
 
 export interface StaleMixedSecondaryRecoveryPorts {
+  /** True while the team carries a stop marker: stopped, and not relaunched yet. */
+  isTeamLaunchStopped(teamName: string): Promise<boolean>;
   hasMixedSecondaryLaunchMetadata(snapshot: PersistedTeamLaunchSnapshot | null): boolean;
   shouldRecoverStalePersistedMixedLaunchSnapshot(snapshot: PersistedTeamLaunchSnapshot): boolean;
   readTeamMeta(teamName: string): Promise<StaleMixedSecondaryTeamMeta | null>;
@@ -163,6 +165,12 @@ export async function recoverStaleMixedSecondaryLaunchSnapshotWithPorts(
   persistedSnapshot: PersistedTeamLaunchSnapshot | null,
   ports: StaleMixedSecondaryRecoveryPorts
 ): Promise<PersistedTeamLaunchSnapshot | null> {
+  // A stopped team has nothing to recover: re-deriving lanes from the leftover
+  // metadata of the run that was just stopped produced a phantom
+  // "starting / never spawned" launch snapshot on the team card.
+  if (await ports.isTeamLaunchStopped(teamName)) {
+    return persistedSnapshot;
+  }
   if (
     persistedSnapshot &&
     ports.hasMixedSecondaryLaunchMetadata(persistedSnapshot) &&
@@ -250,10 +258,7 @@ export async function recoverStaleMixedSecondaryLaunchSnapshotWithPorts(
             },
           });
 
-    if (
-      laneIdentity.laneKind !== 'secondary' ||
-      laneIdentity.laneOwnerProviderId !== 'opencode'
-    ) {
+    if (laneIdentity.laneKind !== 'secondary' || laneIdentity.laneOwnerProviderId !== 'opencode') {
       primaryMembers.push(member);
       continue;
     }

--- a/src/main/services/team/provisioning/TeamProvisioningStopFlowPortsFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStopFlowPortsFactory.ts
@@ -1,3 +1,5 @@
+import { isProcessAlive } from '@main/utils/processHealth';
+
 import {
   type OpenCodeRuntimeStopFlowPorts,
   stopMixedSecondaryRuntimeLanes,
@@ -180,6 +182,7 @@ export function createOpenCodeRuntimeStopFlowPortsFromDeps<TRun extends TeamProv
     stoppingSecondaryRuntimeTeams: deps.stoppingSecondaryRuntimeTeams,
     getOpenCodeRuntimeAdapter: () => deps.getOpenCodeRuntimeAdapter(),
     readLaunchState: (teamName) => deps.readLaunchState(teamName),
+    isRuntimeProcessAlive: isProcessAlive,
     writeLaunchStateSnapshot: (teamName, snapshot) =>
       deps.writeLaunchStateSnapshot(teamName, snapshot),
     readPersistedTeamProjectPath: (teamName) => deps.readPersistedTeamProjectPath(teamName),

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningCancellationBoundary.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningCancellationBoundary.test.ts
@@ -412,7 +412,7 @@ describe('TeamProvisioningCancellationBoundary', () => {
         provisioningRunByTeam: new Map(),
         invalidateRuntimeSnapshotCaches: vi.fn(),
         emitTeamChange: vi.fn(),
-        logger: { warn: vi.fn() },
+        logger: { warn: vi.fn(), info: vi.fn() },
         nowIso: () => '2026-01-01T00:00:02.000Z',
       };
       const ports = makePorts({

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningCancellationBoundary.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningCancellationBoundary.test.ts
@@ -413,6 +413,7 @@ describe('TeamProvisioningCancellationBoundary', () => {
         invalidateRuntimeSnapshotCaches: vi.fn(),
         emitTeamChange: vi.fn(),
         logger: { warn: vi.fn(), info: vi.fn() },
+        isRuntimeProcessAlive: () => false,
         nowIso: () => '2026-01-01T00:00:02.000Z',
       };
       const ports = makePorts({

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchStateStoreBoundary.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchStateStoreBoundary.test.ts
@@ -356,7 +356,7 @@ describe('TeamProvisioningLaunchStateStoreBoundary', () => {
       metaMembers: [{ name: 'Builder', joinedAt: 1 }],
     });
     expect(ports.applyBootstrapStallOverlay).toHaveBeenCalledWith(evidenceOverlay);
-    expect(ports.launchStateStore.write).toHaveBeenCalledWith('demo', stallOverlay);
+    expect(ports.launchStateStore.write).toHaveBeenCalledWith('demo', stallOverlay, undefined);
     expect(result).toEqual({ snapshot: stallOverlay, wrote: true });
 
     setTrackedRunId('run-2');
@@ -420,7 +420,11 @@ describe('TeamProvisioningLaunchStateStoreBoundary', () => {
     });
     expect(result.snapshot.members.Builder.runtimeRunId).toBeUndefined();
     expect(result.snapshot.members.Builder.runtimeSessionId).toBeUndefined();
-    expect(ports.launchStateStore.write).toHaveBeenCalledWith('demo', replacementSnapshot);
+    expect(ports.launchStateStore.write).toHaveBeenCalledWith(
+      'demo',
+      replacementSnapshot,
+      undefined
+    );
   });
 
   it.each([
@@ -533,7 +537,7 @@ describe('TeamProvisioningLaunchStateStoreBoundary', () => {
     });
 
     expect(result).toEqual({ snapshot: next, wrote: true });
-    expect(ports.launchStateStore.write).toHaveBeenCalledWith('demo', next);
+    expect(ports.launchStateStore.write).toHaveBeenCalledWith('demo', next, undefined);
   });
 
   it.each([null, undefined])(
@@ -548,7 +552,7 @@ describe('TeamProvisioningLaunchStateStoreBoundary', () => {
       });
 
       expect(result).toEqual({ snapshot: next, wrote: true });
-      expect(ports.launchStateStore.write).toHaveBeenCalledWith('demo', next);
+      expect(ports.launchStateStore.write).toHaveBeenCalledWith('demo', next, undefined);
       expect(ports.launchStateStore.clear).not.toHaveBeenCalled();
       expect(boundary.getWrittenRunIdByTeam().get('demo')).toBe('run-1');
       expect(ports.logDebug).not.toHaveBeenCalled();

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchStateStoreBoundary.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchStateStoreBoundary.test.ts
@@ -149,8 +149,10 @@ describe('TeamProvisioningLaunchStateStoreBoundary', () => {
     await boundary.writeLaunchStateSnapshotNow('demo', nextSnapshot, { runId: 'run-1' });
     await boundary.clearPersistedLaunchStateNow('demo');
 
-    expect(launchStateStore.write).toHaveBeenCalledWith('demo', nextSnapshot);
-    expect(defaultLaunchStateStore.write).toHaveBeenCalledWith('demo', nextSnapshot);
+    // A launch write carries no publication options: it is the write allowed to
+    // supersede a stop, so it must not be marked as a republication.
+    expect(launchStateStore.write).toHaveBeenCalledWith('demo', nextSnapshot, undefined);
+    expect(defaultLaunchStateStore.write).toHaveBeenCalledWith('demo', nextSnapshot, undefined);
     expect(launchStateStore.clear).toHaveBeenCalledWith('demo');
     expect(defaultLaunchStateStore.clear).toHaveBeenCalledWith('demo');
     expect(clearBootstrapState).toHaveBeenCalledWith('demo');
@@ -198,8 +200,10 @@ describe('TeamProvisioningLaunchStateStoreBoundary', () => {
     const publishing = boundary.writeLaunchStateSnapshot('demo', nextSnapshot);
     await defaultWriteStarted.promise;
 
-    expect(launchStateStore.write).toHaveBeenCalledWith('demo', nextSnapshot);
-    expect(defaultLaunchStateStore.write).toHaveBeenCalledWith('demo', nextSnapshot);
+    // A launch write carries no publication options: it is the write allowed to
+    // supersede a stop, so it must not be marked as a republication.
+    expect(launchStateStore.write).toHaveBeenCalledWith('demo', nextSnapshot, undefined);
+    expect(defaultLaunchStateStore.write).toHaveBeenCalledWith('demo', nextSnapshot, undefined);
     expect(invalidateRuntimeSnapshotCaches).not.toHaveBeenCalled();
 
     defaultWriteGate.resolve();
@@ -681,6 +685,35 @@ describe('TeamProvisioningLaunchStateStoreBoundary', () => {
     expect(ports.launchStateStore.clear).not.toHaveBeenCalled();
     expect(ports.invalidateRuntimeSnapshotCaches).toHaveBeenCalledWith('demo');
     expect(boundary.getWrittenRunIdByTeam().has('demo')).toBe(false);
+  });
+
+  it('restores the overwritten launch truth as a republication so a settled stop survives it', async () => {
+    // The rollback runs after the stale write, so a stop can settle in between.
+    // An active snapshot restored as a launch would republish over that stop and
+    // lift its marker; the restore has to declare that it starts no launch.
+    const previousSnapshot = snapshot({ updatedAt: '2026-01-01T00:00:05.000Z' });
+    const writeStarted = deferred();
+    const writeGate = deferred();
+    const launchStateStore = {
+      read: vi.fn(async () => previousSnapshot),
+      write: vi.fn(async (_teamName: string, nextSnapshot: PersistedTeamLaunchSnapshot) => {
+        if (nextSnapshot === previousSnapshot) return;
+        writeStarted.resolve();
+        await writeGate.promise;
+      }),
+      clear: vi.fn(async () => undefined),
+    };
+    const { boundary, setTrackedRunId } = createBoundary({ launchStateStore });
+
+    const writing = boundary.writeLaunchStateSnapshotNow('demo', snapshot(), { runId: 'run-1' });
+    await writeStarted.promise;
+    setTrackedRunId(undefined);
+    writeGate.resolve();
+
+    await expect(writing).resolves.toMatchObject({ wrote: false });
+    expect(launchStateStore.write).toHaveBeenLastCalledWith('demo', previousSnapshot, {
+      republishesExistingLaunch: true,
+    });
   });
 
   it('serializes queued operations and only removes the current queue entry', async () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchStateStoreBoundary.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchStateStoreBoundary.test.ts
@@ -649,6 +649,40 @@ describe('TeamProvisioningLaunchStateStoreBoundary', () => {
     expect(boundary.getWrittenRunIdByTeam().has('demo')).toBe(false);
   });
 
+  it('restores the launch truth a stale snapshot write overwrote', async () => {
+    const newerSnapshot = snapshot({ updatedAt: '2026-01-01T00:00:05.000Z' });
+    const writeStarted = deferred();
+    const writeGate = deferred();
+    let persistedSnapshot: PersistedTeamLaunchSnapshot | null = newerSnapshot;
+    const launchStateStore = {
+      read: vi.fn(async () => persistedSnapshot),
+      write: vi.fn(async (_teamName: string, nextSnapshot: PersistedTeamLaunchSnapshot) => {
+        if (nextSnapshot === newerSnapshot) {
+          persistedSnapshot = nextSnapshot;
+          return;
+        }
+        writeStarted.resolve();
+        await writeGate.promise;
+        persistedSnapshot = nextSnapshot;
+      }),
+      clear: vi.fn(async () => {
+        persistedSnapshot = null;
+      }),
+    };
+    const { boundary, ports, setTrackedRunId } = createBoundary({ launchStateStore });
+
+    const writing = boundary.writeLaunchStateSnapshotNow('demo', snapshot(), { runId: 'run-1' });
+    await writeStarted.promise;
+    setTrackedRunId(undefined);
+    writeGate.resolve();
+
+    await expect(writing).resolves.toEqual({ snapshot: newerSnapshot, wrote: false });
+    expect(persistedSnapshot).toEqual(newerSnapshot);
+    expect(ports.launchStateStore.clear).not.toHaveBeenCalled();
+    expect(ports.invalidateRuntimeSnapshotCaches).toHaveBeenCalledWith('demo');
+    expect(boundary.getWrittenRunIdByTeam().has('demo')).toBe(false);
+  });
+
   it('serializes queued operations and only removes the current queue entry', async () => {
     const { boundary } = createBoundary();
     const events: string[] = [];

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaneWiring.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaneWiring.test.ts
@@ -261,7 +261,11 @@ describe('TeamProvisioningMixedSecondaryLaneWiring', () => {
     expect(deps.service.tryRecoverMissingOpenCodeSecondaryLaneFromRuntime).toHaveBeenCalledTimes(1);
     expect(deps.service.tryRecoverActiveOpenCodeSecondaryLaneFromRuntime).toHaveBeenCalledTimes(1);
     expect(deps.service.buildAggregateLaunchSnapshot).toHaveBeenCalledTimes(1);
-    expect(deps.service.writeLaunchStateSnapshot).toHaveBeenCalledWith('atlas-hq', snapshot);
+    expect(deps.service.writeLaunchStateSnapshot).toHaveBeenCalledWith(
+      'atlas-hq',
+      snapshot,
+      undefined
+    );
   });
 
   it('builds mixed secondary lane wiring deps from service-shaped dependencies', async () => {
@@ -361,7 +365,7 @@ describe('TeamProvisioningMixedSecondaryLaneWiring', () => {
       lane.laneId
     );
     expect(service.buildAggregateLaunchSnapshot).toHaveBeenCalledTimes(1);
-    expect(service.writeLaunchStateSnapshot).toHaveBeenCalledWith('atlas-hq', snapshot);
+    expect(service.writeLaunchStateSnapshot).toHaveBeenCalledWith('atlas-hq', snapshot, undefined);
   });
 
   it('exposes mixed secondary lane state helpers on the boundary', () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaneWiring.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaneWiring.test.ts
@@ -126,6 +126,7 @@ function createDeps(
     isCurrentTrackedRun: vi.fn(() => true),
     logger: {
       warn: vi.fn(),
+      info: vi.fn(),
     },
   };
 }
@@ -266,7 +267,7 @@ describe('TeamProvisioningMixedSecondaryLaneWiring', () => {
   it('builds mixed secondary lane wiring deps from service-shaped dependencies', async () => {
     const service = createService();
     const has = vi.fn(() => true);
-    const logger = { warn: vi.fn() };
+    const logger = { warn: vi.fn(), info: vi.fn() };
     const host = {
       stoppingSecondaryRuntimeTeams: { has },
       appShellBoundary: {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeStopFlow.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeStopFlow.test.ts
@@ -97,7 +97,7 @@ function makePorts(
   progressUpdates: TeamProvisioningProgress[];
   writeLaunchStateSnapshot: ReturnType<typeof vi.fn>;
   clearOpenCodeRuntimeToolApprovals: ReturnType<typeof vi.fn>;
-  logger: { warn: ReturnType<typeof vi.fn> };
+  logger: { warn: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn> };
 } {
   const runtimeAdapterRunByTeam = new Map([
     [
@@ -117,7 +117,7 @@ function makePorts(
   const progressUpdates: TeamProvisioningProgress[] = [];
   const emittedEvents: unknown[] = [];
   const nowIsoValues = [...(input.nowIsoValues ?? [])];
-  const logger = { warn: vi.fn() };
+  const logger = { warn: vi.fn(), info: vi.fn() };
 
   const defaultSecondaryRuns: SecondaryRuntimeRunEntry[] = [
     {
@@ -246,14 +246,14 @@ function makeSingleLaneStopPorts(
   } = {}
 ): SingleMixedSecondaryRuntimeLaneStopPorts & {
   clearCalls: { teamName: string; laneId: string; expectedRunId?: string }[];
-  logger: { warn: ReturnType<typeof vi.fn> };
+  logger: { warn: ReturnType<typeof vi.fn>; info: ReturnType<typeof vi.fn> };
   upsertOpenCodeRuntimeLaneIndexEntry: ReturnType<typeof vi.fn>;
   clearOpenCodeRuntimeLaneStorage: ReturnType<typeof vi.fn>;
   readLaunchState: ReturnType<typeof vi.fn>;
   deleteSecondaryRuntimeRun: ReturnType<typeof vi.fn>;
 } {
   const clearCalls: { teamName: string; laneId: string; expectedRunId?: string }[] = [];
-  const logger = { warn: vi.fn() };
+  const logger = { warn: vi.fn(), info: vi.fn() };
   return {
     teamsBasePath: '/teams',
     getOpenCodeRuntimeAdapter: vi.fn(() =>
@@ -598,6 +598,56 @@ describe('OpenCode runtime stop flow', () => {
     expect(ports.deleteSecondaryRuntimeRun).not.toHaveBeenCalled();
     expect(ports.clearSecondaryRuntimeRuns).not.toHaveBeenCalled();
     expect(ports.stoppingSecondaryRuntimeTeams.has('team-a')).toBe(false);
+  });
+
+  it('stops mixed secondary lanes concurrently and reports the per-lane timings', async () => {
+    const pending = new Map<string, () => void>();
+    const stop = vi.fn(
+      (input: { runId: string; laneId: string; teamName: string }) =>
+        new Promise<{
+          runId: string;
+          teamName: string;
+          stopped: boolean;
+          members: Record<string, never>;
+          warnings: string[];
+          diagnostics: string[];
+        }>((resolve) => {
+          pending.set(input.laneId, () =>
+            resolve({
+              runId: input.runId,
+              teamName: input.teamName,
+              stopped: true,
+              members: {},
+              warnings: [],
+              diagnostics: [],
+            })
+          );
+        })
+    );
+    const ports = makePorts({
+      adapter: makeAdapter(stop as never),
+      previousLaunchState: snapshot(),
+      secondaryRuns: [
+        { runId: 'run-a', providerId: 'opencode', laneId: 'lane-a', memberName: 'A' },
+        { runId: 'run-b', providerId: 'opencode', laneId: 'lane-b', memberName: 'B' },
+        { runId: 'run-c', providerId: 'opencode', laneId: 'lane-c', memberName: 'C' },
+      ],
+    });
+
+    const stopping = stopMixedSecondaryRuntimeLanes('team-a', ports);
+    await vi.waitFor(() => expect(stop).toHaveBeenCalledTimes(3));
+    // All three orchestrator stops are in flight before any of them resolved.
+    expect(pending.size).toBe(3);
+    for (const resolve of pending.values()) resolve();
+    await stopping;
+
+    expect(ports.deleteSecondaryRuntimeRun).toHaveBeenCalledTimes(3);
+    expect(ports.logger.warn).not.toHaveBeenCalled();
+    expect(ports.logger.info).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /3 secondary lane\(s\) stopped in \d+ms \[lane-[abc]=\d+ms, lane-[abc]=\d+ms, lane-[abc]=\d+ms\]/
+      )
+    );
   });
 
   it('stops every mixed secondary lane but retains a lane whose stop throws', async () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeStopFlow.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeStopFlow.test.ts
@@ -62,6 +62,22 @@ function snapshot(teamName = 'team-a'): PersistedTeamLaunchSnapshot {
   } as unknown as PersistedTeamLaunchSnapshot;
 }
 
+/** A launch snapshot whose only member owns `laneId` and records `runtimePid`. */
+function snapshotWithLanePid(laneId: string, runtimePid: number): PersistedTeamLaunchSnapshot {
+  return {
+    ...snapshot(),
+    members: {
+      Worker: {
+        name: 'Worker',
+        providerId: 'opencode',
+        laneId,
+        laneKind: 'secondary',
+        runtimePid,
+      },
+    },
+  } as unknown as PersistedTeamLaunchSnapshot;
+}
+
 function makeAdapter(
   stop: TeamLaunchRuntimeAdapter['stop'] = vi.fn(async (input) => ({
     runId: input.runId,
@@ -88,6 +104,7 @@ function makePorts(
     previousLaunchState?: PersistedTeamLaunchSnapshot | null;
     nowIsoValues?: string[];
     clearLane?: OpenCodeRuntimeStopFlowPorts['clearOpenCodeRuntimeLaneStorage'];
+    isRuntimeProcessAlive?: OpenCodeRuntimeStopFlowPorts['isRuntimeProcessAlive'];
   } = {}
 ): OpenCodeRuntimeStopFlowPorts & {
   aliveRunByTeam: Map<string, string>;
@@ -165,6 +182,7 @@ function makePorts(
       aliveRunByTeam.delete(teamName);
     }),
     provisioningRunByTeam,
+    isRuntimeProcessAlive: input.isRuntimeProcessAlive ?? ((): boolean => false),
     invalidateRuntimeSnapshotCaches: vi.fn(),
     emitTeamChange: vi.fn((event) => {
       emittedEvents.push(event);
@@ -243,6 +261,7 @@ function makeSingleLaneStopPorts(
     adapter?: TeamLaunchRuntimeAdapter | null;
     previousLaunchState?: PersistedTeamLaunchSnapshot | null;
     clearLane?: SingleMixedSecondaryRuntimeLaneStopPorts['clearOpenCodeRuntimeLaneStorage'];
+    isRuntimeProcessAlive?: SingleMixedSecondaryRuntimeLaneStopPorts['isRuntimeProcessAlive'];
   } = {}
 ): SingleMixedSecondaryRuntimeLaneStopPorts & {
   clearCalls: { teamName: string; laneId: string; expectedRunId?: string }[];
@@ -256,6 +275,7 @@ function makeSingleLaneStopPorts(
   const logger = { warn: vi.fn(), info: vi.fn() };
   return {
     teamsBasePath: '/teams',
+    isRuntimeProcessAlive: input.isRuntimeProcessAlive ?? ((): boolean => false),
     getOpenCodeRuntimeAdapter: vi.fn(() =>
       Object.prototype.hasOwnProperty.call(input, 'adapter')
         ? (input.adapter ?? null)
@@ -598,6 +618,50 @@ describe('OpenCode runtime stop flow', () => {
     expect(ports.deleteSecondaryRuntimeRun).not.toHaveBeenCalled();
     expect(ports.clearSecondaryRuntimeRuns).not.toHaveBeenCalled();
     expect(ports.stoppingSecondaryRuntimeTeams.has('team-a')).toBe(false);
+  });
+
+  it('treats an unconfirmed secondary lane stop with no live host as already stopped', async () => {
+    const stop = vi.fn(async (input) => ({
+      runId: input.runId,
+      teamName: input.teamName,
+      stopped: false,
+      members: {},
+      warnings: [],
+      diagnostics: ['session abort not confirmed'],
+    }));
+    const ports = makePorts({
+      adapter: makeAdapter(stop as never),
+      previousLaunchState: snapshotWithLanePid('secondary-worker', 4242),
+      isRuntimeProcessAlive: () => false,
+    });
+
+    await expect(stopMixedSecondaryRuntimeLanes('team-a', ports)).resolves.toBeUndefined();
+
+    expect(ports.deleteSecondaryRuntimeRun).toHaveBeenCalledTimes(1);
+    expect(ports.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('treating the runtime as already stopped')
+    );
+  });
+
+  it('still fails an unconfirmed secondary lane stop while its recorded host is alive', async () => {
+    const stop = vi.fn(async (input) => ({
+      runId: input.runId,
+      teamName: input.teamName,
+      stopped: false,
+      members: {},
+      warnings: [],
+      diagnostics: ['session abort not confirmed'],
+    }));
+    const ports = makePorts({
+      adapter: makeAdapter(stop as never),
+      previousLaunchState: snapshotWithLanePid('secondary-worker', 4242),
+      isRuntimeProcessAlive: (pid) => pid === 4242,
+    });
+
+    await expect(stopMixedSecondaryRuntimeLanes('team-a', ports)).rejects.toThrow(
+      'host process still alive: pid 4242'
+    );
+    expect(ports.deleteSecondaryRuntimeRun).not.toHaveBeenCalled();
   });
 
   it('stops mixed secondary lanes concurrently and reports the per-lane timings', async () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeStopOutcome.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeStopOutcome.test.ts
@@ -122,6 +122,53 @@ describe('resolveOpenCodeRuntimeStopOutcome', () => {
     expect(outcome).toEqual({ kind: 'failed', detail: '', alivePids: [] });
   });
 
+  it.each([
+    ['Bridge server capability snapshot mismatch'],
+    ['OpenCode bridge capability snapshot mismatch'],
+    ['OpenCode lifecycle command requires the exact persisted lane run and capability snapshot'],
+    ['OpenCode lifecycle capability snapshot does not match the persisted lane manifest'],
+  ])('settles a snapshot-mismatch stop with no recorded host: %s', (detail) => {
+    const outcome = resolveOpenCodeRuntimeStopOutcome({
+      result: { stopped: false, diagnostics: [detail] },
+      laneId: 'lane-a',
+      previousLaunchState: snapshot({ Worker: { laneId: 'lane-a' } }),
+      isRuntimeProcessAlive: () => false,
+    });
+
+    expect(outcome).toEqual({ kind: 'already_stopped', detail, checkedPids: [] });
+  });
+
+  it('still fails a snapshot-mismatch stop whose lane has a live recorded host', () => {
+    const outcome = resolveOpenCodeRuntimeStopOutcome({
+      result: {
+        stopped: false,
+        diagnostics: [
+          'OpenCode lifecycle capability snapshot does not match the persisted lane manifest',
+        ],
+      },
+      laneId: 'lane-a',
+      previousLaunchState: snapshot({ Worker: { laneId: 'lane-a', runtimePid: 101 } }),
+      isRuntimeProcessAlive: () => true,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'failed',
+      detail: 'OpenCode lifecycle capability snapshot does not match the persisted lane manifest',
+      alivePids: [101],
+    });
+  });
+
+  it('still fails an unrelated stop failure that recorded no host pid', () => {
+    const outcome = resolveOpenCodeRuntimeStopOutcome({
+      result: { stopped: false, diagnostics: ['bridge lease acquire timed out'] },
+      laneId: 'lane-a',
+      previousLaunchState: snapshot({ Worker: { laneId: 'lane-a' } }),
+      isRuntimeProcessAlive: () => false,
+    });
+
+    expect(outcome.kind).toBe('failed');
+  });
+
   it('does not read an unreadable process as a live host', () => {
     const outcome = resolveOpenCodeRuntimeStopOutcome({
       result: { stopped: false },
@@ -182,6 +229,28 @@ describe('assertOpenCodeRuntimeStopEffective', () => {
       })
     ).toThrow(
       'OpenCode lane lane-a did not confirm stop: lease still held (host process still alive: pid 101)'
+    );
+  });
+
+  it('says the mismatch is why nothing could be verified when it settles one', () => {
+    const logWarning = vi.fn();
+
+    assertOpenCodeRuntimeStopEffective({
+      result: {
+        stopped: false,
+        diagnostics: [
+          'OpenCode lifecycle command requires the exact persisted lane run and capability snapshot',
+        ],
+      },
+      laneId: 'lane-a',
+      previousLaunchState: snapshot({ Worker: { laneId: 'lane-a' } }),
+      message: 'OpenCode lane lane-a did not confirm stop',
+      logWarning,
+      isRuntimeProcessAlive: () => false,
+    });
+
+    expect(logWarning).toHaveBeenCalledWith(
+      'OpenCode lane lane-a did not confirm stop, but the capability snapshot mismatch left no recorded host pid to verify; treating the runtime as already stopped: OpenCode lifecycle command requires the exact persisted lane run and capability snapshot'
     );
   });
 

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeStopOutcome.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeRuntimeStopOutcome.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  assertOpenCodeRuntimeStopEffective,
+  collectOpenCodeLaneRuntimePids,
+  describeOpenCodeRuntimeStopResult,
+  resolveOpenCodeRuntimeStopOutcome,
+} from '../TeamProvisioningOpenCodeRuntimeStopOutcome';
+
+import type { PersistedTeamLaunchSnapshot } from '@shared/types';
+
+function snapshot(
+  members: Record<string, { laneId?: string; laneKind?: string; runtimePid?: number }>
+): PersistedTeamLaunchSnapshot {
+  return {
+    members: Object.fromEntries(
+      Object.entries(members).map(([name, member]) => [
+        name,
+        { name, providerId: 'opencode', ...member },
+      ])
+    ),
+  } as unknown as PersistedTeamLaunchSnapshot;
+}
+
+describe('collectOpenCodeLaneRuntimePids', () => {
+  it('collects the recorded pids of the members that belong to the lane', () => {
+    const state = snapshot({
+      Worker: { laneId: 'lane-a', runtimePid: 101 },
+      Helper: { laneId: 'lane-a', runtimePid: 101 },
+      Other: { laneId: 'lane-b', runtimePid: 202 },
+    });
+
+    expect(collectOpenCodeLaneRuntimePids(state, 'lane-a')).toEqual([101]);
+    expect(collectOpenCodeLaneRuntimePids(state, 'lane-b')).toEqual([202]);
+  });
+
+  it('treats a member without a lane id as the primary lane', () => {
+    const state = snapshot({ Lead: { runtimePid: 303 } });
+
+    expect(collectOpenCodeLaneRuntimePids(state, 'primary')).toEqual([303]);
+  });
+
+  it('ignores a secondary member with no lane id and any unusable pid', () => {
+    const state = snapshot({
+      Nameless: { laneKind: 'secondary', runtimePid: 404 },
+      NoPid: { laneId: 'lane-a' },
+      ZeroPid: { laneId: 'lane-a', runtimePid: 0 },
+    });
+
+    expect(collectOpenCodeLaneRuntimePids(state, 'primary')).toEqual([]);
+    expect(collectOpenCodeLaneRuntimePids(state, 'lane-a')).toEqual([]);
+  });
+});
+
+describe('describeOpenCodeRuntimeStopResult', () => {
+  it('joins the diagnostics and warnings the orchestrator reported', () => {
+    expect(
+      describeOpenCodeRuntimeStopResult({
+        diagnostics: ['session abort not confirmed', '  '],
+        warnings: [' lease released ', 7],
+      })
+    ).toBe('session abort not confirmed; lease released');
+  });
+
+  it('describes a missing result as nothing rather than failing', () => {
+    expect(describeOpenCodeRuntimeStopResult(null)).toBe('');
+  });
+});
+
+describe('resolveOpenCodeRuntimeStopOutcome', () => {
+  it('accepts a confirmed stop without looking at any process', () => {
+    const isRuntimeProcessAlive = vi.fn(() => true);
+
+    const outcome = resolveOpenCodeRuntimeStopOutcome({
+      result: { stopped: true },
+      laneId: 'lane-a',
+      previousLaunchState: snapshot({ Worker: { laneId: 'lane-a', runtimePid: 101 } }),
+      isRuntimeProcessAlive,
+    });
+
+    expect(outcome).toEqual({ kind: 'stopped' });
+    expect(isRuntimeProcessAlive).not.toHaveBeenCalled();
+  });
+
+  it('settles an unconfirmed stop whose recorded hosts are all gone', () => {
+    const outcome = resolveOpenCodeRuntimeStopOutcome({
+      result: { stopped: false, diagnostics: ['session abort not confirmed'] },
+      laneId: 'lane-a',
+      previousLaunchState: snapshot({ Worker: { laneId: 'lane-a', runtimePid: 101 } }),
+      isRuntimeProcessAlive: () => false,
+    });
+
+    expect(outcome).toEqual({
+      kind: 'already_stopped',
+      detail: 'session abort not confirmed',
+      checkedPids: [101],
+    });
+  });
+
+  it('keeps an unconfirmed stop a failure while a recorded host is alive', () => {
+    const outcome = resolveOpenCodeRuntimeStopOutcome({
+      result: { stopped: false },
+      laneId: 'lane-a',
+      previousLaunchState: snapshot({
+        Worker: { laneId: 'lane-a', runtimePid: 101 },
+        Helper: { laneId: 'lane-a', runtimePid: 102 },
+      }),
+      isRuntimeProcessAlive: (pid) => pid === 102,
+    });
+
+    expect(outcome).toEqual({ kind: 'failed', detail: '', alivePids: [102] });
+  });
+
+  it('keeps an unconfirmed stop a failure when the lane recorded no pid at all', () => {
+    const outcome = resolveOpenCodeRuntimeStopOutcome({
+      result: { stopped: false },
+      laneId: 'lane-a',
+      previousLaunchState: snapshot({ Other: { laneId: 'lane-b', runtimePid: 202 } }),
+      isRuntimeProcessAlive: () => false,
+    });
+
+    expect(outcome).toEqual({ kind: 'failed', detail: '', alivePids: [] });
+  });
+
+  it('does not read an unreadable process as a live host', () => {
+    const outcome = resolveOpenCodeRuntimeStopOutcome({
+      result: { stopped: false },
+      laneId: 'lane-a',
+      previousLaunchState: snapshot({ Worker: { laneId: 'lane-a', runtimePid: 101 } }),
+      isRuntimeProcessAlive: () => {
+        throw new Error('EPERM');
+      },
+    });
+
+    expect(outcome.kind).toBe('already_stopped');
+  });
+});
+
+describe('assertOpenCodeRuntimeStopEffective', () => {
+  it('returns quietly for a confirmed stop', () => {
+    const logWarning = vi.fn();
+
+    const outcome = assertOpenCodeRuntimeStopEffective({
+      result: { stopped: true },
+      laneId: 'lane-a',
+      previousLaunchState: null,
+      message: 'OpenCode lane lane-a did not confirm stop',
+      logWarning,
+      isRuntimeProcessAlive: () => false,
+    });
+
+    expect(outcome.kind).toBe('stopped');
+    expect(logWarning).not.toHaveBeenCalled();
+  });
+
+  it('records why an unconfirmed stop was accepted as already stopped', () => {
+    const logWarning = vi.fn();
+
+    assertOpenCodeRuntimeStopEffective({
+      result: { stopped: false, diagnostics: ['session abort not confirmed'] },
+      laneId: 'lane-a',
+      previousLaunchState: snapshot({ Worker: { laneId: 'lane-a', runtimePid: 101 } }),
+      message: 'OpenCode lane lane-a did not confirm stop',
+      logWarning,
+      isRuntimeProcessAlive: () => false,
+    });
+
+    expect(logWarning).toHaveBeenCalledWith(
+      'OpenCode lane lane-a did not confirm stop, but no recorded host process is alive (checked pid 101); treating the runtime as already stopped: session abort not confirmed'
+    );
+  });
+
+  it('throws with the live pid when a recorded host survived the stop', () => {
+    expect(() =>
+      assertOpenCodeRuntimeStopEffective({
+        result: { stopped: false, warnings: ['lease still held'] },
+        laneId: 'lane-a',
+        previousLaunchState: snapshot({ Worker: { laneId: 'lane-a', runtimePid: 101 } }),
+        message: 'OpenCode lane lane-a did not confirm stop',
+        logWarning: vi.fn(),
+        isRuntimeProcessAlive: () => true,
+      })
+    ).toThrow(
+      'OpenCode lane lane-a did not confirm stop: lease still held (host process still alive: pid 101)'
+    );
+  });
+
+  it('throws and says so when there is no recorded pid to verify against', () => {
+    expect(() =>
+      assertOpenCodeRuntimeStopEffective({
+        result: { stopped: false },
+        laneId: 'lane-a',
+        previousLaunchState: null,
+        message: 'OpenCode lane lane-a did not confirm stop',
+        logWarning: vi.fn(),
+        isRuntimeProcessAlive: () => false,
+      })
+    ).toThrow('OpenCode lane lane-a did not confirm stop (no recorded host pid to verify)');
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningPersistedLaunchReconcilePorts.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningPersistedLaunchReconcilePorts.test.ts
@@ -32,6 +32,7 @@ function createInput(
   overrides: Partial<TeamProvisioningPersistedLaunchReconcilePortsInput> = {}
 ): TeamProvisioningPersistedLaunchReconcilePortsInput {
   return {
+    getTrackedRunId: vi.fn(() => null),
     readLaunchState: vi.fn(async () => null),
     readMembersMeta: vi.fn(async () => []),
     recoverStaleMixedSecondaryLaunchSnapshot: vi.fn(async () => null),
@@ -67,6 +68,9 @@ describe('persisted launch reconcile port factory', () => {
       membersMetaStore: {
         getMembers: vi.fn(async () => []),
       },
+      runTracking: {
+        getTrackedRunId: vi.fn(() => null),
+      },
       recoverStaleMixedSecondaryLaunchSnapshot: vi.fn(async () => persistedSnapshot),
       applyOpenCodeSecondaryEvidenceOverlay: vi.fn(async ({ snapshot }) => snapshot),
       applyOpenCodeSecondaryBootstrapStallOverlay: vi.fn((snapshot) => snapshot),
@@ -99,6 +103,7 @@ describe('persisted launch reconcile port factory', () => {
       persistedSnapshot
     );
     await ports.clearPersistedLaunchState('demo');
+    expect(ports.getTrackedRunId?.('demo')).toBeNull();
     await ports.getLiveTeamAgentRuntimeMetadata('demo');
     expect(
       ports.selectLatestLeadInboxLaunchReconcileMessage({
@@ -123,6 +128,7 @@ describe('persisted launch reconcile port factory', () => {
     expect(service.membersMetaStore.getMembers).toHaveBeenCalledWith('demo');
     expect(service.writeLaunchStateSnapshot).toHaveBeenCalledWith('demo', persistedSnapshot);
     expect(service.clearPersistedLaunchState).toHaveBeenCalledWith('demo');
+    expect(service.runTracking.getTrackedRunId).toHaveBeenCalledWith('demo');
     expect(service.getLiveTeamAgentRuntimeMetadata).toHaveBeenCalledWith('demo');
     expect(service.resolveExpectedLaunchMemberName).toHaveBeenCalledWith(['Builder'], 'Builder');
     expect(service.findBootstrapRuntimeProofObservedAt).toHaveBeenCalledWith(

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningPersistedLaunchReconciliation.runScope.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningPersistedLaunchReconciliation.runScope.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createPersistedLaunchSnapshot } from '../../TeamLaunchStateEvaluator';
+import { TeamProvisioningLaunchStateStoreBoundary } from '../TeamProvisioningLaunchStateStoreBoundary';
+import {
+  type ReconcilePersistedLaunchStatePorts,
+  reconcilePersistedLaunchStateWithPorts,
+} from '../TeamProvisioningPersistedLaunchReconciliation';
+
+import type { PersistedTeamLaunchMemberState, PersistedTeamLaunchSnapshot } from '@shared/types';
+
+const at = '2026-08-27T18:08:00.000Z';
+
+function member(overrides: Partial<PersistedTeamLaunchMemberState> = {}) {
+  return {
+    name: 'Builder',
+    launchState: 'confirmed_alive' as const,
+    agentToolAccepted: true,
+    runtimeAlive: true,
+    bootstrapConfirmed: true,
+    hardFailure: false,
+    livenessKind: 'confirmed_bootstrap' as const,
+    lastEvaluatedAt: at,
+    ...overrides,
+  };
+}
+
+function cleanSnapshot(): PersistedTeamLaunchSnapshot {
+  return createPersistedLaunchSnapshot({
+    teamName: 'demo',
+    expectedMembers: ['Builder'],
+    launchPhase: 'finished',
+    members: { Builder: member() },
+    updatedAt: at,
+  });
+}
+
+function createBoundary(input: {
+  trackedRunId: string | null;
+  stored: PersistedTeamLaunchSnapshot | null;
+}) {
+  const state = { snapshot: input.stored };
+  const clearBootstrapState = vi.fn(async () => undefined);
+  const boundary = new TeamProvisioningLaunchStateStoreBoundary({
+    launchStateStore: {
+      read: async () => state.snapshot,
+      write: async (_teamName, snapshot) => {
+        state.snapshot = snapshot;
+      },
+      clear: async () => {
+        state.snapshot = null;
+      },
+    },
+    membersMetaStore: { getMembers: async () => [] },
+    getTrackedRunId: () => input.trackedRunId,
+    applyOpenCodeSecondaryEvidenceOverlay: async ({ snapshot }) => snapshot,
+    applyBootstrapStallOverlay: (snapshot) => snapshot,
+    areSnapshotsSemanticallyEqual: () => false,
+    clearBootstrapState,
+    invalidateRuntimeSnapshotCaches: vi.fn(),
+    logDebug: vi.fn(),
+    nowMs: () => Date.parse(at),
+  });
+  return { boundary, state, clearBootstrapState };
+}
+
+function createReconcilePorts(
+  overrides: Partial<ReconcilePersistedLaunchStatePorts> = {}
+): ReconcilePersistedLaunchStatePorts {
+  return {
+    readBootstrapLaunchSnapshot: vi.fn(async () => null),
+    readLaunchState: vi.fn(async () => null),
+    readMembersMeta: vi.fn(async () => []),
+    recoverStaleMixedSecondaryLaunchSnapshot: vi.fn(async () => null),
+    applyOpenCodeSecondaryEvidenceOverlay: vi.fn(async ({ snapshot }) => snapshot),
+    applyOpenCodeSecondaryBootstrapStallOverlay: vi.fn((snapshot) => snapshot),
+    writeLaunchStateSnapshot: vi.fn(async (_teamName, snapshot) => snapshot),
+    clearPersistedLaunchState: vi.fn(async () => undefined),
+    applyBootstrapTranscriptEvidenceOverlay: vi.fn(async (snapshot) => snapshot),
+    needsBootstrapAcceptanceReconcile: vi.fn(() => false),
+    needsConfirmedBootstrapDiagnosticReconcile: vi.fn(() => false),
+    cleanConfirmedBootstrapRuntimeDiagnostics: vi.fn((snapshot) => snapshot),
+    hasBootstrapTranscriptLaunchReconcileOutcome: vi.fn(async () => false),
+    choosePreferredLaunchSnapshot: vi.fn(
+      (bootstrapSnapshot, persistedSnapshot) => bootstrapSnapshot ?? persistedSnapshot
+    ),
+    createDefaultLaunchReconcileConfigMembers: vi.fn(() => ({
+      configMembers: new Set<string>(),
+      configBootstrapRunIds: new Map<string, string>(),
+      leadName: 'team-lead',
+    })),
+    parseLaunchReconcileConfigMembers: vi.fn(() => ({
+      configMembers: new Set<string>(),
+      configBootstrapRunIds: new Map<string, string>(),
+      leadName: 'team-lead',
+    })),
+    getTeamsBasePath: vi.fn(() => '/teams'),
+    pathJoin: vi.fn((...parts) => parts.join('/')),
+    readRegularFileUtf8: vi.fn(async () => null),
+    teamJsonReadTimeoutMs: 5_000,
+    teamConfigMaxBytes: 10 * 1024 * 1024,
+    readLeadInboxMessagesForLaunchReconcile: vi.fn(async () => []),
+    hasLeadInboxLaunchReconcileHeartbeat: vi.fn(() => false),
+    getLiveTeamAgentRuntimeMetadata: vi.fn(
+      async () =>
+        new Map([['Builder', { alive: true, livenessKind: 'confirmed_bootstrap' as const }]])
+    ),
+    getPersistedLaunchMemberNames: vi.fn((snapshot) => [...snapshot.expectedMembers]),
+    selectLatestLeadInboxLaunchReconcileMessage: vi.fn(() => null),
+    findBootstrapRuntimeProofObservedAt: vi.fn(async () => null),
+    findBootstrapTranscriptOutcome: vi.fn(async () => null),
+    readProcessBootstrapTransportSummary: vi.fn(async () => null),
+    applyProcessBootstrapTransportOverlay: vi.fn(({ member: current }) => current),
+    nowIso: vi.fn(() => at),
+    nowMs: vi.fn(() => Date.parse(at)),
+    ...overrides,
+  };
+}
+
+/** Records what the reconcile asked the persistence layer to do, in order. */
+function createPersistedWriteLog(boundary: TeamProvisioningLaunchStateStoreBoundary): {
+  persistedWrites: string[];
+  ports: Pick<
+    ReconcilePersistedLaunchStatePorts,
+    'writeLaunchStateSnapshot' | 'clearPersistedLaunchState'
+  >;
+} {
+  const persistedWrites: string[] = [];
+  return {
+    persistedWrites,
+    ports: {
+      writeLaunchStateSnapshot: async (teamName, snapshot, options) => {
+        persistedWrites.push(`write:${options?.runId ?? 'unscoped'}`);
+        return boundary.writeLaunchStateSnapshot(teamName, snapshot, options);
+      },
+      clearPersistedLaunchState: async (teamName, options) => {
+        persistedWrites.push(`clear:${options?.expectedRunId ?? 'unscoped'}`);
+        await boundary.clearPersistedLaunchState(teamName, options);
+      },
+    },
+  };
+}
+
+describe('persisted launch reconcile run scope', () => {
+  it('passes its run id to every write and clear', async () => {
+    const ports = createReconcilePorts({ readLaunchState: vi.fn(async () => cleanSnapshot()) });
+
+    await reconcilePersistedLaunchStateWithPorts('demo', ports, { expectedRunId: 'run-2' });
+
+    expect(ports.clearPersistedLaunchState).toHaveBeenCalledWith('demo', {
+      expectedRunId: 'run-2',
+    });
+  });
+
+  it('takes the run id from the tracked-run port when the caller does not supply one', async () => {
+    const ports = createReconcilePorts({
+      readLaunchState: vi.fn(async () => cleanSnapshot()),
+      getTrackedRunId: vi.fn(() => 'run-3'),
+    });
+
+    await reconcilePersistedLaunchStateWithPorts('demo', ports);
+
+    expect(ports.clearPersistedLaunchState).toHaveBeenCalledWith('demo', {
+      expectedRunId: 'run-3',
+    });
+  });
+
+  it('does not clear a successor run state, and leaves bootstrap state alone', async () => {
+    const stored = cleanSnapshot();
+    const { boundary, state, clearBootstrapState } = createBoundary({
+      trackedRunId: 'run-successor',
+      stored,
+    });
+    const ports = createReconcilePorts({
+      readLaunchState: vi.fn(async () => cleanSnapshot()),
+      clearPersistedLaunchState: (teamName, options) =>
+        boundary.clearPersistedLaunchState(teamName, options),
+    });
+
+    await reconcilePersistedLaunchStateWithPorts('demo', ports, { expectedRunId: 'run-stale' });
+
+    expect(state.snapshot).toBe(stored);
+    expect(clearBootstrapState).not.toHaveBeenCalled();
+  });
+
+  it('still wipes bootstrap state on an unscoped clear, which is why the scope matters', async () => {
+    const { boundary, state, clearBootstrapState } = createBoundary({
+      trackedRunId: 'run-successor',
+      stored: cleanSnapshot(),
+    });
+    const ports = createReconcilePorts({
+      readLaunchState: vi.fn(async () => cleanSnapshot()),
+      clearPersistedLaunchState: (teamName, options) =>
+        boundary.clearPersistedLaunchState(teamName, options),
+    });
+
+    await reconcilePersistedLaunchStateWithPorts('demo', ports);
+
+    expect(state.snapshot).toBeNull();
+    expect(clearBootstrapState).toHaveBeenCalledTimes(1);
+  });
+
+  it('records no clear at all once the run that asked for it has been superseded', async () => {
+    const stored = cleanSnapshot();
+    const { boundary } = createBoundary({ trackedRunId: 'run-successor', stored });
+    const { persistedWrites, ports: writeLogPorts } = createPersistedWriteLog(boundary);
+    const ports = createReconcilePorts({
+      readLaunchState: vi.fn(async () => cleanSnapshot()),
+      ...writeLogPorts,
+    });
+
+    await reconcilePersistedLaunchStateWithPorts('demo', ports, { expectedRunId: 'run-stale' });
+
+    expect(persistedWrites).toEqual(['clear:run-stale']);
+    expect(boundary.canClearPersistedLaunchStateForRun('demo', 'run-stale')).toBe(false);
+  });
+
+  it('behaves exactly as an unscoped reconcile when the tracked-run port answers null', async () => {
+    const { boundary, state, clearBootstrapState } = createBoundary({
+      trackedRunId: null,
+      stored: cleanSnapshot(),
+    });
+    const { persistedWrites, ports: writeLogPorts } = createPersistedWriteLog(boundary);
+    const ports = createReconcilePorts({
+      readLaunchState: vi.fn(async () => cleanSnapshot()),
+      getTrackedRunId: vi.fn(() => null),
+      ...writeLogPorts,
+    });
+
+    await reconcilePersistedLaunchStateWithPorts('demo', ports);
+
+    expect(persistedWrites).toEqual(['clear:unscoped']);
+    expect(state.snapshot).toBeNull();
+    expect(clearBootstrapState).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets the launch-state boundary reject a stale scoped write', async () => {
+    const stored = cleanSnapshot();
+    const { boundary, state } = createBoundary({ trackedRunId: 'run-successor', stored });
+    const written = await boundary.writeLaunchStateSnapshot(
+      'demo',
+      { ...stored, updatedAt: '2026-08-27T18:09:00.000Z' },
+      { runId: 'run-stale' }
+    );
+
+    expect(written).toBe(stored);
+    expect(state.snapshot).toBe(stored);
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningPersistenceReconcileFacade.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningPersistenceReconcileFacade.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { createPersistedLaunchSnapshot } from '../../TeamLaunchStateEvaluator';
 import { type TeamProvisioningPersistedLaunchReconcilePortsInput } from '../TeamProvisioningPersistedLaunchReconcilePorts';
 import {
+  createTeamProvisioningPersistenceReconcileFacadeFromService,
   TeamProvisioningPersistenceReconcileFacade,
   type TeamProvisioningPersistenceReconcileFacadePorts,
+  type TeamProvisioningPersistenceReconcileFacadeServiceHost,
   type TeamProvisioningPersistenceReconcileRun,
 } from '../TeamProvisioningPersistenceReconcileFacade';
 import { createTeamProvisioningPrimaryBootstrapTruthReportingBoundary } from '../TeamProvisioningPrimaryBootstrapTruthReportingPortsFactory';
@@ -92,6 +94,7 @@ function createPorts(
     buildLiveLaunchSnapshotForRun: vi.fn(() => null),
     invalidateRuntimeSnapshotCaches: vi.fn(() => undefined),
     reconcile: {
+      getTrackedRunId: vi.fn(() => 'run-1'),
       recoverStaleMixedSecondaryLaunchSnapshot: vi.fn(async () => null),
       applyOpenCodeSecondaryEvidenceOverlay: vi.fn(
         async (input: { snapshot: PersistedTeamLaunchSnapshot }) => input.snapshot
@@ -266,8 +269,9 @@ describe('TeamProvisioningPersistenceReconcileFacade', () => {
       async (_teamName: string, input: TeamProvisioningPersistedLaunchReconcilePortsInput) => {
         await expect(input.readLaunchState('demo')).resolves.toBe(persistedSnapshot);
         await expect(input.readMembersMeta('demo')).resolves.toEqual([]);
-        await input.writeLaunchStateSnapshot('demo', persistedSnapshot);
-        await input.clearPersistedLaunchState('demo');
+        expect(input.getTrackedRunId('demo')).toBe('run-1');
+        await input.writeLaunchStateSnapshot('demo', persistedSnapshot, { runId: 'run-1' });
+        await input.clearPersistedLaunchState('demo', { expectedRunId: 'run-1' });
         return { snapshot: persistedSnapshot, statuses: {} };
       }
     );
@@ -289,15 +293,38 @@ describe('TeamProvisioningPersistenceReconcileFacade', () => {
         readMembersMeta: expect.any(Function),
         writeLaunchStateSnapshot: expect.any(Function),
         clearPersistedLaunchState: expect.any(Function),
+        getTrackedRunId: expect.any(Function),
       })
     );
     expect(ports.launchStateStoreBoundary.writeLaunchStateSnapshot).toHaveBeenCalledWith(
       'demo',
-      persistedSnapshot
+      persistedSnapshot,
+      { runId: 'run-1' }
     );
-    expect(ports.launchStateStoreBoundary.clearPersistedLaunchState).toHaveBeenCalledWith(
-      'demo',
-      undefined
-    );
+    expect(ports.launchStateStoreBoundary.clearPersistedLaunchState).toHaveBeenCalledWith('demo', {
+      expectedRunId: 'run-1',
+    });
+  });
+
+  it('wires the tracked run of the service into the reconcile ports', async () => {
+    const basePorts = createPorts();
+    const getTrackedRunId = vi.fn(() => 'run-tracked');
+    const service = {
+      ...basePorts.reconcile,
+      getTrackedRunId,
+      launchStateStore: { read: async () => null },
+      membersMetaStore: { getMembers: async () => [] },
+      launchStateStoreBoundary: basePorts.launchStateStoreBoundary,
+      primaryBootstrapTruthReporting: {
+        overlayPrimaryBootstrapTruthIntoRunStatusesFromBootstrapState: async () => undefined,
+      },
+      buildLiveLaunchSnapshotForRun: () => null,
+      invalidateRuntimeSnapshotCaches: vi.fn(),
+    } satisfies TeamProvisioningPersistenceReconcileFacadeServiceHost<TestRun>;
+
+    const facade = createTeamProvisioningPersistenceReconcileFacadeFromService(service);
+    await facade.reconcilePersistedLaunchState('demo');
+
+    expect(getTrackedRunId).toHaveBeenCalledWith('demo');
   });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningStaleMixedSecondaryRecovery.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningStaleMixedSecondaryRecovery.test.ts
@@ -113,6 +113,7 @@ function createPorts(input: Partial<StaleMixedSecondaryRecoveryPorts> = {}): {
   let writtenSnapshot: PersistedTeamLaunchSnapshot | null = null;
   const defaultMember: TeamMember = { name: 'Bob', providerId: 'opencode', cwd: '/repo-bob' };
   const ports: StaleMixedSecondaryRecoveryPorts = {
+    isTeamLaunchStopped: async () => false,
     hasMixedSecondaryLaunchMetadata: () => false,
     shouldRecoverStalePersistedMixedLaunchSnapshot: () => true,
     readTeamMeta: async () => ({ providerId: 'codex', fastMode: 'on' }),
@@ -268,6 +269,40 @@ describe('recoverStaleMixedSecondaryLaunchSnapshotWithPorts', () => {
         },
       },
     ]);
+  });
+
+  it('recovers nothing for a stopped team and hands its persisted snapshot straight back', async () => {
+    const persistedSnapshot = createSnapshot({ leadSessionId: 'lead-session' });
+    const { ports, getAggregateParams, getWrittenSnapshot } = createPorts({
+      isTeamLaunchStopped: async () => true,
+    });
+
+    const result = await recoverStaleMixedSecondaryLaunchSnapshotWithPorts(
+      'team-a',
+      null,
+      persistedSnapshot,
+      ports
+    );
+
+    expect(result).toBe(persistedSnapshot);
+    expect(getAggregateParams()).toBeNull();
+    expect(getWrittenSnapshot()).toBeNull();
+  });
+
+  it('still recovers lane evidence for a team that was never marked stopped', async () => {
+    const { ports, getAggregateParams, getWrittenSnapshot } = createPorts({
+      isTeamLaunchStopped: async () => false,
+    });
+
+    const result = await recoverStaleMixedSecondaryLaunchSnapshotWithPorts(
+      'team-a',
+      null,
+      null,
+      ports
+    );
+
+    expect(result).toBe(getWrittenSnapshot());
+    expect(getAggregateParams()?.secondaryMembers).toHaveLength(1);
   });
 
   it('returns null when no runtime, degraded, or stale lane evidence is recovered', async () => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningStaleMixedSecondaryRecovery.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningStaleMixedSecondaryRecovery.test.ts
@@ -289,6 +289,38 @@ describe('recoverStaleMixedSecondaryLaunchSnapshotWithPorts', () => {
     expect(getWrittenSnapshot()).toBeNull();
   });
 
+  it('publishes the recovered snapshot as a republication so a stop settling meanwhile survives', async () => {
+    // The stop marker check above the recovery cannot cover the runtime probes
+    // that follow it. A stop that lands during them must still win, so the
+    // write is fenced by the marker inside the store's publication queue and
+    // the caller is handed the persisted snapshot rather than the recovery.
+    const persistedSnapshot = createSnapshot({ leadSessionId: 'lead-session' });
+    let stopped = false;
+    const writeOptions: ({ republishesExistingLaunch?: boolean } | undefined)[] = [];
+    const { ports, getAggregateParams } = createPorts({
+      isTeamLaunchStopped: async () => {
+        const wasStopped = stopped;
+        stopped = true;
+        return wasStopped;
+      },
+      writeLaunchStateSnapshot: async (_teamName, snapshot, options) => {
+        writeOptions.push(options);
+        return snapshot;
+      },
+    });
+
+    const result = await recoverStaleMixedSecondaryLaunchSnapshotWithPorts(
+      'team-a',
+      null,
+      persistedSnapshot,
+      ports
+    );
+
+    expect(getAggregateParams()?.secondaryMembers).toHaveLength(1);
+    expect(writeOptions).toEqual([{ republishesExistingLaunch: true }]);
+    expect(result).toBe(persistedSnapshot);
+  });
+
   it('still recovers lane evidence for a team that was never marked stopped', async () => {
     const { ports, getAggregateParams, getWrittenSnapshot } = createPorts({
       isTeamLaunchStopped: async () => false,

--- a/src/main/services/team/teamBackupManifest.ts
+++ b/src/main/services/team/teamBackupManifest.ts
@@ -1,0 +1,70 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { atomicWriteAsync, atomicWriteSync } from '@main/utils/atomicWrite';
+
+/**
+ * The per-team backup manifest: the record that says which identity owns the
+ * backup directory, whether the team was deleted by the user, and what the
+ * source files looked like the last time they were copied.
+ */
+export interface BackupManifest {
+  teamName: string;
+  identityId: string;
+  projectPath?: string;
+  displayName?: string;
+  status: 'active' | 'deleted_by_user';
+  deletedByUserAt?: string;
+  firstBackupAt: string;
+  lastBackupAt: string;
+  fileStats: Record<string, { mtime: number; size: number }>;
+}
+
+export interface BackupManifestWriteOptions {
+  /** Flush the manifest and its directory before returning. */
+  strict?: boolean;
+  /** Last publication fence, evaluated inside the atomic write. */
+  beforeCommit?: () => Promise<void>;
+}
+
+export function getBackupManifestPath(backupDir: string): string {
+  return path.join(backupDir, 'manifest.json');
+}
+
+export async function readBackupManifest(backupDir: string): Promise<BackupManifest | null> {
+  try {
+    const raw = await fs.promises.readFile(getBackupManifestPath(backupDir), 'utf8');
+    return JSON.parse(raw) as BackupManifest;
+  } catch {
+    return null;
+  }
+}
+
+export function readBackupManifestSync(backupDir: string): BackupManifest | null {
+  try {
+    const raw = fs.readFileSync(getBackupManifestPath(backupDir), 'utf8');
+    return JSON.parse(raw) as BackupManifest;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeBackupManifest(
+  backupDir: string,
+  manifest: BackupManifest,
+  { strict = false, beforeCommit }: BackupManifestWriteOptions = {}
+): Promise<void> {
+  await atomicWriteAsync(getBackupManifestPath(backupDir), JSON.stringify(manifest, null, 2), {
+    ...(strict ? { durability: 'strict' as const, syncDirectory: true } : {}),
+    ...(beforeCommit ? { beforeCommit } : {}),
+  });
+}
+
+export function writeBackupManifestSync(backupDir: string, manifest: BackupManifest): void {
+  try {
+    const manifestPath = getBackupManifestPath(backupDir);
+    atomicWriteSync(manifestPath, JSON.stringify(manifest, null, 2));
+  } catch {
+    // best-effort
+  }
+}

--- a/src/main/services/team/teamBackupManifest.ts
+++ b/src/main/services/team/teamBackupManifest.ts
@@ -68,14 +68,16 @@ export function writeBackupManifestSync(backupDir: string, manifest: BackupManif
     const manifestPath = getBackupManifestPath(backupDir);
     atomicWriteSync(manifestPath, JSON.stringify(manifest, null, 2));
   } catch (error) {
-    // Best-effort, because the shutdown backup must go on to the next team.
-    // Reported all the same: the file copies and the registry entry are
-    // already written by the time this runs, so a manifest that did not land
-    // leaves a backup whose restore reads stale ownership and file stats.
+    // Reported here with the team it belongs to, then propagated: the file
+    // copies are already on disk and the registry entry is written after this
+    // call, so swallowing the failure would index a backup whose manifest
+    // still holds the previous ownership and file stats. The shutdown loop
+    // catches it per team and goes on to the next one.
     logger.warn(
       `[Backup] Failed to save manifest for ${manifest.teamName}: ${
         error instanceof Error ? error.message : String(error)
       }`
     );
+    throw error;
   }
 }

--- a/src/main/services/team/teamBackupManifest.ts
+++ b/src/main/services/team/teamBackupManifest.ts
@@ -2,6 +2,9 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { atomicWriteAsync, atomicWriteSync } from '@main/utils/atomicWrite';
+import { createLogger } from '@shared/utils/logger';
+
+const logger = createLogger('TeamBackupService');
 
 /**
  * The per-team backup manifest: the record that says which identity owns the
@@ -64,7 +67,15 @@ export function writeBackupManifestSync(backupDir: string, manifest: BackupManif
   try {
     const manifestPath = getBackupManifestPath(backupDir);
     atomicWriteSync(manifestPath, JSON.stringify(manifest, null, 2));
-  } catch {
-    // best-effort
+  } catch (error) {
+    // Best-effort, because the shutdown backup must go on to the next team.
+    // Reported all the same: the file copies and the registry entry are
+    // already written by the time this runs, so a manifest that did not land
+    // leaves a backup whose restore reads stale ownership and file stats.
+    logger.warn(
+      `[Backup] Failed to save manifest for ${manifest.teamName}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
   }
 }

--- a/src/shared/types/team.ts
+++ b/src/shared/types/team.ts
@@ -616,10 +616,15 @@ export type OpenCodeRuntimeDeliveryStatus = NonNullable<SendMessageResult['runti
 };
 
 export interface TeamForceStopResult {
-  /** Outcome of the bounded regular stop attempt. */
-  stopOutcome: 'stopped' | 'stop_failed' | 'timed_out';
+  /**
+   * Outcome of the bounded regular stop attempt.
+   * `runtime_already_down`: the recorded runtime hosts exited before the
+   * orchestrator acknowledged, so waiting for the ack was pointless.
+   */
+  stopOutcome: 'stopped' | 'stop_failed' | 'timed_out' | 'runtime_already_down';
   /** Incomplete includes unsupported or unconfirmed runtime cleanup. */
   cleanupOutcome: 'completed' | 'incomplete';
+  /** PIDs of retained runtime processes that were killed (process trees on Windows). */
   killedRuntimePids: number[];
   /** Number of pending OpenCode prompt delivery ledger records cancelled. */
   clearedPendingDeliveries: number;

--- a/test/main/http/teamForceStopRoute.test.ts
+++ b/test/main/http/teamForceStopRoute.test.ts
@@ -21,8 +21,10 @@ vi.mock('@main/services/team/lifecycle/teamForceStopFlow', async (importOriginal
   };
 });
 
+const markStopped = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
 vi.mock('@main/services/team/TeamLaunchStateStore', () => ({
-  TeamLaunchStateStore: vi.fn(() => ({ read: vi.fn(() => Promise.resolve(null)) })),
+  TeamLaunchStateStore: vi.fn(() => ({ read: vi.fn(() => Promise.resolve(null)), markStopped })),
 }));
 
 import type { HttpServices } from '@main/http';
@@ -71,6 +73,10 @@ describe('POST /api/teams/:teamName/force-stop', () => {
       clearedPendingDeliveries: 0,
     });
     expect(stopTeam).toHaveBeenCalledWith('fixteam');
+    // The route records the team as stopped itself. Without that write,
+    // reconciliation is free to re-derive a launch snapshot for a team the
+    // user just tore down.
+    expect(markStopped).toHaveBeenCalledWith('fixteam');
   });
 
   it('still answers 200 with stop_failed when the regular stop throws', async () => {

--- a/test/main/ipc/teams/teamStopEscalationSharedFlow.test.ts
+++ b/test/main/ipc/teams/teamStopEscalationSharedFlow.test.ts
@@ -50,6 +50,15 @@ const stopFlowMocks = vi.hoisted(() => ({
 
 vi.mock('@main/services/team/lifecycle/teamForceStopFlow', () => stopFlowMocks);
 
+const launchStateMocks = vi.hoisted(() => ({
+  markStopped: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@main/services/team/TeamLaunchStateStore', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@main/services/team/TeamLaunchStateStore')>()),
+  TeamLaunchStateStore: vi.fn(() => ({ markStopped: launchStateMocks.markStopped })),
+}));
+
 import { registerTeamRoutes } from '@main/http/teams';
 import Fastify from 'fastify';
 
@@ -150,7 +159,24 @@ describe('the escalated stop shares one fenced flow between the IPC handler and 
         ownedRunIds: ['run-observed'],
         ownedLaneIds: ['primary'],
       });
+      // Both ports below are optional on the flow, so nothing but a check here
+      // catches an entry point that dropped one. Without markTeamStopped the
+      // stop is not recorded as final and reconciliation re-derives the run
+      // that was just stopped; without countLiveRuntimeHosts the stop cannot
+      // finish when the hosts are gone and spends the whole budget instead.
+      expect(ports.markTeamStopped).toBeTypeOf('function');
+      await ports.markTeamStopped?.('fixteam');
+      expect(ports.countLiveRuntimeHosts).toBeTypeOf('function');
+      await expect(ports.countLiveRuntimeHosts?.('fixteam')).resolves.toBe(0);
+      expect(ports.stopTimeoutMs).toBe(90_000);
     }
+
+    // Both reach the real collaborators, scoped to the team being stopped.
+    expect(launchStateMocks.markStopped.mock.calls).toEqual([['fixteam'], ['fixteam']]);
+    expect(stopFlowMocks.countLiveRecordedRuntimeHostsForTeam.mock.calls).toEqual([
+      [{ teamName: 'fixteam' }],
+      [{ teamName: 'fixteam' }],
+    ]);
 
     expect(stopFlowMocks.readOwnedOpenCodeRuntimeRunIdsForTeam.mock.calls).toEqual([
       [{ teamName: 'fixteam' }],

--- a/test/main/ipc/teams/teamStopEscalationSharedFlow.test.ts
+++ b/test/main/ipc/teams/teamStopEscalationSharedFlow.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: { getLocale: vi.fn(() => 'en'), getPath: vi.fn(() => '/tmp'), isPackaged: false },
+  Notification: Object.assign(vi.fn(), { isSupported: vi.fn(() => false) }),
+  BrowserWindow: { fromWebContents: vi.fn(() => null), getAllWindows: vi.fn(() => []) },
+}));
+
+vi.mock('@main/services/team/TeamMembersMetaStore', () => ({
+  TeamMembersMetaStore: vi.fn().mockImplementation(() => ({
+    getMeta: vi.fn(() => Promise.resolve(null)),
+  })),
+}));
+
+vi.mock('@main/services/team/TeamDataWorkerClient', () => ({
+  getTeamDataWorkerClient: () => ({
+    invalidateTeamConfig: vi.fn(),
+    invalidateMemberRuntimeAdvisory: vi.fn(),
+  }),
+}));
+
+const stopFlowMocks = vi.hoisted(() => ({
+  stopTeamWithEscalation: vi.fn(() =>
+    Promise.resolve({
+      stopOutcome: 'stopped' as const,
+      killedRuntimePids: [],
+      clearedPendingDeliveries: 0,
+      diagnostics: [],
+    })
+  ),
+  runTeamForceStopFlow: vi.fn(() =>
+    Promise.resolve({
+      stopOutcome: 'stopped' as const,
+      killedRuntimePids: [],
+      clearedPendingDeliveries: 0,
+      diagnostics: [],
+    })
+  ),
+  killRetainedOpenCodeRuntimeProcessesForTeam: vi.fn(() =>
+    Promise.resolve({ killedPids: [], diagnostics: [] })
+  ),
+  clearPendingOpenCodePromptDeliveriesForTeam: vi.fn(() =>
+    Promise.resolve({ cleared: 0, diagnostics: [] })
+  ),
+  readOwnedOpenCodeRuntimeRunIdsForTeam: vi.fn(() => Promise.resolve(['run-observed'])),
+  readOpenCodeRuntimeLaneIdsForTeam: vi.fn(() => Promise.resolve(['primary'])),
+  countLiveRecordedRuntimeHostsForTeam: vi.fn(() => Promise.resolve(0)),
+  STOP_ESCALATION_TIMEOUT_MS: 90_000,
+}));
+
+vi.mock('@main/services/team/lifecycle/teamForceStopFlow', () => stopFlowMocks);
+
+import { registerTeamRoutes } from '@main/http/teams';
+import Fastify from 'fastify';
+
+import {
+  initializeTeamHandlers,
+  registerTeamHandlers,
+  removeTeamHandlers,
+} from '../../../../src/main/ipc/teams';
+import { TEAM_STOP } from '../../../../src/preload/constants/ipcChannels';
+
+import type { HttpServices } from '@main/http';
+import type { TeamForceStopFlowPorts } from '@main/services/team/lifecycle/teamForceStopFlow';
+
+/**
+ * The escalated Stop has the same two entry points force stop has - the in-app
+ * IPC handler and the HTTP route - and reaches the same cleanup. That cleanup
+ * is fenced to the run being torn down, so a relaunch of the same team started
+ * inside the stop budget keeps its own pending deliveries. Both entry points
+ * have to build that fence; an entry point that leaves `observeOwnedRuntimeRunIds`
+ * out, or calls the delivery cleanup without the fence, silently cancels the
+ * successor's work. Nothing else covers that wiring, so this does.
+ */
+describe('the escalated stop shares one fenced flow between the IPC handler and the HTTP route', () => {
+  const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+  const ipcMain = {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
+      handlers.set(channel, handler);
+    }),
+    removeHandler: vi.fn((channel: string) => {
+      handlers.delete(channel);
+    }),
+  };
+
+  const stopTeam = vi.fn(() => Promise.resolve(undefined));
+  const getAliveTeams = vi.fn(() => ['fixteam', 'other-team']);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    removeTeamHandlers(ipcMain as never);
+    handlers.clear();
+  });
+
+  async function callThroughIpc(): Promise<void> {
+    initializeTeamHandlers(
+      { getTeamData: vi.fn(() => Promise.resolve({ members: [] })) } as never,
+      { runtime: { stopTeam, getAliveTeams, isTeamAlive: () => true } } as never
+    );
+    registerTeamHandlers(ipcMain as never);
+    await expect(handlers.get(TEAM_STOP)!({} as never, 'fixteam')).resolves.toMatchObject({
+      success: true,
+    });
+  }
+
+  async function callThroughHttp(): Promise<void> {
+    const app = Fastify();
+    const services = {
+      teamApis: {
+        runtime: {
+          stopTeam,
+          getAliveTeams,
+          getRuntimeState: vi.fn(() => Promise.resolve({ state: 'stopped' })),
+        },
+      },
+    } as unknown as HttpServices;
+    registerTeamRoutes(app, services);
+    await app.ready();
+    const response = await app.inject({ method: 'POST', url: '/api/teams/fixteam/stop' });
+    expect(response.statusCode).toBe(200);
+    await app.close();
+  }
+
+  it('fences the escalated cleanup to the observed run ids from both entry points', async () => {
+    await callThroughIpc();
+    await callThroughHttp();
+
+    expect(stopFlowMocks.stopTeamWithEscalation).toHaveBeenCalledTimes(2);
+    const [ipcCall, httpCall] = stopFlowMocks.stopTeamWithEscalation.mock.calls as unknown as [
+      [string, TeamForceStopFlowPorts],
+      [string, TeamForceStopFlowPorts],
+    ];
+    expect(ipcCall[0]).toBe('fixteam');
+    expect(httpCall[0]).toBe('fixteam');
+
+    for (const [, ports] of [ipcCall, httpCall]) {
+      // Every entry point must supply the run-id observation the fence is
+      // built from: the port is required, not optional, precisely so a caller
+      // cannot opt its cleanup out of the fence.
+      await expect(ports.observeOwnedRuntimeRunIds('fixteam')).resolves.toEqual(['run-observed']);
+      // The lane scope is read before the stop for the same reason: the stop
+      // can remove the lane index, and a cleanup that has to re-read it then
+      // finds nothing to cancel.
+      await expect(ports.observeOwnedRuntimeLaneIds?.('fixteam')).resolves.toEqual(['primary']);
+      await ports.clearPendingPromptDeliveries('fixteam', {
+        requestedAtMs: 1_700_000_000_000,
+        ownedRunIds: ['run-observed'],
+        ownedLaneIds: ['primary'],
+      });
+    }
+
+    expect(stopFlowMocks.readOwnedOpenCodeRuntimeRunIdsForTeam.mock.calls).toEqual([
+      [{ teamName: 'fixteam' }],
+      [{ teamName: 'fixteam' }],
+    ]);
+    // The fence reaches the ledger unchanged from both entry points. A caller
+    // that dropped it would show up here as a call without the run ids.
+    expect(stopFlowMocks.clearPendingOpenCodePromptDeliveriesForTeam.mock.calls).toEqual([
+      [
+        {
+          teamName: 'fixteam',
+          requestedAtMs: 1_700_000_000_000,
+          ownedRunIds: ['run-observed'],
+          ownedLaneIds: ['primary'],
+        },
+      ],
+      [
+        {
+          teamName: 'fixteam',
+          requestedAtMs: 1_700_000_000_000,
+          ownedRunIds: ['run-observed'],
+          ownedLaneIds: ['primary'],
+        },
+      ],
+    ]);
+  });
+});

--- a/test/main/services/team/OpenCodeHostStartupLockCleanup.test.ts
+++ b/test/main/services/team/OpenCodeHostStartupLockCleanup.test.ts
@@ -1,0 +1,151 @@
+import {
+  PERIODIC_STALE_LOCK_INTERVAL_MS,
+  PERIODIC_STALE_LOCK_MIN_AGE_MS,
+  purgeStaleOpenCodeHostStartupLocks,
+  resolveOpenCodeHostStartupLocksDir,
+  startPeriodicOpenCodeHostStartupLockPurge,
+} from '@main/services/team/opencode/bridge/OpenCodeHostStartupLockCleanup';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let locksDir = '';
+
+function writeLock(name: string, ageMs: number): string {
+  const lockPath = path.join(locksDir, name);
+  fs.writeFileSync(lockPath, '');
+  const mtime = new Date(Date.now() - ageMs);
+  fs.utimesSync(lockPath, mtime, mtime);
+  return lockPath;
+}
+
+beforeEach(() => {
+  locksDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-host-locks-'));
+});
+
+afterEach(() => {
+  fs.rmSync(locksDir, { recursive: true, force: true });
+});
+
+describe('resolveOpenCodeHostStartupLocksDir', () => {
+  it('prefers an absolute data-home override on every platform', () => {
+    const override = path.join(os.tmpdir(), 'multimodel-data-home');
+
+    expect(
+      resolveOpenCodeHostStartupLocksDir({
+        platform: 'win32',
+        env: { CLAUDE_MULTIMODEL_DATA_HOME: override },
+      })
+    ).toBe(path.join(override, 'opencode', 'host-startup-locks'));
+  });
+
+  it('falls back to the platform data directory when the override is not absolute', () => {
+    const resolved = resolveOpenCodeHostStartupLocksDir({
+      platform: 'darwin',
+      env: { CLAUDE_MULTIMODEL_DATA_HOME: 'relative/path' },
+      homeDir: path.join(os.tmpdir(), 'home'),
+    });
+
+    expect(resolved).toBe(
+      path.join(
+        os.tmpdir(),
+        'home',
+        'Library',
+        'Application Support',
+        'claude-multimodel-nodejs',
+        'opencode',
+        'host-startup-locks'
+      )
+    );
+  });
+});
+
+describe('purgeStaleOpenCodeHostStartupLocks', () => {
+  it('removes only lock entries that are at least as old as the threshold', async () => {
+    writeLock('old.lock', 20 * 60_000);
+    writeLock('fresh.lock', 1_000);
+    fs.writeFileSync(path.join(locksDir, 'not-a-lock.json'), '{}');
+
+    const result = await purgeStaleOpenCodeHostStartupLocks({
+      locksDir,
+      minAgeMs: PERIODIC_STALE_LOCK_MIN_AGE_MS,
+    });
+
+    expect(result).toMatchObject({ scanned: 2, removed: 1, kept: 1, diagnostics: [] });
+    expect(fs.existsSync(path.join(locksDir, 'old.lock'))).toBe(false);
+    expect(fs.existsSync(path.join(locksDir, 'fresh.lock'))).toBe(true);
+    expect(fs.existsSync(path.join(locksDir, 'not-a-lock.json'))).toBe(true);
+  });
+
+  it('reports nothing at all when the lock directory does not exist', async () => {
+    const result = await purgeStaleOpenCodeHostStartupLocks({
+      locksDir: path.join(locksDir, 'missing'),
+    });
+
+    expect(result).toMatchObject({ scanned: 0, removed: 0, kept: 0, diagnostics: [] });
+  });
+});
+
+describe('startPeriodicOpenCodeHostStartupLockPurge', () => {
+  // Only the interval is faked: the purge itself does real file I/O, which has
+  // to keep resolving on the real event loop while the schedule is driven.
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('purges stale locks on its own schedule and reports what it removed', async () => {
+    writeLock('old.lock', 20 * 60_000);
+    writeLock('fresh.lock', 1_000);
+    const logInfo = vi.fn();
+    const stop = startPeriodicOpenCodeHostStartupLockPurge({ locksDir, logInfo });
+
+    try {
+      // Nothing runs before the first interval elapses.
+      expect(fs.existsSync(path.join(locksDir, 'old.lock'))).toBe(true);
+      await vi.advanceTimersByTimeAsync(PERIODIC_STALE_LOCK_INTERVAL_MS);
+      await vi.waitFor(() => expect(logInfo).toHaveBeenCalled());
+
+      expect(fs.existsSync(path.join(locksDir, 'old.lock'))).toBe(false);
+      expect(fs.existsSync(path.join(locksDir, 'fresh.lock'))).toBe(true);
+      expect(logInfo).toHaveBeenCalledWith(
+        '[OpenCode] periodic purge removed 1 stale host startup lock(s) (1 kept)'
+      );
+    } finally {
+      stop();
+    }
+  });
+
+  it('stops purging once it is stopped', async () => {
+    const logInfo = vi.fn();
+    const stop = startPeriodicOpenCodeHostStartupLockPurge({ locksDir, logInfo });
+    stop();
+
+    writeLock('old.lock', 20 * 60_000);
+    await vi.advanceTimersByTimeAsync(PERIODIC_STALE_LOCK_INTERVAL_MS * 3);
+
+    expect(fs.existsSync(path.join(locksDir, 'old.lock'))).toBe(true);
+    expect(logInfo).not.toHaveBeenCalled();
+  });
+
+  it('says nothing on a round that removed no lock', async () => {
+    writeLock('fresh.lock', 1_000);
+    const logInfo = vi.fn();
+    const logWarning = vi.fn();
+    const stop = startPeriodicOpenCodeHostStartupLockPurge({ locksDir, logInfo, logWarning });
+
+    try {
+      await vi.advanceTimersByTimeAsync(PERIODIC_STALE_LOCK_INTERVAL_MS);
+
+      expect(fs.existsSync(path.join(locksDir, 'fresh.lock'))).toBe(true);
+      expect(logInfo).not.toHaveBeenCalled();
+      expect(logWarning).not.toHaveBeenCalled();
+    } finally {
+      stop();
+    }
+  });
+});

--- a/test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts
+++ b/test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts
@@ -16436,7 +16436,9 @@ describe(
       }) as typeof adapter.stop;
 
       const stopPromise = svc.stopTeam(teamName);
-      await waitForCondition(() => adapter.stopInputs.length === 1);
+      // The lanes stop concurrently, so what matters here is that a stop is in
+      // flight, not that exactly one of them is.
+      await waitForCondition(() => adapter.stopInputs.length >= 1);
       try {
         await expect(
           svc.deliverOpenCodeMemberMessage(teamName, {

--- a/test/main/services/team/TeamBackupService.test.ts
+++ b/test/main/services/team/TeamBackupService.test.ts
@@ -310,6 +310,74 @@ describe('TeamBackupService', () => {
     expect(restoredLaunchSummary.teamLaunchState).toBe('partial_pending');
     expect(restoredRuntimeLaneIndex.lanes['secondary:opencode:tom'].state).toBe('active');
     expect(restoredRuntimeManifest.activeRunId).toBe('lane-run-1');
+    // A team that was never stopped gains no stop marker from a restore.
+    await expect(fs.access(path.join(teamDir, 'launch-stopped.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('does not resurrect launch state for a stopped team from a pre-stop backup', async () => {
+    const service = new TeamBackupService();
+    const teamName = 'stopped-team';
+    const teamDir = path.join(hoisted.teamsBase, teamName);
+    const projectPath = path.join(tempDir, 'project');
+    await fs.mkdir(teamDir, { recursive: true });
+    const config = {
+      name: 'Stopped Team',
+      projectPath,
+      members: [{ name: 'team-lead', agentType: 'team-lead' }],
+    };
+    const launchState = { version: 2, teamName, launchPhase: 'reconciled', members: {} };
+    const launchSummary = { version: 1, teamName, teamLaunchState: 'partial_failure' };
+    await fs.writeFile(path.join(teamDir, 'config.json'), JSON.stringify(config), 'utf8');
+    await fs.writeFile(
+      path.join(teamDir, 'launch-state.json'),
+      JSON.stringify(launchState),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(teamDir, 'launch-summary.json'),
+      JSON.stringify(launchSummary),
+      'utf8'
+    );
+
+    await service.initialize();
+    await service.backupTeam(teamName);
+
+    // Stop: the store removes both publication files and leaves the marker.
+    await fs.rm(path.join(teamDir, 'launch-state.json'), { force: true });
+    await fs.rm(path.join(teamDir, 'launch-summary.json'), { force: true });
+    await fs.writeFile(
+      path.join(teamDir, 'launch-stopped.json'),
+      JSON.stringify({ version: 1, teamName, stoppedAt: '2026-08-23T00:10:00.000Z' }),
+      'utf8'
+    );
+
+    // Partial restore (the config is present): the pre-stop snapshot stays gone.
+    await service.restoreIfNeeded();
+    await expect(fs.access(path.join(teamDir, 'launch-state.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(fs.access(path.join(teamDir, 'launch-summary.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+
+    // Once the stop itself is backed up, a full restore after losing the team
+    // directory keeps the team stopped too.
+    await service.backupTeam(teamName);
+    const backupDir = path.join(hoisted.backupsBase, 'teams', teamName);
+    await expect(fs.access(path.join(backupDir, 'launch-stopped.json'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(backupDir, 'launch-state.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await fs.rm(teamDir, { recursive: true, force: true });
+    const restored = await service.restoreIfNeeded();
+    service.dispose();
+    expect(restored).toContain(teamName);
+    await expect(fs.access(path.join(teamDir, 'launch-stopped.json'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(teamDir, 'launch-state.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
   });
 
   it('fences startup restore after the durable destructive deletion boundary', async () => {

--- a/test/main/services/team/TeamBackupService.test.ts
+++ b/test/main/services/team/TeamBackupService.test.ts
@@ -26,6 +26,7 @@ import type {
   PermanentDeletionTarget,
   TeamPermanentDeletionIntent,
 } from '../../../../src/main/services/team/TeamBackupService';
+import { TeamLaunchStateStore } from '../../../../src/main/services/team/TeamLaunchStateStore';
 import { removePathWithIdentityFenceAsync } from '../../../../src/main/utils/atomicWrite';
 
 async function removePreparedDeletionTargets(
@@ -495,6 +496,90 @@ describe('TeamBackupService', () => {
       expect.stringContaining(`Could not read the stop marker for ${teamName}`)
     );
     vi.mocked(console.warn).mockClear();
+  });
+
+  it('does not restore launch state for a team stopped after the restore read the fence', async () => {
+    // The stop fence is read once, before the restore loop. A stop that lands
+    // while the loop works removes the publication files and writes its marker
+    // after them, so a commit that is not fenced again puts the pre-stop launch
+    // state back with no marker left to hold it.
+    const service = new TeamBackupService();
+    const teamName = 'stopped-mid-restore-team';
+    const teamDir = path.join(hoisted.teamsBase, teamName);
+    await fs.mkdir(teamDir, { recursive: true });
+    await fs.writeFile(
+      path.join(teamDir, 'config.json'),
+      JSON.stringify({
+        name: 'Stopped Mid Restore Team',
+        projectPath: path.join(tempDir, 'project'),
+        members: [{ name: 'team-lead', agentType: 'team-lead' }],
+      }),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(teamDir, 'launch-state.json'),
+      JSON.stringify({ version: 2, teamName, launchPhase: 'reconciled', members: {} }),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(teamDir, 'launch-summary.json'),
+      JSON.stringify({ version: 1, teamName, teamLaunchState: 'partial_failure' }),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(teamDir, 'team.meta.json'),
+      JSON.stringify({ providerId: 'codex' }),
+      'utf8'
+    );
+
+    await service.initialize();
+    await service.backupTeam(teamName);
+
+    // What the restore is about to put back is gone and nothing says the team
+    // was stopped, so the fence read before the loop lets all three through.
+    await fs.rm(path.join(teamDir, 'launch-state.json'), { force: true });
+    await fs.rm(path.join(teamDir, 'launch-summary.json'), { force: true });
+    await fs.rm(path.join(teamDir, 'team.meta.json'), { force: true });
+
+    const backupLaunchState = path.join(
+      hoisted.backupsBase,
+      'teams',
+      teamName,
+      'launch-state.json'
+    );
+    const realReadFile = nativeFs.promises.readFile as (...args: unknown[]) => Promise<unknown>;
+    let stoppedDuringRestore = false;
+    const readFileSpy = vi.spyOn(nativeFs.promises, 'readFile').mockImplementation((async (
+      ...args: unknown[]
+    ) => {
+      const content = await realReadFile(...args);
+      if (!stoppedDuringRestore && String(args[0]) === backupLaunchState) {
+        stoppedDuringRestore = true;
+        // The stop lands after the restore read its fence and before it
+        // commits the publication file it has just read out of the backup.
+        await new TeamLaunchStateStore().markStopped(teamName);
+      }
+      return content;
+    }) as unknown as typeof nativeFs.promises.readFile);
+
+    await service.restoreIfNeeded();
+    readFileSpy.mockRestore();
+    service.dispose();
+
+    expect(stoppedDuringRestore).toBe(true);
+    await expect(fs.access(path.join(teamDir, 'launch-state.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(fs.access(path.join(teamDir, 'launch-summary.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(fs.access(path.join(teamDir, 'launch-stopped.json'))).resolves.toBeUndefined();
+    // The rest of the restore is untouched: only the publication files are
+    // fenced, so this is a restore that ran and skipped them, not one that
+    // never reached a commit.
+    await expect(fs.readFile(path.join(teamDir, 'team.meta.json'), 'utf8')).resolves.toContain(
+      'codex'
+    );
   });
 
   it('does not index a shutdown backup whose manifest could not be persisted', async () => {

--- a/test/main/services/team/TeamBackupService.test.ts
+++ b/test/main/services/team/TeamBackupService.test.ts
@@ -380,6 +380,69 @@ describe('TeamBackupService', () => {
     });
   });
 
+  it('does not index a shutdown backup whose manifest could not be persisted', async () => {
+    // The shutdown backup copies the files first and writes the registry entry
+    // afterwards. A manifest that never landed leaves the backup directory with
+    // new files and the previous ownership and file stats, so the registry must
+    // not advertise it as the current backup.
+    const service = new TeamBackupService();
+    const blockedTeam = 'blocked-manifest-team';
+    const healthyTeam = 'healthy-manifest-team';
+    for (const teamName of [blockedTeam, healthyTeam]) {
+      const teamDir = path.join(hoisted.teamsBase, teamName);
+      await fs.mkdir(teamDir, { recursive: true });
+      await fs.writeFile(
+        path.join(teamDir, 'config.json'),
+        JSON.stringify({
+          name: teamName,
+          projectPath: path.join(tempDir, 'project'),
+          members: [{ name: 'team-lead', agentType: 'team-lead' }],
+        }),
+        'utf8'
+      );
+    }
+
+    await service.initialize();
+    await service.backupTeam(blockedTeam);
+    await service.backupTeam(healthyTeam);
+
+    const registryPath = path.join(hoisted.backupsBase, 'registry.json');
+    const registryBefore = JSON.parse(await fs.readFile(registryPath, 'utf8')) as {
+      teams: Record<string, { lastBackupAt: string }>;
+    };
+
+    // A directory where the manifest belongs: the atomic rename cannot land.
+    const blockedManifest = path.join(hoisted.backupsBase, 'teams', blockedTeam, 'manifest.json');
+    await fs.rm(blockedManifest, { force: true });
+    await fs.mkdir(blockedManifest, { recursive: true });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-04T12:00:00.000Z'));
+    service.runShutdownBackupSync();
+    vi.useRealTimers();
+
+    const registryAfter = JSON.parse(await fs.readFile(registryPath, 'utf8')) as {
+      teams: Record<string, { lastBackupAt: string }>;
+    };
+    expect(registryAfter.teams[blockedTeam].lastBackupAt).toBe(
+      registryBefore.teams[blockedTeam].lastBackupAt
+    );
+    // The loop still reaches every later team: the failure belongs to one team.
+    expect(registryAfter.teams[healthyTeam].lastBackupAt).toBe('2026-09-04T12:00:00.000Z');
+
+    // Both layers report it: the manifest writer names the team, the shutdown
+    // loop names the backup it gave up on.
+    expect(console.warn).toHaveBeenCalledWith(
+      '[TeamBackupService]',
+      expect.stringContaining(`Failed to save manifest for ${blockedTeam}`)
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      '[TeamBackupService]',
+      expect.stringContaining(`shutdown backup failed for ${blockedTeam}`)
+    );
+    vi.mocked(console.warn).mockClear();
+  });
+
   it('fences startup restore after the durable destructive deletion boundary', async () => {
     const teamName = 'delete-crash-team';
     const teamDir = path.join(hoisted.teamsBase, teamName);

--- a/test/main/services/team/TeamBackupService.test.ts
+++ b/test/main/services/team/TeamBackupService.test.ts
@@ -380,6 +380,71 @@ describe('TeamBackupService', () => {
     });
   });
 
+  it('does not restore pre-stop launch state when the stop marker cannot be read', async () => {
+    // The live marker is the only evidence a team is stopped until the marker
+    // itself reaches the backup. A read that fails for anything but ENOENT does
+    // not prove the team was never stopped, so it must not license the restore
+    // to put the pre-stop launch publication back and undo the stop.
+    const service = new TeamBackupService();
+    const teamName = 'unreadable-marker-team';
+    const teamDir = path.join(hoisted.teamsBase, teamName);
+    await fs.mkdir(teamDir, { recursive: true });
+    await fs.writeFile(
+      path.join(teamDir, 'config.json'),
+      JSON.stringify({
+        name: 'Unreadable Marker Team',
+        projectPath: path.join(tempDir, 'project'),
+        members: [{ name: 'team-lead', agentType: 'team-lead' }],
+      }),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(teamDir, 'launch-state.json'),
+      JSON.stringify({ version: 2, teamName, launchPhase: 'reconciled', members: {} }),
+      'utf8'
+    );
+    await fs.writeFile(
+      path.join(teamDir, 'launch-summary.json'),
+      JSON.stringify({ version: 1, teamName, teamLaunchState: 'partial_failure' }),
+      'utf8'
+    );
+
+    await service.initialize();
+    await service.backupTeam(teamName);
+
+    // Stop, before the marker itself reached the backup.
+    await fs.rm(path.join(teamDir, 'launch-state.json'), { force: true });
+    await fs.rm(path.join(teamDir, 'launch-summary.json'), { force: true });
+    const markerPath = path.join(teamDir, 'launch-stopped.json');
+    await fs.writeFile(markerPath, JSON.stringify({ version: 1, teamName }), 'utf8');
+
+    const realAccess = nativeFs.promises.access;
+    const accessSpy = vi
+      .spyOn(nativeFs.promises, 'access')
+      .mockImplementation(async (target, mode) => {
+        if (target === markerPath) {
+          throw Object.assign(new Error('EPERM: operation not permitted'), { code: 'EPERM' });
+        }
+        return realAccess(target, mode);
+      });
+
+    await service.restoreIfNeeded();
+    accessSpy.mockRestore();
+    service.dispose();
+
+    await expect(fs.access(path.join(teamDir, 'launch-state.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(fs.access(path.join(teamDir, 'launch-summary.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    expect(console.warn).toHaveBeenCalledWith(
+      '[TeamBackupService]',
+      expect.stringContaining(`Could not read the stop marker for ${teamName}`)
+    );
+    vi.mocked(console.warn).mockClear();
+  });
+
   it('does not index a shutdown backup whose manifest could not be persisted', async () => {
     // The shutdown backup copies the files first and writes the registry entry
     // afterwards. A manifest that never landed leaves the backup directory with

--- a/test/main/services/team/TeamBackupService.test.ts
+++ b/test/main/services/team/TeamBackupService.test.ts
@@ -380,6 +380,58 @@ describe('TeamBackupService', () => {
     });
   });
 
+  it('drops a stop marker the relaunched team no longer has from the shutdown backup', async () => {
+    // Stop, relaunch, shutdown, restore. The synchronous shutdown backup only
+    // adds files, so the marker copied during the stop would outlive it in the
+    // backup and freeze the restore of the launch state the relaunch produced.
+    const service = new TeamBackupService();
+    const teamName = 'relaunched-team';
+    const teamDir = path.join(hoisted.teamsBase, teamName);
+    const backupDir = path.join(hoisted.backupsBase, 'teams', teamName);
+    await fs.mkdir(teamDir, { recursive: true });
+    await fs.writeFile(
+      path.join(teamDir, 'config.json'),
+      JSON.stringify({
+        name: 'Relaunched Team',
+        projectPath: path.join(tempDir, 'project'),
+        members: [{ name: 'team-lead', agentType: 'team-lead' }],
+      }),
+      'utf8'
+    );
+    const markerPath = path.join(teamDir, 'launch-stopped.json');
+    await fs.writeFile(markerPath, JSON.stringify({ version: 1, teamName }), 'utf8');
+
+    await service.initialize();
+    await service.backupTeam(teamName);
+    await expect(fs.access(path.join(backupDir, 'launch-stopped.json'))).resolves.toBeUndefined();
+
+    // Relaunch: the store lifts the marker and publishes the launch state.
+    await fs.rm(markerPath, { force: true });
+    await fs.writeFile(
+      path.join(teamDir, 'launch-state.json'),
+      JSON.stringify({ version: 2, teamName, launchPhase: 'active', members: {} }),
+      'utf8'
+    );
+
+    service.runShutdownBackupSync();
+
+    await expect(fs.access(path.join(backupDir, 'launch-stopped.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(fs.access(path.join(backupDir, 'launch-state.json'))).resolves.toBeUndefined();
+
+    // A full restore after losing the team directory brings the launch back
+    // instead of treating the outlived marker as a current stop.
+    await fs.rm(teamDir, { recursive: true, force: true });
+    const restoringService = new TeamBackupService();
+    await restoringService.initialize();
+    restoringService.dispose();
+    await expect(fs.access(path.join(teamDir, 'launch-state.json'))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(teamDir, 'launch-stopped.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
   it('does not restore pre-stop launch state when the stop marker cannot be read', async () => {
     // The live marker is the only evidence a team is stopped until the marker
     // itself reaches the backup. A read that fails for anything but ENOENT does

--- a/test/main/services/team/TeamLaunchStateStore.test.ts
+++ b/test/main/services/team/TeamLaunchStateStore.test.ts
@@ -330,6 +330,49 @@ describe('TeamLaunchStateStore', () => {
     await expect(new TeamLaunchStateStore().markStopped('removed-team')).resolves.toBeUndefined();
   });
 
+  it('records the stop marker and still reports a publication that survived the stop', async () => {
+    // read() answers from the launch state and never from the marker, so a
+    // snapshot that could not be revoked is still served. The stop stays final
+    // - the marker is written either way - but the survivor is reported.
+    const stateRemovalError = Object.assign(new Error('state file is busy'), { code: 'EBUSY' });
+    const remove = vi
+      .spyOn(fs.promises, 'rm')
+      .mockRejectedValueOnce(stateRemovalError)
+      .mockResolvedValueOnce(undefined);
+
+    try {
+      await expect(new TeamLaunchStateStore().markStopped('demo')).rejects.toBe(stateRemovalError);
+
+      expect(mocks.atomicWriteAsync).toHaveBeenCalledTimes(1);
+      expect(mocks.atomicWriteAsync.mock.calls[0]?.[0]).toBe(
+        getTeamLaunchStoppedMarkerPath('demo')
+      );
+    } finally {
+      remove.mockRestore();
+    }
+  });
+
+  it('reports every publication that survived the stop', async () => {
+    const stateRemovalError = Object.assign(new Error('state file is busy'), { code: 'EBUSY' });
+    const summaryRemovalError = Object.assign(new Error('summary is read-only'), { code: 'EROFS' });
+    const remove = vi
+      .spyOn(fs.promises, 'rm')
+      .mockRejectedValueOnce(stateRemovalError)
+      .mockRejectedValueOnce(summaryRemovalError);
+
+    try {
+      await expect(new TeamLaunchStateStore().markStopped('demo')).rejects.toMatchObject({
+        errors: [stateRemovalError, summaryRemovalError],
+        message: '[demo] Failed to clear launch-state publication',
+      });
+      expect(mocks.atomicWriteAsync.mock.calls[0]?.[0]).toBe(
+        getTeamLaunchStoppedMarkerPath('demo')
+      );
+    } finally {
+      remove.mockRestore();
+    }
+  });
+
   it('ignores a late reconciled launch-state write while the team is stopped', async () => {
     writeStopMarkerOnDisk('demo');
     const stale = { ...snapshot(), launchPhase: 'reconciled' as const };

--- a/test/main/services/team/TeamLaunchStateStore.test.ts
+++ b/test/main/services/team/TeamLaunchStateStore.test.ts
@@ -76,6 +76,40 @@ describe('TeamLaunchStateStore', () => {
     }
   });
 
+  it('separates a launch state that is absent from one it could not read', async () => {
+    const store = new TeamLaunchStateStore();
+
+    await expect(store.readResult('demo')).resolves.toEqual({ status: 'absent' });
+
+    const statePath = getTeamLaunchStatePath('demo');
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, '{ not json');
+
+    // Both answer `null` through `read`, which is why a caller that has to tell
+    // "nothing recorded" from "nothing readable" cannot use it.
+    await expect(store.read('demo')).resolves.toBeNull();
+    await expect(store.readResult('demo')).resolves.toMatchObject({ status: 'unreadable' });
+  });
+
+  it('reports a launch state the filesystem refused as unreadable, not absent', async () => {
+    const readFile = vi
+      .spyOn(fs.promises, 'readFile')
+      .mockRejectedValue(Object.assign(new Error('permission denied'), { code: 'EACCES' }));
+
+    try {
+      const statePath = getTeamLaunchStatePath('demo');
+      fs.mkdirSync(path.dirname(statePath), { recursive: true });
+      fs.writeFileSync(statePath, JSON.stringify(snapshot()));
+
+      await expect(new TeamLaunchStateStore().readResult('demo')).resolves.toEqual({
+        status: 'unreadable',
+        reason: 'permission denied',
+      });
+    } finally {
+      readFile.mockRestore();
+    }
+  });
+
   it('rejects when a live team directory cannot persist the complete launch publication', async () => {
     const writeError = Object.assign(new Error('disk full'), { code: 'ENOSPC' });
     mocks.atomicWriteAsync.mockResolvedValueOnce(undefined).mockRejectedValueOnce(writeError);

--- a/test/main/services/team/TeamLaunchStateStore.test.ts
+++ b/test/main/services/team/TeamLaunchStateStore.test.ts
@@ -1,12 +1,13 @@
 import { createPersistedLaunchSnapshot } from '@main/services/team/TeamLaunchStateEvaluator';
 import {
   getTeamLaunchStatePath,
+  getTeamLaunchStoppedMarkerPath,
   getTeamLaunchSummaryPath,
   TeamLaunchStateStore,
 } from '@main/services/team/TeamLaunchStateStore';
 import * as fs from 'fs';
 import * as path from 'path';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { PersistedTeamLaunchSnapshot } from '@shared/types';
 
@@ -43,9 +44,20 @@ function snapshot(updatedAt = '2026-01-01T00:00:00.000Z'): PersistedTeamLaunchSn
   });
 }
 
+function writeStopMarkerOnDisk(teamName: string): void {
+  const markerPath = getTeamLaunchStoppedMarkerPath(teamName);
+  fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+  fs.writeFileSync(markerPath, '{"version":1}\n');
+}
+
 describe('TeamLaunchStateStore', () => {
   beforeEach(() => {
     mocks.atomicWriteAsync.mockReset();
+    fs.rmSync(mocks.teamsBasePath, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(mocks.teamsBasePath, { recursive: true, force: true });
   });
 
   it('rejects a versioned snapshot whose persisted team identity does not match its path', async () => {
@@ -287,6 +299,90 @@ describe('TeamLaunchStateStore', () => {
     } finally {
       remove.mockRestore();
     }
+  });
+
+  it('drops both publications and records the stop marker when a team is marked stopped', async () => {
+    const remove = vi.spyOn(fs.promises, 'rm').mockResolvedValue(undefined);
+
+    try {
+      await new TeamLaunchStateStore().markStopped('demo');
+
+      expect(remove).toHaveBeenNthCalledWith(1, getTeamLaunchStatePath('demo'), { force: true });
+      expect(remove).toHaveBeenNthCalledWith(2, getTeamLaunchSummaryPath('demo'), { force: true });
+      expect(mocks.atomicWriteAsync).toHaveBeenCalledTimes(1);
+      const [markerPath, markerPayload] = mocks.atomicWriteAsync.mock.calls[0] as [string, string];
+      expect(markerPath).toBe(getTeamLaunchStoppedMarkerPath('demo'));
+      expect(JSON.parse(markerPayload)).toMatchObject({ version: 1, teamName: 'demo' });
+    } finally {
+      remove.mockRestore();
+    }
+  });
+
+  it('keeps the stop marker as a compatible no-op when the team directory disappeared', async () => {
+    const markerPath = getTeamLaunchStoppedMarkerPath('removed-team');
+    const missingDirectoryError = Object.assign(new Error('directory removed'), {
+      code: 'ENOENT',
+      path: path.join(path.dirname(markerPath), '.tmp.removed'),
+      dest: markerPath,
+    });
+    mocks.atomicWriteAsync.mockRejectedValueOnce(missingDirectoryError);
+
+    await expect(new TeamLaunchStateStore().markStopped('removed-team')).resolves.toBeUndefined();
+  });
+
+  it('ignores a late reconciled launch-state write while the team is stopped', async () => {
+    writeStopMarkerOnDisk('demo');
+    const stale = { ...snapshot(), launchPhase: 'reconciled' as const };
+
+    await expect(new TeamLaunchStateStore().write('demo', stale)).resolves.toBeUndefined();
+
+    expect(mocks.atomicWriteAsync).not.toHaveBeenCalled();
+    expect(await new TeamLaunchStateStore().isStopped('demo')).toBe(true);
+  });
+
+  it('lifts the stop marker when a real launch publishes an active snapshot', async () => {
+    writeStopMarkerOnDisk('demo');
+    mocks.atomicWriteAsync.mockResolvedValue(undefined);
+
+    await new TeamLaunchStateStore().write('demo', snapshot());
+
+    expect(mocks.atomicWriteAsync).toHaveBeenCalledTimes(2);
+    expect(await new TeamLaunchStateStore().isStopped('demo')).toBe(false);
+  });
+
+  it('keeps the stop marker across a launch-state clear', async () => {
+    writeStopMarkerOnDisk('demo');
+
+    await new TeamLaunchStateStore().clear('demo');
+
+    expect(await new TeamLaunchStateStore().isStopped('demo')).toBe(true);
+  });
+
+  it('still revokes both publications for a team that was never marked stopped', async () => {
+    const remove = vi.spyOn(fs.promises, 'rm').mockResolvedValue(undefined);
+
+    try {
+      await new TeamLaunchStateStore().clear('demo');
+
+      expect(remove.mock.calls.map(([targetPath]) => targetPath)).toEqual([
+        getTeamLaunchStatePath('demo'),
+        getTeamLaunchSummaryPath('demo'),
+      ]);
+    } finally {
+      remove.mockRestore();
+    }
+  });
+
+  it('publishes a reconciled snapshot for a team that was never marked stopped', async () => {
+    mocks.atomicWriteAsync.mockResolvedValue(undefined);
+    const stale = { ...snapshot(), launchPhase: 'reconciled' as const };
+
+    await new TeamLaunchStateStore().write('demo', stale);
+
+    expect(mocks.atomicWriteAsync.mock.calls.map(([targetPath]) => targetPath)).toEqual([
+      getTeamLaunchStatePath('demo'),
+      getTeamLaunchSummaryPath('demo'),
+    ]);
   });
 
   it('reports every I/O failure when neither publication file can be revoked', async () => {

--- a/test/main/services/team/TeamLaunchStateStore.test.ts
+++ b/test/main/services/team/TeamLaunchStateStore.test.ts
@@ -4,6 +4,7 @@ import {
   getTeamLaunchStoppedMarkerPath,
   getTeamLaunchSummaryPath,
   TeamLaunchStateStore,
+  withTeamLaunchStatePublicationLock,
 } from '@main/services/team/TeamLaunchStateStore';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -108,6 +109,25 @@ describe('TeamLaunchStateStore', () => {
     } finally {
       readFile.mockRestore();
     }
+  });
+
+  it('holds a caller-supplied publication until an in-flight stop has finished', async () => {
+    // markStopped removes the publication files and writes its marker after
+    // them. A caller that publishes those files from outside the store - the
+    // backup restore - must not run between the two, so it shares the queue
+    // rather than checking the marker on its own.
+    const order: string[] = [];
+    mocks.atomicWriteAsync.mockImplementation(async (target: string) => {
+      order.push(`stop-marker:${path.basename(target)}`);
+    });
+
+    const stopping = new TeamLaunchStateStore().markStopped('demo');
+    const restoring = withTeamLaunchStatePublicationLock('demo', async () => {
+      order.push('restore-commit');
+    });
+    await Promise.all([stopping, restoring]);
+
+    expect(order).toEqual(['stop-marker:launch-stopped.json', 'restore-commit']);
   });
 
   it('rejects when a live team directory cannot persist the complete launch publication', async () => {

--- a/test/main/services/team/TeamLaunchStateStore.test.ts
+++ b/test/main/services/team/TeamLaunchStateStore.test.ts
@@ -393,6 +393,31 @@ describe('TeamLaunchStateStore', () => {
     expect(await new TeamLaunchStateStore().isStopped('demo')).toBe(false);
   });
 
+  it('ignores a republished active snapshot while the team is stopped', async () => {
+    // The rollback of a stale write, and a recovery re-deriving the run that was
+    // just stopped, both republish an active snapshot they read earlier. Neither
+    // is a launch, so the stop stays final over them.
+    writeStopMarkerOnDisk('demo');
+    mocks.atomicWriteAsync.mockResolvedValue(undefined);
+
+    await new TeamLaunchStateStore().write('demo', snapshot(), {
+      republishesExistingLaunch: true,
+    });
+
+    expect(mocks.atomicWriteAsync).not.toHaveBeenCalled();
+    expect(await new TeamLaunchStateStore().isStopped('demo')).toBe(true);
+  });
+
+  it('publishes a republished active snapshot for a team that was never stopped', async () => {
+    mocks.atomicWriteAsync.mockResolvedValue(undefined);
+
+    await new TeamLaunchStateStore().write('demo', snapshot(), {
+      republishesExistingLaunch: true,
+    });
+
+    expect(mocks.atomicWriteAsync).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps the stop marker across a launch-state clear', async () => {
     writeStopMarkerOnDisk('demo');
 

--- a/test/main/services/team/teamBackupManifest.test.ts
+++ b/test/main/services/team/teamBackupManifest.test.ts
@@ -9,11 +9,11 @@ import {
   getBackupManifestPath,
   readBackupManifestSync,
   writeBackupManifestSync,
-} from '../../../../src/main/services/team/teamBackupManifest';
+} from '@main/services/team/teamBackupManifest';
 
 let tempRoot = '';
 
-function manifest(teamName = 'demo'): BackupManifest {
+function buildManifest(teamName = 'demo'): BackupManifest {
   return {
     teamName,
     identityId: 'identity-1',
@@ -36,10 +36,10 @@ describe('writeBackupManifestSync', () => {
   it('persists a manifest a restore can read back', () => {
     const backupDir = path.join(tempRoot, 'demo');
 
-    writeBackupManifestSync(backupDir, manifest());
+    writeBackupManifestSync(backupDir, buildManifest());
 
     expect(fs.existsSync(getBackupManifestPath(backupDir))).toBe(true);
-    expect(readBackupManifestSync(backupDir)).toEqual(manifest());
+    expect(readBackupManifestSync(backupDir)).toEqual(buildManifest());
     expect(console.warn).not.toHaveBeenCalled();
   });
 
@@ -50,7 +50,7 @@ describe('writeBackupManifestSync', () => {
     const backupDir = path.join(tempRoot, 'blocked');
     fs.writeFileSync(backupDir, 'a file where the backup directory belongs');
 
-    expect(() => writeBackupManifestSync(backupDir, manifest('blocked-team'))).not.toThrow();
+    expect(() => writeBackupManifestSync(backupDir, buildManifest('blocked-team'))).not.toThrow();
 
     expect(console.warn).toHaveBeenCalledWith(
       '[TeamBackupService]',

--- a/test/main/services/team/teamBackupManifest.test.ts
+++ b/test/main/services/team/teamBackupManifest.test.ts
@@ -62,14 +62,15 @@ describe('writeBackupManifestSync', () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
-  it('reports the team whose manifest could not be persisted', () => {
-    // The shutdown backup copies the files and updates the registry before it
-    // saves the manifest, so a write that fails silently leaves a backup that
-    // restores from stale ownership and stale file stats with nothing said.
+  it('reports and propagates the team whose manifest could not be persisted', () => {
+    // The shutdown backup copies the files first and indexes the team in the
+    // registry afterwards, so a write that fails silently leaves a registry
+    // entry pointing at a backup whose manifest still holds the previous
+    // ownership and file stats. The caller has to see the failure.
     const backupDir = path.join(tempRoot, 'blocked');
     fs.writeFileSync(backupDir, 'a file where the backup directory belongs');
 
-    expect(() => writeBackupManifestSync(backupDir, buildManifest('blocked-team'))).not.toThrow();
+    expect(() => writeBackupManifestSync(backupDir, buildManifest('blocked-team'))).toThrow();
 
     expect(console.warn).toHaveBeenCalledWith(
       '[TeamBackupService]',

--- a/test/main/services/team/teamBackupManifest.test.ts
+++ b/test/main/services/team/teamBackupManifest.test.ts
@@ -1,0 +1,61 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  type BackupManifest,
+  getBackupManifestPath,
+  readBackupManifestSync,
+  writeBackupManifestSync,
+} from '../../../../src/main/services/team/teamBackupManifest';
+
+let tempRoot = '';
+
+function manifest(teamName = 'demo'): BackupManifest {
+  return {
+    teamName,
+    identityId: 'identity-1',
+    status: 'active',
+    firstBackupAt: '2026-01-01T00:00:00.000Z',
+    lastBackupAt: '2026-01-01T00:00:00.000Z',
+    fileStats: { 'config.json': { mtime: 1, size: 2 } },
+  };
+}
+
+describe('writeBackupManifestSync', () => {
+  beforeEach(() => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'team-backup-manifest-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('persists a manifest a restore can read back', () => {
+    const backupDir = path.join(tempRoot, 'demo');
+
+    writeBackupManifestSync(backupDir, manifest());
+
+    expect(fs.existsSync(getBackupManifestPath(backupDir))).toBe(true);
+    expect(readBackupManifestSync(backupDir)).toEqual(manifest());
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('reports the team whose manifest could not be persisted', () => {
+    // The shutdown backup copies the files and updates the registry before it
+    // saves the manifest, so a write that fails silently leaves a backup that
+    // restores from stale ownership and stale file stats with nothing said.
+    const backupDir = path.join(tempRoot, 'blocked');
+    fs.writeFileSync(backupDir, 'a file where the backup directory belongs');
+
+    expect(() => writeBackupManifestSync(backupDir, manifest('blocked-team'))).not.toThrow();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      '[TeamBackupService]',
+      expect.stringContaining('Failed to save manifest for blocked-team')
+    );
+    vi.mocked(console.warn).mockClear();
+  });
+});

--- a/test/main/services/team/teamBackupManifest.test.ts
+++ b/test/main/services/team/teamBackupManifest.test.ts
@@ -13,7 +13,7 @@ import {
 
 let tempRoot = '';
 
-function buildManifest(teamName = 'demo'): BackupManifest {
+function buildManifest(teamName = 'demo', overrides: Partial<BackupManifest> = {}): BackupManifest {
   return {
     teamName,
     identityId: 'identity-1',
@@ -21,6 +21,7 @@ function buildManifest(teamName = 'demo'): BackupManifest {
     firstBackupAt: '2026-01-01T00:00:00.000Z',
     lastBackupAt: '2026-01-01T00:00:00.000Z',
     fileStats: { 'config.json': { mtime: 1, size: 2 } },
+    ...overrides,
   };
 }
 
@@ -40,6 +41,24 @@ describe('writeBackupManifestSync', () => {
 
     expect(fs.existsSync(getBackupManifestPath(backupDir))).toBe(true);
     expect(readBackupManifestSync(backupDir)).toEqual(buildManifest());
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('persists a deleted-by-user manifest with its deletion timestamp', () => {
+    const backupDir = path.join(tempRoot, 'deleted');
+    const deleted = buildManifest('deleted', {
+      status: 'deleted_by_user',
+      deletedByUserAt: '2026-02-01T00:00:00.000Z',
+      projectPath: 'D:/projects/deleted',
+      displayName: 'Deleted team',
+    });
+
+    writeBackupManifestSync(backupDir, deleted);
+
+    const restored = readBackupManifestSync(backupDir);
+    expect(restored).toEqual(deleted);
+    expect(restored?.status).toBe('deleted_by_user');
+    expect(restored?.deletedByUserAt).toBe('2026-02-01T00:00:00.000Z');
     expect(console.warn).not.toHaveBeenCalled();
   });
 

--- a/test/main/services/team/teamForceStopFlow.test.ts
+++ b/test/main/services/team/teamForceStopFlow.test.ts
@@ -1,4 +1,7 @@
-import { runTeamForceStopFlow } from '@main/services/team/lifecycle/teamForceStopFlow';
+import {
+  runTeamForceStopFlow,
+  stopTeamWithEscalation,
+} from '@main/services/team/lifecycle/teamForceStopFlow';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { TeamForceStopFlowPorts } from '@main/services/team/lifecycle/teamForceStopFlow';
@@ -271,5 +274,90 @@ describe('runTeamForceStopFlow', () => {
     expect(ports.logWarning).toHaveBeenCalledWith(
       '[fixteam] Could not persist stopped launch state: team directory is read-only'
     );
+  });
+});
+
+describe('stopTeamWithEscalation', () => {
+  it('touches no other process when the regular stop confirms', async () => {
+    const ports = createPorts({ markTeamStopped: vi.fn(() => Promise.resolve()) });
+
+    const result = await stopTeamWithEscalation('fixteam', ports);
+
+    expect(ports.stopTeam).toHaveBeenCalledWith('fixteam');
+    expect(ports.killRetainedRuntimeProcesses).not.toHaveBeenCalled();
+    expect(ports.clearPendingPromptDeliveries).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      stopOutcome: 'stopped',
+      cleanupOutcome: 'completed',
+      killedRuntimePids: [],
+      clearedPendingDeliveries: 0,
+      diagnostics: [],
+    });
+    expect(ports.markTeamStopped).toHaveBeenCalledWith('fixteam');
+  });
+
+  it('does not cancel deliveries up front the way the force stop does', async () => {
+    // The force stop cancels before the stop so a stop that removes the lane
+    // index cannot strand the ledger. A regular Stop cannot: it does not yet
+    // know whether it will have to escalate, and a confirmed Stop must leave
+    // pending work alone.
+    const escalating = createPorts({
+      observeOwnedRuntimeLaneIds: () => Promise.resolve(['primary']),
+    });
+    await stopTeamWithEscalation('fixteam', escalating);
+    expect(escalating.clearPendingPromptDeliveries).not.toHaveBeenCalled();
+
+    const forcing = createPorts({ observeOwnedRuntimeLaneIds: () => Promise.resolve(['primary']) });
+    await runTeamForceStopFlow('fixteam', forcing);
+    expect(forcing.clearPendingPromptDeliveries).toHaveBeenCalled();
+  });
+
+  it('escalates to the force-stop cleanup when the regular stop rejects', async () => {
+    const ports = createPorts({
+      stopTeam: vi.fn(() =>
+        Promise.reject(new Error('did not confirm stop; retaining runtime ownership'))
+      ),
+    });
+
+    const result = await stopTeamWithEscalation('fixteam', ports);
+
+    expect(result.stopOutcome).toBe('stop_failed');
+    expect(result.killedRuntimePids).toEqual([4242]);
+    expect(result.clearedPendingDeliveries).toBe(2);
+  });
+
+  it('escalates to the force-stop cleanup when the regular stop runs out of budget', async () => {
+    const ports = createPorts({
+      stopTeam: vi.fn(() => new Promise<void>(() => undefined)),
+    });
+
+    const result = await stopTeamWithEscalation('fixteam', ports);
+
+    expect(result.stopOutcome).toBe('timed_out');
+    expect(ports.killRetainedRuntimeProcesses).toHaveBeenCalledWith('fixteam', {
+      requestedAtMs: expect.any(Number),
+    });
+    // The escalated cleanup carries the same run fence the force stop does:
+    // a relaunch started inside the stop budget keeps its deliveries.
+    expect(ports.clearPendingPromptDeliveries).toHaveBeenCalledWith('fixteam', {
+      requestedAtMs: expect.any(Number),
+      ownedRunIds: ['run-a'],
+    });
+    expect(ports.clearPendingPromptDeliveries).toHaveBeenCalledTimes(1);
+  });
+
+  it('scopes the escalated cancellation to the lanes read before the stop', async () => {
+    const ports = createPorts({
+      observeOwnedRuntimeLaneIds: () => Promise.resolve(['primary']),
+      stopTeam: vi.fn(() => Promise.reject(new Error('did not confirm stop'))),
+    });
+
+    await stopTeamWithEscalation('fixteam', ports);
+
+    expect(ports.clearPendingPromptDeliveries).toHaveBeenCalledWith('fixteam', {
+      requestedAtMs: expect.any(Number),
+      ownedRunIds: ['run-a'],
+      ownedLaneIds: ['primary'],
+    });
   });
 });

--- a/test/main/services/team/teamForceStopFlow.test.ts
+++ b/test/main/services/team/teamForceStopFlow.test.ts
@@ -446,12 +446,19 @@ describe('stopTeamWithEscalation runtime-host evidence', () => {
     });
 
     const stopping = stopTeamWithEscalation('fixteam', ports);
+    let settled = false;
+    void stopping.then(() => {
+      settled = true;
+    });
     await vi.advanceTimersByTimeAsync(4_999);
-    const settledEarly = await Promise.race([stopping.then(() => true), Promise.resolve(false)]);
-    expect(settledEarly).toBe(false);
+    expect(settled).toBe(false);
     await vi.advanceTimersByTimeAsync(2);
 
     await expect(stopping).resolves.toMatchObject({ stopOutcome: 'timed_out' });
+    // The same flag on the same promise, one tick past the budget: that is what
+    // makes the reading above evidence that the flow waited rather than a flag
+    // nothing was ever going to set.
+    expect(settled).toBe(true);
   });
 
   it('never arms the poller when the first sample already reports no live host', async () => {

--- a/test/main/services/team/teamForceStopFlow.test.ts
+++ b/test/main/services/team/teamForceStopFlow.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PersistedTeamLaunchSnapshot } from '@shared/types';
 
 import type { TeamForceStopFlowPorts } from '@main/services/team/lifecycle/teamForceStopFlow';
+import type { TeamLaunchStateReadResult } from '@main/services/team/TeamLaunchStateStore';
 
 function createPorts(overrides: Partial<TeamForceStopFlowPorts> = {}): {
   [K in keyof TeamForceStopFlowPorts]: TeamForceStopFlowPorts[K];
@@ -36,6 +37,28 @@ function createPorts(overrides: Partial<TeamForceStopFlowPorts> = {}): {
     stopTimeoutMs: 20,
     ...overrides,
   } as never;
+}
+
+/** A launch state that recorded one OpenCode host pid per lane. */
+function recordedSnapshot(pids: Record<string, number | undefined>): TeamLaunchStateReadResult {
+  return {
+    status: 'snapshot',
+    snapshot: {
+      members: Object.fromEntries(
+        Object.entries(pids).map(([laneId, runtimePid]) => [
+          laneId,
+          { name: laneId, providerId: 'opencode', laneId, runtimePid },
+        ])
+      ),
+    } as unknown as PersistedTeamLaunchSnapshot,
+  };
+}
+
+/** A launch-state store that answers every read with the same result. */
+function launchStateStore(result: TeamLaunchStateReadResult): {
+  readResult: () => Promise<TeamLaunchStateReadResult>;
+} {
+  return { readResult: () => Promise.resolve(result) };
 }
 
 describe('runTeamForceStopFlow', () => {
@@ -495,35 +518,90 @@ describe('stopTeamWithEscalation runtime-host evidence', () => {
 
     expect(countLiveRuntimeHosts).toHaveBeenCalledTimes(samplesAtStopEnd);
   });
+
+  /**
+   * Arms the poller on a live host, then blinds the probe, and holds the
+   * orchestrator's stop open until the assertions are made. A stop that ends as
+   * `stopped` is evidence the flow kept waiting for the acknowledgement: had it
+   * read the blind samples as "the hosts are gone" it would have ended on its
+   * own, reported `runtime_already_down`, and run the force-stop cleanup.
+   */
+  async function expectBlindProbeKeepsStopOnItsNormalPath(
+    countLiveRuntimeHosts: TeamForceStopFlowPorts['countLiveRuntimeHosts']
+  ): Promise<void> {
+    let confirmStop: (() => void) | undefined;
+    const ports = createPorts({
+      stopTeam: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            confirmStop = resolve;
+          })
+      ),
+      stopTimeoutMs: STOP_ESCALATION_TIMEOUT_MS,
+      countLiveRuntimeHosts,
+    });
+
+    const stopping = stopTeamWithEscalation('fixteam', ports);
+    let settled = false;
+    void stopping.then(() => {
+      settled = true;
+    });
+    await advanceThroughSamples(4);
+
+    expect(settled).toBe(false);
+    expect(ports.killRetainedRuntimeProcesses).not.toHaveBeenCalled();
+    expect(ports.clearPendingPromptDeliveries).not.toHaveBeenCalled();
+
+    confirmStop?.();
+    const result = await stopping;
+
+    expect(result.stopOutcome).toBe('stopped');
+    expect(result.diagnostics.join('\n')).not.toContain('Runtime hosts were gone');
+    expect(ports.killRetainedRuntimeProcesses).not.toHaveBeenCalled();
+    expect(ports.clearPendingPromptDeliveries).not.toHaveBeenCalled();
+  }
+
+  it('does not read a probe that rejects as hosts that are gone', async () => {
+    let samples = 0;
+
+    await expectBlindProbeKeepsStopOnItsNormalPath(() => {
+      samples += 1;
+      return samples === 1 ? Promise.resolve(2) : Promise.reject(new Error('probe exploded'));
+    });
+  });
+
+  it('does not read a failed launch-state read as hosts that are gone', async () => {
+    // The recorded-host probe in production: a launch state that named a live
+    // host, then a read that failed. A failed read names no host either, and
+    // that must not pass for a team that finished exiting.
+    let reads = 0;
+    const store = {
+      readResult: (): Promise<TeamLaunchStateReadResult> => {
+        reads += 1;
+        return Promise.resolve(
+          reads === 1 ? recordedSnapshot({ 'lane-a': 11 }) : { status: 'unreadable', reason: 'EIO' }
+        );
+      },
+    };
+
+    await expectBlindProbeKeepsStopOnItsNormalPath((teamName) =>
+      countLiveRecordedRuntimeHostsForTeam({
+        teamName,
+        launchStateStore: store as never,
+        isRuntimeProcessAlive: () => true,
+      })
+    );
+  });
 });
 
 describe('countLiveRecordedRuntimeHostsForTeam', () => {
-  function launchStateStore(snapshot: PersistedTeamLaunchSnapshot | null): {
-    read: () => Promise<PersistedTeamLaunchSnapshot | null>;
-  } {
-    return { read: () => Promise.resolve(snapshot) };
-  }
-
-  function snapshotWithLanePids(
-    pids: Record<string, number | undefined>
-  ): PersistedTeamLaunchSnapshot {
-    return {
-      members: Object.fromEntries(
-        Object.entries(pids).map(([laneId, runtimePid]) => [
-          laneId,
-          { name: laneId, providerId: 'opencode', laneId, runtimePid },
-        ])
-      ),
-    } as unknown as PersistedTeamLaunchSnapshot;
-  }
-
   it('counts only the pids the launch state recorded for this team', async () => {
     const alivePids = new Set([11, 22]);
 
     const live = await countLiveRecordedRuntimeHostsForTeam({
       teamName: 'fixteam',
       launchStateStore: launchStateStore(
-        snapshotWithLanePids({ 'lane-a': 11, 'lane-b': 33, 'lane-c': undefined })
+        recordedSnapshot({ 'lane-a': 11, 'lane-b': 33, 'lane-c': undefined })
       ) as never,
       isRuntimeProcessAlive: (pid) => alivePids.has(pid),
     });
@@ -531,20 +609,40 @@ describe('countLiveRecordedRuntimeHostsForTeam', () => {
     expect(live).toBe(1);
   });
 
-  it('reports no live host when the launch state cannot be read', async () => {
+  it('counts no live host for a team that published no launch state', async () => {
     const live = await countLiveRecordedRuntimeHostsForTeam({
       teamName: 'fixteam',
-      launchStateStore: { read: () => Promise.reject(new Error('unreadable')) } as never,
+      launchStateStore: launchStateStore({ status: 'absent' }) as never,
       isRuntimeProcessAlive: () => true,
     });
 
     expect(live).toBe(0);
   });
 
+  it('reports unknown, not zero, when the launch state could not be read', async () => {
+    const live = await countLiveRecordedRuntimeHostsForTeam({
+      teamName: 'fixteam',
+      launchStateStore: launchStateStore({ status: 'unreadable', reason: 'EBUSY' }) as never,
+      isRuntimeProcessAlive: () => true,
+    });
+
+    expect(live).toBeNull();
+  });
+
+  it('reports unknown when the launch state read itself rejects', async () => {
+    const live = await countLiveRecordedRuntimeHostsForTeam({
+      teamName: 'fixteam',
+      launchStateStore: { readResult: () => Promise.reject(new Error('unreadable')) } as never,
+      isRuntimeProcessAlive: () => true,
+    });
+
+    expect(live).toBeNull();
+  });
+
   it('does not count a process whose liveness cannot be read', async () => {
     const live = await countLiveRecordedRuntimeHostsForTeam({
       teamName: 'fixteam',
-      launchStateStore: launchStateStore(snapshotWithLanePids({ 'lane-a': 11 })) as never,
+      launchStateStore: launchStateStore(recordedSnapshot({ 'lane-a': 11 })) as never,
       isRuntimeProcessAlive: () => {
         throw new Error('EPERM');
       },

--- a/test/main/services/team/teamForceStopFlow.test.ts
+++ b/test/main/services/team/teamForceStopFlow.test.ts
@@ -223,4 +223,53 @@ describe('runTeamForceStopFlow', () => {
     expect(result.clearedPendingDeliveries).toBe(3);
     expect(result.cleanupOutcome).toBe('completed');
   });
+
+  it('persists the stopped state after the cleanup steps have run', async () => {
+    const order: string[] = [];
+    const markTeamStopped = vi.fn(() => {
+      order.push('markTeamStopped');
+      return Promise.resolve();
+    });
+    const ports = createPorts({
+      clearPendingPromptDeliveries: vi.fn(() => {
+        order.push('clearPendingPromptDeliveries');
+        return Promise.resolve({ cleared: 0, diagnostics: [] });
+      }),
+      markTeamStopped,
+    });
+
+    await runTeamForceStopFlow('fixteam', ports);
+
+    expect(markTeamStopped).toHaveBeenCalledWith('fixteam');
+    expect(order).toEqual(['clearPendingPromptDeliveries', 'markTeamStopped']);
+  });
+
+  it('marks the team stopped even when the regular stop never confirmed', async () => {
+    const markTeamStopped = vi.fn(() => Promise.resolve());
+    const ports = createPorts({
+      stopTeam: vi.fn(() => Promise.reject(new Error('did not confirm stop'))),
+      markTeamStopped,
+    });
+
+    const result = await runTeamForceStopFlow('fixteam', ports);
+
+    expect(result.stopOutcome).toBe('stop_failed');
+    expect(markTeamStopped).toHaveBeenCalledWith('fixteam');
+  });
+
+  it('reports a failing stopped-state write as a diagnostic instead of failing the force stop', async () => {
+    const ports = createPorts({
+      markTeamStopped: vi.fn(() => Promise.reject(new Error('team directory is read-only'))),
+    });
+
+    const result = await runTeamForceStopFlow('fixteam', ports);
+
+    expect(result.stopOutcome).toBe('stopped');
+    expect(result.diagnostics.join('\n')).toContain(
+      'Stopped-state persistence failed: team directory is read-only'
+    );
+    expect(ports.logWarning).toHaveBeenCalledWith(
+      '[fixteam] Could not persist stopped launch state: team directory is read-only'
+    );
+  });
 });

--- a/test/main/services/team/teamForceStopFlow.test.ts
+++ b/test/main/services/team/teamForceStopFlow.test.ts
@@ -1,8 +1,13 @@
 import {
+  countLiveRecordedRuntimeHostsForTeam,
+  RUNTIME_HOSTS_POLL_INTERVAL_MS,
   runTeamForceStopFlow,
+  STOP_ESCALATION_TIMEOUT_MS,
   stopTeamWithEscalation,
 } from '@main/services/team/lifecycle/teamForceStopFlow';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PersistedTeamLaunchSnapshot } from '@shared/types';
 
 import type { TeamForceStopFlowPorts } from '@main/services/team/lifecycle/teamForceStopFlow';
 
@@ -359,5 +364,185 @@ describe('stopTeamWithEscalation', () => {
       ownedRunIds: ['run-a'],
       ownedLaneIds: ['primary'],
     });
+  });
+});
+
+describe('stopTeamWithEscalation runtime-host evidence', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Advances fake time in poll-sized steps, letting each sample settle. */
+  async function advanceThroughSamples(samples: number): Promise<void> {
+    for (let sample = 0; sample < samples; sample += 1) {
+      await vi.advanceTimersByTimeAsync(RUNTIME_HOSTS_POLL_INTERVAL_MS);
+    }
+  }
+
+  it('finishes the moment the recorded hosts are gone instead of waiting out the budget', async () => {
+    let liveHosts = 2;
+    const ports = createPorts({
+      stopTeam: vi.fn(() => new Promise<void>(() => undefined)),
+      stopTimeoutMs: STOP_ESCALATION_TIMEOUT_MS,
+      countLiveRuntimeHosts: vi.fn(() => Promise.resolve(liveHosts)),
+    });
+
+    const stopping = stopTeamWithEscalation('fixteam', ports);
+    await advanceThroughSamples(2);
+    liveHosts = 0;
+    await advanceThroughSamples(2);
+    const result = await stopping;
+
+    expect(result.stopOutcome).toBe('runtime_already_down');
+    expect(result.diagnostics.join('\n')).toContain('Runtime hosts were gone');
+    // The team is down but the cleanup still runs: startup locks and pending
+    // deliveries outlive the hosts.
+    expect(ports.killRetainedRuntimeProcesses).toHaveBeenCalledWith('fixteam', {
+      requestedAtMs: expect.any(Number),
+    });
+    expect(ports.clearPendingPromptDeliveries).toHaveBeenCalledWith('fixteam', {
+      requestedAtMs: expect.any(Number),
+      ownedRunIds: ['run-a'],
+    });
+  });
+
+  it('samples the hosts on their own evidence after the force stop cancelled deliveries up front', async () => {
+    // The force stop persists the cancellation before it asks for the stop.
+    // That write reaches the delivery ledger, never the launch state the poll
+    // reads, so the poll must still end the wait on host evidence alone and a
+    // lane must not read as down merely because its records were cancelled.
+    const order: string[] = [];
+    let liveHosts = 1;
+    const ports = createPorts({
+      stopTeam: vi.fn(() => new Promise<void>(() => undefined)),
+      stopTimeoutMs: STOP_ESCALATION_TIMEOUT_MS,
+      clearPendingPromptDeliveries: vi.fn(() => {
+        order.push('cancel');
+        return Promise.resolve({ cleared: 1, diagnostics: [] });
+      }),
+      countLiveRuntimeHosts: vi.fn(() => {
+        order.push('sample');
+        return Promise.resolve(liveHosts);
+      }),
+    });
+
+    const stopping = runTeamForceStopFlow('fixteam', ports);
+    await advanceThroughSamples(2);
+    expect(order).toEqual(['cancel', 'sample', 'sample', 'sample']);
+    liveHosts = 0;
+    await advanceThroughSamples(1);
+
+    await expect(stopping).resolves.toMatchObject({ stopOutcome: 'runtime_already_down' });
+  });
+
+  it('keeps the previous fixed budget when no host counter is supplied', async () => {
+    const ports = createPorts({
+      stopTeam: vi.fn(() => new Promise<void>(() => undefined)),
+      stopTimeoutMs: 5_000,
+    });
+
+    const stopping = stopTeamWithEscalation('fixteam', ports);
+    await vi.advanceTimersByTimeAsync(4_999);
+    const settledEarly = await Promise.race([stopping.then(() => true), Promise.resolve(false)]);
+    expect(settledEarly).toBe(false);
+    await vi.advanceTimersByTimeAsync(2);
+
+    await expect(stopping).resolves.toMatchObject({ stopOutcome: 'timed_out' });
+  });
+
+  it('never arms the poller when the first sample already reports no live host', async () => {
+    const countLiveRuntimeHosts = vi.fn(() => Promise.resolve(0));
+    const ports = createPorts({
+      stopTeam: vi.fn(() => new Promise<void>(() => undefined)),
+      stopTimeoutMs: 5_000,
+      countLiveRuntimeHosts,
+    });
+
+    const stopping = stopTeamWithEscalation('fixteam', ports);
+    await advanceThroughSamples(4);
+    // A team with nothing recorded must not be read as "everything exited".
+    expect(countLiveRuntimeHosts).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(stopping).resolves.toMatchObject({ stopOutcome: 'timed_out' });
+  });
+
+  it('stops sampling once the flow leaves the stop phase, including when it throws', async () => {
+    const countLiveRuntimeHosts = vi.fn(() => Promise.resolve(1));
+    const ports = createPorts({
+      stopTeam: vi.fn(() => new Promise<void>(() => undefined)),
+      stopTimeoutMs: 2_000,
+      countLiveRuntimeHosts,
+      killRetainedRuntimeProcesses: vi.fn(() => Promise.reject(new Error('kill exploded'))),
+    });
+
+    const stopping = stopTeamWithEscalation('fixteam', ports);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await stopping;
+    const samplesAtStopEnd = countLiveRuntimeHosts.mock.calls.length;
+    await advanceThroughSamples(5);
+
+    expect(countLiveRuntimeHosts).toHaveBeenCalledTimes(samplesAtStopEnd);
+  });
+});
+
+describe('countLiveRecordedRuntimeHostsForTeam', () => {
+  function launchStateStore(snapshot: PersistedTeamLaunchSnapshot | null): {
+    read: () => Promise<PersistedTeamLaunchSnapshot | null>;
+  } {
+    return { read: () => Promise.resolve(snapshot) };
+  }
+
+  function snapshotWithLanePids(
+    pids: Record<string, number | undefined>
+  ): PersistedTeamLaunchSnapshot {
+    return {
+      members: Object.fromEntries(
+        Object.entries(pids).map(([laneId, runtimePid]) => [
+          laneId,
+          { name: laneId, providerId: 'opencode', laneId, runtimePid },
+        ])
+      ),
+    } as unknown as PersistedTeamLaunchSnapshot;
+  }
+
+  it('counts only the pids the launch state recorded for this team', async () => {
+    const alivePids = new Set([11, 22]);
+
+    const live = await countLiveRecordedRuntimeHostsForTeam({
+      teamName: 'fixteam',
+      launchStateStore: launchStateStore(
+        snapshotWithLanePids({ 'lane-a': 11, 'lane-b': 33, 'lane-c': undefined })
+      ) as never,
+      isRuntimeProcessAlive: (pid) => alivePids.has(pid),
+    });
+
+    expect(live).toBe(1);
+  });
+
+  it('reports no live host when the launch state cannot be read', async () => {
+    const live = await countLiveRecordedRuntimeHostsForTeam({
+      teamName: 'fixteam',
+      launchStateStore: { read: () => Promise.reject(new Error('unreadable')) } as never,
+      isRuntimeProcessAlive: () => true,
+    });
+
+    expect(live).toBe(0);
+  });
+
+  it('does not count a process whose liveness cannot be read', async () => {
+    const live = await countLiveRecordedRuntimeHostsForTeam({
+      teamName: 'fixteam',
+      launchStateStore: launchStateStore(snapshotWithLanePids({ 'lane-a': 11 })) as never,
+      isRuntimeProcessAlive: () => {
+        throw new Error('EPERM');
+      },
+    });
+
+    expect(live).toBe(0);
   });
 });


### PR DESCRIPTION
Builds on #568 (merged), which made a force stop cancel the pending deliveries of the run it tears down - before the stop, so a stop that removes the lane index cannot strand the ledger, and again after - and report a `cleanupOutcome` when hard runtime cleanup cannot be confirmed, in the app and over HTTP.

## Problem

After Stop, the app kept resurrecting the team it had just stopped, and Stop itself often could not finish. Six defects, in the order a user hits them:

1. **A stopped team came back as "failed partway".** The stale mixed-secondary recovery re-derived a launch snapshot from the lane metadata of the run that had just been stopped, so the card said "Last launch failed partway, 2/3 teammates did not join" for a team the user stopped on purpose. A backup restore did the same.
2. **A stale launch-state write cleared what it had overwritten** instead of restoring it, and the persisted-launch reconcile could clear bootstrap state that belonged to a newer run than the one that started the reconcile.
3. **Stop could leave a team running.** The orchestrator holds a per-team lock, and a stop command that exits non-zero or never returns leaves the hosts alive with the run still tracked; the only way out was Force stop, which is a different promise: it cancels the run's pending deliveries whatever the stop does, which is more than the user asked for when they pressed Stop.
4. **Mixed secondary lanes stopped one at a time**, so a stop of a mixed team took the sum of its lane stops.
5. **The stop budget could not be met.** Measured per-lane stops run 17–48 s (a capability probe plus a registry lock per command), so a flat 20 s budget escalated every mixed team, and a 45 s budget cut off a lane that confirmed at 47.6 s.
6. **A stop of a runtime that was already gone was read as a failed stop.** The orchestrator reports `stopped: false` whenever a session abort does not confirm, which is exactly what happens when the host crashed or a force stop killed it; the run stayed tracked, `/stop` answered 500 in a loop, and the team never left the alive list. The same happened, before any handshake, when the OpenCode user config had changed under running lanes and the persisted-manifest precondition rejected the stop. The runtime also leaves startup locks behind that its readiness probe then waits on, so launches slowed to a crawl in a long session.

## Fix

Ten commits, and five more from review round 1, listed after them.

1. `refactor(team): extract the backup manifest writer from the backup service`: `TeamBackupService.ts` sat exactly on its frozen cap (1236) and commit 3 needs one line. The manifest accessors move to `teamBackupManifest.ts`, bodies unchanged apart from the receiver becoming an explicit `backupDir` argument and the repeated path expression getting a name. 1236 → 1207.
2. `fix(team): a stopped team keeps a stop marker and reconciliation stops resurrecting a phantom half-launched snapshot`: `TeamLaunchStateStore` records the difference with a `launch-stopped.json` marker. While it exists the store ignores non-active launch-state writes and the stale recovery hands the persisted snapshot straight back. Only a launch lifts it, and round 2 below narrows what counts as one; a `clear()` deliberately does not, because the regular stop can finish long after the force stop escalated past it and ends with a clear. The force-stop flow gets the write as an optional `markTeamStopped` port that runs after the cleanup steps; a failure to persist is a diagnostic, not a failed force stop. The marker is written before a publication file that could not be deleted is reported, and that order is deliberate: `read()` answers from `launch-state.json` and never from the marker, because the stop flow itself reads the snapshot for the host pids it polls, so a surviving publication has to be reported, but reporting it before the marker exists would leave the team unmarked and hand it straight back to the two guards the marker exists for.
3. `fix(team): a backup restore keeps a stopped team stopped`.
4. `fix(team): a stale launch-state write restores what it overwrote instead of clearing`.
5. `fix(team): the persisted launch reconcile writes are scoped to their run`: the reconcile learns the tracked run through `getTrackedRunId` and the existing `canClearPersistedLaunchStateForRun` guard skips the clear when the run changed hands. Wired on the live path (the persistence reconcile facade, from `service.getTrackedRunId`) and on the service-shaped port factory; optional on the reconcile contract, where a caller that already knows its run passes `expectedRunId` directly, required on the provisioning ports input so no provisioning path can opt out silently. This is the write fence that the read-only member diagnostics PR left out because it had no caller then; it has one now.
6. `fix(team): Stop escalates to force-stop cleanup only when the regular stop fails`: both entry points go through `stopTeamWithEscalation`, one implementation shared with the force stop, differing in exactly one decision — whether the delivery cancellation is unconditional. The force stop keeps #568's ordering unchanged. A regular Stop cannot cancel up front, because it does not yet know whether it will have to escalate, so its cancellation runs after the stop and under #568's own `stopOutcome !== 'stopped'` decision — the same condition that already gates the cleanup step, not a second copy of it. A stop that confirms cancels nothing and reaches nothing else; it only records the team as stopped. HTTP `/stop` gets the same behaviour as the in-app control rather than a second, weaker stop. Both entry points build the same fenced ports the force stop uses — `observeOwnedRuntimeRunIds`, `observeOwnedRuntimeLaneIds`, and the `{ requestedAtMs, ownedRunIds, ownedLaneIds }` fence threaded into `clearPendingPromptDeliveries` — so an escalated cleanup cancels the deliveries of the run it stopped and not a relaunch's, over the lane scope read before the stop; a shared-flow test asserts that from both entry points, the way #568's does for force stop.
7. `fix(team): mixed OpenCode secondary lanes stop concurrently`, with the end-to-end expectation that encoded sequential stops updated in the same commit.
8. `fix(team): Stop waits for the orchestrator as long as it needs and finishes the moment the hosts are gone`: the budget stops being the thing the stop waits on. While the orchestrator works the flow samples how many of the team's recorded runtime host processes are still alive and finishes as soon as none is; the budget is now 90 s and bounds a genuine hang rather than a slow success, so a healthy stop never spends it. The evidence is narrow: only the OpenCode lane host pids the launch snapshot recorded for this team, the same evidence the stopped-lane cleanup uses, so no unrelated process can hold a stop open; the poller arms only after a first sample that sees a live host, so a team without recorded pids behaves exactly as before; the interval is cancelled in the flow's `finally`. It reads the launch snapshot and never the delivery ledger, so #568's pre-stop cancellation cannot make a lane read as down; a test pins that order. The new `runtime_already_down` outcome is logged at info; it widens `TeamForceStopResult['stopOutcome']` in the shared types, alongside the `cleanupOutcome` #568 added, and if you would rather keep the distinction internal it maps to `stopped` at the boundary.
9. `fix(opencode): an OpenCode lane stop is idempotent and stale startup locks are purged periodically`: a lane stop resolves against evidence rather than against the acknowledgement: recorded host pids none of which is running means the stop is complete; a live recorded host keeps the failure with the pid in the message; no recorded pid keeps the failure too, because with no evidence either way the safe reading is that the stop did not happen. The liveness probe is a required port wired to the real probe by both port factories. Separately, `OpenCodeHostStartupLockCleanup.ts` purges locks older than ten minutes every five minutes (a lock that old cannot belong to a host still starting; a lock the orchestrator still holds fails to unlink and is left alone), stopped on shutdown. That purge deletes files in the orchestrator's data directory on a timer; if you would rather it were opt-in or behind a port, say so and it becomes one.
10. `fix(opencode): a capability-snapshot-mismatch stop with no recorded host settles instead of failing`: a stop whose failure carries a snapshot-mismatch marker and whose lane has no recorded host pid settles as already stopped, with a warning that says exactly why nothing could be verified. Both halves are load-bearing: a live recorded host still fails, and any other failure with no pid still fails. The marker list covers the handshake rejection and the two pre-handshake manifest preconditions your #531 added, matched on the shortest stable substring so a prefix change does not unhook them silently. Keying on message substrings is fragile across orchestrator versions; a structured reason from the bridge would make the list unnecessary, and I would take that over this.

Review round 1 adds five: the shutdown stop of the lock purge moves ahead of the first awaited shutdown step, since `runShutdownStep` stops waiting on a step without cancelling it; `writeBackupManifestSync` reports a manifest it could not persist instead of swallowing it, on a path where the file copies and the registry entry are already written; `markStopped` reports a publication file that survived the stop, after the marker rather than before it; the fixed-budget test trades a `Promise.race` that could not fail for a settlement flag asserted on both sides of the budget; and `TeamBackupRestoreService` drops its duplicate `BackupManifest` declaration for the shared one.

Review round 2 adds six. The marker fence stops trusting `launchPhase` on its own: `TeamLaunchStateStore.write` takes publication options, and a write that declares itself a republication of launch truth that already existed is fenced by the marker exactly like a reconciled write is, inside the same publication queue, so no stop can settle between the check and the write. Two writes declare it. The stale-write rollback from commit 4 restored the pre-stop `active` snapshot it had overwritten and deleted the marker along the way, which handed a stopped team its phantom card back; and the stale mixed-secondary recovery checks the marker above the runtime probes it then spends, so a stop landing inside that window used to be published over. On the backup side: `writeBackupManifestSync` propagates the failure it already reported, so `doBackupTeamSync` stops before the registry entry and `runShutdownBackupSync` names the team and goes on to the next one, instead of indexing a backup whose manifest still holds the previous ownership and file stats; `isLaunchStateFrozenByStop` treats only `ENOENT` as proof the live marker is gone, the same rule the rest of that file already applies through `isEnoent`, because a permission error is not evidence that a team was never stopped; and the synchronous shutdown backup, which prunes nothing unlike the asynchronous one, drops a backed-up `launch-stopped.json` once the live marker is provably absent, so stop, relaunch, shutdown, restore no longer freezes the relaunched team's launch state for good. The shared-flow test also pins `markTeamStopped` and `countLiveRuntimeHosts` at both stop entry points: both ports are optional on the flow, so an entry point that drops one still compiles and still passes.

Review round 3 adds two. A stop probe that could not answer is no longer read as "the hosts are gone": `countLiveRuntimeHosts` now answers `number | null`, a rejected probe or a launch state the store could not read yields `null`, and the poller resolves `runtime_already_down` only on a definite zero, so a blind sample cannot fire the deferred cancellation or the retained-process cleanup. `TeamLaunchStateStore` gained `readResult` (`snapshot` | `absent` | `unreadable`) for that distinction; `read()` keeps its contract for every other caller (`aae9028ce`). And a restore that commits `launch-state.json` or `launch-summary.json` now does so inside the store's own per-team publication queue (`withTeamLaunchStatePublicationLock`) and re-reads the stop marker there, so a Stop that lands between the restore's marker check and its commit cannot be published over; every other restored file keeps its previous path (`2a044b4e3`).

`handleStopTeam` gains the rationale comment it did not have, naming only the causes that survive; the watermark check your `44390ecc2` removed is deliberately not among them. No test-only production parameters: the wave these came from had injectable poll intervals and a `purge` seam; the tests drive the real constants on fake timers.

Sizes: `TeamBackupService.ts` 1230/1236, `main/index.ts` 3647/3719, `ipc/teams.ts` 5612/5661, `shared/types/team.ts` 1769/1958, `teamLifecycleRoutes.ts` 208, `lifecycle/teamForceStopFlow.ts` 549, `TeamProvisioningOpenCodeRuntimeStopFlow.ts` 505; new modules 83 (manifest), 173 (lock cleanup), 150 (stop outcome). `scripts/ci/source-file-size-baseline.json` and `test/setup.ts` untouched.

## Tests

Negative controls, each its own test and each mutation-checked (the rule was broken, the named tests went red, the rule restored):

- A team that was never marked stopped still gets stale-mixed recovery, still has its launch state restored from a backup, and still publishes a reconciled snapshot; forcing the stopped guard true at all three sites fails six tests, among them those three inverses. `clear()` revokes both publications unconditionally - it has no stopped guard, by design - and re-adding marker removal to `clear()` fails "keeps the stop marker across a launch-state clear".
- `countLiveRuntimeHosts` omitted → the previous fixed budget; a first sample of zero never arms the poller (exactly one sample); the interval is cleared on every exit including a throwing kill step; a lane with a recorded live pid still throws.
- A snapshot-mismatch stop with a live recorded host still fails; an unrelated failure with no pid still fails; all four marker strings settle, asserted with `it.each`.
- Run-scoped reconcile, inverse: an unscoped reconcile still clears and still wipes bootstrap state, which is why the scope exists; a mismatching run leaves the snapshot and bootstrap state untouched and `persistedWrites` records the skipped clear. Hard-coding `expectedRunId` away fails all four run-scope tests and the facade wiring test, while the unscoped-behaviour tests in the same file stay green.
- The live path passes `getTrackedRunId` (asserted on the facade and on the factory), and a port answering `null` behaves exactly as an unscoped reconcile.
- A restore into a team that is not stopped never writes the marker.
- The escalated stop keeps the cleanup fenced at both entry points: dropping `observeOwnedRuntimeRunIds` from the ports, and calling `clearPendingPromptDeliveries` without the `{ requestedAtMs, ownedRunIds, ownedLaneIds }` fence, each fail the shared-flow test on their own (checked separately).
- The one decision that separates the two flows is pinned from both sides: making the regular Stop cancel up front the way the force stop does fails four escalation tests, and taking the deferred cancellation away fails four others - every case that asserts an escalated stop still cancels, including the `runtime_already_down` one. A force stop that has already cancelled still samples the hosts and still finishes on `runtime_already_down`, so the ordering #568 introduced and the evidence poll do not read each other's state.
- The motion commit changes no behaviour: it touches no test file, the backup service keeps its 27 existing tests green at that commit, and the file goes 1236 to 1207 before commit 3 adds its one line.
- Review round: a `markStopped` whose publication delete fails still writes the marker and now reports the survivor; discarding the removal results again fails both new store tests, and reporting them before the marker write fails both on the marker assertion. A `writeBackupManifestSync` that cannot write names the team it failed for; restoring the empty catch fails that test with nothing logged. The fixed-budget test tracks settlement on the stop promise and asserts it on both sides of the budget; halving the budget so the stop settles early fails it, where the previous `Promise.race` form could not.
- Review round 2: a republished `active` snapshot is ignored while the team is stopped and a launch still lifts the marker; dropping either half of the fence fails the store test and the boundary test that pins the rollback as a republication, while "lifts the stop marker when a real launch publishes an active snapshot" stays green. The recovery test flips the stop between its check and its write and asserts both the flag and the persisted snapshot handed back; restoring the unflagged write fails it, with the two existing stopped and never-stopped recovery tests still green. A shutdown backup whose manifest cannot be written leaves that team's registry entry untouched and still indexes the next team, driven by a real `EPERM` from a directory put where the manifest belongs; swallowing the failure again refreshes the entry and fails it. A marker probe that fails with `EPERM` keeps the launch state frozen; the bare catch restores the pre-stop publication and fails it. Stop, relaunch, shutdown, restore keeps the relaunched launch state; removing the prune leaves the marker in the backup and fails it. Dropping `markTeamStopped` from the IPC handler, or `countLiveRuntimeHosts` from the HTTP route, each fail the shared-flow test on their own (checked separately).

At the tip: `pnpm typecheck`, the source-file size guard, the team-provisioning architecture guard, `eslint` (0 errors), and the targeted vitest set covering every test this branch touches plus the tests over the modules it changes - all green. `prettier --check` is clean on every changed `src/` file, `src/main/index.ts` included: the announcements block that used to fail on `main` itself - and that this branch does not touch - was reformatted upstream in #599, so that inherited violation is gone; two other files this branch touches were unformatted on main and come out clean. Full suite, measured at the tip before the rebase onto `192560997`: 1422 test files, 15676 cases (15568 passed, 106 skipped), two failures - `createMemberWorkSyncFeature` and `OpenCodeAgendaSyncRecovery.safe-e2e`, both timing-sensitive files that import nothing this branch changes. Run on its own the agenda-sync file passes twice; `createMemberWorkSyncFeature` fails the same way on an unmodified `main @ 01f5527ec` on this machine, in two of four standalone runs there and on a different case each time. Two earlier full runs of the same tip were green apart from one of these two files and, once, a Windows `EPERM` inside a backup lock-serialization test that passes twice on its own; this machine is the constraint, not the branch.

## Tested on

Windows 11 Pro, from source, against `main @ 192560997` (which includes #568). Every defect above was hit on live mixed-provider runs during the earlier campaign: the "failed partway" card after a deliberate stop, a Stop that escalated on every mixed team, the `/stop` 500 loop after a host died, and the stop rejected after an OpenCode config change. With the series in place a healthy stop finishes when the hosts are gone, a dead runtime stops cleanly, and the stopped team stays stopped across reconcile, recovery and restore. The 17–48 s per-lane spread was measured on this machine only. Not tested on macOS or Linux; nothing here is platform-specific.

Refs #443 (a Stop that finishes on evidence rather than on a clock is the durable answer to the timeout shape reported there). #504 is adjacent context only; its watermark cause was fixed upstream in `44390ecc2`.

---
**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.
