### PR TITLE
fix(team): OpenCode host cleanup is fenced to this app's own leftovers, and the lead vetoes launch promotion

### DIFF
--- a/src/main/http/teams/teamLifecycleRoutes.ts
+++ b/src/main/http/teams/teamLifecycleRoutes.ts
@@ -13,6 +13,7 @@ import {
   killRetainedOpenCodeRuntimeProcessesForTeam,
   readOpenCodeRuntimeLaneIdsForTeam,
   readOwnedOpenCodeRuntimeRunIdsForTeam,
+  releaseSharedRuntimeResourcesAfterStop,
   runTeamForceStopFlow,
   STOP_ESCALATION_TIMEOUT_MS,
   stopTeamWithEscalation,
@@ -93,6 +94,11 @@ export function registerTeamLifecycleRoutes(
           stopTimeoutMs: STOP_ESCALATION_TIMEOUT_MS,
           countLiveRuntimeHosts: (name) => countLiveRecordedRuntimeHostsForTeam({ teamName: name }),
           markTeamStopped: (name) => new TeamLaunchStateStore().markStopped(name),
+          releaseSharedRuntimeResources: (name) =>
+            releaseSharedRuntimeResourcesAfterStop({
+              teamName: name,
+              otherAliveTeams: teamRuntimeApi.getAliveTeams().filter((alive) => alive !== name),
+            }),
         });
         if (result.stopOutcome === 'runtime_already_down') {
           logger.info(
@@ -153,6 +159,11 @@ export function registerTeamLifecycleRoutes(
             }),
           logWarning: (message) => logger.warn(message),
           markTeamStopped: (name) => new TeamLaunchStateStore().markStopped(name),
+          releaseSharedRuntimeResources: (name) =>
+            releaseSharedRuntimeResourcesAfterStop({
+              teamName: name,
+              otherAliveTeams: teamRuntimeApi.getAliveTeams().filter((alive) => alive !== name),
+            }),
         });
         return reply.send(result);
       } catch (error) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -746,6 +746,7 @@ async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'):
       ownershipMarkers: getOpenCodeProcessOwnershipMarkers(),
       logSweepResult: (message) => logger.diagnostic(`[OpenCode] ${message}`),
       logWarning: (message) => logger.warn(message),
+      logError: (message) => logger.error(message),
     });
     // A host that was killed never released its orchestrator startup lock, and
     // the next launch readiness probe waits on every leftover in turn. The
@@ -2110,6 +2111,7 @@ async function initializeServices(): Promise<void> {
     appStartedAtMs,
     logSweepResult: (message) => logger.diagnostic(`[OpenCode] ${message}`),
     logWarning: (message) => logger.warn(message),
+    logError: (message) => logger.error(message),
   });
   publishStartupStatus({
     phase: 'runtime',

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -251,6 +251,7 @@ import {
 } from './services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
 import {
   purgeStaleOpenCodeHostStartupLocks,
+  resolveStartupStaleLockMinAgeMs,
   startPeriodicOpenCodeHostStartupLockPurge,
 } from './services/team/opencode/bridge/OpenCodeHostStartupLockCleanup';
 import { cleanupManagedOpenCodeServeProcesses } from './services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup';
@@ -749,9 +750,12 @@ async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'):
     // A host that was killed never released its orchestrator startup lock, and
     // the next launch readiness probe waits on every leftover in turn. The
     // reap above has just run, so a lock still held open belongs to a live
-    // host and its unlink fails harmlessly; the half-minute floor keeps a host
-    // that is starting right now out of scope.
-    const lockPurge = await purgeStaleOpenCodeHostStartupLocks({ minAgeMs: 30_000 });
+    // host: on Windows its unlink fails harmlessly, and where the OS unlinks
+    // an open file instead the floor alone has to keep a host that is starting
+    // right now out of scope.
+    const lockPurge = await purgeStaleOpenCodeHostStartupLocks({
+      minAgeMs: resolveStartupStaleLockMinAgeMs(),
+    });
     if (lockPurge.removed > 0) {
       logger.diagnostic(
         `opencode_startup_locks_purged phase=startup removed=${lockPurge.removed} kept=${lockPurge.kept} dir=${lockPurge.locksDir}`

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -693,7 +693,6 @@ let stopPeriodicOpenCodeHostStartupLockPurge: (() => void) | null = null;
 async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'): Promise<void> {
   let registryHostPids = new Set<number>();
   let registryCleanupAvailable = false;
-  const sweepCommandIssuedAtMs = Date.now();
   if (openCodeLifecycleBridge) {
     const result = await openCodeLifecycleBridge.cleanupOpenCodeHosts({
       reason,
@@ -720,6 +719,11 @@ async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'):
       diagnostic.startsWith('OpenCode host cleanup bridge failed:')
     );
   }
+  // After the command, not before it: the managed host the registry sweep
+  // boots in this process directory is younger than the moment the command was
+  // issued, so an issue-time fence keeps the one host the tail below exists to
+  // reap.
+  const sweepCommandSettledAtMs = Date.now();
 
   if (reason === 'startup' && !registryCleanupAvailable) {
     logger.warn(
@@ -731,13 +735,14 @@ async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'):
   await cleanupOpenCodeHostProcessFallback(`${reason} fallback`, {
     mode: reason === 'shutdown' ? 'force' : 'orphaned',
     excludePids: reason === 'startup' ? registryHostPids : undefined,
-    ...(reason === 'shutdown' ? getOpenCodeShutdownProcessOwnershipMarkers() : {}),
+    ...(reason === 'shutdown' ? getOpenCodeProcessOwnershipMarkers() : {}),
     startedBeforeMs: reason === 'startup' ? appStartedAtMs : null,
   });
 
   if (reason === 'startup') {
     await runOpenCodeStartupRuntimeSweepTail({
-      sweepCommandIssuedAtMs,
+      sweepCommandSettledAtMs,
+      ownershipMarkers: getOpenCodeProcessOwnershipMarkers(),
       logSweepResult: (message) => logger.diagnostic(`[OpenCode] ${message}`),
       logWarning: (message) => logger.warn(message),
     });
@@ -758,7 +763,7 @@ async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'):
   }
 }
 
-function getOpenCodeShutdownProcessOwnershipMarkers(): Pick<
+function getOpenCodeProcessOwnershipMarkers(): Pick<
   Parameters<typeof cleanupManagedOpenCodeServeProcesses>[0],
   'requiredDetailsMarkers' | 'requiredServeConfigMarkersAny'
 > {
@@ -3101,7 +3106,7 @@ async function shutdownServices(): Promise<void> {
       () =>
         cleanupOpenCodeHostProcessFallback('post-subprocess shutdown fallback', {
           mode: 'force',
-          ...getOpenCodeShutdownProcessOwnershipMarkers(),
+          ...getOpenCodeProcessOwnershipMarkers(),
         }),
       5_000
     );

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -249,7 +249,10 @@ import {
   createOpenCodeBridgeClientIdentity,
   OpenCodeBridgeCommandHandshakePort,
 } from './services/team/opencode/bridge/OpenCodeBridgeHandshakeClient';
-import { startPeriodicOpenCodeHostStartupLockPurge } from './services/team/opencode/bridge/OpenCodeHostStartupLockCleanup';
+import {
+  purgeStaleOpenCodeHostStartupLocks,
+  startPeriodicOpenCodeHostStartupLockPurge,
+} from './services/team/opencode/bridge/OpenCodeHostStartupLockCleanup';
 import { cleanupManagedOpenCodeServeProcesses } from './services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup';
 import { OpenCodeStateChangingBridgeCommandService } from './services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import { OpenCodeRuntimeLaunchAuthorityWriter } from './services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
@@ -725,6 +728,23 @@ async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'):
     ...(reason === 'shutdown' ? getOpenCodeShutdownProcessOwnershipMarkers() : {}),
     startedBeforeMs: reason === 'startup' ? appStartedAtMs : null,
   });
+
+  if (reason === 'startup') {
+    // A host that was killed never released its orchestrator startup lock, and
+    // the next launch readiness probe waits on every leftover in turn. The
+    // reap above has just run, so a lock still held open belongs to a live
+    // host and its unlink fails harmlessly; the half-minute floor keeps a host
+    // that is starting right now out of scope.
+    const lockPurge = await purgeStaleOpenCodeHostStartupLocks({ minAgeMs: 30_000 });
+    if (lockPurge.removed > 0) {
+      logger.diagnostic(
+        `opencode_startup_locks_purged phase=startup removed=${lockPurge.removed} kept=${lockPurge.kept} dir=${lockPurge.locksDir}`
+      );
+    }
+    for (const diagnostic of lockPurge.diagnostics) {
+      logger.warn(`[OpenCode] startup lock purge: ${diagnostic}`);
+    }
+  }
 }
 
 function getOpenCodeShutdownProcessOwnershipMarkers(): Pick<

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -254,6 +254,8 @@ import {
   startPeriodicOpenCodeHostStartupLockPurge,
 } from './services/team/opencode/bridge/OpenCodeHostStartupLockCleanup';
 import { cleanupManagedOpenCodeServeProcesses } from './services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup';
+import { runOpenCodeStartupRuntimeSweepTail } from './services/team/opencode/bridge/OpenCodeStartupRuntimeSweep';
+import { beginOpenCodeStartupRuntimeSweep } from './services/team/opencode/bridge/OpenCodeStartupSweepGate';
 import { OpenCodeStateChangingBridgeCommandService } from './services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import { OpenCodeRuntimeLaunchAuthorityWriter } from './services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
 import { OpenCodeRuntimeManifestEvidenceReader } from './services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
@@ -688,6 +690,7 @@ let stopPeriodicOpenCodeHostStartupLockPurge: (() => void) | null = null;
 async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'): Promise<void> {
   let registryHostPids = new Set<number>();
   let registryCleanupAvailable = false;
+  const sweepCommandIssuedAtMs = Date.now();
   if (openCodeLifecycleBridge) {
     const result = await openCodeLifecycleBridge.cleanupOpenCodeHosts({
       reason,
@@ -730,6 +733,11 @@ async function cleanupOpenCodeHostsForLifecycle(reason: 'startup' | 'shutdown'):
   });
 
   if (reason === 'startup') {
+    await runOpenCodeStartupRuntimeSweepTail({
+      sweepCommandIssuedAtMs,
+      logSweepResult: (message) => logger.diagnostic(`[OpenCode] ${message}`),
+      logWarning: (message) => logger.warn(message),
+    });
     // A host that was killed never released its orchestrator startup lock, and
     // the next launch readiness probe waits on every leftover in turn. The
     // reap above has just run, so a lock still held open belongs to a live
@@ -766,7 +774,12 @@ async function cleanupOpenCodeHostProcessFallback(
 ): Promise<void> {
   const fallback = await cleanupManagedOpenCodeServeProcesses(options);
   if (fallback.killed > 0) {
-    logger.info(`[OpenCode] ${label} cleanup killed ${fallback.killed} managed host(s)`);
+    // Durable, not a warning: this is the app's most destructive lifecycle
+    // action, and the count has to still be readable when someone asks why a
+    // host they expected is gone. `info` never reaches a sink at all.
+    logger.diagnostic(
+      `[OpenCode] opencode_managed_hosts_killed sweep=${label} count=${fallback.killed}`
+    );
   }
   for (const diagnostic of fallback.diagnostics) {
     logger.warn(`[OpenCode] ${label} cleanup: ${diagnostic}`);
@@ -2083,10 +2096,15 @@ async function initializeServices(): Promise<void> {
     )
   );
   teamRuntimeRecoveryFeature.start();
+  // Armed before the delay, not inside the task, so a launch requested during
+  // the scheduling delay serialises behind the sweep as well.
+  const settleStartupRuntimeSweep = beginOpenCodeStartupRuntimeSweep();
   scheduleStartupTask(() => {
-    void cleanupOpenCodeHostsForLifecycle('startup').catch((error: unknown) =>
-      logger.warn(`[OpenCode] Startup host cleanup failed: ${String(error)}`)
-    );
+    void cleanupOpenCodeHostsForLifecycle('startup')
+      .catch((error: unknown) =>
+        logger.warn(`[OpenCode] Startup host cleanup failed: ${String(error)}`)
+      )
+      .finally(settleStartupRuntimeSweep);
   }, STARTUP_RECOVERY_DELAY_MS);
   stopPeriodicOpenCodeHostStartupLockPurge = startPeriodicOpenCodeHostStartupLockPurge({
     logInfo: (message) => logger.info(message),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -254,7 +254,10 @@ import {
   startPeriodicOpenCodeHostStartupLockPurge,
 } from './services/team/opencode/bridge/OpenCodeHostStartupLockCleanup';
 import { cleanupManagedOpenCodeServeProcesses } from './services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup';
-import { runOpenCodeStartupRuntimeSweepTail } from './services/team/opencode/bridge/OpenCodeStartupRuntimeSweep';
+import {
+  reapOrphanedOpenCodeHostsBeforeRuntimeRegistry,
+  runOpenCodeStartupRuntimeSweepTail,
+} from './services/team/opencode/bridge/OpenCodeStartupRuntimeSweep';
 import { beginOpenCodeStartupRuntimeSweep } from './services/team/opencode/bridge/OpenCodeStartupSweepGate';
 import { OpenCodeStateChangingBridgeCommandService } from './services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import { OpenCodeRuntimeLaunchAuthorityWriter } from './services/team/opencode/store/OpenCodeRuntimeLaunchAuthorityWriter';
@@ -2086,6 +2089,19 @@ async function initializeServices(): Promise<void> {
   teamProvisioningService.setMemberRuntimeAdvisoryInvalidator(
     createMemberRuntimeAdvisoryInvalidator(teamMemberRuntimeAdvisoryService)
   );
+  // Awaited, and before the runtime adapter registry exists: a managed host
+  // orphaned by a previous app instance still holds the fixed loopback ports a
+  // new host needs, and whoever gets there first wins. Reaping afterwards would
+  // mean the first launch of this session races a host it cannot see.
+  publishStartupStatus({
+    phase: 'runtime-host-preflight',
+    message: 'Cleaning up stale runtime hosts...',
+  });
+  await reapOrphanedOpenCodeHostsBeforeRuntimeRegistry({
+    appStartedAtMs,
+    logSweepResult: (message) => logger.diagnostic(`[OpenCode] ${message}`),
+    logWarning: (message) => logger.warn(message),
+  });
   publishStartupStatus({
     phase: 'runtime',
     message: 'Resolving local runtime...',

--- a/src/main/ipc/teams.ts
+++ b/src/main/ipc/teams.ts
@@ -148,6 +148,7 @@ import {
   killRetainedOpenCodeRuntimeProcessesForTeam,
   readOpenCodeRuntimeLaneIdsForTeam,
   readOwnedOpenCodeRuntimeRunIdsForTeam,
+  releaseSharedRuntimeResourcesAfterStop,
   runTeamForceStopFlow,
   STOP_ESCALATION_TIMEOUT_MS,
   stopTeamWithEscalation,
@@ -4245,6 +4246,13 @@ async function handleStopTeam(
       stopTimeoutMs: STOP_ESCALATION_TIMEOUT_MS,
       countLiveRuntimeHosts: (name) => countLiveRecordedRuntimeHostsForTeam({ teamName: name }),
       markTeamStopped: (name) => new TeamLaunchStateStore().markStopped(name),
+      releaseSharedRuntimeResources: (name) =>
+        releaseSharedRuntimeResourcesAfterStop({
+          teamName: name,
+          otherAliveTeams: getTeamRuntimeApi()
+            .getAliveTeams()
+            .filter((alive) => alive !== name),
+        }),
     });
     if (result.stopOutcome === 'runtime_already_down') {
       logger.info(
@@ -4292,6 +4300,13 @@ async function handleForceStopTeam(
         }),
       logWarning: (message) => logger.warn(message),
       markTeamStopped: (name) => new TeamLaunchStateStore().markStopped(name),
+      releaseSharedRuntimeResources: (name) =>
+        releaseSharedRuntimeResourcesAfterStop({
+          teamName: name,
+          otherAliveTeams: getTeamRuntimeApi()
+            .getAliveTeams()
+            .filter((alive) => alive !== name),
+        }),
     });
   });
 }

--- a/src/main/services/team/TeamLaunchFailureReasonText.ts
+++ b/src/main/services/team/TeamLaunchFailureReasonText.ts
@@ -1,0 +1,58 @@
+/**
+ * Persisted launch-failure reasons are sometimes the raw JSON body of a
+ * `SendMessage` result, and older builds truncated it mid-string. These helpers
+ * recover the human-readable part from both shapes.
+ */
+
+function decodeJsonStringLiteral(value: string): string {
+  try {
+    return JSON.parse(`"${value}"`) as string;
+  } catch {
+    return value.replace(/\\"/g, '"').replace(/\\n/g, '\n').replace(/\\\\/g, '\\');
+  }
+}
+
+function extractLooseJsonStringField(text: string, fieldName: string): string | undefined {
+  const strictMatch = new RegExp(`"${fieldName}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`).exec(text);
+  if (strictMatch?.[1]) {
+    return decodeJsonStringLiteral(strictMatch[1]).trim() || undefined;
+  }
+
+  const looseMatch = new RegExp(`"${fieldName}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)$`).exec(text);
+  return looseMatch?.[1] ? decodeJsonStringLiteral(looseMatch[1]).trim() || undefined : undefined;
+}
+
+function joinUniqueReasonParts(parts: readonly (string | undefined)[]): string | undefined {
+  const uniqueParts = Array.from(
+    new Set(parts.map((part) => part?.trim()).filter((part): part is string => !!part))
+  );
+  return uniqueParts.length > 0 ? uniqueParts.join(': ') : undefined;
+}
+
+export function extractMessageSendRoutingReason(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed.includes('Message sent to') && !trimmed.includes('"routing"')) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      success?: unknown;
+      message?: unknown;
+      routing?: { summary?: unknown; content?: unknown };
+    };
+    if (parsed.success === true && parsed.routing && typeof parsed.routing === 'object') {
+      return joinUniqueReasonParts([
+        typeof parsed.routing.summary === 'string' ? parsed.routing.summary : undefined,
+        typeof parsed.routing.content === 'string' ? parsed.routing.content : undefined,
+      ]);
+    }
+  } catch {
+    // Fall through to loose extraction for persisted reasons truncated by older builds.
+  }
+
+  return joinUniqueReasonParts([
+    extractLooseJsonStringField(trimmed, 'summary'),
+    extractLooseJsonStringField(trimmed, 'content'),
+  ]);
+}

--- a/src/main/services/team/TeamLaunchStateEvaluator.ts
+++ b/src/main/services/team/TeamLaunchStateEvaluator.ts
@@ -3,6 +3,9 @@ import { migrateProviderBackendId } from '@shared/utils/providerBackend';
 import { normalizeProviderBillingMode } from '@shared/utils/providerBillingMode';
 import { normalizeOptionalTeamProviderId } from '@shared/utils/teamProvider';
 
+import { extractMessageSendRoutingReason } from './TeamLaunchFailureReasonText';
+import { isPersistedOpenCodePrimaryLaneLeadMember } from './TeamPersistedOpenCodeLaneMemberPolicy';
+
 import type {
   MemberLaunchState,
   MemberSpawnLivenessSource,
@@ -230,59 +233,6 @@ function normalizeOpenCodeAppManagedBootstrapCandidate(
     ...(model ? { model } : {}),
     ...(agent ? { agent } : {}),
   };
-}
-
-function decodeJsonStringLiteral(value: string): string {
-  try {
-    return JSON.parse(`"${value}"`) as string;
-  } catch {
-    return value.replace(/\\"/g, '"').replace(/\\n/g, '\n').replace(/\\\\/g, '\\');
-  }
-}
-
-function extractLooseJsonStringField(text: string, fieldName: string): string | undefined {
-  const strictMatch = new RegExp(`"${fieldName}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`).exec(text);
-  if (strictMatch?.[1]) {
-    return decodeJsonStringLiteral(strictMatch[1]).trim() || undefined;
-  }
-
-  const looseMatch = new RegExp(`"${fieldName}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)$`).exec(text);
-  return looseMatch?.[1] ? decodeJsonStringLiteral(looseMatch[1]).trim() || undefined : undefined;
-}
-
-function joinUniqueReasonParts(parts: readonly (string | undefined)[]): string | undefined {
-  const uniqueParts = Array.from(
-    new Set(parts.map((part) => part?.trim()).filter((part): part is string => !!part))
-  );
-  return uniqueParts.length > 0 ? uniqueParts.join(': ') : undefined;
-}
-
-function extractMessageSendRoutingReason(text: string): string | undefined {
-  const trimmed = text.trim();
-  if (!trimmed.includes('Message sent to') && !trimmed.includes('"routing"')) {
-    return undefined;
-  }
-
-  try {
-    const parsed = JSON.parse(trimmed) as {
-      success?: unknown;
-      message?: unknown;
-      routing?: { summary?: unknown; content?: unknown };
-    };
-    if (parsed.success === true && parsed.routing && typeof parsed.routing === 'object') {
-      return joinUniqueReasonParts([
-        typeof parsed.routing.summary === 'string' ? parsed.routing.summary : undefined,
-        typeof parsed.routing.content === 'string' ? parsed.routing.content : undefined,
-      ]);
-    }
-  } catch {
-    // Fall through to loose extraction for persisted reasons truncated by older builds.
-  }
-
-  return joinUniqueReasonParts([
-    extractLooseJsonStringField(trimmed, 'summary'),
-    extractLooseJsonStringField(trimmed, 'content'),
-  ]);
 }
 
 export function normalizeLaunchFailureReasonText(value: unknown): string | undefined {
@@ -590,7 +540,15 @@ function normalizePersistedMemberState(
   }
   const parsed = value as Record<string, unknown>;
   const normalizedName = normalizeMemberName(memberName);
-  if (!normalizedName || normalizedName === 'user' || isLeadMember({ name: normalizedName })) {
+  // A lane-owned OpenCode lead is the one lead that survives read-back: it is a
+  // real runtime member with its own lane, and dropping it is what made a team
+  // with a dead lead report `clean_success` with no liveness at all.
+  if (
+    !normalizedName ||
+    normalizedName === 'user' ||
+    (isLeadMember({ name: normalizedName }) &&
+      !isPersistedOpenCodePrimaryLaneLeadMember({ ...parsed, name: normalizedName }))
+  ) {
     return null;
   }
   const providerId = normalizeOptionalTeamProviderId(parsed.providerId);
@@ -1041,6 +999,11 @@ export function normalizePersistedLaunchSnapshot(
       typeof record.teamName === 'string' && record.teamName.trim().length > 0
         ? record.teamName.trim()
         : teamName,
+    // The lead survives in `members` (so `teamLaunchState` and the member
+    // diagnostics finally see it) but is deliberately NOT added to
+    // `expectedMembers`: that list is the team roster the UI renders, and the
+    // lead has never been a card in it. `summarizePersistedLaunchMembers` unions
+    // both, so the aggregate state is honest either way.
     expectedMembers,
     leadSessionId:
       typeof record.leadSessionId === 'string' && record.leadSessionId.trim().length > 0

--- a/src/main/services/team/TeamPersistedOpenCodeLaneMemberPolicy.ts
+++ b/src/main/services/team/TeamPersistedOpenCodeLaneMemberPolicy.ts
@@ -1,0 +1,41 @@
+import { isLeadMember } from '@shared/utils/leadDetection';
+
+/**
+ * The three lane fields `toOpenCodePersistedLaunchMember` stamps on every member
+ * it writes - and the only writer that stamps all three. They are the whole
+ * discriminator for "this snapshot belongs to a pure-OpenCode member lane", so a
+ * Claude/Codex/Gemini lead can never match.
+ */
+interface PersistedOpenCodeLaneMemberShape {
+  name?: unknown;
+  providerId?: unknown;
+  laneId?: unknown;
+  laneKind?: unknown;
+  laneOwnerProviderId?: unknown;
+}
+
+function isOpenCodeLaneOwned(member: PersistedOpenCodeLaneMemberShape | null | undefined): boolean {
+  return member?.providerId === 'opencode' && member.laneOwnerProviderId === 'opencode';
+}
+
+export function isPersistedOpenCodePrimaryLaneMember(
+  member: PersistedOpenCodeLaneMemberShape | null | undefined
+): boolean {
+  return (
+    isOpenCodeLaneOwned(member) &&
+    (member?.laneKind === 'primary' ||
+      (member?.laneKind === undefined && member?.laneId === 'primary'))
+  );
+}
+
+/**
+ * The OpenCode aggregate lead. `normalizePersistedLaunchSnapshot` used to drop
+ * every lead on read-back, so a team whose lead was dead still reported
+ * `teamLaunchState: 'clean_success'` and the lead card had no liveness at all.
+ */
+export function isPersistedOpenCodePrimaryLaneLeadMember(
+  member: PersistedOpenCodeLaneMemberShape | null | undefined
+): boolean {
+  const name = typeof member?.name === 'string' ? member.name.trim() : '';
+  return name.length > 0 && isLeadMember({ name }) && isPersistedOpenCodePrimaryLaneMember(member);
+}

--- a/src/main/services/team/contracts/TeamProvisioningApis.ts
+++ b/src/main/services/team/contracts/TeamProvisioningApis.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@shared/utils/logger';
 
 import { purgeStaleOpenCodeHostStartupLocksBeforeLaunch } from '../opencode/bridge/OpenCodeHostStartupLockCleanup';
+import { whenOpenCodeStartupRuntimeSweepSettled } from '../opencode/bridge/OpenCodeStartupSweepGate';
 
 import type { OpenCodeRuntimeControlAck, OpenCodeRuntimeControlApi } from '../runtime-control';
 import type { TeamProvisioningStatusApi as FeatureTeamProvisioningStatusApi } from '@features/team-provisioning/contracts';
@@ -312,6 +313,12 @@ export interface TeamToolApprovalApi {
   updateToolApprovalSettings(teamName: string, settings: ToolApprovalSettings): void;
 }
 
+export interface TeamProvisioningStartHookInput {
+  teamName: string;
+  request: TeamCreateRequest | TeamLaunchRequest;
+  onProgress: (progress: TeamProvisioningProgress) => void;
+}
+
 export function bindTeamProvisioningStartApi(
   source: TeamProvisioningStartApi,
   options: {
@@ -320,7 +327,7 @@ export function bindTeamProvisioningStartApi(
      * preparation step, never a precondition: a failure is swallowed here so
      * that nothing it does can be the reason a team fails to start.
      */
-    beforeStart?: (teamName: string) => Promise<void>;
+    beforeStart?: (input: TeamProvisioningStartHookInput) => Promise<void>;
   } = {}
 ): TeamProvisioningStartApi {
   const beforeStart = options.beforeStart;
@@ -330,15 +337,15 @@ export function bindTeamProvisioningStartApi(
       launchTeam: source.launchTeam.bind(source),
     };
   }
-  const runBeforeStart = async (teamName: string): Promise<void> => {
+  const runBeforeStart = async (input: TeamProvisioningStartHookInput): Promise<void> => {
     try {
-      await beforeStart(teamName);
+      await beforeStart(input);
     } catch (error) {
       // Durable, not a warning: the start is going ahead regardless, so there
       // is nothing for a developer to act on in the moment - but the line has
       // to survive for whoever asks later why a launch was slow.
       logger.diagnostic(
-        `opencode_pre_start_preparation_failed team=${teamName} reason=${JSON.stringify(
+        `opencode_pre_start_preparation_failed team=${input.teamName} reason=${JSON.stringify(
           error instanceof Error ? error.message : String(error)
         )}`
       );
@@ -346,27 +353,72 @@ export function bindTeamProvisioningStartApi(
   };
   return {
     async createTeam(request, onProgress) {
-      await runBeforeStart(request.teamName);
+      await runBeforeStart({ teamName: request.teamName, request, onProgress });
       return source.createTeam.call(source, request, onProgress);
     },
     async launchTeam(request, onProgress) {
-      await runBeforeStart(request.teamName);
+      await runBeforeStart({ teamName: request.teamName, request, onProgress });
       return source.launchTeam.call(source, request, onProgress);
     },
   };
 }
 
 /**
- * The pre-start step both entry points install: drop the OpenCode host startup
- * locks an earlier run left behind. A clean stop does not release them, and the
- * orchestrator waits on each one in turn during launch readiness, so a launch
- * that follows a few stopped runs can sit in "spawning" for minutes over files
- * that guard nothing.
+ * The startup sweep only reaps `opencode serve` hosts, so a start that cannot
+ * produce one has nothing to lose to it and must never pay the wait. A start
+ * whose provider is not stated is resolved later from the saved config and can
+ * still be OpenCode, so it keeps the wait. A launch request carries no roster:
+ * a mixed team whose lead is not OpenCode relies on the sweep's own start-time
+ * fence rather than on this gate.
  */
-function bindPreLaunchHostLockPurge(source: {
+function startRequestMayRaceOpenCodeStartupSweep(
+  request: TeamCreateRequest | TeamLaunchRequest
+): boolean {
+  if (request.providerId === undefined || request.providerId === 'opencode') {
+    return true;
+  }
+  const members = 'members' in request ? request.members : undefined;
+  return members?.some((member) => member.providerId === 'opencode') === true;
+}
+
+function buildStartupSweepWaitProgress(teamName: string): TeamProvisioningProgress {
+  const observedAt = new Date().toISOString();
+  return {
+    // No run exists before `beforeStart` returns. The pending prefix is the
+    // shape the UI already uses for its own optimistic entry, so the real run
+    // replaces this card instead of competing with it.
+    runId: `pending:${teamName}:opencode-startup-sweep`,
+    teamName,
+    state: 'validating',
+    message: 'Waiting for the startup runtime host cleanup to finish...',
+    startedAt: observedAt,
+    updatedAt: observedAt,
+  };
+}
+
+/**
+ * The pre-start step both entry points install. It clears the two things an
+ * earlier run leaves in a new launch's way: the startup sweep still reaping
+ * hosts, which a launch waits out rather than races, and the OpenCode host
+ * startup locks a clean stop never released, on which the orchestrator waits
+ * one at a time during launch readiness - enough of them and a launch sits in
+ * "spawning" for minutes over files that guard nothing.
+ */
+function bindOpenCodeStartPreparation(source: {
   getAliveTeams(): string[];
-}): (teamName: string) => Promise<void> {
-  return async (teamName) => {
+}): (input: TeamProvisioningStartHookInput) => Promise<void> {
+  return async ({ teamName, request, onProgress }) => {
+    // Belt and braces against the startup runtime sweep: it force-reaps managed
+    // hosts, and a launch that starts inside that window can lose its own
+    // readiness-probe host to it. Serialise instead of racing.
+    if (startRequestMayRaceOpenCodeStartupSweep(request)) {
+      await whenOpenCodeStartupRuntimeSweepSettled({
+        logWaited: (message) => logger.diagnostic(message),
+        // A silent multi-second park reads as a frozen UI and makes an HTTP
+        // client retry into a duplicate launch.
+        onWaitStart: () => onProgress(buildStartupSweepWaitProgress(teamName)),
+      });
+    }
     await purgeStaleOpenCodeHostStartupLocksBeforeLaunch({
       teamName,
       aliveTeams: source.getAliveTeams(),
@@ -465,7 +517,7 @@ export function bindTeamHttpHandlerApis(
 ): TeamHttpHandlerApis {
   return {
     provisioningStart: bindTeamProvisioningStartApi(source, {
-      beforeStart: bindPreLaunchHostLockPurge(source),
+      beforeStart: bindOpenCodeStartPreparation(source),
     }),
     provisioningStatus: bindTeamProvisioningStatusApi(source),
     taskActivity: bindTeamTaskActivityRepairApi(source),
@@ -499,7 +551,7 @@ export function bindTeamIpcHandlerApis(
 ): TeamIpcHandlerApis {
   return {
     provisioningStart: bindTeamProvisioningStartApi(source, {
-      beforeStart: bindPreLaunchHostLockPurge(source),
+      beforeStart: bindOpenCodeStartPreparation(source),
     }),
     provisioningStatus: bindTeamProvisioningStatusApi(source),
     preflight: bindTeamProvisioningPreflightApi(source),

--- a/src/main/services/team/contracts/TeamProvisioningApis.ts
+++ b/src/main/services/team/contracts/TeamProvisioningApis.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '@shared/utils/logger';
+
+import { purgeStaleOpenCodeHostStartupLocksBeforeLaunch } from '../opencode/bridge/OpenCodeHostStartupLockCleanup';
+
 import type { OpenCodeRuntimeControlAck, OpenCodeRuntimeControlApi } from '../runtime-control';
 import type { TeamProvisioningStatusApi as FeatureTeamProvisioningStatusApi } from '@features/team-provisioning/contracts';
 import type {
@@ -29,6 +33,8 @@ import type {
   TeamViewSnapshot,
   ToolApprovalSettings,
 } from '@shared/types/team';
+
+const logger = createLogger('Service:TeamProvisioningApis');
 
 export interface TeamProvisioningStartApi {
   createTeam(
@@ -307,11 +313,68 @@ export interface TeamToolApprovalApi {
 }
 
 export function bindTeamProvisioningStartApi(
-  source: TeamProvisioningStartApi
+  source: TeamProvisioningStartApi,
+  options: {
+    /**
+     * Runs immediately before every create and every launch. It is a
+     * preparation step, never a precondition: a failure is swallowed here so
+     * that nothing it does can be the reason a team fails to start.
+     */
+    beforeStart?: (teamName: string) => Promise<void>;
+  } = {}
 ): TeamProvisioningStartApi {
+  const beforeStart = options.beforeStart;
+  if (!beforeStart) {
+    return {
+      createTeam: source.createTeam.bind(source),
+      launchTeam: source.launchTeam.bind(source),
+    };
+  }
+  const runBeforeStart = async (teamName: string): Promise<void> => {
+    try {
+      await beforeStart(teamName);
+    } catch (error) {
+      // Durable, not a warning: the start is going ahead regardless, so there
+      // is nothing for a developer to act on in the moment - but the line has
+      // to survive for whoever asks later why a launch was slow.
+      logger.diagnostic(
+        `opencode_pre_start_preparation_failed team=${teamName} reason=${JSON.stringify(
+          error instanceof Error ? error.message : String(error)
+        )}`
+      );
+    }
+  };
   return {
-    createTeam: source.createTeam.bind(source),
-    launchTeam: source.launchTeam.bind(source),
+    async createTeam(request, onProgress) {
+      await runBeforeStart(request.teamName);
+      return source.createTeam.call(source, request, onProgress);
+    },
+    async launchTeam(request, onProgress) {
+      await runBeforeStart(request.teamName);
+      return source.launchTeam.call(source, request, onProgress);
+    },
+  };
+}
+
+/**
+ * The pre-start step both entry points install: drop the OpenCode host startup
+ * locks an earlier run left behind. A clean stop does not release them, and the
+ * orchestrator waits on each one in turn during launch readiness, so a launch
+ * that follows a few stopped runs can sit in "spawning" for minutes over files
+ * that guard nothing.
+ */
+function bindPreLaunchHostLockPurge(source: {
+  getAliveTeams(): string[];
+}): (teamName: string) => Promise<void> {
+  return async (teamName) => {
+    await purgeStaleOpenCodeHostStartupLocksBeforeLaunch({
+      teamName,
+      aliveTeams: source.getAliveTeams(),
+      // Durable, not a warning: this is the counter that explains a launch
+      // which was slow before and is not any more.
+      logRemoved: (message) => logger.diagnostic(message),
+      logWarning: (message) => logger.warn(message),
+    });
   };
 }
 
@@ -401,7 +464,9 @@ export function bindTeamHttpHandlerApis(
     TeamHttpMemberDiagnosticsApi
 ): TeamHttpHandlerApis {
   return {
-    provisioningStart: bindTeamProvisioningStartApi(source),
+    provisioningStart: bindTeamProvisioningStartApi(source, {
+      beforeStart: bindPreLaunchHostLockPurge(source),
+    }),
     provisioningStatus: bindTeamProvisioningStatusApi(source),
     taskActivity: bindTeamTaskActivityRepairApi(source),
     runtime: bindTeamHttpRuntimeApi(source),
@@ -433,7 +498,9 @@ export function bindTeamIpcHandlerApis(
     TeamToolApprovalApi
 ): TeamIpcHandlerApis {
   return {
-    provisioningStart: bindTeamProvisioningStartApi(source),
+    provisioningStart: bindTeamProvisioningStartApi(source, {
+      beforeStart: bindPreLaunchHostLockPurge(source),
+    }),
     provisioningStatus: bindTeamProvisioningStatusApi(source),
     preflight: bindTeamProvisioningPreflightApi(source),
     provisioningRun: bindTeamProvisioningRunApi(source),

--- a/src/main/services/team/contracts/__tests__/TeamProvisioningApis.test.ts
+++ b/src/main/services/team/contracts/__tests__/TeamProvisioningApis.test.ts
@@ -89,6 +89,48 @@ describe('TeamProvisioning API binders', () => {
     ).resolves.toEqual({ runId: 'run-start' });
   });
 
+  it('runs the pre-start step before every create and every launch', async () => {
+    const order: string[] = [];
+    const source: TeamProvisioningStartApi = {
+      createTeam(): Promise<TeamCreateResponse> {
+        order.push('createTeam');
+        return Promise.resolve({ runId: 'run-start' });
+      },
+      launchTeam(): Promise<TeamLaunchResponse> {
+        order.push('launchTeam');
+        return Promise.resolve({ runId: 'run-start' });
+      },
+    };
+
+    const api = bindTeamProvisioningStartApi(source, {
+      beforeStart: (teamName) => {
+        order.push(`beforeStart:${teamName}`);
+        return Promise.resolve();
+      },
+    });
+    await api.createTeam({ teamName: 'team-a', cwd: TEST_TEAM_CWD, members: [] }, () => undefined);
+    await api.launchTeam({ teamName: 'team-b', cwd: TEST_TEAM_CWD }, () => undefined);
+
+    expect(order).toEqual(['beforeStart:team-a', 'createTeam', 'beforeStart:team-b', 'launchTeam']);
+  });
+
+  // It is a preparation step, not a precondition: whatever it does is worth
+  // less than the launch it precedes.
+  it('starts the team anyway when the pre-start step fails', async () => {
+    const source: TeamProvisioningStartApi = {
+      createTeam: () => Promise.resolve({ runId: 'run-start' }),
+      launchTeam: () => Promise.resolve({ runId: 'run-start' }),
+    };
+
+    const api = bindTeamProvisioningStartApi(source, {
+      beforeStart: () => Promise.reject(new Error('lock dir unreadable')),
+    });
+
+    await expect(
+      api.launchTeam({ teamName: 'team-a', cwd: TEST_TEAM_CWD }, () => undefined)
+    ).resolves.toEqual({ runId: 'run-start' });
+  });
+
   it('binds provisioning status methods to the source object', async () => {
     interface StatusSource extends TeamProvisioningStatusApi {
       readonly runId: string;

--- a/src/main/services/team/contracts/__tests__/TeamProvisioningApis.test.ts
+++ b/src/main/services/team/contracts/__tests__/TeamProvisioningApis.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 
+import { beginOpenCodeStartupRuntimeSweep } from '../../opencode/bridge/OpenCodeStartupSweepGate';
 import {
   bindTeamClaudeLogsApi,
   bindTeamCrossTeamMessagingApi,
@@ -103,7 +104,7 @@ describe('TeamProvisioning API binders', () => {
     };
 
     const api = bindTeamProvisioningStartApi(source, {
-      beforeStart: (teamName) => {
+      beforeStart: ({ teamName }) => {
         order.push(`beforeStart:${teamName}`);
         return Promise.resolve();
       },
@@ -1175,6 +1176,81 @@ describe('TeamProvisioning API binders', () => {
       teamName: 'team-bound',
       settings,
       sourceName: 'approval-source',
+    });
+  });
+});
+
+describe('the OpenCode start preparation both entry points install', () => {
+  function startApiFor(
+    request: TeamCreateRequest,
+    onProgress: (progress: TeamProvisioningProgress) => void
+  ): Promise<void> {
+    const declared: Record<string, unknown> = {
+      createTeam: () => Promise.resolve({ runId: 'run-start' }),
+      launchTeam: () => Promise.resolve({ runId: 'run-start' }),
+      // No other team alive would let the lock purge reach the real data
+      // directory; a second live team keeps this test off the filesystem.
+      getAliveTeams: () => ['someone-else'],
+    };
+    // The aggregate binder binds every method on the service; only the start
+    // path is exercised here, so the rest resolve to a shared no-op.
+    const source = new Proxy(declared, {
+      get: (target, key: string) => target[key] ?? (() => Promise.resolve(undefined)),
+    }) as unknown as Parameters<typeof bindTeamHttpHandlerApis>[0];
+
+    return bindTeamHttpHandlerApis(source)
+      .provisioningStart.createTeam(request, onProgress)
+      .then(() => undefined);
+  }
+
+  // A start that cannot produce an `opencode serve` host has nothing to lose to
+  // the sweep, and must not be parked behind it.
+  it('does not wait for the startup sweep when no member can be an OpenCode host', async () => {
+    const settle = beginOpenCodeStartupRuntimeSweep();
+    const onProgress = vi.fn();
+
+    try {
+      await startApiFor(
+        {
+          teamName: 'team-a',
+          cwd: TEST_TEAM_CWD,
+          providerId: 'claude',
+          members: [{ name: 'lead', role: 'Lead', providerId: 'claude' }],
+        } as unknown as TeamCreateRequest,
+        onProgress
+      );
+    } finally {
+      settle();
+    }
+
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['an OpenCode start', { providerId: 'opencode' }],
+    ['a start whose provider is resolved later', {}],
+    ['a mixed team with one OpenCode member', { providerId: 'claude' }],
+  ])('waits for the startup sweep and reports the wait for %s', async (_label, requestShape) => {
+    const settle = beginOpenCodeStartupRuntimeSweep();
+    const onProgress = vi.fn();
+
+    const started = startApiFor(
+      {
+        teamName: 'team-a',
+        cwd: TEST_TEAM_CWD,
+        ...requestShape,
+        members: [{ name: 'lead', role: 'Lead', providerId: 'opencode' }],
+      } as unknown as TeamCreateRequest,
+      onProgress
+    );
+    settle();
+    await started;
+
+    expect(onProgress).toHaveBeenCalledTimes(1);
+    expect(onProgress.mock.calls[0][0]).toMatchObject({
+      runId: 'pending:team-a:opencode-startup-sweep',
+      teamName: 'team-a',
+      state: 'validating',
     });
   });
 });

--- a/src/main/services/team/lifecycle/teamForceStopFlow.ts
+++ b/src/main/services/team/lifecycle/teamForceStopFlow.ts
@@ -12,7 +12,10 @@ import { getTeamsBasePath } from '@main/utils/pathDecoder';
 import { isProcessAlive } from '@main/utils/processHealth';
 import * as fs from 'fs';
 
-import { purgeStaleOpenCodeHostStartupLocks } from '../opencode/bridge/OpenCodeHostStartupLockCleanup';
+import {
+  PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS,
+  purgeStaleOpenCodeHostStartupLocks,
+} from '../opencode/bridge/OpenCodeHostStartupLockCleanup';
 import { createOpenCodePromptDeliveryLedgerStore } from '../opencode/delivery/OpenCodePromptDeliveryLedger';
 import {
   getOpenCodeLaneScopedRuntimeFilePath,
@@ -502,7 +505,12 @@ export async function releaseSharedRuntimeResourcesAfterStop(input: {
   // had to do must not report failure because a lock file was unreadable.
   try {
     const purge = input.purgeHostStartupLocks ?? purgeStaleOpenCodeHostStartupLocks;
-    const lockPurge = await purge();
+    // Same age floor the pre-launch purge uses, and for the same reason: the
+    // alive-team list was read before this ran, so a launch that started in
+    // between holds a lock this purge can see. Without the floor an unheld
+    // lock of a host that is starting right now is removed, and the next host
+    // for the same port starts unserialised beside it.
+    const lockPurge = await purge({ minAgeMs: PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS });
     if (lockPurge.removed > 0) {
       diagnostics.push(`Purged ${lockPurge.removed} stale OpenCode host startup lock(s)`);
     }

--- a/src/main/services/team/lifecycle/teamForceStopFlow.ts
+++ b/src/main/services/team/lifecycle/teamForceStopFlow.ts
@@ -12,6 +12,7 @@ import { getTeamsBasePath } from '@main/utils/pathDecoder';
 import { isProcessAlive } from '@main/utils/processHealth';
 import * as fs from 'fs';
 
+import { purgeStaleOpenCodeHostStartupLocks } from '../opencode/bridge/OpenCodeHostStartupLockCleanup';
 import { createOpenCodePromptDeliveryLedgerStore } from '../opencode/delivery/OpenCodePromptDeliveryLedger';
 import {
   getOpenCodeLaneScopedRuntimeFilePath,
@@ -91,6 +92,13 @@ export interface TeamForceStopFlowPorts {
    * cleanup - a diagnostic sweep, say - leaves the publication alone.
    */
   markTeamStopped?(teamName: string): Promise<void>;
+  /**
+   * Runs once the team is down, on both paths: after a stop that confirmed on
+   * its own, and after the force path finished killing. A running team
+   * reserves shared resources that outlive the stop either way, and only the
+   * caller knows whether anything else still needs them.
+   */
+  releaseSharedRuntimeResources?(teamName: string): Promise<{ diagnostics: string[] }>;
 }
 
 /**
@@ -393,6 +401,9 @@ async function runTeamStopFlow(
     : stopOutcome !== 'stopped';
   if (cancelAfterStop) await cancelOwnedDeliveries();
 
+  // After the kills, never before them: a startup lock a live host still holds
+  // open cannot be unlinked, so it is the kill that turns it into an orphan.
+  await releaseSharedRuntimeResources(teamName, ports, diagnostics);
   await markStopped(teamName, ports, diagnostics);
   return {
     stopOutcome,
@@ -401,6 +412,24 @@ async function runTeamStopFlow(
     clearedPendingDeliveries,
     diagnostics,
   };
+}
+
+async function releaseSharedRuntimeResources(
+  teamName: string,
+  ports: TeamForceStopFlowPorts,
+  diagnostics: string[]
+): Promise<void> {
+  if (!ports.releaseSharedRuntimeResources) {
+    return;
+  }
+  try {
+    const released = await ports.releaseSharedRuntimeResources(teamName);
+    diagnostics.push(...released.diagnostics);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    ports.logWarning(`[${teamName}] Post-stop resource release failed: ${message}`);
+    diagnostics.push(`Post-stop resource release failed: ${message}`);
+  }
 }
 
 async function markStopped(
@@ -438,6 +467,63 @@ export async function killRetainedOpenCodeRuntimeProcessesForTeam(_input: {
       'Hard process cleanup is not confirmed: this runtime does not support targeted forced termination that preserves other teams sharing an OpenCode host. Only the regular scoped stop was attempted; shared hosts were left untouched.',
     ],
   };
+}
+
+/**
+ * Releases what a stopped team still holds beyond its own processes. It
+ * signals nothing and kills nothing: by the time it runs, the runtime has
+ * either confirmed the stop or been killed, and what is left are the shared
+ * resources the team reserved while it was alive.
+ *
+ * Two of them, and both only when this was the last team standing. The
+ * orchestrator startup locks of the stopped hosts are then orphans that would
+ * serialise the next launch behind them one at a time.
+ * `releaseSharedLocalRuntime` is a port with no default: a deployment whose
+ * members share a runtime this app can ask to stand down hands one in, and
+ * everywhere else its absence means the step does not exist rather than a
+ * no-op branch the app carries around.
+ */
+export async function releaseSharedRuntimeResourcesAfterStop(input: {
+  teamName: string;
+  otherAliveTeams: readonly string[];
+  releaseSharedLocalRuntime?: () => Promise<void>;
+  purgeHostStartupLocks?: typeof purgeStaleOpenCodeHostStartupLocks;
+}): Promise<{ diagnostics: string[] }> {
+  if (input.otherAliveTeams.length > 0) {
+    return {
+      diagnostics: [
+        `Kept shared runtime resources: other teams are still alive (${input.otherAliveTeams.join(', ')})`,
+      ],
+    };
+  }
+
+  const diagnostics: string[] = [];
+  // Never throws upward: this is a cleanup tail, and a stop that did what it
+  // had to do must not report failure because a lock file was unreadable.
+  try {
+    const purge = input.purgeHostStartupLocks ?? purgeStaleOpenCodeHostStartupLocks;
+    const lockPurge = await purge();
+    if (lockPurge.removed > 0) {
+      diagnostics.push(`Purged ${lockPurge.removed} stale OpenCode host startup lock(s)`);
+    }
+    diagnostics.push(...lockPurge.diagnostics.map((entry) => `lock purge: ${entry}`));
+  } catch (error) {
+    diagnostics.push(
+      `lock purge failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  if (input.releaseSharedLocalRuntime) {
+    try {
+      await input.releaseSharedLocalRuntime();
+      diagnostics.push('Released the shared runtime held for this team');
+    } catch (error) {
+      diagnostics.push(
+        `Shared runtime release failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+  return { diagnostics };
 }
 
 export async function readOpenCodeRuntimeLaneIdsForTeam(

--- a/src/main/services/team/opencode/bridge/OpenCodeHostStartupLockCleanup.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeHostStartupLockCleanup.ts
@@ -56,6 +56,14 @@ export interface PurgeOpenCodeHostStartupLocksOptions extends ResolveClaudeMulti
   /** Only remove entries whose mtime is at least this old (0 = everything). */
   minAgeMs?: number;
   now?: () => number;
+  /**
+   * Removes one lock entry; defaults to unlinking it. This is the only step
+   * here that touches the disk destructively, and it is a port because the
+   * outcome that matters most - the OS refusing removal because a live host
+   * still holds the lock open - is a sharing violation no test can provoke the
+   * same way on every platform.
+   */
+  removeLockEntry?: (entry: { path: string; isDirectory: boolean }) => Promise<void>;
 }
 
 export interface PurgeOpenCodeHostStartupLocksResult {
@@ -64,6 +72,14 @@ export interface PurgeOpenCodeHostStartupLocksResult {
   removed: number;
   kept: number;
   diagnostics: string[];
+}
+
+async function unlinkLockEntry(entry: { path: string; isDirectory: boolean }): Promise<void> {
+  if (entry.isDirectory) {
+    await fs.promises.rm(entry.path, { recursive: true, force: false });
+    return;
+  }
+  await fs.promises.unlink(entry.path);
 }
 
 function isHeldError(error: unknown): boolean {
@@ -77,6 +93,7 @@ export async function purgeStaleOpenCodeHostStartupLocks(
   const locksDir = options.locksDir ?? resolveOpenCodeHostStartupLocksDir(options);
   const minAgeMs = Math.max(0, options.minAgeMs ?? 0);
   const nowMs = (options.now ?? Date.now)();
+  const removeLockEntry = options.removeLockEntry ?? unlinkLockEntry;
   const result: PurgeOpenCodeHostStartupLocksResult = {
     locksDir,
     scanned: 0,
@@ -109,11 +126,7 @@ export async function purgeStaleOpenCodeHostStartupLocks(
           continue;
         }
       }
-      if (entry.isDirectory()) {
-        await fs.promises.rm(entryPath, { recursive: true, force: false });
-      } else {
-        await fs.promises.unlink(entryPath);
-      }
+      await removeLockEntry({ path: entryPath, isDirectory: entry.isDirectory() });
       result.removed += 1;
     } catch (error) {
       result.kept += 1;
@@ -123,6 +136,61 @@ export async function purgeStaleOpenCodeHostStartupLocks(
     }
   }
   return result;
+}
+
+/**
+ * Locks of a host that is genuinely starting are at most a few seconds old, so
+ * anything older than this immediately before a launch belongs to a host that
+ * is already gone.
+ */
+export const PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS = 120_000;
+
+/**
+ * Pre-launch purge. A clean (non-escalated) stop leaves the stopped hosts'
+ * startup locks behind, and the orchestrator serialises the next launch behind
+ * every one of them in turn. With no other team alive there is nothing left to
+ * protect, so every lock past the pre-launch threshold goes.
+ *
+ * Returns `null` when it declined to purge or could not: this runs on the way
+ * into a launch and must never be the reason one fails, so it swallows its own
+ * failure rather than propagating it.
+ */
+export async function purgeStaleOpenCodeHostStartupLocksBeforeLaunch(
+  input: Omit<PurgeOpenCodeHostStartupLocksOptions, 'minAgeMs'> & {
+    teamName: string;
+    aliveTeams: readonly string[];
+    logRemoved?: (message: string) => void;
+    logWarning?: (message: string) => void;
+  }
+): Promise<PurgeOpenCodeHostStartupLocksResult | null> {
+  const { teamName, aliveTeams, logRemoved, logWarning, ...purgeOptions } = input;
+  // A lock the team being launched left behind is fair game; one belonging to
+  // a team that is still running is not, and nothing here can tell them apart.
+  if (aliveTeams.some((alive) => alive !== teamName)) {
+    return null;
+  }
+  try {
+    const result = await purgeStaleOpenCodeHostStartupLocks({
+      ...purgeOptions,
+      minAgeMs: PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS,
+    });
+    if (result.removed > 0) {
+      logRemoved?.(
+        `opencode_startup_locks_purged team=${teamName} phase=pre_launch removed=${result.removed} kept=${result.kept}`
+      );
+    }
+    for (const diagnostic of result.diagnostics) {
+      logWarning?.(`[${teamName}] Pre-launch OpenCode host startup lock purge: ${diagnostic}`);
+    }
+    return result;
+  } catch (error) {
+    logWarning?.(
+      `[${teamName}] Pre-launch OpenCode host startup lock purge failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return null;
+  }
 }
 
 /** A host finishes starting within a couple of minutes; older locks guard nothing. */

--- a/src/main/services/team/opencode/bridge/OpenCodeHostStartupLockCleanup.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeHostStartupLockCleanup.ts
@@ -146,6 +146,31 @@ export async function purgeStaleOpenCodeHostStartupLocks(
 export const PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS = 120_000;
 
 /**
+ * Startup floor, applied once the reap of managed hosts has run. Half a minute
+ * is safe only where the OS refuses to unlink a lock a live host still holds
+ * open: that refusal, and not the age, is what keeps an active startup's lock.
+ */
+export const STARTUP_STALE_LOCK_MIN_AGE_MS = 30_000;
+
+/**
+ * The startup floor this platform may use. Windows refuses to unlink a file a
+ * live host holds open, so a lock that survives the purge there proves its
+ * owner is alive. POSIX unlinks an open file happily - the holder keeps its
+ * descriptor and only the directory entry goes - so an orchestrator startup
+ * that is still running loses its lock and the serialisation with it, and a
+ * later launch proceeds concurrently. These locks belong to the
+ * claude-multimodel orchestrator and carry no owner this app may read, so
+ * where the refusal is missing the age is the whole guard: it has to be the
+ * age past which a host cannot still be starting, which is the pre-launch
+ * floor the same module already trusts at a far more exposed moment.
+ */
+export function resolveStartupStaleLockMinAgeMs(
+  platform: NodeJS.Platform = process.platform
+): number {
+  return platform === 'win32' ? STARTUP_STALE_LOCK_MIN_AGE_MS : PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS;
+}
+
+/**
  * Pre-launch purge. A clean (non-escalated) stop leaves the stopped hosts'
  * startup locks behind, and the orchestrator serialises the next launch behind
  * every one of them in turn. With no other team alive there is nothing left to

--- a/src/main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup.ts
@@ -3,6 +3,7 @@ import {
   type RuntimeProcessTableRow,
 } from '@features/tmux-installer/main';
 import { killProcessByPid, killProcessByPidAndWait } from '@main/utils/processKill';
+import { readProcessStartTimeMs } from '@main/utils/processStartTime';
 import { listWindowsProcessTable } from '@main/utils/windowsProcessTable';
 import { execFile, type ExecFileException } from 'child_process';
 
@@ -56,6 +57,27 @@ const MANAGED_INLINE_OPENCODE_CONFIG_PATTERNS = [
   /OPENCODE_CONFIG_CONTENT=[\s\S]*"(?:agent-teams|agent_teams|mcp__agent-teams|mcp__agent_teams)_\*"/i,
 ] as const;
 
+/**
+ * The managed-host sweep is the only cleanup step that reaches processes this
+ * app never recorded a pid for, so every path that uses it goes through a port
+ * rather than calling the sweep directly: a deployment that would rather never
+ * touch an unattributed host hands in a port that reports itself disabled, and
+ * each caller then confines itself to what it can name.
+ */
+export interface OpenCodeManagedHostSweepPort {
+  isEnabled(): boolean;
+  sweepManagedHosts(input: { startedBeforeMs: number }): Promise<OpenCodeManagedHostCleanupResult>;
+}
+
+export const DEFAULT_OPEN_CODE_MANAGED_HOST_SWEEP_PORT: OpenCodeManagedHostSweepPort = {
+  isEnabled: () => true,
+  sweepManagedHosts: (input) =>
+    cleanupManagedOpenCodeServeProcesses({
+      mode: 'force',
+      startedBeforeMs: input.startedBeforeMs,
+    }),
+};
+
 export async function cleanupManagedOpenCodeServeProcesses(
   options: OpenCodeManagedHostProcessCleanupOptions
 ): Promise<OpenCodeManagedHostCleanupResult> {
@@ -80,8 +102,7 @@ export async function cleanupManagedOpenCodeServeProcesses(
     options.readProcessDetails ??
     (platform === 'win32' ? async () => null : readNativeProcessCommandWithEnv);
   const readStartTimeMs =
-    options.readProcessStartTimeMs ??
-    (platform === 'win32' ? readWindowsProcessStartTimeMs : readNativeProcessStartTimeMs);
+    options.readProcessStartTimeMs ?? ((pid: number) => readProcessStartTimeMs(pid, platform));
   const disposeServeHost = options.disposeServeHost ?? disposeOpenCodeServeHost;
   const readServeHostConfig = options.readServeHostConfig ?? readOpenCodeServeHostConfig;
   const killProcess = options.killProcess;
@@ -467,39 +488,6 @@ async function readOpenCodeServeHostConfig(baseUrl: string): Promise<string | nu
 
 async function readNativeProcessCommandWithEnv(pid: number): Promise<string | null> {
   return execFileText('ps', ['eww', '-p', String(pid), '-o', 'command='], 2_000, 2 * 1024 * 1024);
-}
-
-async function readNativeProcessStartTimeMs(pid: number): Promise<number | null> {
-  const output = await execFileText('ps', ['-p', String(pid), '-o', 'lstart='], 2_000, 64 * 1024);
-  if (!output) {
-    return null;
-  }
-  const parsed = Date.parse(output.trim());
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-async function readWindowsProcessStartTimeMs(pid: number): Promise<number | null> {
-  const normalizedPid = Math.trunc(pid);
-  if (!Number.isFinite(normalizedPid) || normalizedPid <= 0) {
-    return null;
-  }
-
-  const script = [
-    '$ErrorActionPreference = "Stop"',
-    `$process = Get-Process -Id ${normalizedPid} -ErrorAction Stop`,
-    '$process.StartTime.ToUniversalTime().ToString("o")',
-  ].join('; ');
-  const output = await execFileText(
-    'powershell.exe',
-    ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
-    2_000,
-    64 * 1024
-  );
-  if (!output) {
-    return null;
-  }
-  const parsed = Date.parse(output.trim());
-  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function isNativeProcessAlive(pid: number): boolean {

--- a/src/main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup.ts
@@ -43,8 +43,21 @@ export interface OpenCodeManagedHostProcessCleanupOptions {
 
 const OPENCODE_SERVE_COMMAND_RE =
   /(^|[/\\\s"])opencode(?:\.exe)?(?:"?)(?=\s|$).*?(?:^|\s)serve(?=\s|$)/i;
+// The orchestrator binary is this app's own, bundled or explicitly configured.
+// Standalone user tooling is the plain `opencode` CLI, so an orchestrator serve
+// host is app-managed by the fact that it exists at all.
+const ORCHESTRATOR_SERVE_COMMAND_RE =
+  /(^|[/\\\s"])claude-multimodel(?:\.exe)?(?:"?)(?=\s|$).*?(?:^|\s)serve(?=\s|$)/i;
 const WINDOWS_APP_MANAGED_OPENCODE_SERVE_RE =
   /[\\/]runtimes[\\/]opencode[\\/]versions[\\/][^"'\s]+[\\/]opencode-windows-[^"'\s]+[\\/]opencode\.exe(?:"|\s|$)/i;
+// Strings only this app writes into a managed host's effective OpenCode config:
+// the app-scoped MCP instance fragment, the local MCP launch environment key,
+// the managed teammate agent description. A standalone serve config has none.
+const MANAGED_SERVE_HOST_CONFIG_PATTERNS = [
+  /agent-teams-app-instance=/i,
+  /"AGENT_TEAMS_MCP_CLAUDE_DIR"/,
+  /claude-multimodel runtime orchestration/i,
+] as const;
 const MANAGED_ENV_MARKERS = ['CLAUDE_MULTIMODEL_DATA_HOME=', 'OPENCODE_CONFIG_CONTENT='] as const;
 const MANAGED_ENV_IDENTITY_MARKERS = [
   'AGENT_TEAMS_MCP_CLAUDE_DIR=',
@@ -66,14 +79,21 @@ const MANAGED_INLINE_OPENCODE_CONFIG_PATTERNS = [
  */
 export interface OpenCodeManagedHostSweepPort {
   isEnabled(): boolean;
-  sweepManagedHosts(input: { startedBeforeMs: number }): Promise<OpenCodeManagedHostCleanupResult>;
+  sweepManagedHosts(input: {
+    startedBeforeMs: number;
+    /**
+     * `force` reaps a confirmed-managed host outright; `orphaned` additionally
+     * spares one whose parent is still alive. Defaults to `force`.
+     */
+    mode?: OpenCodeManagedHostCleanupMode;
+  }): Promise<OpenCodeManagedHostCleanupResult>;
 }
 
 export const DEFAULT_OPEN_CODE_MANAGED_HOST_SWEEP_PORT: OpenCodeManagedHostSweepPort = {
   isEnabled: () => true,
   sweepManagedHosts: (input) =>
     cleanupManagedOpenCodeServeProcesses({
-      mode: 'force',
+      mode: input.mode ?? 'force',
       startedBeforeMs: input.startedBeforeMs,
     }),
 };
@@ -119,7 +139,7 @@ export async function cleanupManagedOpenCodeServeProcesses(
   const sleepMs = options.sleepMs ?? sleep;
 
   for (const row of rows) {
-    if (!isOpenCodeServeCommand(row.command)) {
+    if (!isOpenCodeServeCommand(row.command) && !isOrchestratorServeCommand(row.command)) {
       continue;
     }
     result.scanned += 1;
@@ -137,17 +157,27 @@ export async function cleanupManagedOpenCodeServeProcesses(
     const baseUrl = getOpenCodeServeLoopbackBaseUrl(row.command);
     const details = await readDetails(row.pid);
     const isManagedByWindowsCommand =
-      platform === 'win32' && isAppManagedWindowsOpenCodeServeCommand(row.command);
-    const isManaged =
+      platform === 'win32' &&
+      (isAppManagedWindowsOpenCodeServeCommand(row.command) ||
+        isOrchestratorServeCommand(row.command));
+    let isManaged =
       isManagedByWindowsCommand ||
       Boolean(details && isManagedOpenCodeServeProcessDetails(details));
+    let serveConfig: string | null = null;
+    if (!isManaged && platform === 'win32' && baseUrl) {
+      // Windows cannot read another process's environment, and a runtime
+      // resolved through PATH does not carry the app-managed install path, so
+      // the last way to tell whose host this is asks the host itself over
+      // loopback. Silence still reads as "not ours".
+      serveConfig = await readServeHostConfig(baseUrl).catch(() => null);
+      isManaged = Boolean(serveConfig && isManagedOpenCodeServeHostConfig(serveConfig));
+    }
     const hasRequiredDetailsMarkers =
       requiredDetailsMarkers.length === 0 ||
       Boolean(details && processDetailsIncludeMarkers(details, requiredDetailsMarkers));
-    const serveConfig =
-      requiredServeConfigMarkersAny.length > 0 && baseUrl
-        ? await readServeHostConfig(baseUrl).catch(() => null)
-        : null;
+    if (requiredServeConfigMarkersAny.length > 0 && baseUrl && serveConfig === null) {
+      serveConfig = await readServeHostConfig(baseUrl).catch(() => null);
+    }
     const hasRequiredServeConfigMarker =
       requiredServeConfigMarkersAny.length === 0 ||
       Boolean(serveConfig && stringIncludesAnyMarker(serveConfig, requiredServeConfigMarkersAny));
@@ -394,6 +424,14 @@ export async function cleanupManagedOpenCodeServeProcesses(
 
 export function isOpenCodeServeCommand(command: string): boolean {
   return OPENCODE_SERVE_COMMAND_RE.test(command.trim());
+}
+
+export function isOrchestratorServeCommand(command: string): boolean {
+  return ORCHESTRATOR_SERVE_COMMAND_RE.test(command.trim());
+}
+
+export function isManagedOpenCodeServeHostConfig(config: string): boolean {
+  return MANAGED_SERVE_HOST_CONFIG_PATTERNS.some((pattern) => pattern.test(config));
 }
 
 export function isAppManagedWindowsOpenCodeServeCommand(command: string): boolean {

--- a/src/main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup.ts
@@ -156,10 +156,19 @@ export async function cleanupManagedOpenCodeServeProcesses(
 
     const baseUrl = getOpenCodeServeLoopbackBaseUrl(row.command);
     const details = await readDetails(row.pid);
+    // The install path is evidence; the binary name is not.
+    //
+    // `isAppManagedWindowsOpenCodeServeCommand` matches a runtime under this
+    // app's own versioned install directory, which a host of another program
+    // cannot be running from. `isOrchestratorServeCommand` only says the process
+    // is AN orchestrator - it says nothing about WHOSE. Reading it as proof made
+    // every `claude-multimodel serve` on the machine app-managed by definition,
+    // including one belonging to a second installation or a copy of this app the
+    // user is running side by side. It stays in scope, so the loopback probe
+    // below still gets to ask the host who it belongs to, but it no longer
+    // answers that question by itself.
     const isManagedByWindowsCommand =
-      platform === 'win32' &&
-      (isAppManagedWindowsOpenCodeServeCommand(row.command) ||
-        isOrchestratorServeCommand(row.command));
+      platform === 'win32' && isAppManagedWindowsOpenCodeServeCommand(row.command);
     let isManaged =
       isManagedByWindowsCommand ||
       Boolean(details && isManagedOpenCodeServeProcessDetails(details));

--- a/src/main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep.ts
@@ -81,12 +81,21 @@ export async function runOpenCodeStartupRuntimeSweepTail(
     ports.waitMs ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   await waitMs(OPEN_CODE_STARTUP_SWEEP_HOST_SETTLE_MS);
 
-  const sweep = await sweepManagedHosts({ startedBeforeMs: ports.sweepCommandIssuedAtMs });
-  ports.logSweepResult(
-    `opencode_managed_hosts_killed sweep=startup count=${sweep.killed} scanned=${sweep.scanned}`
-  );
-  for (const diagnostic of sweep.diagnostics) {
-    ports.logWarning(`[OpenCode] startup sweep host cleanup: ${diagnostic}`);
+  // Never throws, for the same reason the preflight reap does not: this runs
+  // inside the startup host cleanup and the stale-lock purge comes after it.
+  // A scan that could not read the process table would otherwise take the
+  // purge with it, and the locks of the hosts it did not reach are exactly the
+  // ones the next launch then queues behind.
+  try {
+    const sweep = await sweepManagedHosts({ startedBeforeMs: ports.sweepCommandIssuedAtMs });
+    ports.logSweepResult(
+      `opencode_managed_hosts_killed sweep=startup count=${sweep.killed} scanned=${sweep.scanned}`
+    );
+    for (const diagnostic of sweep.diagnostics) {
+      ports.logWarning(`[OpenCode] startup sweep host cleanup: ${diagnostic}`);
+    }
+  } catch (error) {
+    ports.logWarning(`[OpenCode] Startup sweep host cleanup failed: ${String(error)}`);
   }
 }
 

--- a/src/main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep.ts
@@ -1,6 +1,9 @@
 import { cleanupManagedOpenCodeServeProcesses } from './OpenCodeManagedHostProcessCleanup';
 
-import type { OpenCodeManagedHostCleanupResult } from './OpenCodeManagedHostProcessCleanup';
+import type {
+  OpenCodeManagedHostCleanupMode,
+  OpenCodeManagedHostCleanupResult,
+} from './OpenCodeManagedHostProcessCleanup';
 
 /**
  * Tail of the startup host cleanup: reap the managed host the orchestrator's
@@ -32,11 +35,16 @@ export const OPEN_CODE_STARTUP_SWEEP_HOST_SETTLE_MS = 8_000;
  */
 export type OpenCodeManagedHostSweep = (input: {
   startedBeforeMs: number;
+  /**
+   * `force` reaps a confirmed-managed host outright; `orphaned` additionally
+   * spares one whose parent is still alive. Defaults to `force`.
+   */
+  mode?: OpenCodeManagedHostCleanupMode;
 }) => Promise<OpenCodeManagedHostCleanupResult>;
 
 const sweepManagedHostsByProcessScan: OpenCodeManagedHostSweep = (input) =>
   cleanupManagedOpenCodeServeProcesses({
-    mode: 'force',
+    mode: input.mode ?? 'force',
     startedBeforeMs: input.startedBeforeMs,
   });
 
@@ -79,5 +87,41 @@ export async function runOpenCodeStartupRuntimeSweepTail(
   );
   for (const diagnostic of sweep.diagnostics) {
     ports.logWarning(`[OpenCode] startup sweep host cleanup: ${diagnostic}`);
+  }
+}
+
+/**
+ * Reaps `opencode serve` hosts a previous app instance left behind. It runs
+ * before the runtime adapter registry exists, because an orphan still holds
+ * the fixed loopback ports a new host needs and whoever gets there first wins:
+ * reaping afterwards would mean this session's first launch races a host it
+ * cannot see.
+ *
+ * `orphaned` rather than `force`, and fenced by this instance's start, so it
+ * only reaches a host that is both older than this app and no longer parented
+ * by anything alive - on top of the command-line and environment proof the
+ * scan itself demands. Never throws: the app has to start even when it cannot
+ * clean up first.
+ */
+export async function reapOrphanedOpenCodeHostsBeforeRuntimeRegistry(ports: {
+  appStartedAtMs: number;
+  sweepManagedHosts?: OpenCodeManagedHostSweep;
+  logSweepResult(message: string): void;
+  logWarning(message: string): void;
+}): Promise<void> {
+  const sweepManagedHosts = ports.sweepManagedHosts ?? sweepManagedHostsByProcessScan;
+  try {
+    const sweep = await sweepManagedHosts({
+      mode: 'orphaned',
+      startedBeforeMs: ports.appStartedAtMs,
+    });
+    ports.logSweepResult(
+      `opencode_managed_hosts_killed sweep=startup_preflight count=${sweep.killed} scanned=${sweep.scanned}`
+    );
+    for (const diagnostic of sweep.diagnostics) {
+      ports.logWarning(`[OpenCode] startup preflight cleanup: ${diagnostic}`);
+    }
+  } catch (error) {
+    ports.logWarning(`[OpenCode] Startup preflight host cleanup failed: ${String(error)}`);
   }
 }

--- a/src/main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep.ts
@@ -1,0 +1,83 @@
+import { cleanupManagedOpenCodeServeProcesses } from './OpenCodeManagedHostProcessCleanup';
+
+import type { OpenCodeManagedHostCleanupResult } from './OpenCodeManagedHostProcessCleanup';
+
+/**
+ * Tail of the startup host cleanup: reap the managed host the orchestrator's
+ * own registry sweep leaves running.
+ *
+ * The registry sweep is executed without a project path, which boots a managed
+ * host in the app's process directory. That host then owns the loopback port
+ * the runtime proxy is pinned to, and every lane launched afterwards is routed
+ * through it: wrong workspace, wrong profile, none of the user's own MCP
+ * servers. Nothing else reaps it, because it is not in the registry the sweep
+ * just cleaned.
+ *
+ * Every step here is destructive, so every step is fenced by a start time:
+ * nothing this app instance started after the fence may be killed. Without one
+ * the sweep reaped the `opencode serve` host of a readiness probe a user
+ * launch had just started, and refused that launch before its first
+ * state-changing bridge command.
+ */
+
+/** How long the orchestrator may still be booting its sweep host. */
+export const OPEN_CODE_STARTUP_SWEEP_HOST_SETTLE_MS = 8_000;
+
+/**
+ * The reap itself, injectable so the fence can be tested without a process
+ * table. Whatever is handed in inherits the proof the scan demands: only a
+ * process whose own command line - and, off Windows, its own environment -
+ * names it an app-managed OpenCode host is ever signalled, so nothing reached
+ * from here is a host this app merely recorded a pid for.
+ */
+export type OpenCodeManagedHostSweep = (input: {
+  startedBeforeMs: number;
+}) => Promise<OpenCodeManagedHostCleanupResult>;
+
+const sweepManagedHostsByProcessScan: OpenCodeManagedHostSweep = (input) =>
+  cleanupManagedOpenCodeServeProcesses({
+    mode: 'force',
+    startedBeforeMs: input.startedBeforeMs,
+  });
+
+export interface OpenCodeStartupRuntimeSweepPorts {
+  /**
+   * The instant the registry sweep command was issued, and the fence for the
+   * reap below. Fencing it by app start instead would make it a guaranteed
+   * no-op: the sweep host is booted by this app instance, so it is always
+   * younger than app start and would always be kept. A host younger than the
+   * sweep command may belong to an in-flight launch and is still kept.
+   */
+  sweepCommandIssuedAtMs: number;
+  sweepManagedHosts?: OpenCodeManagedHostSweep;
+  /** Durable counter for the app's most destructive startup action. */
+  logSweepResult(message: string): void;
+  logWarning(message: string): void;
+  /**
+   * Declared as a property rather than a method so the default below reads it
+   * unbound without borrowing `ports` as `this`.
+   */
+  waitMs?: (ms: number) => Promise<void>;
+}
+
+export async function runOpenCodeStartupRuntimeSweepTail(
+  ports: OpenCodeStartupRuntimeSweepPorts
+): Promise<void> {
+  const sweepManagedHosts = ports.sweepManagedHosts ?? sweepManagedHostsByProcessScan;
+
+  // The orchestrator may still be booting its sweep host when the sweep
+  // command returns, so give it a moment to appear before reaping. It cannot
+  // outrun the fence by waiting: the fence is the moment the command was
+  // issued, which is already in the past.
+  const waitMs =
+    ports.waitMs ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  await waitMs(OPEN_CODE_STARTUP_SWEEP_HOST_SETTLE_MS);
+
+  const sweep = await sweepManagedHosts({ startedBeforeMs: ports.sweepCommandIssuedAtMs });
+  ports.logSweepResult(
+    `opencode_managed_hosts_killed sweep=startup count=${sweep.killed} scanned=${sweep.scanned}`
+  );
+  for (const diagnostic of sweep.diagnostics) {
+    ports.logWarning(`[OpenCode] startup sweep host cleanup: ${diagnostic}`);
+  }
+}

--- a/src/main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep.ts
@@ -3,6 +3,7 @@ import { cleanupManagedOpenCodeServeProcesses } from './OpenCodeManagedHostProce
 import type {
   OpenCodeManagedHostCleanupMode,
   OpenCodeManagedHostCleanupResult,
+  OpenCodeManagedHostProcessCleanupOptions,
 } from './OpenCodeManagedHostProcessCleanup';
 
 /**
@@ -16,11 +17,13 @@ import type {
  * servers. Nothing else reaps it, because it is not in the registry the sweep
  * just cleaned.
  *
- * Every step here is destructive, so every step is fenced by a start time:
- * nothing this app instance started after the fence may be killed. Without one
- * the sweep reaped the `opencode serve` host of a readiness probe a user
- * launch had just started, and refused that launch before its first
- * state-changing bridge command.
+ * Every step here is destructive, so every step is fenced twice. A start time
+ * keeps out anything younger than the fence: without it the sweep reaped the
+ * `opencode serve` host of a readiness probe a user launch had just started,
+ * and refused that launch before its first state-changing bridge command. And
+ * this app instance's own ownership markers keep out every host it did not
+ * start, so a second install, or an orchestrator a user runs themselves, is
+ * never a candidate for the reap however old it is.
  */
 
 /** How long the orchestrator may still be booting its sweep host. */
@@ -33,30 +36,58 @@ export const OPEN_CODE_STARTUP_SWEEP_HOST_SETTLE_MS = 8_000;
  * names it an app-managed OpenCode host is ever signalled, so nothing reached
  * from here is a host this app merely recorded a pid for.
  */
-export type OpenCodeManagedHostSweep = (input: {
-  startedBeforeMs: number;
-  /**
-   * `force` reaps a confirmed-managed host outright; `orphaned` additionally
-   * spares one whose parent is still alive. Defaults to `force`.
-   */
-  mode?: OpenCodeManagedHostCleanupMode;
-}) => Promise<OpenCodeManagedHostCleanupResult>;
+export type OpenCodeManagedHostSweep = (
+  input: OpenCodeManagedHostOwnershipMarkers & {
+    startedBeforeMs: number;
+    /**
+     * `force` reaps a confirmed-managed host outright; `orphaned` additionally
+     * spares one whose parent is still alive. Defaults to `force`.
+     */
+    mode?: OpenCodeManagedHostCleanupMode;
+  }
+) => Promise<OpenCodeManagedHostCleanupResult>;
+
+/**
+ * Strings only a host this app instance started carries: its own environment
+ * off Windows, and - because Windows forbids reading another process's
+ * environment - its own answer over loopback there.
+ */
+export type OpenCodeManagedHostOwnershipMarkers = Pick<
+  OpenCodeManagedHostProcessCleanupOptions,
+  'requiredDetailsMarkers' | 'requiredServeConfigMarkersAny'
+>;
 
 const sweepManagedHostsByProcessScan: OpenCodeManagedHostSweep = (input) =>
   cleanupManagedOpenCodeServeProcesses({
     mode: input.mode ?? 'force',
     startedBeforeMs: input.startedBeforeMs,
+    ...(input.requiredDetailsMarkers
+      ? { requiredDetailsMarkers: input.requiredDetailsMarkers }
+      : {}),
+    ...(input.requiredServeConfigMarkersAny
+      ? { requiredServeConfigMarkersAny: input.requiredServeConfigMarkersAny }
+      : {}),
   });
 
 export interface OpenCodeStartupRuntimeSweepPorts {
   /**
-   * The instant the registry sweep command was issued, and the fence for the
-   * reap below. Fencing it by app start instead would make it a guaranteed
-   * no-op: the sweep host is booted by this app instance, so it is always
-   * younger than app start and would always be kept. A host younger than the
-   * sweep command may belong to an in-flight launch and is still kept.
+   * The instant the registry sweep command SETTLED, and the fence for the reap
+   * below. The host this tail exists to reap is booted by that command, so it
+   * is younger than the moment the command was issued and older than the moment
+   * it returned; fencing by either app start or the issue instant keeps it
+   * every time and makes the whole tail a no-op. A host younger than the
+   * settled command may belong to an in-flight launch and is still kept, and
+   * the startup sweep gate parks a launch requested inside the window rather
+   * than letting it race the reap.
    */
-  sweepCommandIssuedAtMs: number;
+  sweepCommandSettledAtMs: number;
+  /**
+   * Proof of ownership the reap adds to the scan's own command-line check. The
+   * host booted by the registry sweep command inherits this instance's bridge
+   * environment, so it carries them; a host of another install, or one a user
+   * started, does not and is kept.
+   */
+  ownershipMarkers?: OpenCodeManagedHostOwnershipMarkers;
   sweepManagedHosts?: OpenCodeManagedHostSweep;
   /** Durable counter for the app's most destructive startup action. */
   logSweepResult(message: string): void;
@@ -87,7 +118,10 @@ export async function runOpenCodeStartupRuntimeSweepTail(
   // purge with it, and the locks of the hosts it did not reach are exactly the
   // ones the next launch then queues behind.
   try {
-    const sweep = await sweepManagedHosts({ startedBeforeMs: ports.sweepCommandIssuedAtMs });
+    const sweep = await sweepManagedHosts({
+      startedBeforeMs: ports.sweepCommandSettledAtMs,
+      ...(ports.ownershipMarkers ?? {}),
+    });
     ports.logSweepResult(
       `opencode_managed_hosts_killed sweep=startup count=${sweep.killed} scanned=${sweep.scanned}`
     );

--- a/src/main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep.ts
@@ -93,6 +93,13 @@ export interface OpenCodeStartupRuntimeSweepPorts {
   logSweepResult(message: string): void;
   logWarning(message: string): void;
   /**
+   * The reap failed outright, which is a caught main-process failure and not a
+   * warning about one host. `warn` reaches the durable sinks either way, but
+   * its console line is filtered out at the production log level, so the one
+   * failure that explains why nothing was reaped is the one nobody sees.
+   */
+  logError(message: string): void;
+  /**
    * Declared as a property rather than a method so the default below reads it
    * unbound without borrowing `ports` as `this`.
    */
@@ -129,7 +136,7 @@ export async function runOpenCodeStartupRuntimeSweepTail(
       ports.logWarning(`[OpenCode] startup sweep host cleanup: ${diagnostic}`);
     }
   } catch (error) {
-    ports.logWarning(`[OpenCode] Startup sweep host cleanup failed: ${String(error)}`);
+    ports.logError(`[OpenCode] Startup sweep host cleanup failed: ${String(error)}`);
   }
 }
 
@@ -151,6 +158,8 @@ export async function reapOrphanedOpenCodeHostsBeforeRuntimeRegistry(ports: {
   sweepManagedHosts?: OpenCodeManagedHostSweep;
   logSweepResult(message: string): void;
   logWarning(message: string): void;
+  /** As above: a sweep that could not run at all is a failure, not a warning. */
+  logError(message: string): void;
 }): Promise<void> {
   const sweepManagedHosts = ports.sweepManagedHosts ?? sweepManagedHostsByProcessScan;
   try {
@@ -165,6 +174,6 @@ export async function reapOrphanedOpenCodeHostsBeforeRuntimeRegistry(ports: {
       ports.logWarning(`[OpenCode] startup preflight cleanup: ${diagnostic}`);
     }
   } catch (error) {
-    ports.logWarning(`[OpenCode] Startup preflight host cleanup failed: ${String(error)}`);
+    ports.logError(`[OpenCode] Startup preflight host cleanup failed: ${String(error)}`);
   }
 }

--- a/src/main/services/team/opencode/bridge/OpenCodeStartupSweepGate.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeStartupSweepGate.ts
@@ -1,0 +1,97 @@
+/**
+ * The app's startup runtime sweep force-reaps managed OpenCode hosts for
+ * several seconds after start, and it is fire-and-forget, so a team launch
+ * requested inside that window used to race it: the sweep killed the launch's
+ * own readiness-probe host, the launch was refused before any state-changing
+ * bridge command ran, and the user saw a launch fail for no reason they could
+ * see.
+ *
+ * This gate lets such a launch serialise behind the sweep instead of racing
+ * it. It is belt and braces on top of the start-time fence the sweep itself
+ * applies, because the sweep is reachable from more than one lifecycle path
+ * and a fence can only protect processes that already exist when it is read.
+ */
+
+/** A stuck sweep must never park launches forever. */
+export const OPEN_CODE_STARTUP_SWEEP_WAIT_TIMEOUT_MS = 60_000;
+
+interface PendingStartupSweep {
+  promise: Promise<void>;
+  settle: () => void;
+}
+
+let pendingStartupSweep: PendingStartupSweep | null = null;
+
+/**
+ * Marks the startup runtime sweep as pending. Call it when the sweep is
+ * scheduled, not when it starts running, so a launch requested during the
+ * scheduling delay also waits. The returned callback must be invoked from a
+ * `finally`: a sweep that throws still has to release the launches waiting on
+ * it, and that is the only reason this is a callback rather than a promise the
+ * gate awaits itself.
+ */
+export function beginOpenCodeStartupRuntimeSweep(): () => void {
+  if (!pendingStartupSweep) {
+    let settle!: () => void;
+    const promise = new Promise<void>((resolve) => {
+      settle = resolve;
+    });
+    pendingStartupSweep = { promise, settle };
+  }
+  const current = pendingStartupSweep;
+  return () => {
+    current.settle();
+    if (pendingStartupSweep === current) {
+      pendingStartupSweep = null;
+    }
+  };
+}
+
+export interface WhenOpenCodeStartupRuntimeSweepSettledOptions {
+  timeoutMs?: number;
+  logWaited?: (message: string) => void;
+  /** Runs only when the caller really parks, so it can report the wait. */
+  onWaitStart?: () => void;
+  nowMs?: () => number;
+  setTimeoutImpl?: typeof setTimeout;
+}
+
+/**
+ * Resolves immediately when no startup sweep is pending. Otherwise waits for
+ * it and records the observed wait, so a launch that was slow because it
+ * queued behind the sweep says so instead of leaving it to be inferred from
+ * timestamps.
+ */
+export async function whenOpenCodeStartupRuntimeSweepSettled(
+  options: WhenOpenCodeStartupRuntimeSweepSettledOptions = {}
+): Promise<void> {
+  const current = pendingStartupSweep;
+  if (!current) {
+    return;
+  }
+  options.onWaitStart?.();
+  const nowMs = options.nowMs ?? (() => Date.now());
+  const setTimeoutImpl = options.setTimeoutImpl ?? setTimeout;
+  const timeoutMs = options.timeoutMs ?? OPEN_CODE_STARTUP_SWEEP_WAIT_TIMEOUT_MS;
+  const startedAtMs = nowMs();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = await Promise.race([
+    current.promise.then(() => false),
+    new Promise<boolean>((resolve) => {
+      timer = setTimeoutImpl(() => resolve(true), timeoutMs);
+    }),
+  ]);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+  }
+  if (timedOut && pendingStartupSweep === current) {
+    // Giving up once is enough: a sweep that already blew the bound would make
+    // every later launch pay it again, which is exactly the forever-park this
+    // gate exists to prevent. The sweep's own start-time fence stays in force.
+    pendingStartupSweep = null;
+  }
+  const waitedMs = nowMs() - startedAtMs;
+  options.logWaited?.(
+    `opencode_startup_sweep_wait waitedMs=${waitedMs} settled=${String(!timedOut)}`
+  );
+}

--- a/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodeMemberMessageDeliveryService.ts
@@ -375,10 +375,13 @@ export class OpenCodeMemberMessageDeliveryService {
         if (appMcpTransportMismatch) {
           refreshedOpenCodeBootstrapSessionToStamp = bootstrapSession;
           forceOpenCodeSessionRefreshReason = appMcpTransportMismatch;
-          logger.info(
-            `[${teamName}] OpenCode delivery detected stale app MCP transport for ` +
-              `${canonicalMemberName}; requesting bridge session refresh before send. ` +
-              appMcpTransportMismatch
+          // Durable: a forced session refresh is the only trace that this
+          // delivery started from a rebuilt session, and it has to still be
+          // readable when the lane-scoped ledger is gone.
+          logger.diagnostic(
+            `[${teamName}] opencode_delivery_app_mcp_transport_stale ` +
+              `${canonicalMemberName}/${laneIdentity.laneId} ` +
+              `reason=${JSON.stringify(appMcpTransportMismatch)}`
           );
         }
       }

--- a/src/main/services/team/provisioning/OpenCodeAggregatePrimaryLaneStopHelpers.ts
+++ b/src/main/services/team/provisioning/OpenCodeAggregatePrimaryLaneStopHelpers.ts
@@ -1,0 +1,145 @@
+import { getErrorMessage } from '@shared/utils/errorHandling';
+
+import {
+  assertAggregatePrimaryStopConfirmed,
+  getCancelledAggregateLaunchError,
+} from './OpenCodeAggregatePrimaryRestartPolicy';
+
+import type { TeamLaunchRuntimeAdapter } from '../runtime';
+import type { RuntimeAdapterRunByTeamEntry } from './TeamProvisioningServiceComposition';
+import type { PersistedTeamLaunchSnapshot, TeamCreateRequest } from '@shared/types';
+
+/**
+ * The two exact-owner primary-lane stops the aggregate restart path needs.
+ * Extracted verbatim from the facade so the facade can host the lead
+ * bootstrap work without pushing past the source-size cap; the ownership
+ * identity comparisons are load-bearing and therefore travel through
+ * accessors, never through copies.
+ */
+export interface OpenCodeAggregatePrimaryLaneStopPorts {
+  getRuntimeOwner(teamName: string): RuntimeAdapterRunByTeamEntry | undefined;
+  setRuntimeOwner(teamName: string, owner: RuntimeAdapterRunByTeamEntry): void;
+  deleteRuntimeOwner(teamName: string): void;
+  getOpenCodeRuntimeLaunchCwd(baseCwd: string, members: TeamCreateRequest['members']): string;
+  publishPending(message: string): void;
+  publishFailed(message: string, error: unknown): void;
+  logWarn(message: string): void;
+}
+
+export interface OpenCodeAggregatePrimaryLaneStopRun {
+  runId: string;
+  teamName: string;
+  request: TeamCreateRequest;
+  effectiveMembers: TeamCreateRequest['members'];
+}
+
+export async function stopUnretainableOpenCodePrimaryLane(
+  input: {
+    adapter: TeamLaunchRuntimeAdapter;
+    run: OpenCodeAggregatePrimaryLaneStopRun;
+    previousEffectiveMembers: TeamCreateRequest['members'];
+    previousLaunchState: PersistedTeamLaunchSnapshot | null;
+  },
+  ports: OpenCodeAggregatePrimaryLaneStopPorts
+): Promise<void> {
+  const teamName = input.run.teamName;
+  const cwd = ports.getOpenCodeRuntimeLaunchCwd(
+    input.run.request.cwd,
+    input.previousEffectiveMembers
+  );
+  const currentOwner = ports.getRuntimeOwner(teamName);
+  const exactStopOwner = currentOwner ?? {
+    runId: input.run.runId,
+    providerId: 'opencode' as const,
+    cwd,
+    ...(input.run.request.allowExperimentalLocalModels === true
+      ? { allowExperimentalLocalModels: true }
+      : {}),
+  };
+  if (!currentOwner) {
+    ports.setRuntimeOwner(teamName, exactStopOwner);
+  }
+  ports.publishPending('Stopping unretainable OpenCode primary lane');
+  try {
+    const stopResult = await input.adapter.stop({
+      runId: input.run.runId,
+      laneId: 'primary',
+      teamName,
+      cwd,
+      providerId: 'opencode',
+      reason: 'cleanup',
+      previousLaunchState: input.previousLaunchState,
+      force: true,
+    });
+    assertAggregatePrimaryStopConfirmed(stopResult);
+    if (ports.getRuntimeOwner(teamName) !== exactStopOwner) {
+      throw getCancelledAggregateLaunchError(teamName);
+    }
+  } catch (error) {
+    if (ports.getRuntimeOwner(teamName) === exactStopOwner) {
+      ports.publishFailed('Unretainable OpenCode primary lane cleanup failed', error);
+    }
+    ports.logWarn(
+      `[${teamName}] Failed to stop unretainable OpenCode primary lane: ${getErrorMessage(error)}`
+    );
+    throw error;
+  }
+}
+
+export async function stopFailedOpenCodeAggregatePrimaryRelaunchCandidate(
+  input: {
+    adapter: TeamLaunchRuntimeAdapter;
+    run: OpenCodeAggregatePrimaryLaneStopRun;
+    previousLaunchState: PersistedTeamLaunchSnapshot | null;
+    previousOwner: { runId: string; providerId: string; cwd?: string } | undefined;
+  },
+  ports: OpenCodeAggregatePrimaryLaneStopPorts
+): Promise<void> {
+  const teamName = input.run.teamName;
+  const currentOwner = ports.getRuntimeOwner(teamName);
+  if (
+    currentOwner &&
+    (currentOwner === input.previousOwner ||
+      currentOwner.providerId !== 'opencode' ||
+      currentOwner.runId !== input.run.runId)
+  ) {
+    throw getCancelledAggregateLaunchError(teamName);
+  }
+  const cwd =
+    currentOwner?.cwd ??
+    ports.getOpenCodeRuntimeLaunchCwd(input.run.request.cwd, input.run.effectiveMembers);
+  const expectedOwner = currentOwner ?? {
+    runId: input.run.runId,
+    providerId: 'opencode' as const,
+    cwd,
+    ...(input.run.request.allowExperimentalLocalModels === true
+      ? { allowExperimentalLocalModels: true }
+      : {}),
+  };
+  if (!currentOwner) {
+    ports.setRuntimeOwner(teamName, expectedOwner);
+  }
+  ports.publishPending('Stopping failed OpenCode primary relaunch candidate');
+  try {
+    const stopResult = await input.adapter.stop({
+      runId: input.run.runId,
+      laneId: 'primary',
+      teamName,
+      cwd,
+      providerId: 'opencode',
+      reason: 'cleanup',
+      previousLaunchState: input.previousLaunchState,
+      force: true,
+    });
+    assertAggregatePrimaryStopConfirmed(stopResult);
+    if (ports.getRuntimeOwner(teamName) !== expectedOwner) {
+      throw getCancelledAggregateLaunchError(teamName);
+    }
+    ports.deleteRuntimeOwner(teamName);
+  } catch (error) {
+    if (ports.getRuntimeOwner(teamName) === expectedOwner) {
+      ports.publishFailed('Failed OpenCode primary relaunch candidate cleanup failed', error);
+    }
+    throw error;
+  }
+}

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchRuntimeStatusCompatibilityFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchRuntimeStatusCompatibilityFacade.ts
@@ -9,7 +9,11 @@ import {
   recoverDeterministicBootstrapCompletionWithService,
 } from './TeamProvisioningDeterministicBootstrapCompletionRecovery';
 import { TeamProvisioningLaunchStateCompatibilityFacade } from './TeamProvisioningLaunchStateCompatibilityFacade';
-import { guardCommittedOpenCodeSecondaryLaneEvidence as guardCommittedOpenCodeSecondaryLaneEvidenceHelper } from './TeamProvisioningLaunchStateReconciliation';
+import {
+  guardCommittedOpenCodeLaneEvidence as guardCommittedOpenCodeLaneEvidenceHelper,
+  guardCommittedOpenCodeSecondaryLaneEvidence as guardCommittedOpenCodeSecondaryLaneEvidenceHelper,
+  type GuardCommittedOpenCodeSecondaryLaneEvidencePorts,
+} from './TeamProvisioningLaunchStateReconciliation';
 import {
   commitOpenCodeRuntimeAdapterLaunchSessionEvidence,
   launchOpenCodeAggregatePrimaryLane as launchOpenCodeAggregatePrimaryLaneHelper,
@@ -184,7 +188,11 @@ export abstract class TeamProvisioningLaunchRuntimeStatusCompatibilityFacade<
     return launchOpenCodeAggregatePrimaryLaneHelper(
       params,
       createTeamProvisioningOpenCodeAggregatePrimaryLanePortsFromService(
-        this as unknown as TeamProvisioningOpenCodeAggregatePrimaryLaneServiceHost
+        this as unknown as TeamProvisioningOpenCodeAggregatePrimaryLaneServiceHost,
+        {
+          guardCommittedOpenCodeLaneEvidence: (input) =>
+            this.guardCommittedOpenCodeLaneEvidence(input),
+        }
       )
     );
   }
@@ -221,6 +229,22 @@ export abstract class TeamProvisioningLaunchRuntimeStatusCompatibilityFacade<
     );
   }
 
+  private createOpenCodeLaneEvidencePorts(): GuardCommittedOpenCodeSecondaryLaneEvidencePorts {
+    return createTeamProvisioningOpenCodeSecondaryLaneEvidencePortsFromService(
+      this as unknown as TeamProvisioningOpenCodeSecondaryLaneEvidenceServiceHost,
+      { logWarn: (message) => logger.warn(message) }
+    );
+  }
+
+  protected async guardCommittedOpenCodeLaneEvidence(params: {
+    teamName: string;
+    laneId: string;
+    result: TeamRuntimeLaunchResult;
+    memberNames: readonly string[];
+  }): Promise<TeamRuntimeLaunchResult> {
+    return guardCommittedOpenCodeLaneEvidenceHelper(params, this.createOpenCodeLaneEvidencePorts());
+  }
+
   protected async guardCommittedOpenCodeSecondaryLaneEvidence(params: {
     teamName: string;
     laneId: string;
@@ -229,12 +253,7 @@ export abstract class TeamProvisioningLaunchRuntimeStatusCompatibilityFacade<
   }): Promise<TeamRuntimeLaunchResult> {
     return guardCommittedOpenCodeSecondaryLaneEvidenceHelper(
       params,
-      createTeamProvisioningOpenCodeSecondaryLaneEvidencePortsFromService(
-        this as unknown as TeamProvisioningOpenCodeSecondaryLaneEvidenceServiceHost,
-        {
-          logWarn: (message) => logger.warn(message),
-        }
-      )
+      this.createOpenCodeLaneEvidencePorts()
     );
   }
 

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchRuntimeStatusCompatibilityFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchRuntimeStatusCompatibilityFacade.ts
@@ -192,7 +192,7 @@ export abstract class TeamProvisioningLaunchRuntimeStatusCompatibilityFacade<
   private createOpenCodeLaunchPersistencePorts() {
     return createTeamProvisioningOpenCodeLaunchPersistencePortsFromService(
       this as unknown as TeamProvisioningOpenCodeLaunchPersistenceServiceHost,
-      { nowIso }
+      { nowIso, logDiagnostic: (message) => logger.diagnostic(message) }
     );
   }
 

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchStateReconciliation.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchStateReconciliation.ts
@@ -654,6 +654,12 @@ export async function guardCommittedOpenCodeLaneEvidence(
   const uncommittedMemberNames = await collectUncommittedOpenCodeLaneMemberNames(
     {
       ...params,
+      // The COMMITTED result, not the one that came in: the commit promotes a
+      // matching app-managed candidate to confirmed, and reading the pre-commit
+      // result made the collector skip exactly those members - the ones whose
+      // confirmation this commit just created and nothing has yet read back the
+      // way the delivery path will.
+      result: committedResult,
       guardedMemberNames,
       laneHasRuntimeEvidenceOnDisk: storage.hasRuntimeEvidenceOnDisk,
     },
@@ -695,8 +701,8 @@ export async function guardCommittedOpenCodeLaneEvidence(
 
   const teamLaunchState = summarizeRuntimeLaunchResultMembers(members);
   return {
-    ...params.result,
-    launchPhase: teamLaunchState === 'clean_success' ? params.result.launchPhase : 'active',
+    ...committedResult,
+    launchPhase: teamLaunchState === 'clean_success' ? committedResult.launchPhase : 'active',
     teamLaunchState,
     members,
     diagnostics: Array.from(new Set([...committedResult.diagnostics, ...diagnostics])),

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchStateReconciliation.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchStateReconciliation.ts
@@ -106,6 +106,21 @@ export interface GuardCommittedOpenCodeSecondaryLaneEvidencePorts {
     state: 'active';
     diagnostics: string[];
   }): Promise<void>;
+  /**
+   * Per-member committed-session lookup. `hasRuntimeEvidenceOnDisk` is a LANE
+   * flag: it flips as soon as one member commits, so on a multi-member primary
+   * lane a teammate's session record masks a lead that has none - the exact
+   * member this gate exists for. Optional so a caller that wires no reader keeps
+   * the lane-level behaviour. Declared as a plain function value, not a method:
+   * the gate reads it off the ports object once and calls it per member, so an
+   * implementation may never depend on its `this`.
+   */
+  hasCommittedOpenCodeLaneMemberSessionEvidence?: (input: {
+    teamName: string;
+    laneId: string;
+    runId: string;
+    memberName: string;
+  }) => Promise<boolean>;
   logWarn(message: string): void;
 }
 
@@ -516,38 +531,114 @@ export function promoteOpenCodeSecondaryMemberFromCommittedBootstrapEvidence(inp
   };
 }
 
-export async function guardCommittedOpenCodeSecondaryLaneEvidence(
+/**
+ * The exact failure string the runtime store invariants produce for this
+ * condition. That invariant was never wired into a launch path, so a lead
+ * promoted to `confirmed_alive` with no session record broke it silently; the
+ * promotion gate now names the invariant it enforces.
+ */
+export function buildMissingOpenCodeSessionRecordDiagnostic(memberName: string): string {
+  return `confirmed member ${memberName} has no matching OpenCode session record`;
+}
+
+function claimsOpenCodeBootstrapConfirmed(
+  evidence: TeamRuntimeLaunchResult['members'][string] | undefined
+): boolean {
+  return (
+    evidence != null &&
+    (evidence.launchState === 'confirmed_alive' ||
+      evidence.bootstrapConfirmed === true ||
+      evidence.livenessKind === 'confirmed_bootstrap')
+  );
+}
+
+function matchesOpenCodeAppManagedBootstrapCandidate(params: {
+  teamName: string;
+  laneId: string;
+  runId: string;
+  memberName: string;
+  evidence: TeamRuntimeLaunchResult['members'][string];
+}): boolean {
+  const { evidence } = params;
+  const candidate =
+    evidence.bootstrapEvidenceSource === 'app_managed_bootstrap' &&
+    evidence.bootstrapMode === 'app_managed_context'
+      ? evidence.appManagedBootstrapCandidate
+      : undefined;
+  return (
+    candidate?.source === 'app_managed_bootstrap' &&
+    candidate.teamName === params.teamName &&
+    candidate.memberName === params.memberName &&
+    candidate.runId === params.runId &&
+    candidate.laneId === params.laneId &&
+    candidate.runtimeSessionId === evidence.sessionId?.trim()
+  );
+}
+
+async function collectUncommittedOpenCodeLaneMemberNames(
   params: {
     teamName: string;
     laneId: string;
     result: TeamRuntimeLaunchResult;
-    memberName: string;
+    guardedMemberNames: readonly string[];
+    laneHasRuntimeEvidenceOnDisk: boolean;
+  },
+  ports: GuardCommittedOpenCodeSecondaryLaneEvidencePorts
+): Promise<string[]> {
+  const readMemberEvidence = ports.hasCommittedOpenCodeLaneMemberSessionEvidence;
+  const uncommittedMemberNames: string[] = [];
+  for (const memberName of params.guardedMemberNames) {
+    if (!claimsOpenCodeBootstrapConfirmed(params.result.members[memberName])) {
+      continue;
+    }
+    const committed = readMemberEvidence
+      ? // A read that throws cannot disprove anything, so it may never downgrade
+        // a healthy member; only an answered `false` is proof of a missing record.
+        await readMemberEvidence({
+          teamName: params.teamName,
+          laneId: params.laneId,
+          runId: params.result.runId,
+          memberName,
+        }).catch(() => true)
+      : params.laneHasRuntimeEvidenceOnDisk;
+    if (!committed) {
+      uncommittedMemberNames.push(memberName);
+    }
+  }
+  return uncommittedMemberNames;
+}
+
+/**
+ * The single promotion gate that turns app-managed OpenCode bootstrap into
+ * `confirmed_alive` only after durable lane evidence exists on disk. Lane-kind
+ * agnostic on purpose: the primary lane's lead is the one member that used to
+ * skip it, which is exactly how a team whose lead held no session record was
+ * still promoted to a healthy `ready`.
+ */
+export async function guardCommittedOpenCodeLaneEvidence(
+  params: {
+    teamName: string;
+    laneId: string;
+    result: TeamRuntimeLaunchResult;
+    memberNames: readonly string[];
   },
   ports: GuardCommittedOpenCodeSecondaryLaneEvidencePorts
 ): Promise<TeamRuntimeLaunchResult> {
-  const memberEvidence = params.result.members[params.memberName];
-  if (!memberEvidence) {
-    return params.result;
-  }
-
-  const claimsBootstrapConfirmed =
-    memberEvidence.launchState === 'confirmed_alive' ||
-    memberEvidence.bootstrapConfirmed === true ||
-    memberEvidence.livenessKind === 'confirmed_bootstrap';
-  const runtimeSessionId = memberEvidence.sessionId?.trim();
-  const appManagedCandidate =
-    memberEvidence.bootstrapEvidenceSource === 'app_managed_bootstrap' &&
-    memberEvidence.bootstrapMode === 'app_managed_context'
-      ? memberEvidence.appManagedBootstrapCandidate
-      : undefined;
-  const appManagedCandidateMatches =
-    appManagedCandidate?.source === 'app_managed_bootstrap' &&
-    appManagedCandidate.teamName === params.teamName &&
-    appManagedCandidate.memberName === params.memberName &&
-    appManagedCandidate.runId === params.result.runId &&
-    appManagedCandidate.laneId === params.laneId &&
-    appManagedCandidate.runtimeSessionId === runtimeSessionId;
-  if (!claimsBootstrapConfirmed && !appManagedCandidateMatches) {
+  const guardedMemberNames = params.memberNames.filter((memberName) => {
+    const evidence = params.result.members[memberName];
+    return (
+      evidence != null &&
+      (claimsOpenCodeBootstrapConfirmed(evidence) ||
+        matchesOpenCodeAppManagedBootstrapCandidate({
+          teamName: params.teamName,
+          laneId: params.laneId,
+          runId: params.result.runId,
+          memberName,
+          evidence,
+        }))
+    );
+  });
+  if (guardedMemberNames.length === 0) {
     return params.result;
   }
   const committedResult = await ports.commitOpenCodeRuntimeAdapterLaunchSessionEvidence({
@@ -555,27 +646,38 @@ export async function guardCommittedOpenCodeSecondaryLaneEvidence(
     laneId: params.laneId,
     result: params.result,
   });
-  const committedMemberEvidence = committedResult.members[params.memberName] ?? memberEvidence;
 
   const storage = await ports.inspectOpenCodeRuntimeLaneStorage({
     teamName: params.teamName,
     laneId: params.laneId,
   });
-  if (storage.hasRuntimeEvidenceOnDisk) {
-    return committedResult;
-  }
-  if (!claimsBootstrapConfirmed) {
+  const uncommittedMemberNames = await collectUncommittedOpenCodeLaneMemberNames(
+    {
+      ...params,
+      guardedMemberNames,
+      laneHasRuntimeEvidenceOnDisk: storage.hasRuntimeEvidenceOnDisk,
+    },
+    ports
+  );
+  if (uncommittedMemberNames.length === 0) {
     return committedResult;
   }
 
-  const diagnostics = buildOpenCodeUncommittedBootstrapDiagnostic(storage);
-  const members = {
-    ...committedResult.members,
-    [params.memberName]: downgradeUncommittedOpenCodeBootstrapEvidence(
-      committedMemberEvidence,
-      diagnostics
-    ),
-  };
+  const laneDiagnostics = buildOpenCodeUncommittedBootstrapDiagnostic(storage);
+  const diagnostics = [
+    ...laneDiagnostics,
+    ...uncommittedMemberNames.map(buildMissingOpenCodeSessionRecordDiagnostic),
+  ];
+  const members = { ...committedResult.members };
+  for (const memberName of uncommittedMemberNames) {
+    // Each member carries only its OWN missing-record diagnostic: a union would
+    // make one member's evidence name other members, which reads as a wider
+    // outage than the one that happened.
+    members[memberName] = downgradeUncommittedOpenCodeBootstrapEvidence(
+      committedResult.members[memberName] ?? params.result.members[memberName],
+      [...laneDiagnostics, buildMissingOpenCodeSessionRecordDiagnostic(memberName)]
+    );
+  }
   await ports
     .upsertOpenCodeRuntimeLaneIndexEntry({
       teamName: params.teamName,
@@ -599,4 +701,19 @@ export async function guardCommittedOpenCodeSecondaryLaneEvidence(
     members,
     diagnostics: Array.from(new Set([...committedResult.diagnostics, ...diagnostics])),
   };
+}
+
+export async function guardCommittedOpenCodeSecondaryLaneEvidence(
+  params: {
+    teamName: string;
+    laneId: string;
+    result: TeamRuntimeLaunchResult;
+    memberName: string;
+  },
+  ports: GuardCommittedOpenCodeSecondaryLaneEvidencePorts
+): Promise<TeamRuntimeLaunchResult> {
+  return await guardCommittedOpenCodeLaneEvidence(
+    { ...params, memberNames: [params.memberName] },
+    ports
+  );
 }

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateLaunchPersistence.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateLaunchPersistence.ts
@@ -132,6 +132,17 @@ export interface LaunchOpenCodeAggregatePrimaryLanePorts {
     state: 'disconnected' | 'failed';
     message: string;
   }): void;
+  /**
+   * The promotion gate every secondary lane already passes. Applied to the
+   * primary lane it is what stops a lead that claims `confirmed_alive` without a
+   * committed session record from being promoted at all.
+   */
+  guardCommittedOpenCodeLaneEvidence?(input: {
+    teamName: string;
+    laneId: string;
+    memberNames: readonly string[];
+    result: TeamRuntimeLaunchResult;
+  }): Promise<TeamRuntimeLaunchResult>;
   logWarning?(message: string): void;
   /** Durable sink for expected operational events, separate from failures. */
   logDiagnostic?(message: string): void;
@@ -237,8 +248,18 @@ export async function launchOpenCodeAggregatePrimaryLane(
       describeBlockedOpenCodePrimaryLaneLaunch({ teamName, runId, result: launchResult })
     );
   }
+  // The gate runs its own commit first, so the persist commit below is
+  // idempotent: the same id/member/run replaces the same session record.
+  const guardedLaunchResult = ports.guardCommittedOpenCodeLaneEvidence
+    ? await ports.guardCommittedOpenCodeLaneEvidence({
+        teamName,
+        laneId: 'primary',
+        memberNames: expectedMembers.map((member) => member.name),
+        result: launchResult,
+      })
+    : launchResult;
   const { snapshot, result } = await ports.persistOpenCodeRuntimeAdapterLaunchResult(
-    launchResult,
+    guardedLaunchResult,
     launchInput
   );
   params.assertStillCurrentAfterPersistence?.();

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateLaunchPersistence.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateLaunchPersistence.ts
@@ -6,6 +6,11 @@ import {
 } from '../TeamLaunchStateEvaluator';
 
 import {
+  buildUncommittableOpenCodeSessionDiagnostic,
+  describeBlockedOpenCodePrimaryLaneLaunch,
+  describeClearedOpenCodePrimaryLaneStorage,
+} from './TeamProvisioningOpenCodeBlockedLaunchReporting';
+import {
   commitOpenCodeRuntimeBootstrapSessionEvidence,
   hasCommittedOpenCodeRuntimeBootstrapSessionEvidence,
   type OpenCodeRuntimeBootstrapEvidencePorts,
@@ -46,6 +51,8 @@ export interface OpenCodeAggregatePrimaryLaneRun {
 export interface PersistOpenCodeRuntimeAdapterLaunchResultPorts {
   createOpenCodeRuntimeBootstrapEvidencePorts(): OpenCodeRuntimeBootstrapEvidencePorts;
   nowIso(): string;
+  /** Durable sink for members whose session evidence could not be committed. */
+  logDiagnostic?(message: string): void;
   writeLaunchStateSnapshot(
     teamName: string,
     snapshot: PersistedTeamLaunchSnapshot,
@@ -126,6 +133,8 @@ export interface LaunchOpenCodeAggregatePrimaryLanePorts {
     message: string;
   }): void;
   logWarning?(message: string): void;
+  /** Durable sink for expected operational events, separate from failures. */
+  logDiagnostic?(message: string): void;
 }
 
 function collectOpenCodeAggregateRuntimeMemberEvidence(
@@ -220,6 +229,14 @@ export async function launchOpenCodeAggregatePrimaryLane(
     previousLaunchState: params.previousLaunchState,
   };
   const launchResult = await params.adapter.launch(launchInput);
+  if (launchResult.teamLaunchState === 'partial_failure') {
+    // The single most important line in this flow: without it a primary lane
+    // that never reached session bootstrap produced zero output between app
+    // start and the first "No stored OpenCode session record" relay failure.
+    ports.logDiagnostic?.(
+      describeBlockedOpenCodePrimaryLaneLaunch({ teamName, runId, result: launchResult })
+    );
+  }
   const { snapshot, result } = await ports.persistOpenCodeRuntimeAdapterLaunchResult(
     launchResult,
     launchInput
@@ -307,6 +324,10 @@ export async function launchOpenCodeAggregatePrimaryLane(
         if (!cleared) {
           throw new Error('OpenCode primary lane did not confirm exact-runtime storage cleanup');
         }
+        // This is the operation that destroys the lane's session store, manifest
+        // and receipts. Only the failing catch below used to log, so a successful
+        // evidence wipe was completely silent.
+        ports.logDiagnostic?.(describeClearedOpenCodePrimaryLaneStorage({ teamName, runId }));
         ports.deleteRuntimeAdapterRunByTeamIfOwned?.(teamName, exactCleanupOwner);
       } catch (error) {
         ports.logWarning?.(
@@ -442,10 +463,12 @@ export async function commitOpenCodeRuntimeAdapterLaunchSessionEvidence(
   },
   ports: Pick<
     PersistOpenCodeRuntimeAdapterLaunchResultPorts,
-    'createOpenCodeRuntimeBootstrapEvidencePorts' | 'nowIso'
+    'createOpenCodeRuntimeBootstrapEvidencePorts' | 'nowIso' | 'logDiagnostic'
   >
 ): Promise<TeamRuntimeLaunchResult> {
   let changed = false;
+  let promoted = false;
+  const uncommittableDiagnostics: string[] = [];
   const members: Record<string, TeamRuntimeMemberLaunchEvidence> = { ...params.result.members };
   const bootstrapEvidencePorts = ports.createOpenCodeRuntimeBootstrapEvidencePorts();
   for (const [memberName, evidence] of Object.entries(params.result.members)) {
@@ -467,6 +490,27 @@ export async function commitOpenCodeRuntimeAdapterLaunchSessionEvidence(
       appManagedCandidate.laneId === params.laneId &&
       appManagedCandidate.runtimeSessionId === runtimeSessionId;
     if ((!confirmed && !appManagedCandidateMatches) || !runtimeSessionId) {
+      // A bare `continue` here is the silence in the incident: a lead that
+      // claimed confirmation but could not be committed produced no log line,
+      // no diagnostic and no downgrade, and the launch promoted anyway.
+      //
+      // Primary lane only. A secondary member that is `confirmed_alive` before
+      // its session id lands is an ordinary launch race the lane guard already
+      // covers; reporting it would add a line on every healthy launch.
+      if (params.laneId === 'primary' && (confirmed || appManagedCandidate)) {
+        const diagnostic = buildUncommittableOpenCodeSessionDiagnostic({
+          memberName,
+          reason: runtimeSessionId
+            ? 'app_managed_candidate_mismatch'
+            : 'missing_runtime_session_id',
+        });
+        members[memberName] = {
+          ...evidence,
+          diagnostics: appendDiagnosticOnce(evidence.diagnostics, diagnostic),
+        };
+        uncommittableDiagnostics.push(diagnostic);
+        ports.logDiagnostic?.(`[${params.teamName}] ${diagnostic} (lane=${params.laneId})`);
+      }
       continue;
     }
     // For app-managed bootstrap, promotion is intentionally two-phase:
@@ -507,10 +551,28 @@ export async function commitOpenCodeRuntimeAdapterLaunchSessionEvidence(
     if (appManagedCandidateMatches && verified && !confirmed) {
       members[memberName] = promoteCommittedOpenCodeAppManagedBootstrapEvidence(evidence);
       changed = true;
+      promoted = true;
     }
   }
-  if (!changed) {
+  if (!changed && uncommittableDiagnostics.length === 0) {
     return params.result;
+  }
+  const diagnostics = Array.from(
+    new Set([
+      ...params.result.diagnostics,
+      ...(promoted
+        ? [
+            'OpenCode app-managed bootstrap evidence was committed and read back before readiness promotion.',
+          ]
+        : []),
+      ...uncommittableDiagnostics,
+    ])
+  );
+  if (!changed) {
+    // Reporting only. Re-summarizing here would let a member-level annotation
+    // silently UPGRADE a partial_failure launch to clean_success; the promotion
+    // decision belongs to the lane evidence guard, which reads disk.
+    return { ...params.result, members, diagnostics };
   }
   const teamLaunchState = summarizeRuntimeLaunchResultMembers(members);
   return {
@@ -518,9 +580,6 @@ export async function commitOpenCodeRuntimeAdapterLaunchSessionEvidence(
     launchPhase: teamLaunchState === 'clean_success' ? 'finished' : params.result.launchPhase,
     teamLaunchState,
     members,
-    diagnostics: appendDiagnosticOnce(
-      params.result.diagnostics,
-      'OpenCode app-managed bootstrap evidence was committed and read back before readiness promotion.'
-    ),
+    diagnostics,
   };
 }

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateLaunchPromotion.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateLaunchPromotion.ts
@@ -1,0 +1,244 @@
+import { isLeadMember } from '@shared/utils/leadDetection';
+
+import { selectOpenCodeLaunchFailureDiagnostic } from './TeamProvisioningOpenCodeDiagnosticsPolicy';
+import {
+  hasOpenCodeRuntimeHandle,
+  hasRetainableOpenCodeRuntimeMember,
+} from './TeamProvisioningOpenCodeRuntimeEvidencePolicy';
+
+import type { TeamRuntimeLaunchResult } from '../runtime';
+import type { MixedSecondaryRuntimeLaneState } from './TeamProvisioningSecondaryRuntimeRuns';
+
+/**
+ * THE LEAD IS A VETO, NOT A VOTE.
+ *
+ * `summarizeOpenCodeAggregateLaunchState` treats the primary lane as one voice
+ * among many, and the retainability check only asked whether *some* lane still
+ * held a usable member. Two healthy side lanes were therefore enough to promote
+ * a team whose lead held no runtime session to `ready`, message "OpenCode team
+ * is running with unavailable members" - and then hand that lead the launch
+ * prompt. A team with no usable lead cannot function, so the lead's bootstrap
+ * state overrides the aggregate vote in both directions.
+ */
+export type OpenCodePrimaryLeadBootstrapState = 'confirmed' | 'pending' | 'failed';
+
+export function resolveOpenCodeAggregatePrimaryLeadName(
+  members: readonly { name: string }[]
+): string | null {
+  return members.find((member) => isLeadMember(member))?.name?.trim() || null;
+}
+
+export function findOpenCodePrimaryLeadEvidence(
+  result: TeamRuntimeLaunchResult | null,
+  leadName: string
+): TeamRuntimeLaunchResult['members'][string] | undefined {
+  if (!result) {
+    return undefined;
+  }
+  const normalizedLeadName = leadName.trim().toLowerCase();
+  return Object.entries(result.members).find(
+    ([name, evidence]) =>
+      (evidence.memberName?.trim() || name.trim()).toLowerCase() === normalizedLeadName
+  )?.[1];
+}
+
+export function buildOpenCodePrimaryLeadBootstrapFailureReason(leadName: string): string {
+  return `OpenCode team lead "${leadName}" has no committed runtime session on the primary lane`;
+}
+
+/**
+ * A lead the bridge parked on a permission prompt holds no pid and no session
+ * id yet, so `hasOpenCodeRuntimeHandle` alone reads it as a dead lead and tears
+ * the whole team down. It is a lead WAITING, not a lead that failed: every other
+ * retainability predicate in the codebase (`isRecoverableOpenCodeRuntimeEvidence`,
+ * `isRecoverablePersistedOpenCodeRuntimeCandidate`) counts it as live, and the
+ * user answering the prompt is what unblocks the lane.
+ */
+function isOpenCodePermissionBlockedLeadEvidence(
+  evidence: TeamRuntimeLaunchResult['members'][string]
+): boolean {
+  return (
+    (evidence.pendingPermissionRequestIds?.length ?? 0) > 0 ||
+    evidence.launchState === 'runtime_pending_permission' ||
+    evidence.livenessKind === 'permission_blocked'
+  );
+}
+
+/**
+ * `committedSessionEvidence` is the disk read the delivery path will repeat
+ * shortly afterwards. It may only ever DOWNGRADE: `false` is proof, while `null`
+ * (read failed, or no reader wired) must not defer a healthy launch's prompt on
+ * an I/O hiccup.
+ */
+export function classifyOpenCodePrimaryLeadBootstrap(input: {
+  leadName: string | null;
+  primaryResult: TeamRuntimeLaunchResult | null;
+  committedSessionEvidence?: boolean | null;
+}): OpenCodePrimaryLeadBootstrapState {
+  if (!input.leadName) {
+    // No lead on the primary lane: there is nothing for this gate to veto.
+    return 'confirmed';
+  }
+  const evidence = findOpenCodePrimaryLeadEvidence(input.primaryResult, input.leadName);
+  if (!evidence) {
+    // No entry for the lead at all is not this gate's failure shape:
+    // `normalizeExpectedOpenCodeRuntimeLaunchMembers` turns a genuinely missing
+    // expected member into `failed_to_start`, so an absent entry means the
+    // result never went through normalization. Inventing a veto here would
+    // fail launches whose primary lane simply reported a different member.
+    return 'confirmed';
+  }
+  if (evidence.launchState === 'failed_to_start' || evidence.hardFailure === true) {
+    return 'failed';
+  }
+  const claimsConfirmed =
+    evidence.launchState === 'confirmed_alive' ||
+    evidence.bootstrapConfirmed === true ||
+    evidence.livenessKind === 'confirmed_bootstrap';
+  if (claimsConfirmed && input.committedSessionEvidence !== false) {
+    return 'confirmed';
+  }
+  // Materialized but uncommitted is the grace case: the commit may still land,
+  // so the run stays active rather than failing the whole team.
+  return hasOpenCodeRuntimeHandle(evidence) || isOpenCodePermissionBlockedLeadEvidence(evidence)
+    ? 'pending'
+    : 'failed';
+}
+
+export function resolveOpenCodeAggregateLaunchStateForLeadBootstrap(
+  launchState: TeamRuntimeLaunchResult['teamLaunchState'],
+  leadBootstrap: OpenCodePrimaryLeadBootstrapState
+): TeamRuntimeLaunchResult['teamLaunchState'] {
+  if (leadBootstrap === 'failed') {
+    return 'partial_failure';
+  }
+  if (leadBootstrap === 'pending' && launchState === 'clean_success') {
+    return 'partial_pending';
+  }
+  return launchState;
+}
+
+const PRIMARY_LANE_DIAGNOSTIC_PREFIX = 'primary:';
+
+/**
+ * Primary-lane diagnostics were excluded from the progress tail entirely, which
+ * is why a primary lane could never contribute a launch-timing line to the
+ * runtime view even in a healthy run.
+ */
+export function collectOpenCodeAggregateLaneDiagnostics(input: {
+  primaryResult: TeamRuntimeLaunchResult | null;
+  lanes: readonly MixedSecondaryRuntimeLaneState[];
+}): string[] {
+  return [
+    ...(input.primaryResult?.diagnostics ?? []).map(
+      (diagnostic) => `${PRIMARY_LANE_DIAGNOSTIC_PREFIX} ${diagnostic}`
+    ),
+    ...input.lanes.flatMap((lane) => lane.diagnostics),
+  ];
+}
+
+export interface OpenCodeAggregateLaunchPromotion {
+  failed: boolean;
+  partialTeamCanContinue: boolean;
+  terminalFailure: boolean;
+  laneDiagnostics: string[];
+  terminalFailureError: string | null;
+}
+
+export function summarizeOpenCodeAggregateLaunchPromotion(input: {
+  launchState: TeamRuntimeLaunchResult['teamLaunchState'];
+  leadBootstrap: OpenCodePrimaryLeadBootstrapState;
+  leadName: string | null;
+  primaryResult: TeamRuntimeLaunchResult | null;
+  lanes: readonly MixedSecondaryRuntimeLaneState[];
+}): OpenCodeAggregateLaunchPromotion {
+  const failed = input.launchState === 'partial_failure' || input.leadBootstrap === 'failed';
+  const retainableResults = [input.primaryResult, ...input.lanes.map((lane) => lane.result)].filter(
+    (result): result is TeamRuntimeLaunchResult => result != null
+  );
+  const partialTeamCanContinue =
+    failed &&
+    input.leadBootstrap !== 'failed' &&
+    retainableResults.some((result) => hasRetainableOpenCodeRuntimeMember(result));
+  const laneDiagnostics = collectOpenCodeAggregateLaneDiagnostics({
+    primaryResult: input.primaryResult,
+    lanes: input.lanes,
+  });
+  const leadFailureReason =
+    input.leadBootstrap === 'failed' && input.leadName
+      ? buildOpenCodePrimaryLeadBootstrapFailureReason(input.leadName)
+      : null;
+  return {
+    failed,
+    partialTeamCanContinue,
+    terminalFailure: failed && !partialTeamCanContinue,
+    laneDiagnostics,
+    // The lead reason LEADS - it is prepended, never substituted, so the
+    // underlying diagnostic survives in the same failure artifact.
+    terminalFailureError:
+      [
+        leadFailureReason,
+        selectOpenCodeLaunchFailureDiagnostic([
+          ...retainableResults.flatMap((launchResult) => [
+            ...Object.values(launchResult.members).flatMap((member) => [
+              member.hardFailureReason,
+              member.runtimeDiagnostic,
+              ...member.diagnostics,
+            ]),
+            ...launchResult.diagnostics,
+          ]),
+          ...laneDiagnostics,
+        ]),
+      ]
+        .filter((part): part is string => Boolean(part))
+        .join(': ') || null,
+  };
+}
+
+export interface OpenCodeAggregatePrimaryLeadBootstrapPorts {
+  /**
+   * Fresh lane-storage read for the lead. Absent (or throwing) means "cannot
+   * disprove"; only an explicit `false` downgrades the classification.
+   */
+  hasCommittedOpenCodePrimaryLeadSessionEvidence?(input: {
+    teamName: string;
+    runId: string;
+    laneId: string;
+    memberName: string;
+  }): Promise<boolean>;
+}
+
+export interface OpenCodeAggregatePrimaryLeadBootstrapOutcome {
+  state: OpenCodePrimaryLeadBootstrapState;
+  leadName: string | null;
+}
+
+export async function resolveOpenCodeAggregatePrimaryLeadBootstrap(
+  params: {
+    teamName: string;
+    runId: string;
+    effectiveMembers: readonly { name: string }[];
+    primaryResult: TeamRuntimeLaunchResult | null;
+  },
+  ports: OpenCodeAggregatePrimaryLeadBootstrapPorts
+): Promise<OpenCodeAggregatePrimaryLeadBootstrapOutcome> {
+  const leadName = resolveOpenCodeAggregatePrimaryLeadName(params.effectiveMembers);
+  const committedSessionEvidence = leadName
+    ? ((await ports
+        .hasCommittedOpenCodePrimaryLeadSessionEvidence?.({
+          teamName: params.teamName,
+          runId: params.runId,
+          laneId: 'primary',
+          memberName: leadName,
+        })
+        .catch(() => null)) ?? null)
+    : null;
+  return {
+    state: classifyOpenCodePrimaryLeadBootstrap({
+      leadName,
+      primaryResult: params.primaryResult,
+      committedSessionEvidence,
+    }),
+    leadName,
+  };
+}

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateLaunchPromotion.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateLaunchPromotion.ts
@@ -81,12 +81,25 @@ export function classifyOpenCodePrimaryLeadBootstrap(input: {
   }
   const evidence = findOpenCodePrimaryLeadEvidence(input.primaryResult, input.leadName);
   if (!evidence) {
-    // No entry for the lead at all is not this gate's failure shape:
+    // An absent lead is not proof of a healthy one.
+    //
+    // This used to answer `'confirmed'`, on the grounds that
     // `normalizeExpectedOpenCodeRuntimeLaunchMembers` turns a genuinely missing
-    // expected member into `failed_to_start`, so an absent entry means the
-    // result never went through normalization. Inventing a veto here would
-    // fail launches whose primary lane simply reported a different member.
-    return 'confirmed';
+    // expected member into `failed_to_start`, so an absent entry could only mean
+    // an unnormalized result. That function is not called anywhere in production
+    // code, so the premise never held: an absent entry was the ordinary case,
+    // and this gate waved through exactly the launches it exists to stop.
+    //
+    // It is still not a veto. A primary lane that reported a different member
+    // than the one this app calls the lead is a naming mismatch, not a dead
+    // team, and failing there would take down launches that work. `'pending'`
+    // is the honest answer: the team is not ready, and the bootstrap check-in
+    // path is given its chance to land the evidence.
+    //
+    // Disk evidence still outranks the absence, for the same reason it may only
+    // ever downgrade elsewhere: a lane that already committed a lead session is
+    // confirmed no matter what this particular result carried.
+    return input.committedSessionEvidence === true ? 'confirmed' : 'pending';
   }
   if (evidence.launchState === 'failed_to_start' || evidence.hardFailure === true) {
     return 'failed';

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateLaunchPromotion.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateLaunchPromotion.ts
@@ -22,10 +22,27 @@ import type { MixedSecondaryRuntimeLaneState } from './TeamProvisioningSecondary
  */
 export type OpenCodePrimaryLeadBootstrapState = 'confirmed' | 'pending' | 'failed';
 
+/**
+ * The lead this gate is entitled to judge: the one that runs ON this lane.
+ *
+ * A team can have a lead on another runtime - a Cursor lead beside OpenCode side
+ * lanes is an ordinary, working shape - and such a lead is absent from an
+ * OpenCode launch result for a completely legitimate reason. Vetoing on it would
+ * hold back a launch that is fine, so a lead with an explicit non-OpenCode
+ * provider is not this gate's business. A member with no provider recorded takes
+ * the lane's own runtime, which is the historical default and stays included.
+ */
 export function resolveOpenCodeAggregatePrimaryLeadName(
-  members: readonly { name: string }[]
+  members: readonly { name: string; providerId?: string }[]
 ): string | null {
-  return members.find((member) => isLeadMember(member))?.name?.trim() || null;
+  return (
+    members
+      .find(
+        (member) =>
+          isLeadMember(member) && (member.providerId ?? 'opencode') === 'opencode'
+      )
+      ?.name?.trim() || null
+  );
 }
 
 export function findOpenCodePrimaryLeadEvidence(
@@ -96,10 +113,14 @@ export function classifyOpenCodePrimaryLeadBootstrap(input: {
     // is the honest answer: the team is not ready, and the bootstrap check-in
     // path is given its chance to land the evidence.
     //
-    // Disk evidence still outranks the absence, for the same reason it may only
-    // ever downgrade elsewhere: a lane that already committed a lead session is
-    // confirmed no matter what this particular result carried.
-    return input.committedSessionEvidence === true ? 'confirmed' : 'pending';
+    // Only a NEGATIVE disk read downgrades, exactly as everywhere else in this
+    // function: `false` is proof that no lead session was committed, while
+    // `null` means the read failed or no reader is wired, and an absence of
+    // evidence may not hold back a launch on its own. Downgrading on `null` also
+    // fails the legitimate shape where the lead does not belong to this lane at
+    // all - a Cursor lead beside OpenCode side lanes - which is a launch that
+    // works today.
+    return input.committedSessionEvidence === false ? 'pending' : 'confirmed';
   }
   if (evidence.launchState === 'failed_to_start' || evidence.hardFailure === true) {
     return 'failed';

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryFacade.ts
@@ -5,7 +5,6 @@ import { createLogger } from '@shared/utils/logger';
 import { type TeamLaunchStateStore } from '../TeamLaunchStateStore';
 
 import {
-  type OpenCodeAggregatePrimaryLaneStopPorts,
   stopFailedOpenCodeAggregatePrimaryRelaunchCandidate as stopFailedOpenCodeAggregatePrimaryRelaunchCandidateHelper,
   stopUnretainableOpenCodePrimaryLane as stopUnretainableOpenCodePrimaryLaneHelper,
 } from './OpenCodeAggregatePrimaryLaneStopHelpers';
@@ -25,6 +24,10 @@ import {
   type LiveRosterAttachReason,
   type ProvisioningRun as MemberLifecycleProvisioningRun,
 } from './TeamProvisioningMemberLifecycleTypes';
+import {
+  createOpenCodeAggregatePrimaryLaneStopPorts,
+  type OpenCodeAggregatePrimaryLaneWiringHost,
+} from './TeamProvisioningOpenCodeAggregatePrimaryLaneWiring';
 import {
   hasRetainableOpenCodeRuntimeMember,
   isRecoverableOpenCodeRuntimeEvidence,
@@ -48,7 +51,7 @@ const logger = createLogger('Service:TeamProvisioning');
 
 /** Owns serialized lifecycle and aggregate-primary restart orchestration. */
 export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends TeamProvisioningServiceMemberLifecycleFacade {
-  private readonly aggregatePrimaryProgress = new OpenCodeAggregatePrimaryProgressPublisher({
+  private readonly aggregatePrimaryLaneHost: OpenCodeAggregatePrimaryLaneWiringHost = {
     usesRetainedProgressState: () =>
       Boolean(this.compatibilityDelegation?.retainedProvisioningProgressState),
     setRuntimeAdapterProgress: (progress, onProgress) =>
@@ -58,7 +61,22 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
     rememberProgress: (progress) =>
       this.runtimeAdapterProgressByRunId.set(progress.runId, progress),
     invalidateRuntimeSnapshotCaches: (teamName) => this.invalidateRuntimeSnapshotCaches(teamName),
-  });
+    getRuntimeOwner: (teamName) => this.runtimeAdapterRunByTeam.get(teamName),
+    setRuntimeOwner: (teamName, owner) => {
+      this.runtimeAdapterRunByTeam.set(teamName, owner);
+    },
+    deleteRuntimeOwner: (teamName) => {
+      this.runtimeAdapterRunByTeam.delete(teamName);
+    },
+    getOpenCodeRuntimeLaunchCwd: (baseCwd, members) =>
+      this.prepareFacade.getOpenCodeRuntimeLaunchCwd(baseCwd, members),
+    logWarn: (message) => logger.warn(message),
+  };
+
+  private readonly aggregatePrimaryProgress = new OpenCodeAggregatePrimaryProgressPublisher(
+    this.aggregatePrimaryLaneHost
+  );
+
   private runAfterInFlightTeamOperation<T>(
     teamName: string,
     operation: () => Promise<T>
@@ -480,7 +498,11 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
   }): Promise<void> {
     return stopUnretainableOpenCodePrimaryLaneHelper(
       input,
-      this.createAggregatePrimaryLaneStopPorts(input.run)
+      createOpenCodeAggregatePrimaryLaneStopPorts(
+        this.aggregatePrimaryLaneHost,
+        this.aggregatePrimaryProgress,
+        input.run
+      )
     );
   }
 
@@ -492,28 +514,12 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
   }): Promise<void> {
     return stopFailedOpenCodeAggregatePrimaryRelaunchCandidateHelper(
       input,
-      this.createAggregatePrimaryLaneStopPorts(input.run)
+      createOpenCodeAggregatePrimaryLaneStopPorts(
+        this.aggregatePrimaryLaneHost,
+        this.aggregatePrimaryProgress,
+        input.run
+      )
     );
-  }
-
-  private createAggregatePrimaryLaneStopPorts(
-    run: ProvisioningRun
-  ): OpenCodeAggregatePrimaryLaneStopPorts {
-    return {
-      getRuntimeOwner: (teamName) => this.runtimeAdapterRunByTeam.get(teamName),
-      setRuntimeOwner: (teamName, owner) => {
-        this.runtimeAdapterRunByTeam.set(teamName, owner);
-      },
-      deleteRuntimeOwner: (teamName) => {
-        this.runtimeAdapterRunByTeam.delete(teamName);
-      },
-      getOpenCodeRuntimeLaunchCwd: (baseCwd, members) =>
-        this.prepareFacade.getOpenCodeRuntimeLaunchCwd(baseCwd, members),
-      publishPending: (message) => this.aggregatePrimaryProgress.publishPending(run, message),
-      publishFailed: (message, error) =>
-        this.aggregatePrimaryProgress.publishFailed(run, message, error),
-      logWarn: (message) => logger.warn(message),
-    };
   }
 
   override async attachLiveRosterMember(

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryFacade.ts
@@ -4,9 +4,13 @@ import { createLogger } from '@shared/utils/logger';
 
 import { type TeamLaunchStateStore } from '../TeamLaunchStateStore';
 
+import {
+  type OpenCodeAggregatePrimaryLaneStopPorts,
+  stopFailedOpenCodeAggregatePrimaryRelaunchCandidate as stopFailedOpenCodeAggregatePrimaryRelaunchCandidateHelper,
+  stopUnretainableOpenCodePrimaryLane as stopUnretainableOpenCodePrimaryLaneHelper,
+} from './OpenCodeAggregatePrimaryLaneStopHelpers';
 import { OpenCodeAggregatePrimaryProgressPublisher } from './OpenCodeAggregatePrimaryProgressPublisher';
 import {
-  assertAggregatePrimaryStopConfirmed,
   beginAggregatePrimaryRestart,
   clearCancelledAggregateRestartState,
   clearPersistedAggregateLaunchStateIfOwned,
@@ -51,7 +55,8 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
       this.runtimeAdapterProgressState.setRuntimeAdapterProgress(progress, onProgress),
     enrichRuntimeAdapterProgressTrace: (progress) =>
       this.runtimeAdapterProgressState.enrichRuntimeAdapterProgressTrace(progress),
-    rememberProgress: (progress) => this.runtimeAdapterProgressByRunId.set(progress.runId, progress),
+    rememberProgress: (progress) =>
+      this.runtimeAdapterProgressByRunId.set(progress.runId, progress),
     invalidateRuntimeSnapshotCaches: (teamName) => this.invalidateRuntimeSnapshotCaches(teamName),
   });
   private runAfterInFlightTeamOperation<T>(
@@ -152,7 +157,8 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
       lastWrittenRunIds: this.launchStateWrittenRunIdByTeam,
       restarts: this.openCodeAggregatePrimaryRestartByTeam,
       launchStateStore: this.launchStateStore,
-      withLaunchStateLock: (operation) => this.enqueueLaunchStateStoreOperation(teamName, operation),
+      withLaunchStateLock: (operation) =>
+        this.enqueueLaunchStateStoreOperation(teamName, operation),
       invalidateRuntimeSnapshotCaches: (candidateTeamName) =>
         this.invalidateRuntimeSnapshotCaches(candidateTeamName),
     });
@@ -466,130 +472,48 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
     }
   }
 
-  private async stopUnretainableOpenCodePrimaryLane(input: {
+  private stopUnretainableOpenCodePrimaryLane(input: {
     adapter: TeamLaunchRuntimeAdapter;
     run: ProvisioningRun;
     previousEffectiveMembers: TeamCreateRequest['members'];
     previousLaunchState: Awaited<ReturnType<TeamLaunchStateStore['read']>>;
   }): Promise<void> {
-    const cwd = this.prepareFacade.getOpenCodeRuntimeLaunchCwd(
-      input.run.request.cwd,
-      input.previousEffectiveMembers
+    return stopUnretainableOpenCodePrimaryLaneHelper(
+      input,
+      this.createAggregatePrimaryLaneStopPorts(input.run)
     );
-    const currentOwner = this.runtimeAdapterRunByTeam.get(input.run.teamName);
-    const exactStopOwner = currentOwner ?? {
-      runId: input.run.runId,
-      providerId: 'opencode' as const,
-      cwd,
-      ...(input.run.request.allowExperimentalLocalModels === true
-        ? { allowExperimentalLocalModels: true }
-        : {}),
-    };
-    if (!currentOwner) {
-      this.runtimeAdapterRunByTeam.set(input.run.teamName, exactStopOwner);
-    }
-    this.aggregatePrimaryProgress.publishPending(
-      input.run,
-      'Stopping unretainable OpenCode primary lane'
-    );
-    try {
-      const stopResult = await input.adapter.stop({
-        runId: input.run.runId,
-        laneId: 'primary',
-        teamName: input.run.teamName,
-        cwd,
-        providerId: 'opencode',
-        reason: 'cleanup',
-        previousLaunchState: input.previousLaunchState,
-        force: true,
-      });
-      assertAggregatePrimaryStopConfirmed(stopResult);
-      if (this.runtimeAdapterRunByTeam.get(input.run.teamName) !== exactStopOwner) {
-        throw getCancelledAggregateLaunchError(input.run.teamName);
-      }
-    } catch (error) {
-      if (this.runtimeAdapterRunByTeam.get(input.run.teamName) === exactStopOwner) {
-        this.aggregatePrimaryProgress.publishFailed(
-          input.run,
-          'Unretainable OpenCode primary lane cleanup failed',
-          error
-        );
-      }
-      logger.warn(
-        `[${input.run.teamName}] Failed to stop unretainable OpenCode primary lane: ${getErrorMessage(error)}`
-      );
-      throw error;
-    }
   }
 
-  private async stopFailedOpenCodeAggregatePrimaryRelaunchCandidate(input: {
+  private stopFailedOpenCodeAggregatePrimaryRelaunchCandidate(input: {
     adapter: TeamLaunchRuntimeAdapter;
     run: ProvisioningRun;
     previousLaunchState: Awaited<ReturnType<TeamLaunchStateStore['read']>>;
-    previousOwner:
-      | {
-          runId: string;
-          providerId: string;
-          cwd?: string;
-        }
-      | undefined;
+    previousOwner: { runId: string; providerId: string; cwd?: string } | undefined;
   }): Promise<void> {
-    const currentOwner = this.runtimeAdapterRunByTeam.get(input.run.teamName);
-    if (
-      currentOwner &&
-      (currentOwner === input.previousOwner ||
-        currentOwner.providerId !== 'opencode' ||
-        currentOwner.runId !== input.run.runId)
-    ) {
-      throw getCancelledAggregateLaunchError(input.run.teamName);
-    }
-    const cwd =
-      currentOwner?.cwd ??
-      this.prepareFacade.getOpenCodeRuntimeLaunchCwd(
-        input.run.request.cwd,
-        input.run.effectiveMembers
-      );
-    const expectedOwner = currentOwner ?? {
-      runId: input.run.runId,
-      providerId: 'opencode' as const,
-      cwd,
-      ...(input.run.request.allowExperimentalLocalModels === true
-        ? { allowExperimentalLocalModels: true }
-        : {}),
-    };
-    if (!currentOwner) {
-      this.runtimeAdapterRunByTeam.set(input.run.teamName, expectedOwner);
-    }
-    this.aggregatePrimaryProgress.publishPending(
-      input.run,
-      'Stopping failed OpenCode primary relaunch candidate'
+    return stopFailedOpenCodeAggregatePrimaryRelaunchCandidateHelper(
+      input,
+      this.createAggregatePrimaryLaneStopPorts(input.run)
     );
-    try {
-      const stopResult = await input.adapter.stop({
-        runId: input.run.runId,
-        laneId: 'primary',
-        teamName: input.run.teamName,
-        cwd,
-        providerId: 'opencode',
-        reason: 'cleanup',
-        previousLaunchState: input.previousLaunchState,
-        force: true,
-      });
-      assertAggregatePrimaryStopConfirmed(stopResult);
-      if (this.runtimeAdapterRunByTeam.get(input.run.teamName) !== expectedOwner) {
-        throw getCancelledAggregateLaunchError(input.run.teamName);
-      }
-      this.runtimeAdapterRunByTeam.delete(input.run.teamName);
-    } catch (error) {
-      if (this.runtimeAdapterRunByTeam.get(input.run.teamName) === expectedOwner) {
-        this.aggregatePrimaryProgress.publishFailed(
-          input.run,
-          'Failed OpenCode primary relaunch candidate cleanup failed',
-          error
-        );
-      }
-      throw error;
-    }
+  }
+
+  private createAggregatePrimaryLaneStopPorts(
+    run: ProvisioningRun
+  ): OpenCodeAggregatePrimaryLaneStopPorts {
+    return {
+      getRuntimeOwner: (teamName) => this.runtimeAdapterRunByTeam.get(teamName),
+      setRuntimeOwner: (teamName, owner) => {
+        this.runtimeAdapterRunByTeam.set(teamName, owner);
+      },
+      deleteRuntimeOwner: (teamName) => {
+        this.runtimeAdapterRunByTeam.delete(teamName);
+      },
+      getOpenCodeRuntimeLaunchCwd: (baseCwd, members) =>
+        this.prepareFacade.getOpenCodeRuntimeLaunchCwd(baseCwd, members),
+      publishPending: (message) => this.aggregatePrimaryProgress.publishPending(run, message),
+      publishFailed: (message, error) =>
+        this.aggregatePrimaryProgress.publishFailed(run, message, error),
+      logWarn: (message) => logger.warn(message),
+    };
   }
 
   override async attachLiveRosterMember(

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryLanePortsFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryLanePortsFactory.ts
@@ -39,6 +39,7 @@ export interface TeamProvisioningOpenCodeAggregatePrimaryLanePortsFactoryDeps {
   upsertOpenCodeRuntimeLaneIndexEntry?: LaunchOpenCodeAggregatePrimaryLanePorts['upsertOpenCodeRuntimeLaneIndexEntry'];
   setOpenCodeRuntimeActiveRunManifest?: LaunchOpenCodeAggregatePrimaryLanePorts['setOpenCodeRuntimeActiveRunManifest'];
   clearOpenCodeRuntimeLaneStorage?: LaunchOpenCodeAggregatePrimaryLanePorts['clearOpenCodeRuntimeLaneStorage'];
+  guardCommittedOpenCodeLaneEvidence?: LaunchOpenCodeAggregatePrimaryLanePorts['guardCommittedOpenCodeLaneEvidence'];
   logWarning?: LaunchOpenCodeAggregatePrimaryLanePorts['logWarning'];
   logDiagnostic?: LaunchOpenCodeAggregatePrimaryLanePorts['logDiagnostic'];
 }
@@ -91,6 +92,9 @@ export function createTeamProvisioningOpenCodeAggregatePrimaryLanePortsFromServi
       });
       service.invalidateRuntimeSnapshotCaches(input.teamName);
     },
+    ...(deps.guardCommittedOpenCodeLaneEvidence
+      ? { guardCommittedOpenCodeLaneEvidence: deps.guardCommittedOpenCodeLaneEvidence }
+      : {}),
     logWarning: deps.logWarning ?? ((message) => logger.warn(message)),
     logDiagnostic: deps.logDiagnostic ?? ((message) => logger.diagnostic(message)),
   };

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryLanePortsFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryLanePortsFactory.ts
@@ -40,6 +40,7 @@ export interface TeamProvisioningOpenCodeAggregatePrimaryLanePortsFactoryDeps {
   setOpenCodeRuntimeActiveRunManifest?: LaunchOpenCodeAggregatePrimaryLanePorts['setOpenCodeRuntimeActiveRunManifest'];
   clearOpenCodeRuntimeLaneStorage?: LaunchOpenCodeAggregatePrimaryLanePorts['clearOpenCodeRuntimeLaneStorage'];
   logWarning?: LaunchOpenCodeAggregatePrimaryLanePorts['logWarning'];
+  logDiagnostic?: LaunchOpenCodeAggregatePrimaryLanePorts['logDiagnostic'];
 }
 
 export function createTeamProvisioningOpenCodeAggregatePrimaryLanePortsFromService(
@@ -91,5 +92,6 @@ export function createTeamProvisioningOpenCodeAggregatePrimaryLanePortsFromServi
       service.invalidateRuntimeSnapshotCaches(input.teamName);
     },
     logWarning: deps.logWarning ?? ((message) => logger.warn(message)),
+    logDiagnostic: deps.logDiagnostic ?? ((message) => logger.diagnostic(message)),
   };
 }

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryLaneWiring.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryLaneWiring.ts
@@ -1,0 +1,43 @@
+import type { OpenCodeAggregatePrimaryLaneStopPorts } from './OpenCodeAggregatePrimaryLaneStopHelpers';
+import type {
+  OpenCodeAggregatePrimaryProgressPublisher,
+  OpenCodeAggregatePrimaryProgressPublisherPorts,
+} from './OpenCodeAggregatePrimaryProgressPublisher';
+import type { ProvisioningRun } from './TeamProvisioningRunModel';
+import type { RuntimeAdapterRunByTeamEntry } from './TeamProvisioningServiceComposition';
+import type { TeamCreateRequest } from '@shared/types';
+
+/**
+ * The facade state the aggregate primary lane's helpers are allowed to reach.
+ * Declared once, in one place, so every helper the primary lane grows is wired
+ * through the same named accessors instead of another ad-hoc closure literal
+ * inside an already large facade.
+ */
+export interface OpenCodeAggregatePrimaryLaneWiringHost extends OpenCodeAggregatePrimaryProgressPublisherPorts {
+  getRuntimeOwner(teamName: string): RuntimeAdapterRunByTeamEntry | undefined;
+  setRuntimeOwner(teamName: string, owner: RuntimeAdapterRunByTeamEntry): void;
+  deleteRuntimeOwner(teamName: string): void;
+  getOpenCodeRuntimeLaunchCwd(baseCwd: string, members: TeamCreateRequest['members']): string;
+  logWarn(message: string): void;
+}
+
+/**
+ * Progress is published against one run, so the run is bound here rather than
+ * threaded through every stop helper signature.
+ */
+export function createOpenCodeAggregatePrimaryLaneStopPorts(
+  host: OpenCodeAggregatePrimaryLaneWiringHost,
+  progress: OpenCodeAggregatePrimaryProgressPublisher,
+  run: ProvisioningRun
+): OpenCodeAggregatePrimaryLaneStopPorts {
+  return {
+    getRuntimeOwner: (teamName) => host.getRuntimeOwner(teamName),
+    setRuntimeOwner: (teamName, owner) => host.setRuntimeOwner(teamName, owner),
+    deleteRuntimeOwner: (teamName) => host.deleteRuntimeOwner(teamName),
+    getOpenCodeRuntimeLaunchCwd: (baseCwd, members) =>
+      host.getOpenCodeRuntimeLaunchCwd(baseCwd, members),
+    publishPending: (message) => progress.publishPending(run, message),
+    publishFailed: (message, error) => progress.publishFailed(run, message, error),
+    logWarn: (message) => host.logWarn(message),
+  };
+}

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateRun.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateRun.ts
@@ -24,6 +24,10 @@ import {
 } from './TeamProvisioningOpenCodeAggregateRunRollback';
 import { markOpenCodeLaneBlockedBySharedRuntimeFailure } from './TeamProvisioningOpenCodeBlockedLanePolicy';
 import {
+  describeDeferredOpenCodeLaunchPrompt,
+  describeUnavailableOpenCodeLaunchPromptLead,
+} from './TeamProvisioningOpenCodeBlockedLaunchReporting';
+import {
   takeBlockingOpenCodeSharedRuntimeFailure,
   trackOpenCodeSharedRuntimeFailureFromResult,
 } from './TeamProvisioningOpenCodeSharedRuntimeFailurePolicy';
@@ -31,6 +35,20 @@ import {
 import type { TeamLaunchResponse, TeamProvisioningProgress } from '@shared/types';
 
 export * from './TeamProvisioningOpenCodeAggregateRunModel';
+
+/**
+ * One report reaches two places on purpose: the durable sink, so the line
+ * survives a restart, and the launch diagnostics, so the same text is in the
+ * progress tail the user can already see.
+ */
+function report(
+  message: string,
+  diagnostics: string[],
+  ports: Pick<OpenCodeWorktreeRootAggregateLaunchPorts, 'logDiagnostic'>
+): void {
+  diagnostics.push(message);
+  ports.logDiagnostic?.(message);
+}
 
 export async function prepareOpenCodeWorktreeRootAggregateLaunchPreflight(
   input: {
@@ -314,21 +332,42 @@ export async function runOpenCodeWorktreeRootAggregateLaunch(
     // to the lead's inbox before the run reports its final progress, so a
     // refused inbox is visible in the same place as every other lane diagnostic.
     if (!terminalFailure && promptDelivery.leadInboxPrompt !== null) {
-      await queueLaunchPromptToLeadInbox(
-        {
-          teamName,
-          leadName: resolveOpenCodeAggregateLaunchPromptLeadName(run.effectiveMembers),
-          prompt: promptDelivery.leadInboxPrompt,
-          diagnostics: laneDiagnostics,
-          isLaunchStillCurrent: () => !aggregateLaunchNoLongerCurrent(),
-        },
-        ports
-      );
-      // Waiting for the lead inbox is an await like any other: a stop or a
-      // successor launch can take the team while it runs, and its state must
-      // not be published over the run that replaced this one.
-      if (aggregateLaunchNoLongerCurrent()) {
-        return await finishCancelledAggregateLaunch();
+      const leadName = resolveOpenCodeAggregateLaunchPromptLeadName(run.effectiveMembers);
+      const unavailableLead = describeUnavailableOpenCodeLaunchPromptLead({
+        teamName,
+        leadName,
+        primaryResult,
+      });
+      if (unavailableLead) {
+        // Queueing here would burn the prompt on a session that does not exist.
+        // Nothing is awaited on this path, so the launch cannot have been taken
+        // since the currency check above and no second check is needed.
+        report(unavailableLead, laneDiagnostics, ports);
+      } else {
+        await queueLaunchPromptToLeadInbox(
+          {
+            teamName,
+            leadName,
+            prompt: promptDelivery.leadInboxPrompt,
+            diagnostics: laneDiagnostics,
+            isLaunchStillCurrent: () => !aggregateLaunchNoLongerCurrent(),
+          },
+          ports
+        );
+        // Waiting for the lead inbox is an await like any other: a stop or a
+        // successor launch can take the team while it runs, and its state must
+        // not be published over the run that replaced this one.
+        if (aggregateLaunchNoLongerCurrent()) {
+          return await finishCancelledAggregateLaunch();
+        }
+        if (leadBootstrap === 'pending') {
+          // Only the bridge dispatch waits; the prompt is already in the inbox.
+          report(
+            describeDeferredOpenCodeLaunchPrompt({ teamName, leadName }),
+            laneDiagnostics,
+            ports
+          );
+        }
       }
     }
     const finalProgress = ports.setRuntimeAdapterProgress(

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateRun.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateRun.ts
@@ -1,6 +1,11 @@
 import * as path from 'path';
 
 import {
+  resolveOpenCodeAggregateLaunchStateForLeadBootstrap,
+  resolveOpenCodeAggregatePrimaryLeadBootstrap,
+  summarizeOpenCodeAggregateLaunchPromotion,
+} from './TeamProvisioningOpenCodeAggregateLaunchPromotion';
+import {
   queueLaunchPromptToLeadInbox,
   resolveOpenCodeAggregateLaunchPromptDelivery,
   resolveOpenCodeAggregateLaunchPromptLeadName,
@@ -18,14 +23,11 @@ import {
   stopAndRollbackOpenCodeAggregateRuntimeLanes,
 } from './TeamProvisioningOpenCodeAggregateRunRollback';
 import { markOpenCodeLaneBlockedBySharedRuntimeFailure } from './TeamProvisioningOpenCodeBlockedLanePolicy';
-import { selectOpenCodeLaunchFailureDiagnostic } from './TeamProvisioningOpenCodeDiagnosticsPolicy';
-import { hasRetainableOpenCodeRuntimeMember } from './TeamProvisioningOpenCodeRuntimeEvidencePolicy';
 import {
   takeBlockingOpenCodeSharedRuntimeFailure,
   trackOpenCodeSharedRuntimeFailureFromResult,
 } from './TeamProvisioningOpenCodeSharedRuntimeFailurePolicy';
 
-import type { TeamRuntimeLaunchResult } from '../runtime';
 import type { TeamLaunchResponse, TeamProvisioningProgress } from '@shared/types';
 
 export * from './TeamProvisioningOpenCodeAggregateRunModel';
@@ -274,10 +276,23 @@ export async function runOpenCodeWorktreeRootAggregateLaunch(
     }
 
     run.provisioningComplete = true;
-    const launchState = ports.summarizeOpenCodeAggregateLaunchState({
-      primaryResult,
-      lanes: run.mixedSecondaryLanes,
-    });
+    // The lead's own bootstrap is resolved BEFORE the aggregate state is
+    // summarized, because it can only ever override that summary.
+    const leadBootstrapOutcome = await resolveOpenCodeAggregatePrimaryLeadBootstrap(
+      { teamName, runId, effectiveMembers: run.effectiveMembers, primaryResult },
+      ports
+    );
+    if (aggregateLaunchNoLongerCurrent()) {
+      return await finishCancelledAggregateLaunch();
+    }
+    const leadBootstrap = leadBootstrapOutcome.state;
+    const launchState = resolveOpenCodeAggregateLaunchStateForLeadBootstrap(
+      ports.summarizeOpenCodeAggregateLaunchState({
+        primaryResult,
+        lanes: run.mixedSecondaryLanes,
+      }),
+      leadBootstrap
+    );
     const launchPhase = launchState === 'partial_pending' ? 'active' : 'finished';
     const snapshot = await ports.persistLaunchStateSnapshot(run, launchPhase);
     if (snapshot) {
@@ -287,26 +302,14 @@ export async function runOpenCodeWorktreeRootAggregateLaunch(
       return await finishCancelledAggregateLaunch();
     }
 
-    const failed = launchState === 'partial_failure';
-    const retainableResults = [
+    const promotion = summarizeOpenCodeAggregateLaunchPromotion({
+      launchState,
+      leadBootstrap,
+      leadName: leadBootstrapOutcome.leadName,
       primaryResult,
-      ...run.mixedSecondaryLanes.map((lane) => lane.result),
-    ].filter((result): result is TeamRuntimeLaunchResult => result !== null);
-    const partialTeamCanContinue =
-      failed && retainableResults.some((result) => hasRetainableOpenCodeRuntimeMember(result));
-    const terminalFailure = failed && !partialTeamCanContinue;
-    const laneDiagnostics = run.mixedSecondaryLanes.flatMap((lane) => lane.diagnostics);
-    const terminalFailureError = selectOpenCodeLaunchFailureDiagnostic([
-      ...retainableResults.flatMap((launchResult) => [
-        ...Object.values(launchResult.members).flatMap((member) => [
-          member.hardFailureReason,
-          member.runtimeDiagnostic,
-          ...member.diagnostics,
-        ]),
-        ...launchResult.diagnostics,
-      ]),
-      ...laneDiagnostics,
-    ]);
+      lanes: run.mixedSecondaryLanes,
+    });
+    const { laneDiagnostics, terminalFailure } = promotion;
     // The lanes are ready and this launch owns the team: hand the launch prompt
     // to the lead's inbox before the run reports its final progress, so a
     // refused inbox is visible in the same place as every other lane diagnostic.
@@ -332,10 +335,11 @@ export async function runOpenCodeWorktreeRootAggregateLaunch(
       buildOpenCodeAggregateFinalProgress({
         launching,
         launchState,
+        leadBootstrap,
         laneDiagnostics,
         updatedAt: ports.nowIso(),
-        partialTeamCanContinue,
-        terminalFailureError,
+        partialTeamCanContinue: promotion.partialTeamCanContinue,
+        terminalFailureError: promotion.terminalFailureError,
       }),
       input.onProgress
     );

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateRunModel.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateRunModel.ts
@@ -1,5 +1,9 @@
 import { type TeamRuntimeLanePlan } from '@features/team-runtime-lanes';
 
+import {
+  type OpenCodeAggregatePrimaryLeadBootstrapPorts,
+  type OpenCodePrimaryLeadBootstrapState,
+} from './TeamProvisioningOpenCodeAggregateLaunchPromotion';
 import { type ProvisioningRun } from './TeamProvisioningRunModel';
 import { getTeamsBasePathsToProbe } from './TeamProvisioningRuntimeLaunchSelection';
 import {
@@ -170,7 +174,10 @@ export interface OpenCodeWorktreeRootAggregateLaunchPreflightPorts {
   ): TeamLaunchResponse;
 }
 
-export interface OpenCodeWorktreeRootAggregateLaunchPorts extends OpenCodeWorktreeRootAggregateLaunchPreflightPorts {
+export interface OpenCodeWorktreeRootAggregateLaunchPorts
+  extends
+    OpenCodeWorktreeRootAggregateLaunchPreflightPorts,
+    OpenCodeAggregatePrimaryLeadBootstrapPorts {
   randomUUID(): string;
   nowMs(): number;
   nowIso(): string;
@@ -262,38 +269,60 @@ export interface RunOpenCodeWorktreeRootAggregateLaunchInput {
 export interface OpenCodeAggregateFinalProgressInput {
   launching: TeamProvisioningProgress;
   launchState: TeamRuntimeLaunchResult['teamLaunchState'];
+  /**
+   * The lead's veto. A team whose lead cannot receive a single message is never
+   * "running with unavailable members" and is never a ready config.
+   */
+  leadBootstrap?: OpenCodePrimaryLeadBootstrapState;
   laneDiagnostics: readonly string[];
   updatedAt: string;
   partialTeamCanContinue?: boolean;
   terminalFailureError?: string | null;
 }
 
+function buildOpenCodeAggregateFinalMessage(input: OpenCodeAggregateFinalProgressInput): string {
+  if (input.leadBootstrap === 'failed') {
+    return 'OpenCode lead bootstrap failed; the team has no usable lead';
+  }
+  if (input.leadBootstrap === 'pending') {
+    return 'OpenCode lead is waiting for its runtime bootstrap evidence';
+  }
+  if (input.launchState === 'clean_success') {
+    return 'OpenCode member lanes are ready';
+  }
+  if (input.launchState === 'partial_pending') {
+    return 'OpenCode member lanes are waiting for runtime evidence or permissions';
+  }
+  return input.partialTeamCanContinue
+    ? 'OpenCode team is running with unavailable members'
+    : 'OpenCode member lane launch failed readiness gate';
+}
+
 export function buildOpenCodeAggregateFinalProgress(
   input: OpenCodeAggregateFinalProgressInput
 ): TeamProvisioningProgress {
-  const success = input.launchState === 'clean_success';
   const pending = input.launchState === 'partial_pending';
   const failed = input.launchState === 'partial_failure';
   const terminalFailure = failed && input.partialTeamCanContinue !== true;
   return {
     ...input.launching,
     state: terminalFailure ? 'failed' : 'ready',
-    message: success
-      ? 'OpenCode member lanes are ready'
-      : pending
-        ? 'OpenCode member lanes are waiting for runtime evidence or permissions'
-        : input.partialTeamCanContinue
-          ? 'OpenCode team is running with unavailable members'
-          : 'OpenCode member lane launch failed readiness gate',
+    message: buildOpenCodeAggregateFinalMessage(input),
     messageSeverity:
-      pending || input.partialTeamCanContinue ? 'warning' : failed ? 'error' : undefined,
+      input.leadBootstrap === 'failed'
+        ? 'error'
+        : pending || input.leadBootstrap === 'pending' || input.partialTeamCanContinue
+          ? 'warning'
+          : failed
+            ? 'error'
+            : undefined,
     updatedAt: input.updatedAt,
     error: terminalFailure
       ? (input.terminalFailureError ??
         (input.laneDiagnostics.filter(Boolean).join('\n') || 'OpenCode member lane launch failed'))
       : undefined,
     cliLogsTail: input.laneDiagnostics.join('\n') || undefined,
-    configReady: true,
+    configReady: input.leadBootstrap !== 'failed',
   };
 }
 

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateRunModel.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregateRunModel.ts
@@ -254,6 +254,8 @@ export interface OpenCodeWorktreeRootAggregateLaunchPorts
   setSecondaryRuntimeRun(input: SecondaryRuntimeRunEntry & { teamName: string }): void;
   deleteSecondaryRuntimeRun(teamName: string, laneId: string): void;
   deliverOpenCodeLaunchPromptToLead: OpenCodeAggregateLaunchPromptPorts['deliverOpenCodeLaunchPromptToLead'];
+  /** Durable sink for blocked or undeliverable launch reports. */
+  logDiagnostic?(message: string): void;
 }
 
 export interface RunOpenCodeWorktreeRootAggregateLaunchInput {

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeBlockedLaunchReporting.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeBlockedLaunchReporting.ts
@@ -1,3 +1,5 @@
+import { normalizeOpenCodeFailureMessage } from '../runtime/OpenCodeLaunchGateResult';
+
 import { isRecoverableOpenCodeRuntimeEvidence } from './TeamProvisioningOpenCodeRuntimeEvidencePolicy';
 
 import type { TeamRuntimeLaunchResult } from '../runtime';
@@ -12,6 +14,12 @@ import type { TeamRuntimeLaunchResult } from '../runtime';
  * Everything here BUILDS A STRING. Nothing in this module writes, persists,
  * promotes or decides a launch outcome, so adding a report can never change what
  * a launch does - only what it says.
+ *
+ * What it says goes to a durable sink, though, and every free-form field it
+ * quotes - member diagnostics, a runtime diagnostic, a hard-failure reason -
+ * carries whatever the runtime printed, up to and including a command line
+ * with a key on it. Each one is normalised on the way in, which is the same
+ * redaction the member-facing failure text already applies.
  */
 
 export function describeBlockedOpenCodePrimaryLaneLaunch(input: {
@@ -23,7 +31,9 @@ export function describeBlockedOpenCodePrimaryLaneLaunch(input: {
     (member) => member.launchState === 'failed_to_start' || member.hardFailure === true
   );
   const reason =
-    failedMembers.find((member) => member.hardFailureReason?.trim())?.hardFailureReason?.trim() ??
+    failedMembers
+      .map((member) => normalizeOpenCodeFailureMessage(member.hardFailureReason))
+      .find((message) => message !== undefined) ??
     input.result.preLaunchGate?.reason ??
     'unknown';
   const gate = input.result.preLaunchGate;
@@ -36,7 +46,12 @@ export function describeBlockedOpenCodePrimaryLaneLaunch(input: {
     `preLaunchGate=${gateSummary}`,
     `reason=${reason}`,
     `members=${failedMembers.map((member) => member.memberName).join('/') || 'none'}`,
-    `diagnostics=${input.result.diagnostics.join('; ') || 'none'}`,
+    `diagnostics=${
+      input.result.diagnostics
+        .map((diagnostic) => normalizeOpenCodeFailureMessage(diagnostic))
+        .filter((diagnostic) => diagnostic !== undefined)
+        .join('; ') || 'none'
+    }`,
   ].join(' ');
 }
 
@@ -121,9 +136,11 @@ export function describeUnavailableOpenCodeLaunchPromptLead(input: {
   }
   const leadEvidence = findOpenCodeLeadEvidence(input.primaryResult, input.leadName);
   const reason =
-    leadEvidence?.hardFailureReason?.trim() ||
-    leadEvidence?.runtimeDiagnostic?.trim() ||
-    input.primaryResult?.diagnostics.find((diagnostic) => diagnostic.trim()) ||
+    normalizeOpenCodeFailureMessage(leadEvidence?.hardFailureReason) ||
+    normalizeOpenCodeFailureMessage(leadEvidence?.runtimeDiagnostic) ||
+    input.primaryResult?.diagnostics
+      .map((diagnostic) => normalizeOpenCodeFailureMessage(diagnostic))
+      .find((diagnostic) => diagnostic !== undefined) ||
     input.primaryResult?.preLaunchGate?.reason ||
     'primary_lane_produced_no_runtime_evidence';
   return (

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeBlockedLaunchReporting.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeBlockedLaunchReporting.ts
@@ -1,0 +1,148 @@
+import { isRecoverableOpenCodeRuntimeEvidence } from './TeamProvisioningOpenCodeRuntimeEvidencePolicy';
+
+import type { TeamRuntimeLaunchResult } from '../runtime';
+
+/**
+ * A blocked OpenCode primary lane used to be completely silent: the adapter logs
+ * nothing, the persistence layer only logged a FAILED teardown, and the lane's
+ * refusal to hand over the launch prompt never reached the progress tail. The
+ * team was then promoted to "running with unavailable members" and the prompt
+ * was handed to a lead that had no session.
+ *
+ * Everything here BUILDS A STRING. Nothing in this module writes, persists,
+ * promotes or decides a launch outcome, so adding a report can never change what
+ * a launch does - only what it says.
+ */
+
+export function describeBlockedOpenCodePrimaryLaneLaunch(input: {
+  teamName: string;
+  runId: string;
+  result: TeamRuntimeLaunchResult;
+}): string {
+  const failedMembers = Object.values(input.result.members).filter(
+    (member) => member.launchState === 'failed_to_start' || member.hardFailure === true
+  );
+  const reason =
+    failedMembers.find((member) => member.hardFailureReason?.trim())?.hardFailureReason?.trim() ??
+    input.result.preLaunchGate?.reason ??
+    'unknown';
+  const gate = input.result.preLaunchGate;
+  // preLaunchGate proves the block happened before the runtime launch, i.e.
+  // the lane never reached session bootstrap and holds no runtime evidence.
+  const gateSummary = gate ? `${gate.reason}/retryable=${gate.retryable}` : 'none';
+  return [
+    `[${input.teamName}] opencode_primary_lane_launch_blocked`,
+    `run=${input.runId}`,
+    `preLaunchGate=${gateSummary}`,
+    `reason=${reason}`,
+    `members=${failedMembers.map((member) => member.memberName).join('/') || 'none'}`,
+    `diagnostics=${input.result.diagnostics.join('; ') || 'none'}`,
+  ].join(' ');
+}
+
+export type UncommittableOpenCodeSessionReason =
+  | 'missing_runtime_session_id'
+  | 'app_managed_candidate_mismatch';
+
+/**
+ * A member that claims bootstrap confirmation but cannot have its session record
+ * committed. The commit loop used to skip it with a bare `continue`, which is why
+ * no line existed between "launch prompt queued" and the first relay failure.
+ */
+export function buildUncommittableOpenCodeSessionDiagnostic(input: {
+  memberName: string;
+  reason: UncommittableOpenCodeSessionReason;
+}): string {
+  return `opencode_bootstrap_session_not_committed:${input.memberName}:${input.reason}`;
+}
+
+export function describeClearedOpenCodePrimaryLaneStorage(input: {
+  teamName: string;
+  runId: string;
+}): string {
+  return (
+    `[${input.teamName}] opencode_primary_lane_storage_cleared run=${input.runId} ` +
+    'reason=unretainable_launch detail=lane_has_no_session_record'
+  );
+}
+
+export type OpenCodeLeadLaunchEvidenceState = 'retainable' | 'unretainable' | 'unknown';
+
+/**
+ * `unknown` means the primary lane result carries no entry for the lead at all,
+ * which is not the failure shape this guard is for. Only a lead the primary lane
+ * explicitly reports as failed is blocked from receiving the launch prompt.
+ */
+export function classifyOpenCodeLeadLaunchEvidence(
+  result: TeamRuntimeLaunchResult | null,
+  leadName: string
+): OpenCodeLeadLaunchEvidenceState {
+  const leadEvidence = findOpenCodeLeadEvidence(result, leadName);
+  if (!leadEvidence) {
+    return 'unknown';
+  }
+  return leadEvidence.launchState !== 'failed_to_start' &&
+    leadEvidence.hardFailure !== true &&
+    isRecoverableOpenCodeRuntimeEvidence(leadEvidence)
+    ? 'retainable'
+    : 'unretainable';
+}
+
+function findOpenCodeLeadEvidence(
+  result: TeamRuntimeLaunchResult | null,
+  leadName: string
+): TeamRuntimeLaunchResult['members'][string] | undefined {
+  if (!result) {
+    return undefined;
+  }
+  const normalizedLeadName = leadName.trim().toLowerCase();
+  return Object.entries(result.members).find(
+    ([name, evidence]) =>
+      (evidence.memberName?.trim() || name.trim()).toLowerCase() === normalizedLeadName
+  )?.[1];
+}
+
+/**
+ * Queueing the launch prompt for a lead with no retainable runtime evidence
+ * burns it on a session that does not exist: the bridge answers "No stored
+ * OpenCode session record" until the delivery ledger goes terminal.
+ *
+ * Returns the diagnostic when the prompt must not be queued, and `null` when
+ * there is nothing to report. The caller decides what to do with it; this
+ * function never touches the launch.
+ */
+export function describeUnavailableOpenCodeLaunchPromptLead(input: {
+  teamName: string;
+  leadName: string;
+  primaryResult: TeamRuntimeLaunchResult | null;
+}): string | null {
+  if (classifyOpenCodeLeadLaunchEvidence(input.primaryResult, input.leadName) !== 'unretainable') {
+    return null;
+  }
+  const leadEvidence = findOpenCodeLeadEvidence(input.primaryResult, input.leadName);
+  const reason =
+    leadEvidence?.hardFailureReason?.trim() ||
+    leadEvidence?.runtimeDiagnostic?.trim() ||
+    input.primaryResult?.diagnostics.find((diagnostic) => diagnostic.trim()) ||
+    input.primaryResult?.preLaunchGate?.reason ||
+    'primary_lane_produced_no_runtime_evidence';
+  return (
+    `[${input.teamName}] opencode_launch_prompt_lead_unavailable ` +
+    `lead=${input.leadName} reason=${reason}`
+  );
+}
+
+export const OPENCODE_LAUNCH_PROMPT_DEFERRED_DIAGNOSTIC =
+  'opencode_launch_prompt_deferred_until_lead_bootstrap';
+
+/**
+ * The prompt IS queued while the lead bootstrap is pending - only the bridge
+ * dispatch waits for evidence to commit. Naming the wait is what makes the
+ * progress tail explain a team that looks idle.
+ */
+export function describeDeferredOpenCodeLaunchPrompt(input: {
+  teamName: string;
+  leadName: string;
+}): string {
+  return `[${input.teamName}] ${OPENCODE_LAUNCH_PROMPT_DEFERRED_DIAGNOSTIC} lead=${input.leadName}`;
+}

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeBootstrapEvidence.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeBootstrapEvidence.ts
@@ -575,3 +575,41 @@ export function resolveOpenCodeRuntimeBootstrapCheckinIdempotencyFromMember(inpu
     existingRuntimeSessionId,
   };
 }
+
+/**
+ * States in which the store said something about its own contents. `healthy`
+ * is the obvious one; `missing` means the lane holds no session file at all,
+ * which is exactly the absence these gates exist to catch; and `quarantined`
+ * means the file is there and unreadable, so the delivery path that reads it
+ * the same way finds no record either.
+ *
+ * Everything else - a manifest that could not be read, a store written by a
+ * newer schema, a file whose hash does not match its manifest entry or that
+ * has no entry yet - is a store mid-write or out of reach, not an answer.
+ */
+const ANSWERED_OPEN_CODE_COMMITTED_BOOTSTRAP_STORE_STATES = new Set<
+  OpenCodeCommittedBootstrapSessionEvidence['state']
+>(['healthy', 'missing', 'quarantined']);
+
+/**
+ * The gates that may DOWNGRADE a member on a missing session record read the
+ * store through this. `readCommittedOpenCodeBootstrapSessionEvidence` answers
+ * a store it could not read the same shape it answers an empty one - no
+ * sessions - so a gate that fed it straight into a match would turn a manifest
+ * lock held by a concurrent bootstrap check-in into proof that no record
+ * exists, and tear down a healthy team on an I/O hiccup. Only an answered
+ * store may disprove anything; everything else throws, and each gate maps the
+ * throw to "cannot disprove".
+ */
+export function requireAnsweredOpenCodeCommittedBootstrapSessionEvidence(
+  evidence: OpenCodeCommittedBootstrapSessionEvidence
+): OpenCodeCommittedBootstrapSessionEvidence {
+  if (!ANSWERED_OPEN_CODE_COMMITTED_BOOTSTRAP_STORE_STATES.has(evidence.state)) {
+    throw new Error(
+      `OpenCode committed bootstrap session evidence is unavailable (${evidence.state})${
+        evidence.diagnostics.length > 0 ? `: ${evidence.diagnostics.join('; ')}` : ''
+      }`
+    );
+  }
+  return evidence;
+}

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeLaunchPersistencePortsFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeLaunchPersistencePortsFactory.ts
@@ -8,6 +8,7 @@ export interface TeamProvisioningOpenCodeLaunchPersistenceServiceHost {
 
 export interface TeamProvisioningOpenCodeLaunchPersistencePortsFactoryDeps {
   nowIso: PersistOpenCodeRuntimeAdapterLaunchResultPorts['nowIso'];
+  logDiagnostic?: PersistOpenCodeRuntimeAdapterLaunchResultPorts['logDiagnostic'];
 }
 
 export function createTeamProvisioningOpenCodeLaunchPersistencePortsFromService(
@@ -18,6 +19,7 @@ export function createTeamProvisioningOpenCodeLaunchPersistencePortsFromService(
     createOpenCodeRuntimeBootstrapEvidencePorts: () =>
       service.createOpenCodeRuntimeBootstrapEvidencePorts(),
     nowIso: deps.nowIso,
+    ...(deps.logDiagnostic ? { logDiagnostic: deps.logDiagnostic } : {}),
     writeLaunchStateSnapshot: (teamName, snapshot, options) =>
       service.writeLaunchStateSnapshot(teamName, snapshot, options),
   };

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeLaunchWiring.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeLaunchWiring.ts
@@ -17,6 +17,7 @@ import {
 import {
   createDefaultOpenCodeRuntimeBootstrapEvidencePorts,
   findDeliverableOpenCodeRuntimeBootstrapSessionEvidenceInCommittedEvidence,
+  requireAnsweredOpenCodeCommittedBootstrapSessionEvidence,
 } from './TeamProvisioningOpenCodeBootstrapEvidence';
 import { createOpenCodeLaunchFailureArtifactAdapter } from './TeamProvisioningOpenCodeLaunchFailureArtifact';
 import {
@@ -63,7 +64,8 @@ function nowIso(): string {
  * PROOF that no session exists. A concurrent bootstrap check-in holding the
  * manifest lock - the exact contention this gate races - would then tear a
  * healthy team down. The read must reject so the caller can map it to "cannot
- * disprove".
+ * disprove", which is why an unanswered store is raised here rather than
+ * matched against: the reader reports one as an empty session list.
  */
 async function hasCommittedOpenCodePrimaryLeadSessionEvidence(input: {
   teamName: string;
@@ -75,11 +77,13 @@ async function hasCommittedOpenCodePrimaryLeadSessionEvidence(input: {
     teamsBasePath: getTeamsBasePath(),
     warn: (message) => logger.diagnostic(message),
   });
-  const evidence = await ports.readCommittedBootstrapSessionEvidence({
-    teamsBasePath: ports.teamsBasePath,
-    teamName: input.teamName,
-    laneId: input.laneId,
-  });
+  const evidence = requireAnsweredOpenCodeCommittedBootstrapSessionEvidence(
+    await ports.readCommittedBootstrapSessionEvidence({
+      teamsBasePath: ports.teamsBasePath,
+      teamName: input.teamName,
+      laneId: input.laneId,
+    })
+  );
   return (
     findDeliverableOpenCodeRuntimeBootstrapSessionEvidenceInCommittedEvidence(evidence, input) !=
     null

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeLaunchWiring.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeLaunchWiring.ts
@@ -434,6 +434,7 @@ export function createTeamProvisioningOpenCodeLaunchWiring<Run>(
           deleteSecondaryRuntimeRun: (teamName, laneId) =>
             host.deleteSecondaryRuntimeRun(teamName, laneId),
           hasCommittedOpenCodePrimaryLeadSessionEvidence,
+          logDiagnostic: (message) => logger.diagnostic(message),
         }
       ),
     runOpenCodeTeamRuntimeAdapterLaunch: async (input) =>

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeLaunchWiring.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeLaunchWiring.ts
@@ -14,6 +14,10 @@ import {
   runOpenCodeWorktreeRootAggregateLaunch,
   type RunOpenCodeWorktreeRootAggregateLaunchInput,
 } from './TeamProvisioningOpenCodeAggregateRun';
+import {
+  createDefaultOpenCodeRuntimeBootstrapEvidencePorts,
+  findDeliverableOpenCodeRuntimeBootstrapSessionEvidenceInCommittedEvidence,
+} from './TeamProvisioningOpenCodeBootstrapEvidence';
 import { createOpenCodeLaunchFailureArtifactAdapter } from './TeamProvisioningOpenCodeLaunchFailureArtifact';
 import {
   runOpenCodeTeamRuntimeAdapterLaunch,
@@ -47,6 +51,39 @@ const logger = createLogger('Service:TeamProvisioning');
 
 function nowIso(): string {
   return new Date().toISOString();
+}
+
+/**
+ * The lead's committed session record, read from disk exactly the way the
+ * delivery path will read it later. This is the launch-time half of the lead
+ * veto; the caller treats a throw as "cannot disprove", never as failure.
+ *
+ * Deliberately NOT `hasDeliverableOpenCodeRuntimeBootstrapSessionEvidence`: that
+ * helper swallows the store read and answers `false`, which the veto reads as
+ * PROOF that no session exists. A concurrent bootstrap check-in holding the
+ * manifest lock - the exact contention this gate races - would then tear a
+ * healthy team down. The read must reject so the caller can map it to "cannot
+ * disprove".
+ */
+async function hasCommittedOpenCodePrimaryLeadSessionEvidence(input: {
+  teamName: string;
+  runId: string;
+  laneId: string;
+  memberName: string;
+}): Promise<boolean> {
+  const ports = createDefaultOpenCodeRuntimeBootstrapEvidencePorts({
+    teamsBasePath: getTeamsBasePath(),
+    warn: (message) => logger.diagnostic(message),
+  });
+  const evidence = await ports.readCommittedBootstrapSessionEvidence({
+    teamsBasePath: ports.teamsBasePath,
+    teamName: input.teamName,
+    laneId: input.laneId,
+  });
+  return (
+    findDeliverableOpenCodeRuntimeBootstrapSessionEvidenceInCommittedEvidence(evidence, input) !=
+    null
+  );
 }
 
 export interface OpenCodeLaunchWiringRuntimeRunEntry {
@@ -396,6 +433,7 @@ export function createTeamProvisioningOpenCodeLaunchWiring<Run>(
           },
           deleteSecondaryRuntimeRun: (teamName, laneId) =>
             host.deleteSecondaryRuntimeRun(teamName, laneId),
+          hasCommittedOpenCodePrimaryLeadSessionEvidence,
         }
       ),
     runOpenCodeTeamRuntimeAdapterLaunch: async (input) =>

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeSecondaryLaneEvidencePortsFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeSecondaryLaneEvidencePortsFactory.ts
@@ -2,10 +2,12 @@ import { getTeamsBasePath as getDefaultTeamsBasePath } from '@main/utils/pathDec
 
 import {
   inspectOpenCodeRuntimeLaneStorage as defaultInspectOpenCodeRuntimeLaneStorage,
+  readCommittedOpenCodeBootstrapSessionEvidence as defaultReadCommittedOpenCodeBootstrapSessionEvidence,
   upsertOpenCodeRuntimeLaneIndexEntry as defaultUpsertOpenCodeRuntimeLaneIndexEntry,
 } from '../opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 
 import { type GuardCommittedOpenCodeSecondaryLaneEvidencePorts } from './TeamProvisioningLaunchStateReconciliation';
+import { findDeliverableOpenCodeRuntimeBootstrapSessionEvidenceInCommittedEvidence } from './TeamProvisioningOpenCodeBootstrapEvidence';
 
 export interface TeamProvisioningOpenCodeSecondaryLaneEvidenceServiceHost {
   commitOpenCodeRuntimeAdapterLaunchSessionEvidence: GuardCommittedOpenCodeSecondaryLaneEvidencePorts['commitOpenCodeRuntimeAdapterLaunchSessionEvidence'];
@@ -15,6 +17,7 @@ export interface TeamProvisioningOpenCodeSecondaryLaneEvidencePortsFactoryDeps {
   getTeamsBasePath?: () => string;
   inspectOpenCodeRuntimeLaneStorage?: typeof defaultInspectOpenCodeRuntimeLaneStorage;
   upsertOpenCodeRuntimeLaneIndexEntry?: typeof defaultUpsertOpenCodeRuntimeLaneIndexEntry;
+  readCommittedBootstrapSessionEvidence?: typeof defaultReadCommittedOpenCodeBootstrapSessionEvidence;
   logWarn: GuardCommittedOpenCodeSecondaryLaneEvidencePorts['logWarn'];
 }
 
@@ -27,6 +30,9 @@ export function createTeamProvisioningOpenCodeSecondaryLaneEvidencePortsFromServ
     deps.inspectOpenCodeRuntimeLaneStorage ?? defaultInspectOpenCodeRuntimeLaneStorage;
   const upsertOpenCodeRuntimeLaneIndexEntry =
     deps.upsertOpenCodeRuntimeLaneIndexEntry ?? defaultUpsertOpenCodeRuntimeLaneIndexEntry;
+  const readCommittedBootstrapSessionEvidence =
+    deps.readCommittedBootstrapSessionEvidence ??
+    defaultReadCommittedOpenCodeBootstrapSessionEvidence;
 
   return {
     commitOpenCodeRuntimeAdapterLaunchSessionEvidence: (input) =>
@@ -45,6 +51,22 @@ export function createTeamProvisioningOpenCodeSecondaryLaneEvidencePortsFromServ
         state,
         diagnostics,
       }),
+    // Per-member, not per-lane: the lane flag is true as soon as ONE member
+    // commits, which is how a committed teammate hid a lead with no record.
+    hasCommittedOpenCodeLaneMemberSessionEvidence: async ({
+      teamName,
+      laneId,
+      runId,
+      memberName,
+    }) =>
+      findDeliverableOpenCodeRuntimeBootstrapSessionEvidenceInCommittedEvidence(
+        await readCommittedBootstrapSessionEvidence({
+          teamsBasePath: getTeamsBasePath(),
+          teamName,
+          laneId,
+        }),
+        { teamName, laneId, runId, memberName }
+      ) != null,
     logWarn: (message) => deps.logWarn(message),
   };
 }

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeSecondaryLaneEvidencePortsFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeSecondaryLaneEvidencePortsFactory.ts
@@ -7,7 +7,10 @@ import {
 } from '../opencode/store/OpenCodeRuntimeManifestEvidenceReader';
 
 import { type GuardCommittedOpenCodeSecondaryLaneEvidencePorts } from './TeamProvisioningLaunchStateReconciliation';
-import { findDeliverableOpenCodeRuntimeBootstrapSessionEvidenceInCommittedEvidence } from './TeamProvisioningOpenCodeBootstrapEvidence';
+import {
+  findDeliverableOpenCodeRuntimeBootstrapSessionEvidenceInCommittedEvidence,
+  requireAnsweredOpenCodeCommittedBootstrapSessionEvidence,
+} from './TeamProvisioningOpenCodeBootstrapEvidence';
 
 export interface TeamProvisioningOpenCodeSecondaryLaneEvidenceServiceHost {
   commitOpenCodeRuntimeAdapterLaunchSessionEvidence: GuardCommittedOpenCodeSecondaryLaneEvidencePorts['commitOpenCodeRuntimeAdapterLaunchSessionEvidence'];
@@ -53,6 +56,8 @@ export function createTeamProvisioningOpenCodeSecondaryLaneEvidencePortsFromServ
       }),
     // Per-member, not per-lane: the lane flag is true as soon as ONE member
     // commits, which is how a committed teammate hid a lead with no record.
+    // An unanswered store is raised, not matched: the guard reads only an
+    // answered `false` as proof, and a read that failed proves nothing.
     hasCommittedOpenCodeLaneMemberSessionEvidence: async ({
       teamName,
       laneId,
@@ -60,11 +65,13 @@ export function createTeamProvisioningOpenCodeSecondaryLaneEvidencePortsFromServ
       memberName,
     }) =>
       findDeliverableOpenCodeRuntimeBootstrapSessionEvidenceInCommittedEvidence(
-        await readCommittedBootstrapSessionEvidence({
-          teamsBasePath: getTeamsBasePath(),
-          teamName,
-          laneId,
-        }),
+        requireAnsweredOpenCodeCommittedBootstrapSessionEvidence(
+          await readCommittedBootstrapSessionEvidence({
+            teamsBasePath: getTeamsBasePath(),
+            teamName,
+            laneId,
+          })
+        ),
         { teamName, laneId, runId, memberName }
       ) != null,
     logWarn: (message) => deps.logWarn(message),

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPersistence.primaryLaneGate.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPersistence.primaryLaneGate.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  launchOpenCodeAggregatePrimaryLane,
+  type LaunchOpenCodeAggregatePrimaryLanePorts,
+} from '../TeamProvisioningOpenCodeAggregateLaunchPersistence';
+
+import type { TeamLaunchRuntimeAdapter, TeamRuntimeLaunchResult } from '../../runtime';
+import type { TeamCreateRequest } from '@shared/types';
+
+const lead = { name: 'team-lead', role: 'Team Lead', providerId: 'opencode' as const };
+const ada = { name: 'Ada', role: 'Engineer', providerId: 'opencode' as const };
+
+function primaryResult(): TeamRuntimeLaunchResult {
+  return {
+    runId: 'run-a1',
+    teamName: 'lane-team',
+    launchPhase: 'finished',
+    teamLaunchState: 'clean_success',
+    members: {
+      'team-lead': {
+        memberName: 'team-lead',
+        providerId: 'opencode',
+        launchState: 'confirmed_alive',
+        agentToolAccepted: true,
+        runtimeAlive: true,
+        bootstrapConfirmed: true,
+        hardFailure: false,
+        diagnostics: [],
+      },
+    },
+    warnings: [],
+    diagnostics: [],
+  };
+}
+
+async function runPrimaryLaneLaunch(
+  overrides: Partial<LaunchOpenCodeAggregatePrimaryLanePorts> = {},
+  launchResult: TeamRuntimeLaunchResult = primaryResult()
+): Promise<{ persisted: TeamRuntimeLaunchResult[] }> {
+  const persisted: TeamRuntimeLaunchResult[] = [];
+  await launchOpenCodeAggregatePrimaryLane(
+    {
+      run: {
+        runId: 'run-a1',
+        teamName: 'lane-team',
+        request: {
+          teamName: 'lane-team',
+          cwd: '/fake/project',
+          providerId: 'opencode',
+          members: [lead, ada],
+        } as TeamCreateRequest,
+        effectiveMembers: [lead, ada],
+        memberSpawnStatuses: new Map(),
+        mixedSecondaryLanes: [],
+      },
+      adapter: { launch: vi.fn(async () => launchResult) } as unknown as TeamLaunchRuntimeAdapter,
+      prompt: 'launch',
+      previousLaunchState: null,
+    },
+    {
+      getTeamsBasePath: () => '/safe-test/teams',
+      getOpenCodeRuntimeLaunchCwd: () => '/fake/project',
+      migrateLegacyOpenCodeRuntimeState: async () => ({}),
+      upsertOpenCodeRuntimeLaneIndexEntry: async () => {},
+      setOpenCodeRuntimeActiveRunManifest: async () => {},
+      clearOpenCodeRuntimeLaneStorage: async () => true,
+      persistOpenCodeRuntimeAdapterLaunchResult: async (result: TeamRuntimeLaunchResult) => {
+        persisted.push(result);
+        return { result, snapshot: undefined };
+      },
+      syncOpenCodeRuntimeToolApprovals: () => {},
+      setRuntimeAdapterRunByTeam: () => {},
+      ...overrides,
+    } as unknown as LaunchOpenCodeAggregatePrimaryLanePorts
+  );
+  return { persisted };
+}
+
+describe('the primary lane passes the same promotion gate as every side lane', () => {
+  it('names the primary lane and every expected member, and persists the guarded result', async () => {
+    const downgraded = primaryResult();
+    downgraded.teamLaunchState = 'partial_pending';
+    const guard = vi.fn<
+      NonNullable<LaunchOpenCodeAggregatePrimaryLanePorts['guardCommittedOpenCodeLaneEvidence']>
+    >(async () => downgraded);
+
+    const { persisted } = await runPrimaryLaneLaunch({
+      guardCommittedOpenCodeLaneEvidence: guard,
+    });
+
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(guard.mock.calls[0][0]).toMatchObject({
+      teamName: 'lane-team',
+      laneId: 'primary',
+      memberNames: ['team-lead', 'Ada'],
+    });
+    // What reaches persistence is the GUARDED result, not the adapter's claim.
+    expect(persisted).toEqual([downgraded]);
+  });
+
+  // NEGATIVE CONTROL: the gate is an optional port. Without it the primary lane
+  // persists exactly what the adapter returned, as it did before this change.
+  it('persists the adapter result unchanged when no gate is wired', async () => {
+    const launchResult = primaryResult();
+
+    const { persisted } = await runPrimaryLaneLaunch({}, launchResult);
+
+    expect(persisted).toEqual([launchResult]);
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPersistence.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPersistence.test.ts
@@ -297,7 +297,18 @@ describe('TeamProvisioningOpenCodeAggregateLaunchPersistence', () => {
       requireTrackedRun: true,
       runId: 'run-1',
     });
-    expect(persisted.result).toBe(result);
+    // A primary-lane member that claims confirmation without a runtime session
+    // id now carries the reason it could not be committed. Nothing else about
+    // the result changes: same state, same phase, same members.
+    expect(persisted.result).toMatchObject({
+      teamLaunchState: 'clean_success',
+      launchPhase: 'finished',
+      diagnostics: ['opencode_bootstrap_session_not_committed:alice:missing_runtime_session_id'],
+    });
+    expect(persisted.result.members.alice).toMatchObject({
+      launchState: 'confirmed_alive',
+      diagnostics: ['opencode_bootstrap_session_not_committed:alice:missing_runtime_session_id'],
+    });
     expect(persisted.snapshot).toMatchObject({
       teamName: 'team-a',
       expectedMembers: ['alice'],
@@ -614,7 +625,7 @@ describe('TeamProvisioningOpenCodeAggregateLaunchPersistence', () => {
       throw new Error('cleanup transport failed');
     });
     const logWarning = vi.fn();
-    const laneIndexWrites: Array<{ state: string; diagnostics?: string[] }> = [];
+    const laneIndexWrites: { state: string; diagnostics?: string[] }[] = [];
     let runtimeOwner:
       | Parameters<LaunchOpenCodeAggregatePrimaryLanePorts['setRuntimeAdapterRunByTeam']>[1]
       | undefined;

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPersistence.uncommittableSession.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPersistence.uncommittableSession.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { commitOpenCodeRuntimeAdapterLaunchSessionEvidence } from '../TeamProvisioningOpenCodeAggregateLaunchPersistence';
+
+import type { TeamRuntimeLaunchResult, TeamRuntimeMemberLaunchEvidence } from '../../runtime';
+import type { OpenCodeRuntimeBootstrapEvidencePorts } from '../TeamProvisioningOpenCodeBootstrapEvidence';
+
+function bootstrapEvidencePorts(): OpenCodeRuntimeBootstrapEvidencePorts {
+  return {
+    teamsBasePath: '/safe-test/teams',
+    readFileUtf8: vi.fn(),
+    mkdirRecursive: vi.fn(),
+    readCommittedBootstrapSessionEvidence: vi.fn(),
+    getCurrentAgentTeamsMcpHttpTransportEvidence: vi.fn(() => null),
+    isFileLockTimeoutError: vi.fn(() => false),
+    warn: vi.fn(),
+  };
+}
+
+function member(
+  overrides: Partial<TeamRuntimeMemberLaunchEvidence> = {}
+): TeamRuntimeMemberLaunchEvidence {
+  return {
+    memberName: 'team-lead',
+    providerId: 'opencode',
+    launchState: 'confirmed_alive',
+    agentToolAccepted: true,
+    runtimeAlive: true,
+    bootstrapConfirmed: true,
+    hardFailure: false,
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+function launchResult(
+  members: Record<string, TeamRuntimeMemberLaunchEvidence>
+): TeamRuntimeLaunchResult {
+  return {
+    runId: 'run-a1',
+    teamName: 'lane-team',
+    launchPhase: 'finished',
+    teamLaunchState: 'clean_success',
+    members,
+    warnings: [],
+    diagnostics: [],
+  };
+}
+
+interface UncommittableSessionCommitPorts {
+  createOpenCodeRuntimeBootstrapEvidencePorts: () => OpenCodeRuntimeBootstrapEvidencePorts;
+  nowIso: () => string;
+  logDiagnostic?: (message: string) => void;
+}
+
+function ports(logDiagnostic?: (message: string) => void): UncommittableSessionCommitPorts {
+  return {
+    createOpenCodeRuntimeBootstrapEvidencePorts: () => bootstrapEvidencePorts(),
+    nowIso: () => '2026-08-28T12:20:00.000Z',
+    ...(logDiagnostic ? { logDiagnostic } : {}),
+  };
+}
+
+describe('a primary-lane member whose session cannot be committed says so', () => {
+  it('reports and annotates a confirmed lead with no runtime session id', async () => {
+    const reports: string[] = [];
+    const result = launchResult({ 'team-lead': member() });
+
+    const committed = await commitOpenCodeRuntimeAdapterLaunchSessionEvidence(
+      { teamName: 'lane-team', laneId: 'primary', result },
+      ports((message) => reports.push(message))
+    );
+
+    expect(reports).toEqual([
+      '[lane-team] opencode_bootstrap_session_not_committed:team-lead:missing_runtime_session_id ' +
+        '(lane=primary)',
+    ]);
+    expect(committed.diagnostics).toContain(
+      'opencode_bootstrap_session_not_committed:team-lead:missing_runtime_session_id'
+    );
+    expect(committed.members['team-lead']?.diagnostics).toContain(
+      'opencode_bootstrap_session_not_committed:team-lead:missing_runtime_session_id'
+    );
+  });
+
+  // NEGATIVE CONTROL: reporting never promotes. The annotation is member-level
+  // only; re-summarizing here would let it UPGRADE a partial_failure launch.
+  it('leaves the aggregate launch state exactly as it found it', async () => {
+    const result = {
+      ...launchResult({ 'team-lead': member() }),
+      teamLaunchState: 'partial_failure' as const,
+      launchPhase: 'active' as const,
+    };
+
+    const committed = await commitOpenCodeRuntimeAdapterLaunchSessionEvidence(
+      { teamName: 'lane-team', laneId: 'primary', result },
+      ports()
+    );
+
+    expect(committed.teamLaunchState).toBe('partial_failure');
+    expect(committed.launchPhase).toBe('active');
+    expect(committed.members['team-lead']?.launchState).toBe('confirmed_alive');
+  });
+
+  // NEGATIVE CONTROL: a secondary member that is confirmed before its session id
+  // lands is an ordinary launch race, not an incident. Reporting it would add a
+  // line on every healthy launch.
+  it('says nothing for the same shape on a secondary lane', async () => {
+    const reports: string[] = [];
+    const result = launchResult({ Ada: member({ memberName: 'Ada' }) });
+
+    const committed = await commitOpenCodeRuntimeAdapterLaunchSessionEvidence(
+      { teamName: 'lane-team', laneId: 'secondary:opencode:ada', result },
+      ports((message) => reports.push(message))
+    );
+
+    expect(reports).toEqual([]);
+    expect(committed).toBe(result);
+  });
+
+  // NEGATIVE CONTROL: an unconfirmed member with no candidate is not this
+  // report's shape either - it never claimed anything to be held to.
+  it('says nothing for a primary member that never claimed confirmation', async () => {
+    const reports: string[] = [];
+    const result = launchResult({
+      'team-lead': member({
+        launchState: 'starting',
+        agentToolAccepted: false,
+        runtimeAlive: false,
+        bootstrapConfirmed: false,
+      }),
+    });
+
+    const committed = await commitOpenCodeRuntimeAdapterLaunchSessionEvidence(
+      { teamName: 'lane-team', laneId: 'primary', result },
+      ports((message) => reports.push(message))
+    );
+
+    expect(reports).toEqual([]);
+    expect(committed).toBe(result);
+  });
+
+  // NEGATIVE CONTROL: with no sink wired the returned result is identical, so
+  // the report is observation and nothing else.
+  it('returns the same result with and without a report sink', async () => {
+    const withSink = await commitOpenCodeRuntimeAdapterLaunchSessionEvidence(
+      { teamName: 'lane-team', laneId: 'primary', result: launchResult({ 'team-lead': member() }) },
+      ports(() => undefined)
+    );
+    const withoutSink = await commitOpenCodeRuntimeAdapterLaunchSessionEvidence(
+      { teamName: 'lane-team', laneId: 'primary', result: launchResult({ 'team-lead': member() }) },
+      ports()
+    );
+
+    expect(withoutSink).toEqual(withSink);
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPromotion.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPromotion.test.ts
@@ -1,0 +1,412 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  classifyOpenCodePrimaryLeadBootstrap,
+  collectOpenCodeAggregateLaneDiagnostics,
+  resolveOpenCodeAggregateLaunchStateForLeadBootstrap,
+  resolveOpenCodeAggregatePrimaryLeadBootstrap,
+  summarizeOpenCodeAggregateLaunchPromotion,
+} from '../TeamProvisioningOpenCodeAggregateLaunchPromotion';
+import { buildOpenCodeAggregateFinalProgress } from '../TeamProvisioningOpenCodeAggregateRunModel';
+
+import {
+  buildFailedOpenCodeLaunchResult,
+  buildRetainableOpenCodeLaunchResult,
+  buildUncommittedPrimaryLeadLaunchResult,
+} from './support/openCodeUncommittedPrimaryLane';
+
+import type { TeamRuntimeLaunchResult } from '../../runtime';
+import type { MixedSecondaryRuntimeLaneState } from '../TeamProvisioningSecondaryRuntimeRuns';
+import type { TeamProvisioningProgress } from '@shared/types';
+
+const launching: TeamProvisioningProgress = {
+  runId: 'run-a1',
+  teamName: 'lane-team',
+  state: 'spawning',
+  message: 'Starting OpenCode member runtime lanes',
+  startedAt: '2026-08-28T12:18:00.000Z',
+  updatedAt: '2026-08-28T12:18:00.000Z',
+};
+
+function lane(
+  result: TeamRuntimeLaunchResult | null,
+  diagnostics: string[] = []
+): MixedSecondaryRuntimeLaneState {
+  return { result, diagnostics } as unknown as MixedSecondaryRuntimeLaneState;
+}
+
+describe('the lead veto is not a blanket fail', () => {
+  // NEGATIVE CONTROL, and the first assertion in this file on purpose: the veto
+  // only ever fires on the LEAD. A confirmed lead beside two failed side lanes
+  // must still be a partial success, exactly as it was before this change.
+  it('keeps a confirmed lead with two failed side lanes a partial success', () => {
+    const promotion = summarizeOpenCodeAggregateLaunchPromotion({
+      launchState: 'partial_failure',
+      leadBootstrap: 'confirmed',
+      leadName: 'team-lead',
+      primaryResult: buildRetainableOpenCodeLaunchResult('team-lead'),
+      lanes: [
+        lane(buildFailedOpenCodeLaunchResult('Ada', 'runtime binary unreachable')),
+        lane(buildFailedOpenCodeLaunchResult('Ben', 'runtime binary unreachable')),
+      ],
+    });
+
+    expect(promotion.failed).toBe(true);
+    expect(promotion.partialTeamCanContinue).toBe(true);
+    expect(promotion.terminalFailure).toBe(false);
+  });
+
+  it('does not change the final progress of a healthy launch', () => {
+    const progress = buildOpenCodeAggregateFinalProgress({
+      launching,
+      launchState: 'clean_success',
+      leadBootstrap: 'confirmed',
+      laneDiagnostics: [],
+      updatedAt: '2026-08-28T12:20:00.000Z',
+    });
+
+    expect(progress).toMatchObject({
+      state: 'ready',
+      message: 'OpenCode member lanes are ready',
+      messageSeverity: undefined,
+      configReady: true,
+    });
+  });
+});
+
+describe('classifyOpenCodePrimaryLeadBootstrap', () => {
+  it('confirms when the lead claims bootstrap and the commit is not disproven', () => {
+    expect(
+      classifyOpenCodePrimaryLeadBootstrap({
+        leadName: 'team-lead',
+        primaryResult: buildUncommittedPrimaryLeadLaunchResult(),
+      })
+    ).toBe('confirmed');
+  });
+
+  // NEGATIVE CONTROL: absence of evidence is not evidence of absence. A reader
+  // that answers `null` (not wired, or the read failed) must never delay or
+  // downgrade a launch whose lane already claims confirmation.
+  it('confirms when the committed-session read answers null', () => {
+    expect(
+      classifyOpenCodePrimaryLeadBootstrap({
+        leadName: 'team-lead',
+        primaryResult: buildUncommittedPrimaryLeadLaunchResult(),
+        committedSessionEvidence: null,
+      })
+    ).toBe('confirmed');
+  });
+
+  it('is pending when the lane holds a runtime handle but no committed session', () => {
+    const result = buildUncommittedPrimaryLeadLaunchResult();
+    result.members['team-lead'] = {
+      ...result.members['team-lead'],
+      launchState: 'runtime_pending_bootstrap',
+      bootstrapConfirmed: false,
+      runtimeAlive: false,
+      runtimePid: 4321,
+    };
+    expect(
+      classifyOpenCodePrimaryLeadBootstrap({
+        leadName: 'team-lead',
+        primaryResult: result,
+        committedSessionEvidence: false,
+      })
+    ).toBe('pending');
+  });
+
+  it('fails when the disk read disproves the claim and nothing materialized', () => {
+    expect(
+      classifyOpenCodePrimaryLeadBootstrap({
+        leadName: 'team-lead',
+        primaryResult: buildUncommittedPrimaryLeadLaunchResult(),
+        committedSessionEvidence: false,
+      })
+    ).toBe('failed');
+  });
+
+  it('does not veto when the primary lane returned no entry for the lead at all', () => {
+    // An absent entry means the result never went through expected-member
+    // normalization; a genuinely failed lead arrives as `failed_to_start`.
+    expect(
+      classifyOpenCodePrimaryLeadBootstrap({
+        leadName: 'team-lead',
+        primaryResult: buildRetainableOpenCodeLaunchResult('Ada'),
+      })
+    ).toBe('confirmed');
+  });
+
+  // The bridge parks the lead on a permission prompt before any session exists:
+  // no pid, no session id, `hardFailure: false`. Classifying that as `failed`
+  // forces `partial_failure`, and `partialTeamCanContinue` is false for a failed
+  // lead - so the healthy side lanes would be torn down while the user is still
+  // looking at the permission dialog.
+  const permissionBlockedEvidence = {
+    launchState: 'runtime_pending_permission' as const,
+    bootstrapConfirmed: false,
+    runtimeAlive: false,
+    livenessKind: 'permission_blocked' as const,
+    pendingPermissionRequestIds: ['perm-1'],
+  };
+
+  it('defers a permission-blocked lead instead of vetoing the launch', () => {
+    const result = buildUncommittedPrimaryLeadLaunchResult();
+    result.members['team-lead'] = {
+      ...result.members['team-lead'],
+      ...permissionBlockedEvidence,
+    };
+    expect(
+      classifyOpenCodePrimaryLeadBootstrap({
+        leadName: 'team-lead',
+        primaryResult: result,
+        committedSessionEvidence: false,
+      })
+    ).toBe('pending');
+  });
+
+  it('defers on a pending permission request even without the liveness marker', () => {
+    const result = buildUncommittedPrimaryLeadLaunchResult();
+    result.members['team-lead'] = {
+      ...result.members['team-lead'],
+      launchState: 'starting',
+      bootstrapConfirmed: false,
+      runtimeAlive: false,
+      pendingPermissionRequestIds: ['perm-1'],
+    };
+    expect(
+      classifyOpenCodePrimaryLeadBootstrap({
+        leadName: 'team-lead',
+        primaryResult: result,
+        committedSessionEvidence: false,
+      })
+    ).toBe('pending');
+  });
+
+  it('still fails a permission-blocked lead the lane reported as a hard failure', () => {
+    const result = buildUncommittedPrimaryLeadLaunchResult();
+    result.members['team-lead'] = {
+      ...result.members['team-lead'],
+      ...permissionBlockedEvidence,
+      launchState: 'failed_to_start',
+      hardFailure: true,
+    };
+    expect(
+      classifyOpenCodePrimaryLeadBootstrap({
+        leadName: 'team-lead',
+        primaryResult: result,
+        committedSessionEvidence: false,
+      })
+    ).toBe('failed');
+  });
+
+  it('fails when the lead itself is reported as failed_to_start', () => {
+    const result = buildRetainableOpenCodeLaunchResult('team-lead');
+    result.members['team-lead'] = {
+      ...result.members['team-lead'],
+      launchState: 'failed_to_start',
+      hardFailure: true,
+      hardFailureReason: 'OpenCode model verification completed without assistant output',
+    };
+    expect(
+      classifyOpenCodePrimaryLeadBootstrap({ leadName: 'team-lead', primaryResult: result })
+    ).toBe('failed');
+  });
+
+  it('has nothing to veto when the primary lane holds no lead', () => {
+    expect(classifyOpenCodePrimaryLeadBootstrap({ leadName: null, primaryResult: null })).toBe(
+      'confirmed'
+    );
+  });
+});
+
+describe('summarizeOpenCodeAggregateLaunchPromotion', () => {
+  it('makes the lead a veto, not a vote', () => {
+    // Two healthy side lanes used to be enough to declare the team continuable.
+    const promotion = summarizeOpenCodeAggregateLaunchPromotion({
+      launchState: 'clean_success',
+      leadBootstrap: 'failed',
+      leadName: 'team-lead',
+      primaryResult: buildUncommittedPrimaryLeadLaunchResult(),
+      lanes: [
+        lane(buildRetainableOpenCodeLaunchResult('Ada')),
+        lane(buildRetainableOpenCodeLaunchResult('Ben')),
+      ],
+    });
+
+    expect(promotion.failed).toBe(true);
+    expect(promotion.partialTeamCanContinue).toBe(false);
+    expect(promotion.terminalFailure).toBe(true);
+    expect(promotion.terminalFailureError).toBe(
+      'OpenCode team lead "team-lead" has no committed runtime session on the primary lane'
+    );
+  });
+
+  it('prepends the lead reason without swallowing the underlying diagnostic', () => {
+    const promotion = summarizeOpenCodeAggregateLaunchPromotion({
+      launchState: 'partial_failure',
+      leadBootstrap: 'failed',
+      leadName: 'team-lead',
+      primaryResult: buildFailedOpenCodeLaunchResult('team-lead', 'shared runtime never answered'),
+      lanes: [],
+    });
+
+    expect(promotion.terminalFailureError).toBe(
+      'OpenCode team lead "team-lead" has no committed runtime session on the primary lane: ' +
+        'shared runtime never answered'
+    );
+  });
+
+  it('carries the primary lane diagnostics into the aggregate tail', () => {
+    const promotion = summarizeOpenCodeAggregateLaunchPromotion({
+      launchState: 'clean_success',
+      leadBootstrap: 'confirmed',
+      leadName: 'team-lead',
+      primaryResult: buildRetainableOpenCodeLaunchResult('team-lead', {
+        diagnostics: ['primary lane took 4210 ms'],
+      }),
+      lanes: [lane(buildRetainableOpenCodeLaunchResult('Ada'), ['Ada lane took 980 ms'])],
+    });
+
+    expect(promotion.laneDiagnostics).toEqual([
+      'primary: primary lane took 4210 ms',
+      'Ada lane took 980 ms',
+    ]);
+  });
+});
+
+describe('collectOpenCodeAggregateLaneDiagnostics', () => {
+  it('returns nothing for a launch that produced no diagnostics at all', () => {
+    expect(collectOpenCodeAggregateLaneDiagnostics({ primaryResult: null, lanes: [] })).toEqual([]);
+  });
+});
+
+describe('resolveOpenCodeAggregateLaunchStateForLeadBootstrap', () => {
+  it('forces partial_failure for a failed lead', () => {
+    expect(resolveOpenCodeAggregateLaunchStateForLeadBootstrap('clean_success', 'failed')).toBe(
+      'partial_failure'
+    );
+  });
+
+  it('forces partial_pending for a pending lead so the run stays active', () => {
+    expect(resolveOpenCodeAggregateLaunchStateForLeadBootstrap('clean_success', 'pending')).toBe(
+      'partial_pending'
+    );
+  });
+
+  it('leaves a confirmed lead alone', () => {
+    expect(resolveOpenCodeAggregateLaunchStateForLeadBootstrap('clean_success', 'confirmed')).toBe(
+      'clean_success'
+    );
+  });
+
+  it('never upgrades an already partial_failure launch', () => {
+    expect(
+      resolveOpenCodeAggregateLaunchStateForLeadBootstrap('partial_failure', 'confirmed')
+    ).toBe('partial_failure');
+  });
+});
+
+describe('buildOpenCodeAggregateFinalProgress lead states', () => {
+  it('never reports "running with unavailable members" while the lead is unconfirmed', () => {
+    const progress = buildOpenCodeAggregateFinalProgress({
+      launching,
+      launchState: 'partial_failure',
+      leadBootstrap: 'failed',
+      laneDiagnostics: [],
+      updatedAt: '2026-08-28T12:20:00.000Z',
+      partialTeamCanContinue: false,
+      terminalFailureError: 'lead reason',
+    });
+
+    expect(progress.state).toBe('failed');
+    expect(progress.configReady).toBe(false);
+    expect(progress.message).toBe('OpenCode lead bootstrap failed; the team has no usable lead');
+    expect(progress.messageSeverity).toBe('error');
+  });
+
+  it('warns while the lead is still waiting for its bootstrap evidence', () => {
+    const progress = buildOpenCodeAggregateFinalProgress({
+      launching,
+      launchState: 'partial_pending',
+      leadBootstrap: 'pending',
+      laneDiagnostics: [],
+      updatedAt: '2026-08-28T12:20:00.000Z',
+    });
+
+    expect(progress.state).toBe('ready');
+    expect(progress.configReady).toBe(true);
+    expect(progress.message).toBe('OpenCode lead is waiting for its runtime bootstrap evidence');
+    expect(progress.messageSeverity).toBe('warning');
+  });
+
+  it('keeps the pre-existing wording for a launch that carries no lead state', () => {
+    const progress = buildOpenCodeAggregateFinalProgress({
+      launching,
+      launchState: 'partial_failure',
+      laneDiagnostics: [],
+      updatedAt: '2026-08-28T12:20:00.000Z',
+      partialTeamCanContinue: true,
+    });
+
+    expect(progress.message).toBe('OpenCode team is running with unavailable members');
+    expect(progress.messageSeverity).toBe('warning');
+    expect(progress.configReady).toBe(true);
+  });
+});
+
+describe('resolveOpenCodeAggregatePrimaryLeadBootstrap', () => {
+  const params = {
+    teamName: 'lane-team',
+    runId: 'run-a1',
+    effectiveMembers: [{ name: 'team-lead' }, { name: 'Ada' }],
+    primaryResult: buildUncommittedPrimaryLeadLaunchResult(),
+  };
+
+  it('reads the lead session record for the primary lane only', async () => {
+    const read = vi.fn(async () => false);
+
+    const outcome = await resolveOpenCodeAggregatePrimaryLeadBootstrap(params, {
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: read,
+    });
+
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(read).toHaveBeenCalledWith({
+      teamName: 'lane-team',
+      runId: 'run-a1',
+      laneId: 'primary',
+      memberName: 'team-lead',
+    });
+    expect(outcome).toEqual({ state: 'failed', leadName: 'team-lead' });
+  });
+
+  // NEGATIVE CONTROL: a throwing read cannot disprove anything, so it must leave
+  // a healthy launch alone rather than turning an I/O hiccup into a dead team.
+  it('treats a failing disk read as "cannot disprove", never as failure', async () => {
+    const outcome = await resolveOpenCodeAggregatePrimaryLeadBootstrap(params, {
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => {
+        throw new Error('EBUSY');
+      },
+    });
+
+    expect(outcome.state).toBe('confirmed');
+  });
+
+  // NEGATIVE CONTROL: no reader wired at all is the same "cannot disprove".
+  it('confirms when no committed-session reader is wired', async () => {
+    expect((await resolveOpenCodeAggregatePrimaryLeadBootstrap(params, {})).state).toBe(
+      'confirmed'
+    );
+  });
+
+  it('never reads for a launch with no lead member', async () => {
+    const read = vi.fn(async () => false);
+
+    const outcome = await resolveOpenCodeAggregatePrimaryLeadBootstrap(
+      { ...params, effectiveMembers: [{ name: 'Ada' }] },
+      { hasCommittedOpenCodePrimaryLeadSessionEvidence: read }
+    );
+
+    expect(read).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ state: 'confirmed', leadName: null });
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPromotion.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPromotion.test.ts
@@ -125,13 +125,46 @@ describe('classifyOpenCodePrimaryLeadBootstrap', () => {
     ).toBe('failed');
   });
 
-  it('does not veto when the primary lane returned no entry for the lead at all', () => {
-    // An absent entry means the result never went through expected-member
-    // normalization; a genuinely failed lead arrives as `failed_to_start`.
+  /**
+   * This case used to answer `'confirmed'`, on the premise that an absent entry
+   * could only mean an unnormalized result -
+   * `normalizeExpectedOpenCodeRuntimeLaunchMembers` would otherwise have turned
+   * a missing expected member into `failed_to_start`. That function is not
+   * called anywhere in production code, so an absent entry was the ordinary
+   * case, and the gate waved through exactly the launches it exists to stop.
+   */
+  it('does not confirm a lead the primary lane never reported', () => {
     expect(
       classifyOpenCodePrimaryLeadBootstrap({
         leadName: 'team-lead',
         primaryResult: buildRetainableOpenCodeLaunchResult('Ada'),
+      })
+    ).toBe('pending');
+  });
+
+  /**
+   * Still not a veto: a lane that reported a different member than the one this
+   * app calls the lead is a naming mismatch, not a dead team. `'pending'` keeps
+   * the run alive and leaves the bootstrap check-in path its chance to land the
+   * evidence - `'failed'` would tear down side lanes that work.
+   */
+  it('keeps an unreported lead pending rather than failing the team', () => {
+    expect(
+      classifyOpenCodePrimaryLeadBootstrap({
+        leadName: 'team-lead',
+        primaryResult: buildRetainableOpenCodeLaunchResult('Ada'),
+        committedSessionEvidence: false,
+      })
+    ).toBe('pending');
+  });
+
+  /** Disk evidence outranks the absence: a committed lead session is confirmed. */
+  it('confirms an unreported lead whose session is already committed', () => {
+    expect(
+      classifyOpenCodePrimaryLeadBootstrap({
+        leadName: 'team-lead',
+        primaryResult: buildRetainableOpenCodeLaunchResult('Ada'),
+        committedSessionEvidence: true,
       })
     ).toBe('confirmed');
   });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPromotion.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPromotion.test.ts
@@ -133,13 +133,17 @@ describe('classifyOpenCodePrimaryLeadBootstrap', () => {
    * called anywhere in production code, so an absent entry was the ordinary
    * case, and the gate waved through exactly the launches it exists to stop.
    */
-  it('does not confirm a lead the primary lane never reported', () => {
+  it('does not hold back a launch when the lead is absent and nothing was read', () => {
+    // `null`/absent evidence may not downgrade on its own - that is the same
+    // rule the confirmed branch follows, and it covers the legitimate shape
+    // where the lead does not belong to this lane at all (a Cursor lead beside
+    // OpenCode side lanes).
     expect(
       classifyOpenCodePrimaryLeadBootstrap({
         leadName: 'team-lead',
         primaryResult: buildRetainableOpenCodeLaunchResult('Ada'),
       })
-    ).toBe('pending');
+    ).toBe('confirmed');
   });
 
   /**
@@ -148,6 +152,7 @@ describe('classifyOpenCodePrimaryLeadBootstrap', () => {
    * the run alive and leaves the bootstrap check-in path its chance to land the
    * evidence - `'failed'` would tear down side lanes that work.
    */
+  /** A negative disk read IS proof, and it downgrades. */
   it('keeps an unreported lead pending rather than failing the team', () => {
     expect(
       classifyOpenCodePrimaryLeadBootstrap({

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPromotion.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPromotion.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-  resolveOpenCodeAggregatePrimaryLeadName,
   classifyOpenCodePrimaryLeadBootstrap,
   collectOpenCodeAggregateLaneDiagnostics,
   resolveOpenCodeAggregateLaunchStateForLeadBootstrap,
   resolveOpenCodeAggregatePrimaryLeadBootstrap,
+  resolveOpenCodeAggregatePrimaryLeadName,
   summarizeOpenCodeAggregateLaunchPromotion,
 } from '../TeamProvisioningOpenCodeAggregateLaunchPromotion';
 import { buildOpenCodeAggregateFinalProgress } from '../TeamProvisioningOpenCodeAggregateRunModel';

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPromotion.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPromotion.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  resolveOpenCodeAggregatePrimaryLeadName,
   classifyOpenCodePrimaryLeadBootstrap,
   collectOpenCodeAggregateLaneDiagnostics,
   resolveOpenCodeAggregateLaunchStateForLeadBootstrap,
@@ -446,5 +447,49 @@ describe('resolveOpenCodeAggregatePrimaryLeadBootstrap', () => {
 
     expect(read).not.toHaveBeenCalled();
     expect(outcome).toEqual({ state: 'confirmed', leadName: null });
+  });
+});
+
+/**
+ * The gate may only judge the lead that runs ON this lane.
+ *
+ * A team can run a Cursor (or Claude) lead beside OpenCode side lanes, and such
+ * a lead is absent from an OpenCode launch result for a completely legitimate
+ * reason. Vetoing on it held back a launch that works - caught by
+ * TeamProvisioningService's "keeps a materialized pending OpenCode lane alive
+ * when a Cursor sibling fails first".
+ */
+describe('resolveOpenCodeAggregatePrimaryLeadName', () => {
+  it('takes a lead that runs on OpenCode', () => {
+    expect(
+      resolveOpenCodeAggregatePrimaryLeadName([
+        { name: 'team-lead', providerId: 'opencode' },
+        { name: 'alice', providerId: 'opencode' },
+      ])
+    ).toBe('team-lead');
+  });
+
+  it('takes a lead with no provider recorded, which defaults to this lane', () => {
+    expect(resolveOpenCodeAggregatePrimaryLeadName([{ name: 'team-lead' }])).toBe('team-lead');
+  });
+
+  it('ignores a lead that runs on another runtime', () => {
+    expect(
+      resolveOpenCodeAggregatePrimaryLeadName([
+        { name: 'team-lead', providerId: 'cursor-acp' },
+        { name: 'alice', providerId: 'opencode' },
+      ])
+    ).toBeNull();
+    expect(
+      resolveOpenCodeAggregatePrimaryLeadName([
+        { name: 'team-lead', providerId: 'anthropic' },
+      ])
+    ).toBeNull();
+  });
+
+  it('answers null when the roster names no lead at all', () => {
+    expect(
+      resolveOpenCodeAggregatePrimaryLeadName([{ name: 'alice', providerId: 'opencode' }])
+    ).toBeNull();
   });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateRun.leadVeto.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateRun.leadVeto.test.ts
@@ -132,9 +132,10 @@ function basePorts(
 
 async function runLaunch(
   overrides: Partial<OpenCodeWorktreeRootAggregateLaunchPorts>
-): Promise<{ calls: string[]; progressLog: TeamProvisioningProgress[] }> {
+): Promise<{ calls: string[]; progressLog: TeamProvisioningProgress[]; reports: string[] }> {
   const calls: string[] = [];
   const progressLog: TeamProvisioningProgress[] = [];
+  const reports: string[] = [];
   await runOpenCodeWorktreeRootAggregateLaunch(
     {
       adapter: {} as TeamLaunchRuntimeAdapter,
@@ -144,9 +145,13 @@ async function runLaunch(
       prompt: 'Summarize the repo',
       onProgress: vi.fn(),
     },
-    { ...basePorts(calls, progressLog), ...overrides }
+    {
+      ...basePorts(calls, progressLog),
+      logDiagnostic: (message) => reports.push(message),
+      ...overrides,
+    }
   );
-  return { calls, progressLog };
+  return { calls, progressLog, reports };
 }
 
 describe('OpenCode aggregate launch treats the lead as a veto', () => {
@@ -293,5 +298,95 @@ describe('OpenCode aggregate launch treats the lead as a veto', () => {
     expect(progressLog.at(-1)?.message).toBe('OpenCode member lanes are ready');
     expect(calls).toContain('setAliveRun');
     expect(calls).toContain('deliverLaunchPrompt');
+  });
+});
+
+describe('a blocked primary lane reports why, without changing the launch', () => {
+  const pendingLeadResult = (): ReturnType<typeof buildUncommittedPrimaryLeadLaunchResult> => {
+    const result = buildUncommittedPrimaryLeadLaunchResult();
+    result.members['team-lead'] = {
+      ...result.members['team-lead'],
+      launchState: 'runtime_pending_bootstrap',
+      bootstrapConfirmed: false,
+      runtimeAlive: false,
+      runtimePid: 4321,
+    };
+    return result;
+  };
+
+  // NEGATIVE CONTROL: a team that is not blocked produces ZERO reports.
+  it('emits no report at all for a healthy launch', async () => {
+    const { reports, calls, progressLog } = await runLaunch({
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => true,
+    });
+
+    expect(reports).toEqual([]);
+    expect(progressLog.at(-1)?.cliLogsTail).toBeUndefined();
+    expect(calls).toContain('deliverLaunchPrompt');
+  });
+
+  // NEGATIVE CONTROL: the reports are pure observation. The same launch, run
+  // once with a sink and once with none, produces the identical outcome.
+  it('produces the same launch outcome with and without a report sink', async () => {
+    const withSink = await runLaunch({
+      launchOpenCodeAggregatePrimaryLane: async () => pendingLeadResult(),
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => false,
+    });
+    const withoutSink = await runLaunch({
+      launchOpenCodeAggregatePrimaryLane: async () => pendingLeadResult(),
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => false,
+      logDiagnostic: undefined,
+    });
+
+    expect(withSink.reports.length).toBeGreaterThan(0);
+    expect(withoutSink.calls).toEqual(withSink.calls);
+    // Identical down to the progress tail: the sink is a durable side channel,
+    // never a second source of truth.
+    expect(withoutSink.progressLog).toEqual(withSink.progressLog);
+  });
+
+  it('names the deferred dispatch while the lead bootstrap is pending', async () => {
+    const { reports, progressLog, calls } = await runLaunch({
+      launchOpenCodeAggregatePrimaryLane: async () => pendingLeadResult(),
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => false,
+    });
+
+    expect(reports).toEqual([
+      '[lane-team] opencode_launch_prompt_deferred_until_lead_bootstrap lead=team-lead',
+    ]);
+    // The same text reaches the progress tail the user can already see.
+    expect(progressLog.at(-1)?.cliLogsTail).toContain(
+      'opencode_launch_prompt_deferred_until_lead_bootstrap'
+    );
+    expect(calls).toContain('deliverLaunchPrompt');
+  });
+
+  // The prompt guard is a SECOND gate, on a different question: the veto asks
+  // whether the lead's session is committed, this asks whether the lane holds
+  // any runtime evidence for it at all. A lead that claims `confirmed_alive`
+  // with a committed record but no handle passes the veto and fails this one.
+  it('refuses to burn the prompt on a lead the lane holds no runtime evidence for', async () => {
+    const noEvidenceLead = buildUncommittedPrimaryLeadLaunchResult();
+    noEvidenceLead.members['team-lead'] = {
+      ...noEvidenceLead.members['team-lead'],
+      bootstrapConfirmed: false,
+      runtimeAlive: false,
+      agentToolAccepted: false,
+      runtimeDiagnostic: 'primary lane reported no runtime handle',
+    };
+
+    const { reports, calls, progressLog } = await runLaunch({
+      launchOpenCodeAggregatePrimaryLane: async () => noEvidenceLead,
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => true,
+    });
+
+    expect(calls).not.toContain('deliverLaunchPrompt');
+    expect(reports).toEqual([
+      '[lane-team] opencode_launch_prompt_lead_unavailable lead=team-lead ' +
+        'reason=primary lane reported no runtime handle',
+    ]);
+    // The launch outcome is untouched: the lanes are still promoted.
+    expect(progressLog.at(-1)?.state).toBe('ready');
+    expect(calls).toContain('setAliveRun');
   });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateRun.leadVeto.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateRun.leadVeto.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type OpenCodeWorktreeRootAggregateLaunchPorts,
+  runOpenCodeWorktreeRootAggregateLaunch,
+} from '../TeamProvisioningOpenCodeAggregateRun';
+
+import {
+  buildFailedOpenCodeLaunchResult,
+  buildRetainableOpenCodeLaunchResult,
+  buildUncommittedPrimaryLeadLaunchResult,
+} from './support/openCodeUncommittedPrimaryLane';
+
+import type { TeamLaunchRuntimeAdapter } from '../../runtime';
+import type { OpenCodeAggregateProvisioningRun } from '../TeamProvisioningOpenCodeAggregateRun';
+import type { TeamRuntimeLanePlan } from '@features/team-runtime-lanes';
+import type { TeamCreateRequest, TeamProvisioningProgress } from '@shared/types';
+
+type OpenCodeMemberLanePlan = Extract<TeamRuntimeLanePlan, { mode: 'pure_opencode_member_lanes' }>;
+type OpenCodeMember = OpenCodeMemberLanePlan['allMembers'][number];
+
+const PROJECT_CWD = '/fake/project';
+const TEAMS_BASE_PATH = '/safe-test/teams';
+
+function member(name: string, extra: Partial<OpenCodeMember> = {}): OpenCodeMember {
+  return { name, role: 'Engineer', providerId: 'opencode', cwd: PROJECT_CWD, ...extra };
+}
+
+const lead = member('team-lead', { role: 'Team Lead' });
+const ada = member('Ada');
+const ben = member('Ben');
+
+function request(): TeamCreateRequest {
+  return {
+    teamName: 'lane-team',
+    cwd: PROJECT_CWD,
+    providerId: 'opencode',
+    members: [lead, ada, ben],
+  } as TeamCreateRequest;
+}
+
+function lanePlan(): OpenCodeMemberLanePlan {
+  return {
+    mode: 'pure_opencode_member_lanes',
+    primaryMembers: [lead],
+    sideLanes: [
+      { laneId: 'secondary:opencode:ada', member: ada, providerId: 'opencode' },
+      { laneId: 'secondary:opencode:ben', member: ben, providerId: 'opencode' },
+    ],
+    allMembers: [lead, ada, ben],
+  } as unknown as OpenCodeMemberLanePlan;
+}
+
+function basePorts(
+  calls: string[],
+  progressLog: TeamProvisioningProgress[]
+): OpenCodeWorktreeRootAggregateLaunchPorts {
+  const runs = new Map<string, OpenCodeAggregateProvisioningRun>();
+  const provisioningRuns = new Map<string, string>();
+  const ports: Partial<OpenCodeWorktreeRootAggregateLaunchPorts> = {
+    randomUUID: () => 'run-a1',
+    nowMs: () => 0,
+    nowIso: () => '2026-08-28T12:20:00.000Z',
+    getStopAllTeamsGeneration: () => 0,
+    getStopTeamGeneration: () => 0,
+    getRuntimeAdapterRun: () => undefined,
+    stopOpenCodeRuntimeAdapterTeam: async () => {
+      calls.push('stopPrimary');
+    },
+    hasSecondaryRuntimeRuns: () => true,
+    stopMixedSecondaryRuntimeLanes: async () => {
+      calls.push('stopSecondaryLanes');
+    },
+    getProvisioningRun: (teamName) => provisioningRuns.get(teamName),
+    getRuntimeAdapterProgress: () => undefined,
+    isCancellableRuntimeAdapterProgress: () => false,
+    cancelRuntimeAdapterProvisioning: async () => undefined,
+    recordCancelledOpenCodeRuntimeAdapterLaunch: () => {
+      calls.push('recordCancelledLaunch');
+      return { runId: 'cancelled-run' };
+    },
+    setProvisioningRun: (teamName, runId) => {
+      provisioningRuns.set(teamName, runId);
+    },
+    getRun: (runId) => runs.get(runId),
+    setRuntimeAdapterProgress: (progress) => {
+      progressLog.push(progress);
+      calls.push(`setProgress:${progress.state}`);
+      return progress;
+    },
+    resetTeamScopedTransientStateForNewRun: () => undefined,
+    readLaunchState: async () => null,
+    clearPersistedLaunchState: async () => undefined,
+    setRun: (runId, run) => {
+      runs.set(runId, run);
+    },
+    invalidateRuntimeSnapshotCaches: () => undefined,
+    launchOpenCodeAggregatePrimaryLane: async () => buildUncommittedPrimaryLeadLaunchResult(),
+    launchSingleMixedSecondaryLane: async (_run, lane) => {
+      lane.state = 'finished';
+      lane.result = buildRetainableOpenCodeLaunchResult(lane.member.name);
+    },
+    publishMixedSecondaryLaneStatusChange: async () => undefined,
+    getOpenCodeRuntimeLaunchCwd: (baseCwd) => baseCwd,
+    getSecondaryRuntimeRun: () => undefined,
+    summarizeOpenCodeAggregateLaunchState: () => 'clean_success',
+    persistLaunchStateSnapshot: async (_run, launchPhase) => {
+      calls.push(`persistLaunchState:${launchPhase}`);
+      return null;
+    },
+    syncRunMemberSpawnStatusesFromSnapshot: () => undefined,
+    setAliveRunId: () => {
+      calls.push('setAliveRun');
+    },
+    setRuntimeAdapterRun: () => undefined,
+    deleteAliveRunId: () => undefined,
+    deleteRuntimeAdapterRun: () => undefined,
+    cleanupRun: () => undefined,
+    deleteProvisioningRunIfCurrent: () => undefined,
+    emitTeamProcessChange: () => undefined,
+    consumeCancelledRuntimeAdapterRunId: () => false,
+    getTeamsBasePath: () => TEAMS_BASE_PATH,
+    clearOpenCodeRuntimeLaneStorage: async () => true,
+    setSecondaryRuntimeRun: () => undefined,
+    deleteSecondaryRuntimeRun: () => undefined,
+    deliverOpenCodeLaunchPromptToLead: async () => {
+      calls.push('deliverLaunchPrompt');
+    },
+  };
+  return ports as OpenCodeWorktreeRootAggregateLaunchPorts;
+}
+
+async function runLaunch(
+  overrides: Partial<OpenCodeWorktreeRootAggregateLaunchPorts>
+): Promise<{ calls: string[]; progressLog: TeamProvisioningProgress[] }> {
+  const calls: string[] = [];
+  const progressLog: TeamProvisioningProgress[] = [];
+  await runOpenCodeWorktreeRootAggregateLaunch(
+    {
+      adapter: {} as TeamLaunchRuntimeAdapter,
+      request: request(),
+      members: [lead, ada, ben],
+      lanePlan: lanePlan(),
+      prompt: 'Summarize the repo',
+      onProgress: vi.fn(),
+    },
+    { ...basePorts(calls, progressLog), ...overrides }
+  );
+  return { calls, progressLog };
+}
+
+describe('OpenCode aggregate launch treats the lead as a veto', () => {
+  // NEGATIVE CONTROL, first on purpose: the veto is not a blanket fail. A
+  // confirmed lead beside two FAILED side lanes must still promote the team.
+  it('keeps a confirmed lead with two failed side lanes a partial success', async () => {
+    const { calls, progressLog } = await runLaunch({
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => true,
+      summarizeOpenCodeAggregateLaunchState: () => 'partial_failure',
+      launchSingleMixedSecondaryLane: async (_run, lane) => {
+        lane.state = 'finished';
+        lane.result = buildFailedOpenCodeLaunchResult(lane.member.name, 'runtime never answered');
+      },
+    });
+
+    expect(progressLog.at(-1)?.state).toBe('ready');
+    expect(progressLog.at(-1)?.message).toBe('OpenCode team is running with unavailable members');
+    expect(progressLog.at(-1)?.configReady).toBe(true);
+    expect(calls).toContain('setAliveRun');
+    expect(calls).toContain('deliverLaunchPrompt');
+    // No terminal rollback was taken: no failed progress was ever published.
+    expect(progressLog.some((entry) => entry.state === 'failed')).toBe(false);
+  });
+
+  it('fails the launch when the lead has no committed session, even with two healthy side lanes', async () => {
+    const { calls, progressLog } = await runLaunch({
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => false,
+    });
+
+    const finalProgress = progressLog.at(-1)!;
+    expect(finalProgress.state).toBe('failed');
+    expect(finalProgress.configReady).toBe(false);
+    expect(finalProgress.error).toContain('team-lead');
+    expect(calls).not.toContain('setAliveRun');
+    expect(calls).not.toContain('deliverLaunchPrompt');
+    expect(calls).toContain('stopSecondaryLanes');
+  });
+
+  it('keeps the run active and still queues the prompt while the lead is pending', async () => {
+    const pendingLead = buildUncommittedPrimaryLeadLaunchResult();
+    pendingLead.members['team-lead'] = {
+      ...pendingLead.members['team-lead'],
+      launchState: 'runtime_pending_bootstrap',
+      bootstrapConfirmed: false,
+      runtimeAlive: false,
+      runtimePid: 4321,
+    };
+
+    const { calls, progressLog } = await runLaunch({
+      launchOpenCodeAggregatePrimaryLane: async () => pendingLead,
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => false,
+    });
+
+    expect(calls).toContain('persistLaunchState:active');
+    expect(calls).toContain('setAliveRun');
+    // The prompt reaches the inbox EXACTLY ONCE: dropping it here would leave
+    // the team idle forever with the user's request gone, on a progress that
+    // says ready.
+    expect(calls.filter((call) => call === 'deliverLaunchPrompt')).toEqual(['deliverLaunchPrompt']);
+    expect(progressLog.at(-1)?.message).toBe(
+      'OpenCode lead is waiting for its runtime bootstrap evidence'
+    );
+  });
+
+  it('queues the prompt exactly once whether the lead commits before or after the branch', async () => {
+    const pendingLead = buildUncommittedPrimaryLeadLaunchResult();
+    pendingLead.members['team-lead'] = {
+      ...pendingLead.members['team-lead'],
+      launchState: 'runtime_pending_bootstrap',
+      bootstrapConfirmed: false,
+      runtimeAlive: false,
+      runtimePid: 4321,
+    };
+    const prompts: { teamName: string; leadName: string; prompt: string }[] = [];
+    const collectPrompt = async (input: {
+      teamName: string;
+      leadName: string;
+      prompt: string;
+    }): Promise<void> => {
+      // Only the identity of the queued prompt is asserted here; the inbox port
+      // carries launch-currency plumbing this case says nothing about.
+      prompts.push({ teamName: input.teamName, leadName: input.leadName, prompt: input.prompt });
+    };
+
+    await runLaunch({
+      launchOpenCodeAggregatePrimaryLane: async () => pendingLead,
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => false,
+      deliverOpenCodeLaunchPromptToLead: collectPrompt,
+    });
+    await runLaunch({
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => true,
+      deliverOpenCodeLaunchPromptToLead: collectPrompt,
+    });
+
+    expect(prompts).toEqual([
+      { teamName: 'lane-team', leadName: 'team-lead', prompt: 'Summarize the repo' },
+      { teamName: 'lane-team', leadName: 'team-lead', prompt: 'Summarize the repo' },
+    ]);
+  });
+
+  // A lead parked on a permission prompt holds no pid and no session id, but the
+  // user answering the prompt is what unblocks it: vetoing it would tear the
+  // whole team down while the dialog is still on screen.
+  it('waits for a permission-blocked lead instead of tearing the team down', async () => {
+    const permissionBlockedLead = buildUncommittedPrimaryLeadLaunchResult();
+    permissionBlockedLead.members['team-lead'] = {
+      ...permissionBlockedLead.members['team-lead'],
+      launchState: 'runtime_pending_permission',
+      bootstrapConfirmed: false,
+      runtimeAlive: false,
+      livenessKind: 'permission_blocked',
+      pendingPermissionRequestIds: ['perm-1'],
+    };
+
+    const { calls, progressLog } = await runLaunch({
+      launchOpenCodeAggregatePrimaryLane: async () => permissionBlockedLead,
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => false,
+    });
+
+    expect(progressLog.at(-1)?.state).toBe('ready');
+    expect(progressLog.at(-1)?.configReady).toBe(true);
+    expect(calls).toContain('persistLaunchState:active');
+    expect(calls).toContain('setAliveRun');
+    expect(calls).toContain('deliverLaunchPrompt');
+  });
+
+  it('promotes and delivers normally once the lead session is committed', async () => {
+    const { calls, progressLog } = await runLaunch({
+      hasCommittedOpenCodePrimaryLeadSessionEvidence: async () => true,
+    });
+
+    expect(progressLog.at(-1)?.state).toBe('ready');
+    expect(progressLog.at(-1)?.configReady).toBe(true);
+    expect(calls).toContain('setAliveRun');
+    expect(calls).toContain('deliverLaunchPrompt');
+  });
+
+  // NEGATIVE CONTROL: with no committed-session reader wired the launch must
+  // behave exactly as it did before this change.
+  it('leaves a launch with no committed-session reader completely unchanged', async () => {
+    const { calls, progressLog } = await runLaunch({});
+
+    expect(progressLog.at(-1)?.state).toBe('ready');
+    expect(progressLog.at(-1)?.message).toBe('OpenCode member lanes are ready');
+    expect(calls).toContain('setAliveRun');
+    expect(calls).toContain('deliverLaunchPrompt');
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeBlockedLaunchReporting.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeBlockedLaunchReporting.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildUncommittableOpenCodeSessionDiagnostic,
+  classifyOpenCodeLeadLaunchEvidence,
+  describeBlockedOpenCodePrimaryLaneLaunch,
+  describeClearedOpenCodePrimaryLaneStorage,
+  describeDeferredOpenCodeLaunchPrompt,
+  describeUnavailableOpenCodeLaunchPromptLead,
+  OPENCODE_LAUNCH_PROMPT_DEFERRED_DIAGNOSTIC,
+} from '../TeamProvisioningOpenCodeBlockedLaunchReporting';
+
+import {
+  buildFailedOpenCodeLaunchResult,
+  buildRetainableOpenCodeLaunchResult,
+  buildUncommittedPrimaryLeadLaunchResult,
+} from './support/openCodeUncommittedPrimaryLane';
+
+import type { TeamRuntimeLaunchResult } from '../../runtime';
+
+describe('reporting never changes a launch', () => {
+  // NEGATIVE CONTROL: every export in this module is a pure string builder. If
+  // one of them ever grew a side effect it would have to take a port, and this
+  // call - made with no ports at all - would stop compiling.
+  it('produces reports from the result alone, with no ports and no writes', () => {
+    const result = buildFailedOpenCodeLaunchResult('team-lead', 'runtime binary unreachable');
+    const before = JSON.parse(JSON.stringify(result)) as TeamRuntimeLaunchResult;
+
+    describeBlockedOpenCodePrimaryLaneLaunch({ teamName: 'lane-team', runId: 'run-a1', result });
+    describeClearedOpenCodePrimaryLaneStorage({ teamName: 'lane-team', runId: 'run-a1' });
+    describeUnavailableOpenCodeLaunchPromptLead({
+      teamName: 'lane-team',
+      leadName: 'team-lead',
+      primaryResult: result,
+    });
+    describeDeferredOpenCodeLaunchPrompt({ teamName: 'lane-team', leadName: 'team-lead' });
+    buildUncommittableOpenCodeSessionDiagnostic({
+      memberName: 'team-lead',
+      reason: 'missing_runtime_session_id',
+    });
+
+    // The launch result the reports were built from is byte-identical afterwards.
+    expect(result).toEqual(before);
+  });
+
+  // NEGATIVE CONTROL: a team that is not blocked produces zero reports.
+  it('reports nothing at all for a healthy lead', () => {
+    expect(
+      describeUnavailableOpenCodeLaunchPromptLead({
+        teamName: 'lane-team',
+        leadName: 'team-lead',
+        primaryResult: buildRetainableOpenCodeLaunchResult('team-lead'),
+      })
+    ).toBeNull();
+  });
+
+  it('reports nothing when the primary lane carries no entry for the lead', () => {
+    expect(
+      describeUnavailableOpenCodeLaunchPromptLead({
+        teamName: 'lane-team',
+        leadName: 'team-lead',
+        primaryResult: buildRetainableOpenCodeLaunchResult('Ada'),
+      })
+    ).toBeNull();
+  });
+});
+
+describe('describeBlockedOpenCodePrimaryLaneLaunch', () => {
+  it('names the pre-launch gate, the reason and the members that failed', () => {
+    const result = buildFailedOpenCodeLaunchResult('team-lead', 'runtime binary unreachable');
+    result.preLaunchGate = { blocked: true, reason: 'runtime_unreachable', retryable: true };
+    result.diagnostics = ['probe timed out'];
+
+    expect(
+      describeBlockedOpenCodePrimaryLaneLaunch({ teamName: 'lane-team', runId: 'run-a1', result })
+    ).toBe(
+      '[lane-team] opencode_primary_lane_launch_blocked run=run-a1 ' +
+        'preLaunchGate=runtime_unreachable/retryable=true reason=runtime binary unreachable ' +
+        'members=team-lead diagnostics=probe timed out'
+    );
+  });
+
+  it('says so explicitly when there is no gate, no reason and no diagnostics', () => {
+    const result = buildUncommittedPrimaryLeadLaunchResult({ teamLaunchState: 'partial_failure' });
+
+    expect(
+      describeBlockedOpenCodePrimaryLaneLaunch({ teamName: 'lane-team', runId: 'run-a1', result })
+    ).toBe(
+      '[lane-team] opencode_primary_lane_launch_blocked run=run-a1 preLaunchGate=none ' +
+        'reason=unknown members=none diagnostics=none'
+    );
+  });
+
+  it('falls back to the gate reason when no member carries one', () => {
+    const result = buildUncommittedPrimaryLeadLaunchResult({ teamLaunchState: 'partial_failure' });
+    result.preLaunchGate = { blocked: true, reason: 'shared_runtime_timeout', retryable: false };
+
+    expect(
+      describeBlockedOpenCodePrimaryLaneLaunch({ teamName: 'lane-team', runId: 'run-a1', result })
+    ).toContain('reason=shared_runtime_timeout');
+  });
+});
+
+describe('describeClearedOpenCodePrimaryLaneStorage', () => {
+  it('names the run whose evidence was destroyed', () => {
+    expect(
+      describeClearedOpenCodePrimaryLaneStorage({ teamName: 'lane-team', runId: 'run-a1' })
+    ).toBe(
+      '[lane-team] opencode_primary_lane_storage_cleared run=run-a1 ' +
+        'reason=unretainable_launch detail=lane_has_no_session_record'
+    );
+  });
+});
+
+describe('buildUncommittableOpenCodeSessionDiagnostic', () => {
+  it('distinguishes a missing session id from a candidate mismatch', () => {
+    expect(
+      buildUncommittableOpenCodeSessionDiagnostic({
+        memberName: 'team-lead',
+        reason: 'missing_runtime_session_id',
+      })
+    ).toBe('opencode_bootstrap_session_not_committed:team-lead:missing_runtime_session_id');
+    expect(
+      buildUncommittableOpenCodeSessionDiagnostic({
+        memberName: 'team-lead',
+        reason: 'app_managed_candidate_mismatch',
+      })
+    ).toBe('opencode_bootstrap_session_not_committed:team-lead:app_managed_candidate_mismatch');
+  });
+});
+
+describe('classifyOpenCodeLeadLaunchEvidence', () => {
+  it('is unknown when the lane reports no entry for the lead', () => {
+    expect(classifyOpenCodeLeadLaunchEvidence(null, 'team-lead')).toBe('unknown');
+    expect(
+      classifyOpenCodeLeadLaunchEvidence(buildRetainableOpenCodeLaunchResult('Ada'), 'team-lead')
+    ).toBe('unknown');
+  });
+
+  it('is retainable for a lead the lane reports as alive', () => {
+    expect(
+      classifyOpenCodeLeadLaunchEvidence(
+        buildRetainableOpenCodeLaunchResult('team-lead'),
+        'team-lead'
+      )
+    ).toBe('retainable');
+  });
+
+  it('is unretainable for a lead the lane explicitly failed', () => {
+    expect(
+      classifyOpenCodeLeadLaunchEvidence(
+        buildFailedOpenCodeLaunchResult('team-lead', 'runtime binary unreachable'),
+        'team-lead'
+      )
+    ).toBe('unretainable');
+  });
+
+  it('matches the lead by its evidence member name, not the record key', () => {
+    const result = buildRetainableOpenCodeLaunchResult('team-lead');
+    result.members['lane-0'] = result.members['team-lead'];
+    delete result.members['team-lead'];
+
+    expect(classifyOpenCodeLeadLaunchEvidence(result, 'TEAM-LEAD')).toBe('retainable');
+  });
+});
+
+describe('describeUnavailableOpenCodeLaunchPromptLead', () => {
+  it('names the failure the lane reported for the lead', () => {
+    expect(
+      describeUnavailableOpenCodeLaunchPromptLead({
+        teamName: 'lane-team',
+        leadName: 'team-lead',
+        primaryResult: buildFailedOpenCodeLaunchResult('team-lead', 'runtime binary unreachable'),
+      })
+    ).toBe(
+      '[lane-team] opencode_launch_prompt_lead_unavailable ' +
+        'lead=team-lead reason=runtime binary unreachable'
+    );
+  });
+
+  it('falls back to a named reason when the lane gave none', () => {
+    const result = buildFailedOpenCodeLaunchResult('team-lead', '');
+    result.members['team-lead'] = { ...result.members['team-lead'], hardFailureReason: undefined };
+
+    expect(
+      describeUnavailableOpenCodeLaunchPromptLead({
+        teamName: 'lane-team',
+        leadName: 'team-lead',
+        primaryResult: result,
+      })
+    ).toContain('reason=primary_lane_produced_no_runtime_evidence');
+  });
+});
+
+describe('describeDeferredOpenCodeLaunchPrompt', () => {
+  it('names the lead the dispatch is waiting on', () => {
+    expect(
+      describeDeferredOpenCodeLaunchPrompt({ teamName: 'lane-team', leadName: 'team-lead' })
+    ).toBe(`[lane-team] ${OPENCODE_LAUNCH_PROMPT_DEFERRED_DIAGNOSTIC} lead=team-lead`);
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeBlockedLaunchReporting.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeBlockedLaunchReporting.test.ts
@@ -91,6 +91,29 @@ describe('describeBlockedOpenCodePrimaryLaneLaunch', () => {
     );
   });
 
+  // The report goes to a durable sink, and a runtime that failed while starting
+  // prints the command line it was given. Nothing downstream redacts a
+  // persisted log line, so the redaction has to happen here.
+  it('redacts secrets out of the member reason and the lane diagnostics', () => {
+    const result = buildFailedOpenCodeLaunchResult(
+      'team-lead',
+      'spawn failed: opencode --api-key sk-abcdefghijklmnop01 serve'
+    );
+    result.diagnostics = ['probe rejected: Authorization: Bearer abc.def'];
+
+    const report = describeBlockedOpenCodePrimaryLaneLaunch({
+      teamName: 'lane-team',
+      runId: 'run-a1',
+      result,
+    });
+
+    expect(report).toBe(
+      '[lane-team] opencode_primary_lane_launch_blocked run=run-a1 preLaunchGate=none ' +
+        'reason=spawn failed: opencode --api-key [redacted] serve members=team-lead ' +
+        'diagnostics=probe rejected: Authorization: Bearer [redacted]'
+    );
+  });
+
   it('falls back to the gate reason when no member carries one', () => {
     const result = buildUncommittedPrimaryLeadLaunchResult({ teamLaunchState: 'partial_failure' });
     result.preLaunchGate = { blocked: true, reason: 'shared_runtime_timeout', retryable: false };
@@ -98,6 +121,27 @@ describe('describeBlockedOpenCodePrimaryLaneLaunch', () => {
     expect(
       describeBlockedOpenCodePrimaryLaneLaunch({ teamName: 'lane-team', runId: 'run-a1', result })
     ).toContain('reason=shared_runtime_timeout');
+  });
+});
+
+describe('describeUnavailableOpenCodeLaunchPromptLead', () => {
+  // Same durable sink, same free-form fields: the lead's own runtime
+  // diagnostic is whatever the bridge printed.
+  it('redacts the reason it quotes from the lead evidence', () => {
+    const result = buildFailedOpenCodeLaunchResult('team-lead', '   ');
+    result.members['team-lead'].runtimeDiagnostic =
+      'host refused: Authorization: Bearer eyJhbGciOi.payload';
+
+    expect(
+      describeUnavailableOpenCodeLaunchPromptLead({
+        teamName: 'lane-team',
+        leadName: 'team-lead',
+        primaryResult: result,
+      })
+    ).toBe(
+      '[lane-team] opencode_launch_prompt_lead_unavailable lead=team-lead ' +
+        'reason=host refused: Authorization: Bearer [redacted]'
+    );
   });
 });
 

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeBootstrapEvidence.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeBootstrapEvidence.test.ts
@@ -6,6 +6,7 @@ import {
   hasMatchingCommittedOpenCodeRuntimeBootstrapSessionEvidence,
   mergeOpenCodeRuntimeSessionRecords,
   parseOpenCodeRuntimeSessionStoreRecords,
+  requireAnsweredOpenCodeCommittedBootstrapSessionEvidence,
   resolveOpenCodeRuntimeBootstrapCheckinIdempotencyFromMember,
 } from '../TeamProvisioningOpenCodeBootstrapEvidence';
 
@@ -289,5 +290,75 @@ describe('TeamProvisioningOpenCodeBootstrapEvidence', () => {
         runtimeSessionId: 'session-2',
       }).state
     ).toBe('new');
+  });
+});
+
+describe('requireAnsweredOpenCodeCommittedBootstrapSessionEvidence', () => {
+  function evidence(
+    overrides: Partial<OpenCodeCommittedBootstrapSessionEvidence>
+  ): OpenCodeCommittedBootstrapSessionEvidence {
+    return {
+      state: 'healthy',
+      committed: true,
+      activeRunId: 'run-1',
+      sessions: [],
+      diagnostics: [],
+      ...overrides,
+    };
+  }
+
+  // A store this reader could not read answers the same shape an empty store
+  // does. The gates that may downgrade a member on a missing record therefore
+  // have to be handed a raise, not a `false`: only an answered store proves
+  // anything, and a manifest lock held by a concurrent bootstrap check-in is
+  // the very contention those gates race.
+  it('raises for every state that is not an answered store', () => {
+    expect(() =>
+      requireAnsweredOpenCodeCommittedBootstrapSessionEvidence(
+        evidence({
+          state: 'invalid_store',
+          committed: false,
+          diagnostics: ['OpenCode runtime manifest could not be read.'],
+        })
+      )
+    ).toThrow('unavailable (invalid_store): OpenCode runtime manifest could not be read.');
+    expect(() =>
+      requireAnsweredOpenCodeCommittedBootstrapSessionEvidence(
+        evidence({ state: 'descriptor_missing', committed: false })
+      )
+    ).toThrow('unavailable (descriptor_missing)');
+  });
+
+  // A store mid-write is not an outage either, and it is the one the gates
+  // actually race: the session file lands before its manifest entry does.
+  it('raises for a store that is between its write and its commit', () => {
+    expect(() =>
+      requireAnsweredOpenCodeCommittedBootstrapSessionEvidence(
+        evidence({ state: 'uncommitted_write', committed: false })
+      )
+    ).toThrow('unavailable (uncommitted_write)');
+    expect(() =>
+      requireAnsweredOpenCodeCommittedBootstrapSessionEvidence(
+        evidence({ state: 'hash_mismatch', committed: false })
+      )
+    ).toThrow('unavailable (hash_mismatch)');
+    expect(() =>
+      requireAnsweredOpenCodeCommittedBootstrapSessionEvidence(
+        evidence({ state: 'future_schema', committed: false })
+      )
+    ).toThrow('unavailable (future_schema)');
+  });
+
+  // A lane with no session file at all is the absence these gates exist for,
+  // and a file the app cannot read holds nothing the delivery path could use
+  // either. Both are answers, and both must stay able to disprove.
+  it('passes an answered store through untouched, sessions or none', () => {
+    const answered = evidence({ sessions: [] });
+    const absent = evidence({ state: 'missing', committed: false });
+    const unreadable = evidence({ state: 'quarantined', committed: false });
+
+    expect(requireAnsweredOpenCodeCommittedBootstrapSessionEvidence(answered)).toBe(answered);
+    expect(requireAnsweredOpenCodeCommittedBootstrapSessionEvidence(absent)).toBe(absent);
+    expect(requireAnsweredOpenCodeCommittedBootstrapSessionEvidence(unreadable)).toBe(unreadable);
   });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeSecondaryLaneEvidencePortsFactory.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeSecondaryLaneEvidencePortsFactory.test.ts
@@ -76,4 +76,61 @@ describe('TeamProvisioningOpenCodeSecondaryLaneEvidencePortsFactory', () => {
     });
     expect(logWarn).toHaveBeenCalledWith('warn');
   });
+
+  // The guard this port feeds reads only an answered `false` as proof that a
+  // member holds no session record. The store reader reports a manifest it
+  // could not read - a lock held by a concurrent bootstrap check-in, say - as
+  // an empty session list, so answering from it would turn that contention
+  // into a downgrade of a healthy member. It has to raise instead.
+  it('raises rather than answering false when the committed store did not answer', async () => {
+    const ports = createTeamProvisioningOpenCodeSecondaryLaneEvidencePortsFromService(
+      createHost(),
+      {
+        getTeamsBasePath: () => '/teams',
+        readCommittedBootstrapSessionEvidence: async () => ({
+          state: 'invalid_store' as const,
+          committed: false,
+          activeRunId: null,
+          sessions: [],
+          diagnostics: ['OpenCode runtime manifest could not be read.'],
+        }),
+        logWarn: vi.fn(),
+      }
+    );
+
+    await expect(
+      ports.hasCommittedOpenCodeLaneMemberSessionEvidence?.({
+        teamName: 'alpha',
+        laneId: 'lane-1',
+        runId: 'run-1',
+        memberName: 'ada',
+      })
+    ).rejects.toThrow('unavailable (invalid_store)');
+  });
+
+  it('answers false when the store answered and holds no record for the member', async () => {
+    const ports = createTeamProvisioningOpenCodeSecondaryLaneEvidencePortsFromService(
+      createHost(),
+      {
+        getTeamsBasePath: () => '/teams',
+        readCommittedBootstrapSessionEvidence: async () => ({
+          state: 'healthy' as const,
+          committed: true,
+          activeRunId: 'run-1',
+          sessions: [],
+          diagnostics: [],
+        }),
+        logWarn: vi.fn(),
+      }
+    );
+
+    await expect(
+      ports.hasCommittedOpenCodeLaneMemberSessionEvidence?.({
+        teamName: 'alpha',
+        laneId: 'lane-1',
+        runId: 'run-1',
+        memberName: 'ada',
+      })
+    ).resolves.toBe(false);
+  });
 });

--- a/src/main/services/team/provisioning/__tests__/support/openCodeUncommittedPrimaryLane.ts
+++ b/src/main/services/team/provisioning/__tests__/support/openCodeUncommittedPrimaryLane.ts
@@ -1,0 +1,113 @@
+import type { TeamRuntimeLaunchResult } from '../../../runtime';
+
+/**
+ * The shape every regression in this area is pinned against: a failed primary
+ * lane whose directory held ONLY the prompt delivery ledger - no
+ * `opencode-sessions.json`, no `manifest.json`, no
+ * `opencode-runtime-receipts.json` - while the lead still reported
+ * `confirmed_alive`.
+ */
+export const UNCOMMITTED_PRIMARY_LANE_STORAGE = {
+  laneDirectoryExists: true,
+  hasStateOnDisk: true,
+  hasRuntimeEvidenceOnDisk: false,
+  manifestEntryCount: null,
+  manifestUpdatedAt: null,
+  fileNames: ['opencode-prompt-delivery-ledger.json'],
+} as const;
+
+/** The same lane after the session record and its manifest entry landed. */
+export const COMMITTED_PRIMARY_LANE_STORAGE = {
+  laneDirectoryExists: true,
+  hasStateOnDisk: true,
+  hasRuntimeEvidenceOnDisk: true,
+  manifestEntryCount: 1,
+  manifestUpdatedAt: '2026-08-28T12:28:16.028Z',
+  fileNames: [
+    'opencode-prompt-delivery-ledger.json',
+    'opencode-sessions.json',
+    'manifest.json',
+    'opencode-runtime-receipts.json',
+  ],
+} as const;
+
+export function buildUncommittedPrimaryLeadLaunchResult(
+  overrides: Partial<TeamRuntimeLaunchResult> = {}
+): TeamRuntimeLaunchResult {
+  return {
+    runId: 'run-a1',
+    teamName: 'lane-team',
+    launchPhase: 'finished',
+    teamLaunchState: 'clean_success',
+    members: {
+      'team-lead': {
+        memberName: 'team-lead',
+        providerId: 'opencode',
+        launchState: 'confirmed_alive',
+        agentToolAccepted: true,
+        runtimeAlive: true,
+        bootstrapConfirmed: true,
+        hardFailure: false,
+        // The whole point: no sessionId, no runtimePid, no app-managed candidate.
+        diagnostics: [],
+      },
+    },
+    warnings: [],
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+export function buildRetainableOpenCodeLaunchResult(
+  memberName: string,
+  overrides: Partial<TeamRuntimeLaunchResult> = {}
+): TeamRuntimeLaunchResult {
+  return {
+    runId: 'run-a1',
+    teamName: 'lane-team',
+    launchPhase: 'finished',
+    teamLaunchState: 'clean_success',
+    members: {
+      [memberName]: {
+        memberName,
+        providerId: 'opencode',
+        launchState: 'confirmed_alive',
+        agentToolAccepted: true,
+        runtimeAlive: true,
+        bootstrapConfirmed: true,
+        hardFailure: false,
+        diagnostics: [],
+      },
+    },
+    warnings: [],
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+export function buildFailedOpenCodeLaunchResult(
+  memberName: string,
+  hardFailureReason: string
+): TeamRuntimeLaunchResult {
+  return {
+    runId: 'run-a1',
+    teamName: 'lane-team',
+    launchPhase: 'finished',
+    teamLaunchState: 'partial_failure',
+    members: {
+      [memberName]: {
+        memberName,
+        providerId: 'opencode',
+        launchState: 'failed_to_start',
+        agentToolAccepted: false,
+        runtimeAlive: false,
+        bootstrapConfirmed: false,
+        hardFailure: true,
+        hardFailureReason,
+        diagnostics: [],
+      },
+    },
+    warnings: [],
+    diagnostics: [],
+  };
+}

--- a/src/main/services/team/runtime/OpenCodeLaunchGateResult.ts
+++ b/src/main/services/team/runtime/OpenCodeLaunchGateResult.ts
@@ -85,11 +85,16 @@ export function blockedLaunchResult(
   warnings: string[] = [],
   options: { preLaunchGate?: boolean } = {}
 ): TeamRuntimeLaunchResult {
+  // Every readiness state prepareOpenCodeLaunch can hand on as `reason`: the
+  // state is a code, and the diagnostics beside it are what a member can be
+  // shown. A state missing from this list reaches the member card as the bare
+  // code with its own diagnostic left unread.
   const readinessFailure =
     reason === 'unknown_error' ||
     reason === 'model_unavailable' ||
     reason === 'not_authenticated' ||
     reason === 'mcp_unavailable' ||
+    reason === 'runtime_store_blocked' ||
     reason === 'not_installed';
   const hardFailureReason = readinessFailure
     ? (firstDisplayableOpenCodeFailureMessage(diagnostics, { includeGeneric: false }) ?? reason)

--- a/src/main/services/team/runtime/OpenCodeLaunchGateResult.ts
+++ b/src/main/services/team/runtime/OpenCodeLaunchGateResult.ts
@@ -1,5 +1,19 @@
+import { isOpenCodeTerminalProbeTechnicalDiagnostic } from '../opencode/readiness/OpenCodeFailureDiagnostics';
+
 import type { OpenCodeTeamLaunchReadiness } from '../opencode/readiness/OpenCodeTeamLaunchReadiness';
-import type { TeamRuntimeLaunchResult, TeamRuntimePreLaunchGate } from './TeamRuntimeAdapter';
+import type {
+  TeamRuntimeLaunchInput,
+  TeamRuntimeLaunchResult,
+  TeamRuntimePreLaunchGate,
+} from './TeamRuntimeAdapter';
+
+export const GENERIC_OPEN_CODE_MEMBER_FAILURE_REASON =
+  'OpenCode bridge reported member launch failure';
+
+const SECRET_FLAG_PATTERN =
+  /(--(?:api-key|token|password|secret|authorization|auth-token)(?:=|\s+))("[^"]*"|'[^']*'|\S+)/gi;
+const BEARER_TOKEN_PATTERN = /\bBearer\s+\S+/gi;
+const SECRET_KEY_PATTERN = /\bsk-[A-Za-z0-9_-]{16,}\b/g;
 
 /**
  * Readiness states a user can act on and launch again. It is deliberately wider
@@ -53,5 +67,127 @@ export function isAutoRetryableOpenCodePreLaunchGate(
     gate?.blocked === true &&
     gate.retryable &&
     AUTO_RETRYABLE_PRE_LAUNCH_GATE_REASONS.has(gate.reason)
+  );
+}
+
+/**
+ * The launch result a refused launch reports: every expected member is a hard
+ * failure carrying the same reason, so no caller has to reconstruct one.
+ *
+ * `options.preLaunchGate` is opt-in on purpose. Only a call site that can prove
+ * it ran before the state-changing bridge command may set it, and the absent
+ * marker therefore always reads as "this launch may already own a host".
+ */
+export function blockedLaunchResult(
+  input: TeamRuntimeLaunchInput,
+  reason: string,
+  diagnostics: string[],
+  warnings: string[] = [],
+  options: { preLaunchGate?: boolean } = {}
+): TeamRuntimeLaunchResult {
+  const readinessFailure =
+    reason === 'unknown_error' ||
+    reason === 'model_unavailable' ||
+    reason === 'not_authenticated' ||
+    reason === 'mcp_unavailable' ||
+    reason === 'not_installed';
+  const hardFailureReason = readinessFailure
+    ? (firstDisplayableOpenCodeFailureMessage(diagnostics, { includeGeneric: false }) ?? reason)
+    : reason;
+  const members = Object.fromEntries(
+    input.expectedMembers.map((member) => [
+      member.name,
+      {
+        memberName: member.name,
+        providerId: 'opencode' as const,
+        launchState: 'failed_to_start' as const,
+        agentToolAccepted: false,
+        runtimeAlive: false,
+        bootstrapConfirmed: false,
+        hardFailure: true,
+        hardFailureReason,
+        diagnostics,
+      },
+    ])
+  );
+
+  return {
+    runId: input.runId,
+    teamName: input.teamName,
+    launchPhase: 'finished',
+    teamLaunchState: 'partial_failure',
+    members,
+    warnings,
+    diagnostics,
+    // Attached only where the block provably precedes launchOpenCodeTeam, so an
+    // absent marker always reads as "this launch may already own a host".
+    ...(options.preLaunchGate === true
+      ? { preLaunchGate: buildOpenCodePreLaunchGate(reason) }
+      : {}),
+  };
+}
+
+export function isOpenCodeLaunchTimingDiagnostic(diagnostic: string): boolean {
+  return (
+    diagnostic.startsWith('info:opencode_launch_member_timing:') ||
+    diagnostic.startsWith('info:opencode_launch_total_timing:')
+  );
+}
+
+export function firstDisplayableOpenCodeFailureMessage(
+  values: readonly string[],
+  options: { includeGeneric: boolean }
+): string | undefined {
+  for (const value of values) {
+    const normalized = normalizeOpenCodeFailureMessage(value);
+    if (!normalized) {
+      continue;
+    }
+    if (!options.includeGeneric && isGenericOpenCodeFailureMessage(normalized)) {
+      continue;
+    }
+    return normalized;
+  }
+  return undefined;
+}
+
+export function normalizeOpenCodeFailureMessage(value: string | undefined): string | undefined {
+  const trimmed = value?.replace(/\s+/g, ' ').trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed
+    .replace(SECRET_FLAG_PATTERN, '$1[redacted]')
+    .replace(BEARER_TOKEN_PATTERN, 'Bearer [redacted]')
+    .replace(SECRET_KEY_PATTERN, '[redacted-api-key]');
+}
+
+function isGenericOpenCodeFailureMessage(message: string): boolean {
+  return (
+    message === GENERIC_OPEN_CODE_MEMBER_FAILURE_REASON ||
+    message.startsWith(`${GENERIC_OPEN_CODE_MEMBER_FAILURE_REASON}:`) ||
+    // Reassurance text prepended ahead of the real readiness diagnostic for
+    // mcp_unavailable/unknown_error (see the prepareOpenCodeLaunch caller).
+    // Without this, it wins as the first "displayable" (non-generic) message
+    // and permanently hides the specific diagnostic behind it - which is what
+    // shouldRetryTransientOpenCodeSharedRuntimeFailure pattern-matches on to
+    // decide whether a timeout is worth retrying.
+    message === 'OpenCode is temporarily unavailable. Retry the launch.' ||
+    message.startsWith('OpenCode secondary lane timing:') ||
+    message.startsWith(
+      'OpenCode bridge reported ready without all required durable checkpoints:'
+    ) ||
+    message.startsWith(
+      'OpenCode bridge reported ready before all expected members were confirmed:'
+    ) ||
+    message.startsWith(
+      'OpenCode bootstrap MCP did not complete required tools before assistant response:'
+    ) ||
+    message.startsWith('OpenCode command timed out after') ||
+    message.startsWith('CLI-authenticated providers missing from live host') ||
+    message.startsWith('OpenCode session status') ||
+    isOpenCodeTerminalProbeTechnicalDiagnostic(message) ||
+    (message.startsWith('opencode_app_mcp_tool_proof_') && message.includes('cache_hit')) ||
+    isOpenCodeLaunchTimingDiagnostic(message)
   );
 }

--- a/src/main/services/team/runtime/OpenCodeTeamRuntimeAdapter.ts
+++ b/src/main/services/team/runtime/OpenCodeTeamRuntimeAdapter.ts
@@ -5,10 +5,16 @@ import {
   openCodeReadinessArtifactKey,
   reusableOpenCodeExecutionProof,
 } from '../opencode/readiness/OpenCodeExpectedBehaviorFingerprint';
-import { isOpenCodeTerminalProbeTechnicalDiagnostic } from '../opencode/readiness/OpenCodeFailureDiagnostics';
 import { normalizeOpenCodeProjectIdentity } from '../opencode/readiness/OpenCodeProjectIdentity';
 
-import { buildOpenCodePreLaunchGate, isRetryableReadinessState } from './OpenCodeLaunchGateResult';
+import {
+  blockedLaunchResult,
+  firstDisplayableOpenCodeFailureMessage,
+  GENERIC_OPEN_CODE_MEMBER_FAILURE_REASON,
+  isOpenCodeLaunchTimingDiagnostic,
+  isRetryableReadinessState,
+  normalizeOpenCodeFailureMessage,
+} from './OpenCodeLaunchGateResult';
 import {
   createLocalRuntimeInspectionState,
   preflightOpenCodeLocalModels,
@@ -138,11 +144,6 @@ const REQUIRED_READY_CHECKPOINTS = new Set([
   'member_ready',
   'run_ready',
 ]);
-const GENERIC_OPEN_CODE_MEMBER_FAILURE_REASON = 'OpenCode bridge reported member launch failure';
-const SECRET_FLAG_PATTERN =
-  /(--(?:api-key|token|password|secret|authorization|auth-token)(?:=|\s+))("[^"]*"|'[^']*'|\S+)/gi;
-const BEARER_TOKEN_PATTERN = /\bBearer\s+\S+/gi;
-const SECRET_KEY_PATTERN = /\bsk-[A-Za-z0-9_-]{16,}\b/g;
 const OPEN_CODE_CAPABILITY_SNAPSHOT_REFRESH_RETRY_WARNING =
   'OpenCode capability snapshot changed between readiness and launch; refreshed readiness and retried launch.';
 const OPEN_CODE_CAPABILITY_SNAPSHOT_PRELAUNCH_MISMATCH_MARKERS = [
@@ -1228,64 +1229,6 @@ function selectOpenCodeMemberFailureReason(input: {
   );
 }
 
-function firstDisplayableOpenCodeFailureMessage(
-  values: readonly string[],
-  options: { includeGeneric: boolean }
-): string | undefined {
-  for (const value of values) {
-    const normalized = normalizeOpenCodeFailureMessage(value);
-    if (!normalized) {
-      continue;
-    }
-    if (!options.includeGeneric && isGenericOpenCodeFailureMessage(normalized)) {
-      continue;
-    }
-    return normalized;
-  }
-  return undefined;
-}
-
-function normalizeOpenCodeFailureMessage(value: string | undefined): string | undefined {
-  const trimmed = value?.replace(/\s+/g, ' ').trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  return trimmed
-    .replace(SECRET_FLAG_PATTERN, '$1[redacted]')
-    .replace(BEARER_TOKEN_PATTERN, 'Bearer [redacted]')
-    .replace(SECRET_KEY_PATTERN, '[redacted-api-key]');
-}
-
-function isGenericOpenCodeFailureMessage(message: string): boolean {
-  return (
-    message === GENERIC_OPEN_CODE_MEMBER_FAILURE_REASON ||
-    message.startsWith(`${GENERIC_OPEN_CODE_MEMBER_FAILURE_REASON}:`) ||
-    // Reassurance text prepended ahead of the real readiness diagnostic for
-    // mcp_unavailable/unknown_error (see the prepareOpenCodeLaunch caller).
-    // Without this, it wins as the first "displayable" (non-generic) message
-    // and permanently hides the specific diagnostic behind it - which is what
-    // shouldRetryTransientOpenCodeSharedRuntimeFailure pattern-matches on to
-    // decide whether a timeout is worth retrying.
-    message === 'OpenCode is temporarily unavailable. Retry the launch.' ||
-    message.startsWith('OpenCode secondary lane timing:') ||
-    message.startsWith(
-      'OpenCode bridge reported ready without all required durable checkpoints:'
-    ) ||
-    message.startsWith(
-      'OpenCode bridge reported ready before all expected members were confirmed:'
-    ) ||
-    message.startsWith(
-      'OpenCode bootstrap MCP did not complete required tools before assistant response:'
-    ) ||
-    message.startsWith('OpenCode command timed out after') ||
-    message.startsWith('CLI-authenticated providers missing from live host') ||
-    message.startsWith('OpenCode session status') ||
-    isOpenCodeTerminalProbeTechnicalDiagnostic(message) ||
-    (message.startsWith('opencode_app_mcp_tool_proof_') && message.includes('cache_hit')) ||
-    isOpenCodeLaunchTimingDiagnostic(message)
-  );
-}
-
 function extractCheckpointNames(data: OpenCodeLaunchTeamCommandData): Set<string> {
   const names = new Set<string>();
   for (const checkpoint of data.durableCheckpoints ?? []) {
@@ -1366,62 +1309,6 @@ function isOpenCodePreLaunchCapabilitySnapshotMismatchText(value: string): boole
   return OPEN_CODE_CAPABILITY_SNAPSHOT_PRELAUNCH_MISMATCH_MARKERS.some((marker) =>
     normalized.includes(marker.toLowerCase())
   );
-}
-
-function isOpenCodeLaunchTimingDiagnostic(diagnostic: string): boolean {
-  return (
-    diagnostic.startsWith('info:opencode_launch_member_timing:') ||
-    diagnostic.startsWith('info:opencode_launch_total_timing:')
-  );
-}
-
-function blockedLaunchResult(
-  input: TeamRuntimeLaunchInput,
-  reason: string,
-  diagnostics: string[],
-  warnings: string[] = [],
-  options: { preLaunchGate?: boolean } = {}
-): TeamRuntimeLaunchResult {
-  const readinessFailure =
-    reason === 'unknown_error' ||
-    reason === 'model_unavailable' ||
-    reason === 'not_authenticated' ||
-    reason === 'mcp_unavailable' ||
-    reason === 'not_installed';
-  const hardFailureReason = readinessFailure
-    ? (firstDisplayableOpenCodeFailureMessage(diagnostics, { includeGeneric: false }) ?? reason)
-    : reason;
-  const members = Object.fromEntries(
-    input.expectedMembers.map((member) => [
-      member.name,
-      {
-        memberName: member.name,
-        providerId: 'opencode' as const,
-        launchState: 'failed_to_start' as const,
-        agentToolAccepted: false,
-        runtimeAlive: false,
-        bootstrapConfirmed: false,
-        hardFailure: true,
-        hardFailureReason,
-        diagnostics,
-      },
-    ])
-  );
-
-  return {
-    runId: input.runId,
-    teamName: input.teamName,
-    launchPhase: 'finished',
-    teamLaunchState: 'partial_failure',
-    members,
-    warnings,
-    diagnostics,
-    // Attached only where the block provably precedes launchOpenCodeTeam, so an
-    // absent marker always reads as "this launch may already own a host".
-    ...(options.preLaunchGate === true
-      ? { preLaunchGate: buildOpenCodePreLaunchGate(reason) }
-      : {}),
-  };
 }
 
 function mergeDiagnostics(left: string[], right: string[]): string[] {

--- a/src/main/services/team/runtime/__tests__/OpenCodeLaunchGateResult.test.ts
+++ b/src/main/services/team/runtime/__tests__/OpenCodeLaunchGateResult.test.ts
@@ -1,10 +1,29 @@
-import { describe, expect, it } from 'vitest';
-
 import {
+  blockedLaunchResult,
   buildOpenCodePreLaunchGate,
+  firstDisplayableOpenCodeFailureMessage,
+  GENERIC_OPEN_CODE_MEMBER_FAILURE_REASON,
   isAutoRetryableOpenCodePreLaunchGate,
+  isOpenCodeLaunchTimingDiagnostic,
   isRetryableReadinessState,
+  normalizeOpenCodeFailureMessage,
 } from '../OpenCodeLaunchGateResult';
+
+import type { TeamRuntimeLaunchInput } from '../TeamRuntimeAdapter';
+
+function launchInput(): TeamRuntimeLaunchInput {
+  return {
+    runId: 'run-1',
+    laneId: 'primary',
+    teamName: 'demo-team',
+    cwd: '/repo',
+    prompt: '',
+    providerId: 'opencode',
+    skipPermissions: true,
+    previousLaunchState: null,
+    expectedMembers: [{ name: 'team-lead', role: 'Lead', providerId: 'opencode', cwd: '/repo' }],
+  } as TeamRuntimeLaunchInput;
+}
 
 describe('OpenCodeLaunchGateResult', () => {
   it.each([
@@ -44,5 +63,75 @@ describe('OpenCodeLaunchGateResult', () => {
   it('treats an absent marker as no proof at all', () => {
     expect(isAutoRetryableOpenCodePreLaunchGate({})).toBe(false);
     expect(isAutoRetryableOpenCodePreLaunchGate({ preLaunchGate: undefined })).toBe(false);
+  });
+
+  it('fails every expected member with the first displayable readiness diagnostic', () => {
+    const result = blockedLaunchResult(launchInput(), 'model_unavailable', [
+      // Generic: skipped in favour of the diagnostic that says something.
+      'OpenCode command timed out after 30s',
+      'OpenCode model verification completed without assistant output',
+    ]);
+
+    expect(result.teamLaunchState).toBe('partial_failure');
+    expect(result.launchPhase).toBe('finished');
+    expect(result.members['team-lead']).toMatchObject({
+      launchState: 'failed_to_start',
+      hardFailure: true,
+      runtimeAlive: false,
+      hardFailureReason: 'OpenCode model verification completed without assistant output',
+    });
+  });
+
+  it('reports a non-readiness reason verbatim instead of mining the diagnostics', () => {
+    const result = blockedLaunchResult(launchInput(), 'opencode_launch_bridge_missing', [
+      'OpenCode state-changing launch bridge is not registered.',
+    ]);
+
+    expect(result.members['team-lead'].hardFailureReason).toBe('opencode_launch_bridge_missing');
+  });
+
+  // The marker is opt-in: a block that cannot prove it preceded the
+  // state-changing bridge command must never advertise one.
+  it('omits the pre-launch gate marker unless the call site opts in', () => {
+    expect(
+      blockedLaunchResult(launchInput(), 'model_unavailable', []).preLaunchGate
+    ).toBeUndefined();
+
+    expect(
+      blockedLaunchResult(launchInput(), 'model_unavailable', [], [], { preLaunchGate: true })
+        .preLaunchGate
+    ).toEqual({ blocked: true, reason: 'model_unavailable', retryable: true });
+  });
+
+  it('redacts secrets out of a failure message before it becomes user-facing', () => {
+    expect(
+      normalizeOpenCodeFailureMessage('  spawn failed:  opencode  --api-key sk-abcdefghijklmnop01 ')
+    ).toBe('spawn failed: opencode --api-key [redacted]');
+    expect(normalizeOpenCodeFailureMessage('Authorization: Bearer abc.def')).toBe(
+      'Authorization: Bearer [redacted]'
+    );
+    expect(normalizeOpenCodeFailureMessage('   ')).toBeUndefined();
+  });
+
+  it('falls back to the generic reason only when generics are allowed', () => {
+    const generics = [GENERIC_OPEN_CODE_MEMBER_FAILURE_REASON, 'OpenCode session status busy'];
+
+    expect(firstDisplayableOpenCodeFailureMessage(generics, { includeGeneric: false })).toBe(
+      undefined
+    );
+    expect(firstDisplayableOpenCodeFailureMessage(generics, { includeGeneric: true })).toBe(
+      GENERIC_OPEN_CODE_MEMBER_FAILURE_REASON
+    );
+  });
+
+  it('treats launch timing lines as noise rather than failure text', () => {
+    expect(isOpenCodeLaunchTimingDiagnostic('info:opencode_launch_total_timing:1200')).toBe(true);
+    expect(isOpenCodeLaunchTimingDiagnostic('OpenCode bridge refused the launch')).toBe(false);
+    expect(
+      firstDisplayableOpenCodeFailureMessage(
+        ['info:opencode_launch_member_timing:lead=900', 'OpenCode bridge refused the launch'],
+        { includeGeneric: false }
+      )
+    ).toBe('OpenCode bridge refused the launch');
   });
 });

--- a/src/main/services/team/runtime/__tests__/OpenCodeLaunchGateResult.test.ts
+++ b/src/main/services/team/runtime/__tests__/OpenCodeLaunchGateResult.test.ts
@@ -82,6 +82,20 @@ describe('OpenCodeLaunchGateResult', () => {
     });
   });
 
+  // `runtime_store_blocked` is a readiness state like the other five, and the
+  // runtime-store check hands its own diagnostics on with it. Leaving it out of
+  // the readiness set showed the member the bare code and dropped the one line
+  // that says which store is blocked.
+  it('resolves a blocked runtime store to its readiness diagnostic', () => {
+    const result = blockedLaunchResult(launchInput(), 'runtime_store_blocked', [
+      'OpenCode runtime store opencode.sessionStore is quarantined: invalid_json',
+    ]);
+
+    expect(result.members['team-lead'].hardFailureReason).toBe(
+      'OpenCode runtime store opencode.sessionStore is quarantined: invalid_json'
+    );
+  });
+
   it('reports a non-readiness reason verbatim instead of mining the diagnostics', () => {
     const result = blockedLaunchResult(launchInput(), 'opencode_launch_bridge_missing', [
       'OpenCode state-changing launch bridge is not registered.',

--- a/src/main/utils/persistentAppLog.ts
+++ b/src/main/utils/persistentAppLog.ts
@@ -1,7 +1,7 @@
 import { appendFile, mkdir, rename, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { addLogSink, type LogSinkEntry } from '@shared/utils/logger';
+import { addLogSink, type LogSinkEntry, type LogSinkLevel } from '@shared/utils/logger';
 import { redactSentryEvent } from '@shared/utils/sentryConfig';
 
 const LOG_FILE_NAME = 'app-errors.ndjson';
@@ -28,7 +28,7 @@ export interface PersistentAppLogHandle {
 interface PersistentLogRecord {
   v: 1;
   t: string;
-  level: 'warn' | 'error';
+  level: LogSinkLevel;
   process: 'main' | 'renderer';
   namespace: string;
   appVersion: string;

--- a/src/shared/utils/__tests__/logger.test.ts
+++ b/src/shared/utils/__tests__/logger.test.ts
@@ -33,6 +33,39 @@ describe('shared logger sinks', () => {
     }
   });
 
+  it('persists a diagnostic entry without writing to the console', () => {
+    const entries: LogSinkEntry[] = [];
+    const removeSink = addLogSink((entry) => entries.push(entry));
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      createLogger('TestLogger').diagnostic('opencode_launch_prompt_queued lead=lead chars=12');
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        level: 'diagnostic',
+        namespace: 'TestLogger',
+        args: ['opencode_launch_prompt_queued lead=lead chars=12'],
+      });
+      // The whole point of the level: durable evidence that costs nobody a
+      // console line, so the suite-wide "no unexpected console output"
+      // invariant needs no per-event allowlist.
+      expect(warn).toHaveBeenCalledTimes(0);
+      expect(error).toHaveBeenCalledTimes(0);
+      expect(log).toHaveBeenCalledTimes(0);
+      expect(debug).toHaveBeenCalledTimes(0);
+    } finally {
+      removeSink();
+      debug.mockRestore();
+      log.mockRestore();
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
   it('isolates application behavior from a failing sink', () => {
     const removeSink = addLogSink(() => {
       throw new Error('disk unavailable');

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -22,7 +22,13 @@ enum LogLevel {
   NONE = 4,
 }
 
-export type LogSinkLevel = 'warn' | 'error';
+/**
+ * `diagnostic` is durable-only: it reaches every registered sink and never the
+ * console. Use it for evidence that has to survive the process (a join key
+ * another log line is correlated against, a decision an operator reconstructs
+ * afterwards) but is not a problem report a developer should be shown.
+ */
+export type LogSinkLevel = 'diagnostic' | 'warn' | 'error';
 
 export interface LogSinkEntry {
   timestamp: string;
@@ -74,6 +80,24 @@ class Logger {
     if (Logger.level <= LogLevel.INFO) {
       console.log(`[${this.namespace}]`, ...args);
     }
+  }
+
+  /**
+   * Durable diagnostic. Written to the log sinks at every log level and never
+   * to the console.
+   *
+   * `info` cannot carry this: it is filtered out at the default level in both
+   * development and production, and it never reaches a sink, so the evidence is
+   * gone by the time anyone looks for it. `warn` can carry it, but only by
+   * telling every developer about a line that is not a warning.
+   */
+  diagnostic(...args: unknown[]): void {
+    emitToLogSinks({
+      timestamp: new Date().toISOString(),
+      level: 'diagnostic',
+      namespace: this.namespace,
+      args,
+    });
   }
 
   warn(...args: unknown[]): void {

--- a/test/main/ipc/teams/teamStopEscalationSharedFlow.test.ts
+++ b/test/main/ipc/teams/teamStopEscalationSharedFlow.test.ts
@@ -45,6 +45,7 @@ const stopFlowMocks = vi.hoisted(() => ({
   readOwnedOpenCodeRuntimeRunIdsForTeam: vi.fn(() => Promise.resolve(['run-observed'])),
   readOpenCodeRuntimeLaneIdsForTeam: vi.fn(() => Promise.resolve(['primary'])),
   countLiveRecordedRuntimeHostsForTeam: vi.fn(() => Promise.resolve(0)),
+  releaseSharedRuntimeResourcesAfterStop: vi.fn(() => Promise.resolve({ diagnostics: [] })),
   STOP_ESCALATION_TIMEOUT_MS: 90_000,
 }));
 
@@ -168,6 +169,13 @@ describe('the escalated stop shares one fenced flow between the IPC handler and 
       await ports.markTeamStopped?.('fixteam');
       expect(ports.countLiveRuntimeHosts).toBeTypeOf('function');
       await expect(ports.countLiveRuntimeHosts?.('fixteam')).resolves.toBe(0);
+      // The release runs only when this was the last team standing, so the
+      // alive-team filter is the whole port: an entry point that forgot to
+      // exclude the team it is stopping would keep the shared runtime and the
+      // orphaned startup locks forever. Called without optional chaining on
+      // purpose - an entry point that dropped the port fails here.
+      expect(ports.releaseSharedRuntimeResources).toBeTypeOf('function');
+      await ports.releaseSharedRuntimeResources!('fixteam');
       expect(ports.stopTimeoutMs).toBe(90_000);
     }
 
@@ -176,6 +184,10 @@ describe('the escalated stop shares one fenced flow between the IPC handler and 
     expect(stopFlowMocks.countLiveRecordedRuntimeHostsForTeam.mock.calls).toEqual([
       [{ teamName: 'fixteam' }],
       [{ teamName: 'fixteam' }],
+    ]);
+    expect(stopFlowMocks.releaseSharedRuntimeResourcesAfterStop.mock.calls).toEqual([
+      [{ teamName: 'fixteam', otherAliveTeams: ['other-team'] }],
+      [{ teamName: 'fixteam', otherAliveTeams: ['other-team'] }],
     ]);
 
     expect(stopFlowMocks.readOwnedOpenCodeRuntimeRunIdsForTeam.mock.calls).toEqual([

--- a/test/main/services/team/OpenCodeHostStartupLockCleanup.test.ts
+++ b/test/main/services/team/OpenCodeHostStartupLockCleanup.test.ts
@@ -1,7 +1,9 @@
 import {
   PERIODIC_STALE_LOCK_INTERVAL_MS,
   PERIODIC_STALE_LOCK_MIN_AGE_MS,
+  PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS,
   purgeStaleOpenCodeHostStartupLocks,
+  purgeStaleOpenCodeHostStartupLocksBeforeLaunch,
   resolveOpenCodeHostStartupLocksDir,
   startPeriodicOpenCodeHostStartupLockPurge,
 } from '@main/services/team/opencode/bridge/OpenCodeHostStartupLockCleanup';
@@ -84,6 +86,123 @@ describe('purgeStaleOpenCodeHostStartupLocks', () => {
     });
 
     expect(result).toMatchObject({ scanned: 0, removed: 0, kept: 0, diagnostics: [] });
+  });
+
+  // A lock the OS refuses to remove is held by a host that is still running.
+  // That is the expected outcome of a correct purge, not a problem to report,
+  // and treating it as one would bury the failures that do matter.
+  it.each(['EBUSY', 'EPERM', 'EACCES'])(
+    'keeps a lock whose owner is still alive (%s) without reporting a problem',
+    async (code) => {
+      writeLock('held.lock', 20 * 60_000);
+
+      const result = await purgeStaleOpenCodeHostStartupLocks({
+        locksDir,
+        minAgeMs: PERIODIC_STALE_LOCK_MIN_AGE_MS,
+        removeLockEntry: () => Promise.reject(Object.assign(new Error('in use'), { code })),
+      });
+
+      expect(result).toMatchObject({ scanned: 1, removed: 0, kept: 1, diagnostics: [] });
+      expect(fs.existsSync(path.join(locksDir, 'held.lock'))).toBe(true);
+    }
+  );
+
+  it('reports a removal failure that is not a live owner', async () => {
+    writeLock('broken.lock', 20 * 60_000);
+
+    const result = await purgeStaleOpenCodeHostStartupLocks({
+      locksDir,
+      minAgeMs: PERIODIC_STALE_LOCK_MIN_AGE_MS,
+      removeLockEntry: () => Promise.reject(Object.assign(new Error('nope'), { code: 'EIO' })),
+    });
+
+    expect(result).toMatchObject({ scanned: 1, removed: 0, kept: 1 });
+    expect(result.diagnostics).toEqual(['broken.lock: Error: nope']);
+  });
+});
+
+describe('purgeStaleOpenCodeHostStartupLocksBeforeLaunch', () => {
+  it('purges the locks an earlier run left behind and reports the count durably', async () => {
+    writeLock('old.lock', PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS + 60_000);
+    const logRemoved = vi.fn();
+
+    const result = await purgeStaleOpenCodeHostStartupLocksBeforeLaunch({
+      teamName: 'fixteam',
+      aliveTeams: [],
+      locksDir,
+      logRemoved,
+    });
+
+    expect(result).toMatchObject({ removed: 1, kept: 0 });
+    expect(fs.existsSync(path.join(locksDir, 'old.lock'))).toBe(false);
+    expect(logRemoved).toHaveBeenCalledWith(
+      'opencode_startup_locks_purged team=fixteam phase=pre_launch removed=1 kept=0'
+    );
+  });
+
+  // A lock younger than the threshold belongs to a host that is starting right
+  // now - possibly this very launch's own - so age is the only thing standing
+  // between the purge and a host it must not disturb.
+  it('keeps a lock younger than the pre-launch threshold', async () => {
+    writeLock('starting.lock', PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS - 5_000);
+    const logRemoved = vi.fn();
+
+    const result = await purgeStaleOpenCodeHostStartupLocksBeforeLaunch({
+      teamName: 'fixteam',
+      aliveTeams: [],
+      locksDir,
+      logRemoved,
+    });
+
+    expect(result).toMatchObject({ scanned: 1, removed: 0, kept: 1 });
+    expect(fs.existsSync(path.join(locksDir, 'starting.lock'))).toBe(true);
+    expect(logRemoved).not.toHaveBeenCalled();
+  });
+
+  it('does not purge at all while another team is alive', async () => {
+    writeLock('old.lock', PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS + 60_000);
+
+    const result = await purgeStaleOpenCodeHostStartupLocksBeforeLaunch({
+      teamName: 'fixteam',
+      aliveTeams: ['fixteam', 'other-team'],
+      locksDir,
+    });
+
+    expect(result).toBeNull();
+    expect(fs.existsSync(path.join(locksDir, 'old.lock'))).toBe(true);
+  });
+
+  it("treats the launching team's own liveness as no obstacle", async () => {
+    writeLock('old.lock', PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS + 60_000);
+
+    const result = await purgeStaleOpenCodeHostStartupLocksBeforeLaunch({
+      teamName: 'fixteam',
+      aliveTeams: ['fixteam'],
+      locksDir,
+    });
+
+    expect(result).toMatchObject({ removed: 1 });
+  });
+
+  // It runs on the way into a launch, so a failure here must cost the launch
+  // nothing at all.
+  it('answers null instead of throwing when the purge itself fails', async () => {
+    const logWarning = vi.fn();
+
+    const result = await purgeStaleOpenCodeHostStartupLocksBeforeLaunch({
+      teamName: 'fixteam',
+      aliveTeams: [],
+      locksDir,
+      now: () => {
+        throw new Error('clock unavailable');
+      },
+      logWarning,
+    });
+
+    expect(result).toBeNull();
+    expect(logWarning).toHaveBeenCalledWith(
+      '[fixteam] Pre-launch OpenCode host startup lock purge failed: clock unavailable'
+    );
   });
 });
 

--- a/test/main/services/team/OpenCodeHostStartupLockCleanup.test.ts
+++ b/test/main/services/team/OpenCodeHostStartupLockCleanup.test.ts
@@ -5,7 +5,9 @@ import {
   purgeStaleOpenCodeHostStartupLocks,
   purgeStaleOpenCodeHostStartupLocksBeforeLaunch,
   resolveOpenCodeHostStartupLocksDir,
+  resolveStartupStaleLockMinAgeMs,
   startPeriodicOpenCodeHostStartupLockPurge,
+  STARTUP_STALE_LOCK_MIN_AGE_MS,
 } from '@main/services/team/opencode/bridge/OpenCodeHostStartupLockCleanup';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -118,6 +120,40 @@ describe('purgeStaleOpenCodeHostStartupLocks', () => {
 
     expect(result).toMatchObject({ scanned: 1, removed: 0, kept: 1 });
     expect(result.diagnostics).toEqual(['broken.lock: Error: nope']);
+  });
+});
+
+describe('resolveStartupStaleLockMinAgeMs', () => {
+  // The startup purge protects an active host startup by the OS refusing to
+  // unlink the lock it holds open. Only Windows refuses; POSIX unlinks an open
+  // file and leaves the holder with a descriptor to a lock nothing can see, so
+  // the serialisation is gone and a later launch runs concurrently. There is no
+  // owner to read out of these files - the orchestrator writes them - so the
+  // age has to carry the whole guard wherever the refusal is missing.
+  it('keeps the half-minute floor where the OS refuses to unlink a held lock', () => {
+    expect(resolveStartupStaleLockMinAgeMs('win32')).toBe(STARTUP_STALE_LOCK_MIN_AGE_MS);
+  });
+
+  it.each<NodeJS.Platform>(['linux', 'darwin', 'freebsd'])(
+    'requires the genuinely-starting floor on %s, where an open lock can be unlinked',
+    (platform) => {
+      expect(resolveStartupStaleLockMinAgeMs(platform)).toBe(PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS);
+    }
+  );
+
+  it('leaves an active host startup lock in place on a startup purge that cannot be refused', async () => {
+    // Past the half-minute floor, still inside a startup POSIX cannot rule out.
+    writeLock('starting.lock', 45_000);
+    writeLock('orphan.lock', 20 * 60_000);
+
+    const result = await purgeStaleOpenCodeHostStartupLocks({
+      locksDir,
+      minAgeMs: resolveStartupStaleLockMinAgeMs('linux'),
+    });
+
+    expect(result).toMatchObject({ scanned: 2, removed: 1, kept: 1, diagnostics: [] });
+    expect(fs.existsSync(path.join(locksDir, 'starting.lock'))).toBe(true);
+    expect(fs.existsSync(path.join(locksDir, 'orphan.lock'))).toBe(false);
   });
 });
 

--- a/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
+++ b/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
@@ -387,6 +387,41 @@ describe('OpenCodeManagedHostProcessCleanup', () => {
     expect(result.candidates[0]).toMatchObject({ pid: 401, action: 'killed' });
   });
 
+  // Fail-safe direction: an unobservable start time means "cannot prove this is
+  // mine", and the sweep reaches processes it never recorded a pid for. Reading
+  // it the other way would reap somebody else's host on every sweep.
+  it('keeps a fenced managed process whose start time cannot be read at all', async () => {
+    const killProcess = vi.fn();
+    const forceKillProcess = vi.fn();
+    const requestedAtMs = Date.parse('2026-05-13T17:00:00.000Z');
+
+    const result = await cleanupManagedOpenCodeServeProcesses({
+      mode: 'force',
+      platform: 'darwin',
+      startedBeforeMs: requestedAtMs,
+      listProcessRows: () =>
+        resolved([
+          {
+            pid: 402,
+            ppid: 123,
+            command: '/opt/homebrew/bin/opencode serve --hostname 127.0.0.1 --port 3000',
+          },
+        ]),
+      readProcessDetails: () => resolved(MANAGED_DETAILS),
+      // What `readProcessStartTimeMs` answers when the probe cannot run.
+      readProcessStartTimeMs: () => resolved(null),
+      disposeServeHost: () => resolved(undefined),
+      isProcessAlive: () => true,
+      killProcess,
+      forceKillProcess,
+    });
+
+    expect(killProcess).not.toHaveBeenCalled();
+    expect(forceKillProcess).not.toHaveBeenCalled();
+    expect(result.killed).toBe(0);
+    expect(result.candidates[0]).toMatchObject({ pid: 402, action: 'kept_recent' });
+  });
+
   it('never kills a standalone opencode serve without the managed markers, even in force mode', async () => {
     const killProcess = vi.fn();
     const forceKillProcess = vi.fn();
@@ -421,6 +456,43 @@ describe('OpenCodeManagedHostProcessCleanup', () => {
       }),
     ]);
   });
+
+  it.each(['orphaned' as const, 'force' as const])(
+    'spares a standalone opencode serve in %s mode even when the fence would allow a kill',
+    async (mode) => {
+      const killProcess = vi.fn();
+      const forceKillProcess = vi.fn();
+      const appStartedAtMs = Date.parse('2026-05-13T17:00:00.000Z');
+
+      const result = await cleanupManagedOpenCodeServeProcesses({
+        mode,
+        platform: 'darwin',
+        startedBeforeMs: appStartedAtMs,
+        listProcessRows: () =>
+          resolved([
+            {
+              pid: 910,
+              ppid: 1,
+              command: '/usr/local/bin/opencode serve --hostname 127.0.0.1 --port 4096',
+            },
+          ]),
+        readProcessDetails: () =>
+          resolved(
+            '/usr/local/bin/opencode serve --hostname 127.0.0.1 --port 4096 HOME=/home/user'
+          ),
+        readProcessStartTimeMs: () => resolved(appStartedAtMs - 60_000),
+        disposeServeHost: () => resolved(undefined),
+        isProcessAlive: () => true,
+        killProcess,
+        forceKillProcess,
+      });
+
+      expect(killProcess).not.toHaveBeenCalled();
+      expect(forceKillProcess).not.toHaveBeenCalled();
+      expect(result.killed).toBe(0);
+      expect(result.candidates[0]).toMatchObject({ pid: 910, action: 'kept_unmanaged' });
+    }
+  );
 
   it('escalates force cleanup when a managed OpenCode serve process survives SIGTERM', async () => {
     const killProcess = vi.fn();

--- a/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
+++ b/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
@@ -2,8 +2,10 @@ import {
   cleanupManagedOpenCodeServeProcesses,
   getOpenCodeServeLoopbackBaseUrl,
   isAppManagedWindowsOpenCodeServeCommand,
+  isManagedOpenCodeServeHostConfig,
   isManagedOpenCodeServeProcessDetails,
   isOpenCodeServeCommand,
+  isOrchestratorServeCommand,
 } from '@main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup';
 import { listWindowsProcessTable } from '@main/utils/windowsProcessTable';
 import { describe, expect, it, vi } from 'vitest';
@@ -114,6 +116,32 @@ describe('OpenCodeManagedHostProcessCleanup', () => {
         'opencode serve OPENCODE_CONFIG_CONTENT={"agent":{"teammate":{"permission":{"agent-teams_*":"allow"}}}}'
       )
     ).toBe(false);
+  });
+
+  it('recognises the orchestrator serve host, which only this app runs', () => {
+    expect(isOrchestratorServeCommand('/opt/app/bin/claude-multimodel serve --port 4096')).toBe(
+      true
+    );
+    expect(isOrchestratorServeCommand('C:\\app\\claude-multimodel.exe serve --port 4096')).toBe(
+      true
+    );
+    // Neither a different subcommand nor the standalone CLI a user runs.
+    expect(isOrchestratorServeCommand('/opt/app/bin/claude-multimodel status')).toBe(false);
+    expect(isOrchestratorServeCommand('/usr/local/bin/opencode serve --port 4096')).toBe(false);
+  });
+
+  it('recognises a managed host by its effective config when the environment is unreadable', () => {
+    expect(
+      isManagedOpenCodeServeHostConfig('{"mcp":{"url":"?agent-teams-app-instance=abc"}}')
+    ).toBe(true);
+    expect(
+      isManagedOpenCodeServeHostConfig('{"environment":{"AGENT_TEAMS_MCP_CLAUDE_DIR":"/tmp"}}')
+    ).toBe(true);
+    expect(
+      isManagedOpenCodeServeHostConfig('{"description":"claude-multimodel runtime orchestration"}')
+    ).toBe(true);
+    // A config a user's own `opencode serve` would publish.
+    expect(isManagedOpenCodeServeHostConfig('{"model":"gpt-5","mcp":{"github":{}}}')).toBe(false);
   });
 
   it('extracts only loopback OpenCode serve base URLs for disposal', () => {
@@ -493,6 +521,69 @@ describe('OpenCodeManagedHostProcessCleanup', () => {
       expect(result.candidates[0]).toMatchObject({ pid: 910, action: 'kept_unmanaged' });
     }
   );
+
+  // Windows cannot read another process's environment, and a PATH-resolved
+  // runtime carries no app-managed install path, so the config the host serves
+  // over loopback is the last remaining ownership signal.
+  it('claims a Windows host whose loopback config carries this app instance', async () => {
+    const killProcess = vi.fn();
+    const appStartedAtMs = Date.parse('2026-05-13T17:00:00.000Z');
+
+    const result = await cleanupManagedOpenCodeServeProcesses({
+      mode: 'force',
+      platform: 'win32',
+      startedBeforeMs: appStartedAtMs,
+      listProcessRows: () =>
+        resolved([
+          {
+            pid: 920,
+            ppid: 1,
+            command: 'C:\\tools\\opencode.exe serve --hostname 127.0.0.1 --port 4096',
+          },
+        ]),
+      readProcessDetails: () => resolved(null),
+      readServeHostConfig: () =>
+        resolved('{"environment":{"AGENT_TEAMS_MCP_CLAUDE_DIR":"C:/Users/dev/.claude"}}'),
+      readProcessStartTimeMs: () => resolved(appStartedAtMs - 60_000),
+      disposeServeHost: () => resolved(undefined),
+      isProcessAlive: () => false,
+      killProcess,
+    });
+
+    expect(killProcess).toHaveBeenCalledWith(920);
+    expect(result.candidates[0]).toMatchObject({ pid: 920, action: 'killed' });
+  });
+
+  it('leaves a Windows host alone when its loopback config belongs to somebody else', async () => {
+    const killProcess = vi.fn();
+    const forceKillProcess = vi.fn();
+    const appStartedAtMs = Date.parse('2026-05-13T17:00:00.000Z');
+
+    const result = await cleanupManagedOpenCodeServeProcesses({
+      mode: 'force',
+      platform: 'win32',
+      startedBeforeMs: appStartedAtMs,
+      listProcessRows: () =>
+        resolved([
+          {
+            pid: 921,
+            ppid: 1,
+            command: 'C:\\tools\\opencode.exe serve --hostname 127.0.0.1 --port 4096',
+          },
+        ]),
+      readProcessDetails: () => resolved(null),
+      readServeHostConfig: () => resolved('{"model":"gpt-5","mcp":{"github":{}}}'),
+      readProcessStartTimeMs: () => resolved(appStartedAtMs - 60_000),
+      disposeServeHost: () => resolved(undefined),
+      isProcessAlive: () => true,
+      killProcess,
+      forceKillProcess,
+    });
+
+    expect(killProcess).not.toHaveBeenCalled();
+    expect(forceKillProcess).not.toHaveBeenCalled();
+    expect(result.candidates[0]).toMatchObject({ pid: 921, action: 'kept_unmanaged' });
+  });
 
   it('escalates force cleanup when a managed OpenCode serve process survives SIGTERM', async () => {
     const killProcess = vi.fn();

--- a/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
+++ b/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
@@ -1036,3 +1036,72 @@ describe('OpenCodeManagedHostProcessCleanup', () => {
     expect(result.candidates[0]).toMatchObject({ pid: 500, action: 'kept_unmanaged' });
   });
 });
+
+/**
+ * An orchestrator serve host is in scope for the sweep, but being an
+ * orchestrator is not the same as being THIS app's orchestrator. Treating the
+ * binary name as proof made every `claude-multimodel serve` on the machine
+ * app-managed by definition, including one belonging to a second installation
+ * or to a copy of the app running side by side.
+ */
+describe('whose orchestrator serve host is it', () => {
+  const ORCHESTRATOR = 'C:\\Program Files\\Other App\\claude-multimodel.exe serve --port 4096';
+
+  it('does not kill a Windows orchestrator host that will not identify itself', async () => {
+    const killProcess = vi.fn();
+
+    const result = await cleanupManagedOpenCodeServeProcesses({
+      mode: 'force',
+      platform: 'win32',
+      listProcessRows: () => Promise.resolve([{ pid: 10, ppid: 1, command: ORCHESTRATOR }]),
+      readProcessDetails: async () => null,
+      // The host is reachable but its config carries none of this app's marks.
+      readServeHostConfig: async () => '{"description":"somebody else runtime"}',
+      killProcess,
+      isProcessAlive: () => true,
+    });
+
+    expect(killProcess).not.toHaveBeenCalled();
+    expect(result.killed).toBe(0);
+    expect(result.candidates[0]?.action).toBe('kept_unmanaged');
+  });
+
+  it('does not kill a Windows orchestrator host that does not answer at all', async () => {
+    const killProcess = vi.fn();
+
+    const result = await cleanupManagedOpenCodeServeProcesses({
+      mode: 'force',
+      platform: 'win32',
+      listProcessRows: () => Promise.resolve([{ pid: 10, ppid: 1, command: ORCHESTRATOR }]),
+      readProcessDetails: async () => null,
+      readServeHostConfig: async () => {
+        throw new Error('connection refused');
+      },
+      killProcess,
+      isProcessAlive: () => true,
+    });
+
+    expect(killProcess).not.toHaveBeenCalled();
+    expect(result.killed).toBe(0);
+  });
+
+  /** It stays in scope: a host that DOES identify itself is still reaped. */
+  it('reaps a Windows orchestrator host whose config identifies this app', async () => {
+    const result = await cleanupManagedOpenCodeServeProcesses({
+      mode: 'force',
+      platform: 'win32',
+      listProcessRows: () => Promise.resolve([{ pid: 10, ppid: 1, command: ORCHESTRATOR }]),
+      readProcessDetails: async () => null,
+      readServeHostConfig: async () =>
+        '{"description":"claude-multimodel runtime orchestration"}',
+      disposeServeHost: async () => undefined,
+      killProcess: vi.fn(),
+      // The host is gone by the time the signal would have been sent, so the
+      // sweep counts it as reaped without needing to signal it.
+      isProcessAlive: () => false,
+    });
+
+    expect(result.killed).toBe(1);
+    expect(result.candidates[0]?.action).toBe('killed');
+  });
+});

--- a/test/main/services/team/OpenCodeStartupRuntimeSweep.test.ts
+++ b/test/main/services/team/OpenCodeStartupRuntimeSweep.test.ts
@@ -26,6 +26,7 @@ function sweepPorts(
     sweepCommandSettledAtMs: 1_000,
     logSweepResult: vi.fn(),
     logWarning: vi.fn(),
+    logError: vi.fn(),
     waitMs: vi.fn(() => Promise.resolve()),
     ...overrides,
   };
@@ -135,9 +136,14 @@ describe('runOpenCodeStartupRuntimeSweepTail', () => {
 
     await expect(runOpenCodeStartupRuntimeSweepTail(ports)).resolves.toBeUndefined();
 
-    expect(ports.logWarning).toHaveBeenCalledWith(
+    // A caught main-process failure goes to the error channel: `warn` reaches
+    // the durable sinks but its console line is filtered out at the production
+    // log level, so the failure that explains an empty reap would be invisible
+    // exactly where it matters.
+    expect(ports.logError).toHaveBeenCalledWith(
       '[OpenCode] Startup sweep host cleanup failed: Error: process table unreadable'
     );
+    expect(ports.logWarning).not.toHaveBeenCalled();
     expect(ports.logSweepResult).not.toHaveBeenCalled();
   });
 
@@ -152,6 +158,8 @@ describe('runOpenCodeStartupRuntimeSweepTail', () => {
     expect(ports.logWarning).toHaveBeenCalledWith(
       '[OpenCode] startup sweep host cleanup: pid=91 identity changed'
     );
+    // One host the sweep could not handle is a warning, not a failed sweep.
+    expect(ports.logError).not.toHaveBeenCalled();
   });
 });
 
@@ -168,6 +176,7 @@ describe('reapOrphanedOpenCodeHostsBeforeRuntimeRegistry', () => {
       sweepManagedHosts,
       logSweepResult,
       logWarning: vi.fn(),
+      logError: vi.fn(),
     });
 
     expect(sweepManagedHosts).toHaveBeenCalledWith({ mode: 'orphaned', startedBeforeMs: 7_000 });
@@ -181,6 +190,7 @@ describe('reapOrphanedOpenCodeHostsBeforeRuntimeRegistry', () => {
   // count either.
   it('reports a failing sweep instead of failing the startup', async () => {
     const logWarning = vi.fn();
+    const logError = vi.fn();
     const logSweepResult = vi.fn();
 
     await expect(
@@ -189,12 +199,14 @@ describe('reapOrphanedOpenCodeHostsBeforeRuntimeRegistry', () => {
         sweepManagedHosts: () => Promise.reject(new Error('process table unreadable')),
         logSweepResult,
         logWarning,
+        logError,
       })
     ).resolves.toBeUndefined();
 
-    expect(logWarning).toHaveBeenCalledWith(
+    expect(logError).toHaveBeenCalledWith(
       '[OpenCode] Startup preflight host cleanup failed: Error: process table unreadable'
     );
+    expect(logWarning).not.toHaveBeenCalled();
     expect(logSweepResult).not.toHaveBeenCalled();
   });
 });

--- a/test/main/services/team/OpenCodeStartupRuntimeSweep.test.ts
+++ b/test/main/services/team/OpenCodeStartupRuntimeSweep.test.ts
@@ -23,7 +23,7 @@ function sweepPorts(
   overrides: Partial<Parameters<typeof runOpenCodeStartupRuntimeSweepTail>[0]> = {}
 ) {
   return {
-    sweepCommandIssuedAtMs: 1_000,
+    sweepCommandSettledAtMs: 1_000,
     logSweepResult: vi.fn(),
     logWarning: vi.fn(),
     waitMs: vi.fn(() => Promise.resolve()),
@@ -32,10 +32,14 @@ function sweepPorts(
 }
 
 describe('runOpenCodeStartupRuntimeSweepTail', () => {
-  it('fences the reap by the moment the sweep command was issued', async () => {
+  // The fence is the moment the registry sweep command SETTLED. The host this
+  // tail exists to reap is the one that command boots, so it starts after the
+  // command was issued: an issue-time fence classifies it `kept_recent` and the
+  // tail reaps nothing it was written for.
+  it('fences the reap by the moment the sweep command settled', async () => {
     const sweepManagedHosts = vi.fn(() => Promise.resolve(sweepResult({ scanned: 3, killed: 1 })));
     const ports = sweepPorts({
-      sweepCommandIssuedAtMs: 4_242,
+      sweepCommandSettledAtMs: 4_242,
       sweepManagedHosts,
     });
 
@@ -46,6 +50,26 @@ describe('runOpenCodeStartupRuntimeSweepTail', () => {
     expect(ports.logSweepResult).toHaveBeenCalledWith(
       'opencode_managed_hosts_killed sweep=startup count=1 scanned=3'
     );
+  });
+
+  // The tail runs in `force` mode with no lineage check, so the start-time
+  // fence alone would let it reap an orchestrator host of another install, or
+  // one a user started themselves, purely because its command line names this
+  // app's own binary. The instance markers are what make that impossible.
+  it('carries the ownership markers of this app instance into the reap', async () => {
+    const sweepManagedHosts = vi.fn(() => Promise.resolve(sweepResult()));
+    const ports = sweepPorts({
+      sweepCommandSettledAtMs: 4_242,
+      ownershipMarkers: { requiredDetailsMarkers: ['CLAUDE_TEAM_APP_INSTANCE_ID=9-1000'] },
+      sweepManagedHosts,
+    });
+
+    await runOpenCodeStartupRuntimeSweepTail(ports);
+
+    expect(sweepManagedHosts).toHaveBeenCalledWith({
+      startedBeforeMs: 4_242,
+      requiredDetailsMarkers: ['CLAUDE_TEAM_APP_INSTANCE_ID=9-1000'],
+    });
   });
 
   // The settle window comes first or the reap finds nothing: the orchestrator

--- a/test/main/services/team/OpenCodeStartupRuntimeSweep.test.ts
+++ b/test/main/services/team/OpenCodeStartupRuntimeSweep.test.ts
@@ -1,5 +1,6 @@
 import {
   OPEN_CODE_STARTUP_SWEEP_HOST_SETTLE_MS,
+  reapOrphanedOpenCodeHostsBeforeRuntimeRegistry,
   runOpenCodeStartupRuntimeSweepTail,
 } from '@main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep';
 import {
@@ -110,6 +111,50 @@ describe('runOpenCodeStartupRuntimeSweepTail', () => {
     expect(ports.logWarning).toHaveBeenCalledWith(
       '[OpenCode] startup sweep host cleanup: pid=91 identity changed'
     );
+  });
+});
+
+describe('reapOrphanedOpenCodeHostsBeforeRuntimeRegistry', () => {
+  // `orphaned`, not `force`: a host whose parent is still alive may belong to
+  // an active bridge command, and the fence keeps this instance's own work out
+  // of scope entirely.
+  it('reaps only what predates this instance and is no longer parented', async () => {
+    const sweepManagedHosts = vi.fn(() => Promise.resolve(sweepResult({ scanned: 2, killed: 1 })));
+    const logSweepResult = vi.fn();
+
+    await reapOrphanedOpenCodeHostsBeforeRuntimeRegistry({
+      appStartedAtMs: 7_000,
+      sweepManagedHosts,
+      logSweepResult,
+      logWarning: vi.fn(),
+    });
+
+    expect(sweepManagedHosts).toHaveBeenCalledWith({ mode: 'orphaned', startedBeforeMs: 7_000 });
+    expect(logSweepResult).toHaveBeenCalledWith(
+      'opencode_managed_hosts_killed sweep=startup_preflight count=1 scanned=2'
+    );
+  });
+
+  // It is awaited on the startup path, so it must not be able to stop the app -
+  // and a scan that could not run has reaped nothing, so it must not report a
+  // count either.
+  it('reports a failing sweep instead of failing the startup', async () => {
+    const logWarning = vi.fn();
+    const logSweepResult = vi.fn();
+
+    await expect(
+      reapOrphanedOpenCodeHostsBeforeRuntimeRegistry({
+        appStartedAtMs: 7_000,
+        sweepManagedHosts: () => Promise.reject(new Error('process table unreadable')),
+        logSweepResult,
+        logWarning,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(logWarning).toHaveBeenCalledWith(
+      '[OpenCode] Startup preflight host cleanup failed: Error: process table unreadable'
+    );
+    expect(logSweepResult).not.toHaveBeenCalled();
   });
 });
 

--- a/test/main/services/team/OpenCodeStartupRuntimeSweep.test.ts
+++ b/test/main/services/team/OpenCodeStartupRuntimeSweep.test.ts
@@ -100,6 +100,23 @@ describe('runOpenCodeStartupRuntimeSweepTail', () => {
     }
   });
 
+  // The caller runs the stale-lock purge straight after this tail, and the
+  // locks left by hosts the reap could not reach are the ones the next launch
+  // queues behind. A rejected scan must therefore end here, not take the purge
+  // with it.
+  it('reports a failing reap instead of aborting the cleanup that follows it', async () => {
+    const ports = sweepPorts({
+      sweepManagedHosts: () => Promise.reject(new Error('process table unreadable')),
+    });
+
+    await expect(runOpenCodeStartupRuntimeSweepTail(ports)).resolves.toBeUndefined();
+
+    expect(ports.logWarning).toHaveBeenCalledWith(
+      '[OpenCode] Startup sweep host cleanup failed: Error: process table unreadable'
+    );
+    expect(ports.logSweepResult).not.toHaveBeenCalled();
+  });
+
   it('reports what the sweep could not do without failing the startup', async () => {
     const ports = sweepPorts({
       sweepManagedHosts: () =>

--- a/test/main/services/team/OpenCodeStartupRuntimeSweep.test.ts
+++ b/test/main/services/team/OpenCodeStartupRuntimeSweep.test.ts
@@ -1,0 +1,186 @@
+import {
+  OPEN_CODE_STARTUP_SWEEP_HOST_SETTLE_MS,
+  runOpenCodeStartupRuntimeSweepTail,
+} from '@main/services/team/opencode/bridge/OpenCodeStartupRuntimeSweep';
+import {
+  beginOpenCodeStartupRuntimeSweep,
+  OPEN_CODE_STARTUP_SWEEP_WAIT_TIMEOUT_MS,
+  whenOpenCodeStartupRuntimeSweepSettled,
+} from '@main/services/team/opencode/bridge/OpenCodeStartupSweepGate';
+import { addLogSink, createLogger, type LogSinkEntry } from '@shared/utils/logger';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { OpenCodeManagedHostCleanupResult } from '@main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup';
+
+function sweepResult(
+  overrides: Partial<OpenCodeManagedHostCleanupResult> = {}
+): OpenCodeManagedHostCleanupResult {
+  return { scanned: 0, killed: 0, candidates: [], diagnostics: [], ...overrides };
+}
+
+function sweepPorts(
+  overrides: Partial<Parameters<typeof runOpenCodeStartupRuntimeSweepTail>[0]> = {}
+) {
+  return {
+    sweepCommandIssuedAtMs: 1_000,
+    logSweepResult: vi.fn(),
+    logWarning: vi.fn(),
+    waitMs: vi.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+describe('runOpenCodeStartupRuntimeSweepTail', () => {
+  it('fences the reap by the moment the sweep command was issued', async () => {
+    const sweepManagedHosts = vi.fn(() => Promise.resolve(sweepResult({ scanned: 3, killed: 1 })));
+    const ports = sweepPorts({
+      sweepCommandIssuedAtMs: 4_242,
+      sweepManagedHosts,
+    });
+
+    await runOpenCodeStartupRuntimeSweepTail(ports);
+
+    expect(ports.waitMs).toHaveBeenCalledWith(OPEN_CODE_STARTUP_SWEEP_HOST_SETTLE_MS);
+    expect(sweepManagedHosts).toHaveBeenCalledWith({ startedBeforeMs: 4_242 });
+    expect(ports.logSweepResult).toHaveBeenCalledWith(
+      'opencode_managed_hosts_killed sweep=startup count=1 scanned=3'
+    );
+  });
+
+  // The settle window comes first or the reap finds nothing: the orchestrator
+  // is still booting the host this tail exists to remove when the sweep
+  // command returns, and a reap that ran immediately would report a clean
+  // sweep and leave the host holding the loopback port.
+  it('waits out the settle window before it reaps anything', async () => {
+    const order: string[] = [];
+    const ports = sweepPorts({
+      waitMs: vi.fn(() => {
+        order.push('wait');
+        return Promise.resolve();
+      }),
+      sweepManagedHosts: () => {
+        order.push('sweep');
+        return Promise.resolve(sweepResult());
+      },
+    });
+
+    await runOpenCodeStartupRuntimeSweepTail(ports);
+
+    expect(order).toEqual(['wait', 'sweep']);
+  });
+
+  // The destructive counter has to outlive the process without costing every
+  // developer a console line - the reason it is `diagnostic` and not `warn`,
+  // and the reason the suite needs no per-event console allowlist for it.
+  it('records the kill count durably without writing to the console', async () => {
+    const entries: LogSinkEntry[] = [];
+    const removeSink = addLogSink((entry) => entries.push(entry));
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const logger = createLogger('OpenCode:startup-sweep');
+
+    try {
+      await runOpenCodeStartupRuntimeSweepTail(
+        sweepPorts({
+          logSweepResult: (message) => logger.diagnostic(message),
+          sweepManagedHosts: () => Promise.resolve(sweepResult({ scanned: 2, killed: 2 })),
+        })
+      );
+
+      expect(entries).toEqual([
+        expect.objectContaining({
+          level: 'diagnostic',
+          args: ['opencode_managed_hosts_killed sweep=startup count=2 scanned=2'],
+        }),
+      ]);
+      expect(consoleWarn).toHaveBeenCalledTimes(0);
+    } finally {
+      removeSink();
+      consoleWarn.mockRestore();
+    }
+  });
+
+  it('reports what the sweep could not do without failing the startup', async () => {
+    const ports = sweepPorts({
+      sweepManagedHosts: () =>
+        Promise.resolve(sweepResult({ scanned: 1, diagnostics: ['pid=91 identity changed'] })),
+    });
+
+    await runOpenCodeStartupRuntimeSweepTail(ports);
+
+    expect(ports.logWarning).toHaveBeenCalledWith(
+      '[OpenCode] startup sweep host cleanup: pid=91 identity changed'
+    );
+  });
+});
+
+describe('OpenCodeStartupSweepGate', () => {
+  it('resolves at once when no sweep is pending', async () => {
+    const onWaitStart = vi.fn();
+
+    await whenOpenCodeStartupRuntimeSweepSettled({ onWaitStart });
+
+    expect(onWaitStart).not.toHaveBeenCalled();
+  });
+
+  it('parks a caller until the pending sweep settles, and reports the wait', async () => {
+    const settle = beginOpenCodeStartupRuntimeSweep();
+    const onWaitStart = vi.fn();
+    const logWaited = vi.fn();
+    let now = 0;
+
+    const waiting = whenOpenCodeStartupRuntimeSweepSettled({
+      onWaitStart,
+      logWaited,
+      nowMs: () => now,
+    });
+    expect(onWaitStart).toHaveBeenCalledTimes(1);
+    now = 2_500;
+    settle();
+    await waiting;
+
+    expect(logWaited).toHaveBeenCalledWith(
+      'opencode_startup_sweep_wait waitedMs=2500 settled=true'
+    );
+    // The gate is clear again: the next caller must not pay the wait twice.
+    await whenOpenCodeStartupRuntimeSweepSettled({ onWaitStart });
+    expect(onWaitStart).toHaveBeenCalledTimes(1);
+  });
+
+  // A sweep that throws still has to release everything waiting on it, which is
+  // why the settle callback is invoked from a `finally` at the call site.
+  it('releases waiters when the sweep it fronts fails', async () => {
+    const settle = beginOpenCodeStartupRuntimeSweep();
+    const waiting = whenOpenCodeStartupRuntimeSweepSettled({});
+
+    await Promise.reject(new Error('sweep exploded'))
+      .catch(() => undefined)
+      .finally(settle);
+
+    await expect(waiting).resolves.toBeUndefined();
+  });
+
+  it('gives up after the bound rather than parking a launch forever', async () => {
+    beginOpenCodeStartupRuntimeSweep();
+    const logWaited = vi.fn();
+    const onWaitStart = vi.fn();
+    let now = 0;
+
+    await whenOpenCodeStartupRuntimeSweepSettled({
+      logWaited,
+      nowMs: () => now,
+      setTimeoutImpl: ((resolve: () => void) => {
+        now = OPEN_CODE_STARTUP_SWEEP_WAIT_TIMEOUT_MS;
+        resolve();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as unknown as typeof setTimeout,
+    });
+
+    expect(logWaited).toHaveBeenCalledWith(
+      `opencode_startup_sweep_wait waitedMs=${OPEN_CODE_STARTUP_SWEEP_WAIT_TIMEOUT_MS} settled=false`
+    );
+    // Giving up once is enough: the abandoned sweep must not charge the next
+    // launch the same bound all over again.
+    await whenOpenCodeStartupRuntimeSweepSettled({ onWaitStart });
+    expect(onWaitStart).not.toHaveBeenCalled();
+  });
+});

--- a/test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts
+++ b/test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts
@@ -2461,7 +2461,8 @@ describe(
         runtimeAlive: false,
         pendingPermissionRequestIds: ['perm-alice'],
       });
-      expect(statuses.summary?.pendingCount).toBe(1);
+      // The OpenCode lane lead survives read-back now, so it is counted too.
+      expect(statuses.summary?.pendingCount).toBe(2);
     });
 
     it('routes OpenCode runtime approval UI responses back through the adapter', async () => {
@@ -2774,7 +2775,9 @@ describe(
       expect(statuses.summary).toMatchObject({
         confirmedCount: 1,
         pendingCount: 1,
-        failedCount: 1,
+        // The lead lane failed with the rest of the primary lane and is no
+        // longer discarded on read-back.
+        failedCount: 2,
       });
     });
 
@@ -21859,7 +21862,9 @@ describe(
         source: 'persisted',
         teamLaunchState: 'clean_success',
       });
-      expect(statuses.expectedMembers).toEqual(['alice', 'bob']);
+      // The lead keeps its persisted runtime state after a restart, exactly as
+      // it had one while the launch was in memory.
+      expect(statuses.expectedMembers).toEqual(['alice', 'bob', 'team-lead']);
       expect(statuses.statuses.alice).toMatchObject({
         status: 'online',
         launchState: 'confirmed_alive',

--- a/test/main/services/team/TeamLaunchStateEvaluator.openCodeLead.test.ts
+++ b/test/main/services/team/TeamLaunchStateEvaluator.openCodeLead.test.ts
@@ -1,0 +1,250 @@
+import {
+  createPersistedLaunchSnapshot,
+  normalizePersistedLaunchSnapshot,
+} from '@main/services/team/TeamLaunchStateEvaluator';
+import { describe, expect, it } from 'vitest';
+
+import type { PersistedTeamLaunchMemberState } from '@shared/types';
+
+const at = '2026-08-28T12:20:00.000Z';
+
+/** Exactly the fields `toOpenCodePersistedLaunchMember` stamps on a lane member. */
+function openCodeLaneLead(
+  overrides: Partial<PersistedTeamLaunchMemberState> = {}
+): PersistedTeamLaunchMemberState {
+  return {
+    name: 'team-lead',
+    providerId: 'opencode',
+    laneId: 'primary',
+    laneKind: 'primary',
+    laneOwnerProviderId: 'opencode',
+    launchState: 'failed_to_start',
+    agentToolAccepted: false,
+    runtimeAlive: false,
+    bootstrapConfirmed: false,
+    hardFailure: true,
+    hardFailureReason: 'OpenCode primary lane produced no runtime evidence.',
+    lastEvaluatedAt: at,
+    ...overrides,
+  };
+}
+
+function member(name: string): PersistedTeamLaunchMemberState {
+  return {
+    name,
+    providerId: 'opencode',
+    laneId: `secondary:opencode:${name}`,
+    laneKind: 'secondary',
+    laneOwnerProviderId: 'opencode',
+    launchState: 'confirmed_alive',
+    agentToolAccepted: true,
+    runtimeAlive: true,
+    bootstrapConfirmed: true,
+    hardFailure: false,
+    lastEvaluatedAt: at,
+  };
+}
+
+function readBackOf(teamName: string, written: unknown) {
+  return normalizePersistedLaunchSnapshot(teamName, JSON.parse(JSON.stringify(written)));
+}
+
+describe('normalizePersistedLaunchSnapshot keeps the OpenCode primary-lane lead', () => {
+  it('stops reporting clean_success for a team whose lead is dead', () => {
+    // The snapshot is written with `includeLeadMembers` and was read back without
+    // it, so the lead vanished on read-back and only the healthy side lanes voted.
+    const written = createPersistedLaunchSnapshot({
+      teamName: 'lane-team',
+      expectedMembers: ['team-lead', 'Ada', 'Ben'],
+      includeLeadMembers: true,
+      launchPhase: 'finished',
+      members: {
+        'team-lead': openCodeLaneLead(),
+        Ada: member('Ada'),
+        Ben: member('Ben'),
+      },
+      updatedAt: at,
+    });
+
+    const readBack = readBackOf('lane-team', written);
+
+    expect(readBack?.members['team-lead']?.launchState).toBe('failed_to_start');
+    expect(readBack?.teamLaunchState).toBe('partial_failure');
+    expect(readBack?.summary?.failedCount).toBe(1);
+    // The roster the UI renders is deliberately unchanged: the lead is a runtime
+    // member, not a teammate card.
+    expect(readBack?.expectedMembers).toEqual(['Ada', 'Ben']);
+  });
+
+  it('keeps a healthy lane-owned lead without changing the aggregate state', () => {
+    const written = createPersistedLaunchSnapshot({
+      teamName: 'lane-team',
+      expectedMembers: ['team-lead', 'Ada'],
+      includeLeadMembers: true,
+      launchPhase: 'finished',
+      members: {
+        'team-lead': openCodeLaneLead({
+          launchState: 'confirmed_alive',
+          agentToolAccepted: true,
+          runtimeAlive: true,
+          bootstrapConfirmed: true,
+          hardFailure: false,
+          hardFailureReason: undefined,
+        }),
+        Ada: member('Ada'),
+      },
+      updatedAt: at,
+    });
+
+    const readBack = readBackOf('lane-team', written);
+
+    expect(readBack?.members['team-lead']?.launchState).toBe('confirmed_alive');
+    expect(readBack?.teamLaunchState).toBe('clean_success');
+  });
+
+  // NEGATIVE CONTROL: the persisted-lane policy applies only to lane-owned
+  // members. A stale snapshot whose lead is not lane-owned must read back
+  // exactly as it did before this change - lead dropped, side lanes voting.
+  it('leaves a lead that is not lane-owned dropped exactly as before', () => {
+    const written = createPersistedLaunchSnapshot({
+      teamName: 'native-lead-team',
+      expectedMembers: ['team-lead', 'Ada'],
+      includeLeadMembers: true,
+      launchPhase: 'finished',
+      members: {
+        'team-lead': openCodeLaneLead({
+          providerId: 'anthropic',
+          laneOwnerProviderId: undefined,
+        }),
+        Ada: member('Ada'),
+      },
+      updatedAt: at,
+    });
+
+    const readBack = readBackOf('native-lead-team', written);
+
+    expect(readBack?.members['team-lead']).toBeUndefined();
+    expect(readBack?.teamLaunchState).toBe('clean_success');
+  });
+
+  // NEGATIVE CONTROL: the same stale read-back for a lead that runs on the
+  // OpenCode provider but whose lane is owned by another runtime. Provider alone
+  // is not the discriminator; lane ownership is.
+  it('leaves an OpenCode lead on a foreign-owned lane dropped exactly as before', () => {
+    const written = createPersistedLaunchSnapshot({
+      teamName: 'mixed-lane-team',
+      expectedMembers: ['team-lead', 'Ada'],
+      includeLeadMembers: true,
+      launchPhase: 'finished',
+      members: {
+        'team-lead': openCodeLaneLead({ laneOwnerProviderId: 'anthropic' }),
+        Ada: member('Ada'),
+      },
+      updatedAt: at,
+    });
+
+    const readBack = readBackOf('mixed-lane-team', written);
+
+    expect(readBack?.members['team-lead']).toBeUndefined();
+    expect(readBack?.teamLaunchState).toBe('clean_success');
+  });
+
+  it('does not misclassify a secondary-lane member named team-lead as the primary lead', () => {
+    const written = createPersistedLaunchSnapshot({
+      teamName: 'lane-team',
+      expectedMembers: ['team-lead', 'Ada'],
+      includeLeadMembers: true,
+      launchPhase: 'finished',
+      members: {
+        'team-lead': openCodeLaneLead({
+          laneKind: 'secondary',
+          laneId: 'secondary:opencode:team-lead',
+        }),
+        Ada: member('Ada'),
+      },
+      updatedAt: at,
+    });
+
+    expect(readBackOf('lane-team', written)?.members['team-lead']).toBeUndefined();
+  });
+
+  it('accepts a legacy lane member that carries laneId but no laneKind', () => {
+    const written = createPersistedLaunchSnapshot({
+      teamName: 'lane-team',
+      expectedMembers: ['team-lead', 'Ada'],
+      includeLeadMembers: true,
+      launchPhase: 'finished',
+      members: {
+        'team-lead': openCodeLaneLead({ laneKind: undefined }),
+        Ada: member('Ada'),
+      },
+      updatedAt: at,
+    });
+
+    expect(readBackOf('lane-team', written)?.members['team-lead']?.launchState).toBe(
+      'failed_to_start'
+    );
+  });
+});
+
+describe('normalizeLaunchFailureReasonText recovers a routed SendMessage reason', () => {
+  it('reads the human-readable part out of a complete SendMessage result body', () => {
+    const written = createPersistedLaunchSnapshot({
+      teamName: 'lane-team',
+      expectedMembers: ['team-lead'],
+      includeLeadMembers: true,
+      launchPhase: 'finished',
+      members: {
+        'team-lead': openCodeLaneLead({
+          hardFailureReason: JSON.stringify({
+            success: true,
+            message: 'Message sent to team-lead',
+            routing: { summary: 'lead unreachable', content: 'no session record' },
+          }),
+        }),
+      },
+      updatedAt: at,
+    });
+
+    expect(readBackOf('lane-team', written)?.members['team-lead']?.hardFailureReason).toBe(
+      'lead unreachable: no session record'
+    );
+  });
+
+  it('recovers the reason from a body an older build truncated mid-string', () => {
+    const written = createPersistedLaunchSnapshot({
+      teamName: 'lane-team',
+      expectedMembers: ['team-lead'],
+      includeLeadMembers: true,
+      launchPhase: 'finished',
+      members: {
+        'team-lead': openCodeLaneLead({
+          hardFailureReason:
+            '{"success":true,"message":"Message sent to team-lead","routing":{"summary":"lead unreachable',
+        }),
+      },
+      updatedAt: at,
+    });
+
+    expect(readBackOf('lane-team', written)?.members['team-lead']?.hardFailureReason).toBe(
+      'lead unreachable'
+    );
+  });
+
+  it('leaves a plain failure reason untouched', () => {
+    const written = createPersistedLaunchSnapshot({
+      teamName: 'lane-team',
+      expectedMembers: ['team-lead'],
+      includeLeadMembers: true,
+      launchPhase: 'finished',
+      members: {
+        'team-lead': openCodeLaneLead({ hardFailureReason: 'spawn ENOENT' }),
+      },
+      updatedAt: at,
+    });
+
+    expect(readBackOf('lane-team', written)?.members['team-lead']?.hardFailureReason).toBe(
+      'spawn ENOENT'
+    );
+  });
+});

--- a/test/main/services/team/TeamProvisioningLaunchStateReconciliation.laneEvidence.test.ts
+++ b/test/main/services/team/TeamProvisioningLaunchStateReconciliation.laneEvidence.test.ts
@@ -199,6 +199,63 @@ describe('the promotion gate reads per member, not per lane', () => {
     expect(commit).not.toHaveBeenCalled();
   });
 
+  // The commit promotes a matching app-managed candidate that did not claim
+  // confirmation on the way in. Reading the pre-commit result here made the
+  // collector skip precisely those members, so a promotion the commit had just
+  // created was never read back the way the delivery path reads it - which is
+  // the promotion this gate exists to hold to disk.
+  it('checks a member the commit itself promoted', async () => {
+    const candidate = member('team-lead', {
+      launchState: 'starting',
+      agentToolAccepted: false,
+      runtimeAlive: false,
+      bootstrapConfirmed: false,
+      livenessKind: undefined,
+      bootstrapEvidenceSource: 'app_managed_bootstrap',
+      bootstrapMode: 'app_managed_context',
+      appManagedBootstrapCandidate: {
+        schemaVersion: 1,
+        source: 'app_managed_bootstrap',
+        teamName: 'lane-team',
+        memberName: 'team-lead',
+        runId: 'run-a1',
+        laneId: 'primary',
+        runtimeSessionId: 'session-team-lead',
+        messageID: 'message-1',
+        contextHash: 'context-1',
+        briefingHash: 'briefing-1',
+        injectionVerifiedAt: '2026-08-28T12:20:00.000Z',
+        candidateAt: '2026-08-28T12:20:00.000Z',
+      },
+    });
+    const read = vi.fn(() => Promise.resolve(false));
+
+    const guarded = await guardCommittedOpenCodeLaneEvidence(
+      {
+        teamName: 'lane-team',
+        laneId: 'primary',
+        memberNames: ['team-lead'],
+        result: launchResult([candidate]),
+      },
+      ports({
+        // What the real commit does once it has written the candidate and read
+        // it back: the member now claims confirmation.
+        commitOpenCodeRuntimeAdapterLaunchSessionEvidence: vi.fn(({ result }) =>
+          Promise.resolve({
+            ...result,
+            members: { 'team-lead': member('team-lead') },
+          })
+        ),
+        hasCommittedOpenCodeLaneMemberSessionEvidence: read,
+      })
+    );
+
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(guarded.members['team-lead']?.launchState).toBe('runtime_pending_bootstrap');
+    expect(guarded.members['team-lead']?.bootstrapConfirmed).toBe(false);
+    expect(guarded.diagnostics).toContain(buildMissingOpenCodeSessionRecordDiagnostic('team-lead'));
+  });
+
   it('ignores members that are not named in the guard call', async () => {
     const guarded = await guardCommittedOpenCodeLaneEvidence(
       {

--- a/test/main/services/team/TeamProvisioningLaunchStateReconciliation.laneEvidence.test.ts
+++ b/test/main/services/team/TeamProvisioningLaunchStateReconciliation.laneEvidence.test.ts
@@ -1,0 +1,264 @@
+import {
+  buildMissingOpenCodeSessionRecordDiagnostic,
+  guardCommittedOpenCodeLaneEvidence,
+  guardCommittedOpenCodeSecondaryLaneEvidence,
+} from '@main/services/team/provisioning/TeamProvisioningLaunchStateReconciliation';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GuardCommittedOpenCodeSecondaryLaneEvidencePorts } from '@main/services/team/provisioning/TeamProvisioningLaunchStateReconciliation';
+import type {
+  TeamRuntimeLaunchResult,
+  TeamRuntimeMemberLaunchEvidence,
+} from '@main/services/team/runtime/TeamRuntimeAdapter';
+
+function member(
+  memberName: string,
+  overrides: Partial<TeamRuntimeMemberLaunchEvidence> = {}
+): TeamRuntimeMemberLaunchEvidence {
+  return {
+    memberName,
+    providerId: 'opencode',
+    launchState: 'confirmed_alive',
+    agentToolAccepted: true,
+    runtimeAlive: true,
+    bootstrapConfirmed: true,
+    hardFailure: false,
+    sessionId: `session-${memberName}`,
+    livenessKind: 'confirmed_bootstrap',
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+function launchResult(members: TeamRuntimeMemberLaunchEvidence[]): TeamRuntimeLaunchResult {
+  return {
+    runId: 'run-a1',
+    teamName: 'lane-team',
+    launchPhase: 'active',
+    teamLaunchState: 'clean_success',
+    members: Object.fromEntries(members.map((entry) => [entry.memberName, entry])),
+    warnings: [],
+    diagnostics: [],
+  };
+}
+
+function ports(
+  overrides: Partial<GuardCommittedOpenCodeSecondaryLaneEvidencePorts> = {}
+): GuardCommittedOpenCodeSecondaryLaneEvidencePorts {
+  return {
+    commitOpenCodeRuntimeAdapterLaunchSessionEvidence: vi.fn(({ result }) =>
+      Promise.resolve(result)
+    ),
+    inspectOpenCodeRuntimeLaneStorage: vi.fn(() =>
+      Promise.resolve({
+        // A teammate already committed, so the LANE flag is true. This is the
+        // masking the per-member reader exists to defeat.
+        hasRuntimeEvidenceOnDisk: true,
+        manifestEntryCount: 1,
+        manifestUpdatedAt: '2026-08-28T12:20:00.000Z',
+        fileNames: ['opencode-sessions.json', 'manifest.json'],
+      })
+    ),
+    upsertOpenCodeRuntimeLaneIndexEntry: vi.fn(() => Promise.resolve()),
+    logWarn: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('the promotion gate reads per member, not per lane', () => {
+  it('downgrades a lead a committed teammate was masking', async () => {
+    const upsert = vi.fn(() => Promise.resolve());
+
+    const guarded = await guardCommittedOpenCodeLaneEvidence(
+      {
+        teamName: 'lane-team',
+        laneId: 'primary',
+        memberNames: ['team-lead', 'Ada'],
+        result: launchResult([member('team-lead'), member('Ada')]),
+      },
+      ports({
+        upsertOpenCodeRuntimeLaneIndexEntry: upsert,
+        hasCommittedOpenCodeLaneMemberSessionEvidence: ({ memberName }) =>
+          Promise.resolve(memberName !== 'team-lead'),
+      })
+    );
+
+    expect(guarded.members['team-lead']?.launchState).toBe('runtime_pending_bootstrap');
+    expect(guarded.members['team-lead']?.bootstrapConfirmed).toBe(false);
+    // Ada committed and is left exactly as she was.
+    expect(guarded.members.Ada?.launchState).toBe('confirmed_alive');
+    expect(guarded.members.Ada?.diagnostics).toEqual([]);
+    expect(guarded.teamLaunchState).toBe('partial_pending');
+    expect(guarded.diagnostics).toContain(buildMissingOpenCodeSessionRecordDiagnostic('team-lead'));
+    expect(upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('names only the member it is about in that member evidence', async () => {
+    const guarded = await guardCommittedOpenCodeLaneEvidence(
+      {
+        teamName: 'lane-team',
+        laneId: 'primary',
+        memberNames: ['team-lead', 'Ada'],
+        result: launchResult([member('team-lead'), member('Ada')]),
+      },
+      ports({ hasCommittedOpenCodeLaneMemberSessionEvidence: () => Promise.resolve(false) })
+    );
+
+    expect(guarded.members['team-lead']?.diagnostics).toContain(
+      buildMissingOpenCodeSessionRecordDiagnostic('team-lead')
+    );
+    expect(guarded.members['team-lead']?.diagnostics).not.toContain(
+      buildMissingOpenCodeSessionRecordDiagnostic('Ada')
+    );
+    expect(guarded.members.Ada?.diagnostics).toContain(
+      buildMissingOpenCodeSessionRecordDiagnostic('Ada')
+    );
+    expect(guarded.members.Ada?.diagnostics).not.toContain(
+      buildMissingOpenCodeSessionRecordDiagnostic('team-lead')
+    );
+  });
+
+  // NEGATIVE CONTROL: absence of evidence is not evidence of absence. A reader
+  // that throws cannot disprove anything and must never downgrade a member.
+  it('leaves every member alone when the per-member read throws', async () => {
+    const result = launchResult([member('team-lead'), member('Ada')]);
+
+    const guarded = await guardCommittedOpenCodeLaneEvidence(
+      { teamName: 'lane-team', laneId: 'primary', memberNames: ['team-lead', 'Ada'], result },
+      ports({
+        hasCommittedOpenCodeLaneMemberSessionEvidence: () => Promise.reject(new Error('EBUSY')),
+      })
+    );
+
+    expect(guarded.members['team-lead']?.launchState).toBe('confirmed_alive');
+    expect(guarded.members.Ada?.launchState).toBe('confirmed_alive');
+    expect(guarded.teamLaunchState).toBe('clean_success');
+  });
+
+  // NEGATIVE CONTROL: with no per-member reader wired the gate falls back to
+  // the lane flag, which is exactly what it did before this change.
+  it('falls back to the lane flag when no per-member reader is wired', async () => {
+    const withEvidence = await guardCommittedOpenCodeLaneEvidence(
+      {
+        teamName: 'lane-team',
+        laneId: 'primary',
+        memberNames: ['team-lead'],
+        result: launchResult([member('team-lead')]),
+      },
+      ports()
+    );
+    expect(withEvidence.members['team-lead']?.launchState).toBe('confirmed_alive');
+
+    const withoutEvidence = await guardCommittedOpenCodeLaneEvidence(
+      {
+        teamName: 'lane-team',
+        laneId: 'primary',
+        memberNames: ['team-lead'],
+        result: launchResult([member('team-lead')]),
+      },
+      ports({
+        inspectOpenCodeRuntimeLaneStorage: vi.fn(() =>
+          Promise.resolve({
+            hasRuntimeEvidenceOnDisk: false,
+            manifestEntryCount: 0,
+            manifestUpdatedAt: null,
+            fileNames: [],
+          })
+        ),
+      })
+    );
+    expect(withoutEvidence.members['team-lead']?.launchState).toBe('runtime_pending_bootstrap');
+  });
+
+  // NEGATIVE CONTROL: a member that never claimed confirmation is not this
+  // gate's business, and the gate must not even commit for it.
+  it('does nothing at all when no named member claims confirmation', async () => {
+    const commit = vi.fn(({ result }: { result: TeamRuntimeLaunchResult }) =>
+      Promise.resolve(result)
+    );
+    const result = launchResult([
+      member('team-lead', {
+        launchState: 'starting',
+        agentToolAccepted: false,
+        runtimeAlive: false,
+        bootstrapConfirmed: false,
+        livenessKind: undefined,
+        sessionId: undefined,
+      }),
+    ]);
+
+    const guarded = await guardCommittedOpenCodeLaneEvidence(
+      { teamName: 'lane-team', laneId: 'primary', memberNames: ['team-lead'], result },
+      ports({
+        commitOpenCodeRuntimeAdapterLaunchSessionEvidence: commit,
+        hasCommittedOpenCodeLaneMemberSessionEvidence: () => Promise.resolve(false),
+      })
+    );
+
+    expect(guarded).toBe(result);
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('ignores members that are not named in the guard call', async () => {
+    const guarded = await guardCommittedOpenCodeLaneEvidence(
+      {
+        teamName: 'lane-team',
+        laneId: 'primary',
+        memberNames: ['Ada'],
+        result: launchResult([member('team-lead'), member('Ada')]),
+      },
+      ports({
+        hasCommittedOpenCodeLaneMemberSessionEvidence: ({ memberName }) =>
+          Promise.resolve(memberName !== 'team-lead'),
+      })
+    );
+
+    expect(guarded.members['team-lead']?.launchState).toBe('confirmed_alive');
+    expect(guarded.members.Ada?.launchState).toBe('confirmed_alive');
+  });
+});
+
+describe('the secondary-lane guard keeps its single-member contract', () => {
+  it('delegates to the lane guard with exactly one member name', async () => {
+    const laneStorage = vi.fn(() =>
+      Promise.resolve({
+        hasRuntimeEvidenceOnDisk: false,
+        manifestEntryCount: 0,
+        manifestUpdatedAt: null,
+        fileNames: [],
+      })
+    );
+
+    const guarded = await guardCommittedOpenCodeSecondaryLaneEvidence(
+      {
+        teamName: 'lane-team',
+        laneId: 'secondary:opencode:ada',
+        memberName: 'Ada',
+        result: launchResult([member('Ada')]),
+      },
+      ports({ inspectOpenCodeRuntimeLaneStorage: laneStorage })
+    );
+
+    expect(guarded.members.Ada?.launchState).toBe('runtime_pending_bootstrap');
+    expect(laneStorage).toHaveBeenCalledWith({
+      teamName: 'lane-team',
+      laneId: 'secondary:opencode:ada',
+    });
+  });
+
+  it('returns the result untouched when the lane holds no entry for the member', async () => {
+    const result = launchResult([member('Ada')]);
+
+    expect(
+      await guardCommittedOpenCodeSecondaryLaneEvidence(
+        {
+          teamName: 'lane-team',
+          laneId: 'secondary:opencode:ben',
+          memberName: 'Ben',
+          result,
+        },
+        ports()
+      )
+    ).toBe(result);
+  });
+});

--- a/test/main/services/team/TeamProvisioningService.test.ts
+++ b/test/main/services/team/TeamProvisioningService.test.ts
@@ -19965,7 +19965,11 @@ describe('TeamProvisioningService', () => {
       expect(svc.isTeamAlive(teamName)).toBe(true);
       expect(progress.at(-1)).toMatchObject({
         state: 'ready',
-        message: 'OpenCode team is running with unavailable members',
+        // The lead is absent from this launch result and holds no committed
+        // session on disk, so the lead gate reports it as pending. The team
+        // still promotes - the side lanes carry it - but the message now names
+        // the actual condition instead of the generic "unavailable members".
+        message: 'OpenCode lead is waiting for its runtime bootstrap evidence',
         error: undefined,
       });
 

--- a/test/main/services/team/TeamProvisioningService.test.ts
+++ b/test/main/services/team/TeamProvisioningService.test.ts
@@ -19546,7 +19546,13 @@ describe('TeamProvisioningService', () => {
 
       expect(adapterLaunch).toHaveBeenCalledTimes(1);
       expect(adapterStop).toHaveBeenCalledTimes(1);
-      expect(progress.at(-1)).toMatchObject({ state: 'failed', error: rootCause });
+      // The lead is a veto: the failure artifact now LEADS with the lead reason
+      // and keeps the shared-runtime root cause behind it.
+      expect(progress.at(-1)).toMatchObject({
+        state: 'failed',
+        error: expect.stringContaining(rootCause),
+      });
+      expect(progress.at(-1)?.error).toContain('team-lead');
       const statuses = await svc.getMemberSpawnStatuses(teamName);
       expect(statuses.statuses.alice).toMatchObject({
         status: 'error',

--- a/test/main/services/team/teamForceStopFlow.test.ts
+++ b/test/main/services/team/teamForceStopFlow.test.ts
@@ -1,4 +1,8 @@
 import {
+  PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS,
+  purgeStaleOpenCodeHostStartupLocks,
+} from '@main/services/team/opencode/bridge/OpenCodeHostStartupLockCleanup';
+import {
   countLiveRecordedRuntimeHostsForTeam,
   RUNTIME_HOSTS_POLL_INTERVAL_MS,
   releaseSharedRuntimeResourcesAfterStop,
@@ -6,6 +10,9 @@ import {
   STOP_ESCALATION_TIMEOUT_MS,
   stopTeamWithEscalation,
 } from '@main/services/team/lifecycle/teamForceStopFlow';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { PersistedTeamLaunchSnapshot } from '@shared/types';
@@ -798,6 +805,35 @@ describe('releaseSharedRuntimeResourcesAfterStop', () => {
 
     expect(releaseSharedLocalRuntime).toHaveBeenCalledTimes(1);
     expect(result.diagnostics).toEqual(['Released the shared runtime held for this team']);
+  });
+
+  // The alive-team list is read before this step runs, so a launch that starts
+  // in between owns a lock this purge can already see. The age floor is the
+  // only thing that keeps that lock: an unheld one would otherwise be unlinked
+  // and the next host for the same port would start unserialised beside it.
+  it('keeps the startup lock of a host that is starting right now', async () => {
+    const locksDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-stop-locks-'));
+    try {
+      const startingLock = path.join(locksDir, 'starting.lock');
+      fs.writeFileSync(startingLock, '');
+      const orphanLock = path.join(locksDir, 'orphan.lock');
+      fs.writeFileSync(orphanLock, '');
+      const orphanMtime = new Date(Date.now() - (PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS + 60_000));
+      fs.utimesSync(orphanLock, orphanMtime, orphanMtime);
+
+      const result = await releaseSharedRuntimeResourcesAfterStop({
+        teamName: 'fixteam',
+        otherAliveTeams: [],
+        purgeHostStartupLocks: (options) =>
+          purgeStaleOpenCodeHostStartupLocks({ ...options, locksDir }),
+      });
+
+      expect(result.diagnostics).toEqual(['Purged 1 stale OpenCode host startup lock(s)']);
+      expect(fs.existsSync(startingLock)).toBe(true);
+      expect(fs.existsSync(orphanLock)).toBe(false);
+    } finally {
+      fs.rmSync(locksDir, { recursive: true, force: true });
+    }
   });
 
   it('never throws: a failing purge or release is reported, not raised', async () => {

--- a/test/main/services/team/teamForceStopFlow.test.ts
+++ b/test/main/services/team/teamForceStopFlow.test.ts
@@ -1,6 +1,7 @@
 import {
   countLiveRecordedRuntimeHostsForTeam,
   RUNTIME_HOSTS_POLL_INTERVAL_MS,
+  releaseSharedRuntimeResourcesAfterStop,
   runTeamForceStopFlow,
   STOP_ESCALATION_TIMEOUT_MS,
   stopTeamWithEscalation,
@@ -649,5 +650,167 @@ describe('countLiveRecordedRuntimeHostsForTeam', () => {
     });
 
     expect(live).toBe(0);
+  });
+});
+
+describe('post-stop shared runtime release', () => {
+  it('releases after a stop that confirmed on its own, before the stopped state is written', async () => {
+    const order: string[] = [];
+    const ports = createPorts({
+      releaseSharedRuntimeResources: vi.fn(() => {
+        order.push('release');
+        return Promise.resolve({ diagnostics: ['Purged 3 stale OpenCode host startup lock(s)'] });
+      }),
+      markTeamStopped: vi.fn(() => {
+        order.push('markStopped');
+        return Promise.resolve();
+      }),
+    });
+
+    const result = await stopTeamWithEscalation('fixteam', ports);
+
+    expect(ports.releaseSharedRuntimeResources).toHaveBeenCalledWith('fixteam');
+    expect(ports.killRetainedRuntimeProcesses).not.toHaveBeenCalled();
+    expect(order).toEqual(['release', 'markStopped']);
+    expect(result.diagnostics).toEqual(['Purged 3 stale OpenCode host startup lock(s)']);
+  });
+
+  // The kill has to come first: a lock a live host still holds open cannot be
+  // unlinked, so releasing before the kill would leave every lock behind. The
+  // kill step only runs when the stop did not confirm, so the stop rejects here.
+  it('releases after the kill step on the force path', async () => {
+    const order: string[] = [];
+    const ports = createPorts({
+      stopTeam: vi.fn(() => Promise.reject(new Error('did not confirm stop'))),
+      killRetainedRuntimeProcesses: vi.fn(() => {
+        order.push('kill');
+        return Promise.resolve({ killedPids: [4242], diagnostics: [] });
+      }),
+      releaseSharedRuntimeResources: vi.fn(() => {
+        order.push('release');
+        return Promise.resolve({ diagnostics: [] });
+      }),
+    });
+
+    await runTeamForceStopFlow('fixteam', ports);
+
+    expect(ports.killRetainedRuntimeProcesses).toHaveBeenCalled();
+    expect(order).toEqual(['kill', 'release']);
+  });
+
+  // The port has no upstream default, so the overwhelmingly common case is
+  // that no caller supplies one. That case must be indistinguishable from the
+  // behaviour before the port existed.
+  it('behaves exactly as before when no caller supplies the port', async () => {
+    const ports = createPorts({ markTeamStopped: vi.fn(() => Promise.resolve()) });
+    expect(ports.releaseSharedRuntimeResources).toBeUndefined();
+
+    const result = await stopTeamWithEscalation('fixteam', ports);
+
+    expect(result).toEqual({
+      stopOutcome: 'stopped',
+      cleanupOutcome: 'completed',
+      killedRuntimePids: [],
+      clearedPendingDeliveries: 0,
+      diagnostics: [],
+    });
+    expect(ports.markTeamStopped).toHaveBeenCalledWith('fixteam');
+    expect(ports.logWarning).not.toHaveBeenCalled();
+  });
+
+  it('records a failed release as a diagnostic and still writes the stopped state', async () => {
+    const ports = createPorts({
+      releaseSharedRuntimeResources: vi.fn(() => Promise.reject(new Error('data dir gone'))),
+      markTeamStopped: vi.fn(() => Promise.resolve()),
+    });
+
+    const result = await stopTeamWithEscalation('fixteam', ports);
+
+    expect(result.stopOutcome).toBe('stopped');
+    expect(result.diagnostics).toEqual(['Post-stop resource release failed: data dir gone']);
+    expect(ports.markTeamStopped).toHaveBeenCalledWith('fixteam');
+  });
+});
+
+describe('releaseSharedRuntimeResourcesAfterStop', () => {
+  const purgedNothing = () =>
+    Promise.resolve({ locksDir: '/locks', scanned: 0, removed: 0, kept: 0, diagnostics: [] });
+
+  it('releases nothing at all while another team is alive', async () => {
+    const purgeHostStartupLocks = vi.fn(purgedNothing);
+    const releaseSharedLocalRuntime = vi.fn(() => Promise.resolve());
+
+    const result = await releaseSharedRuntimeResourcesAfterStop({
+      teamName: 'fixteam',
+      otherAliveTeams: ['other-team'],
+      purgeHostStartupLocks,
+      releaseSharedLocalRuntime,
+    });
+
+    expect(purgeHostStartupLocks).not.toHaveBeenCalled();
+    expect(releaseSharedLocalRuntime).not.toHaveBeenCalled();
+    expect(result.diagnostics).toEqual([
+      'Kept shared runtime resources: other teams are still alive (other-team)',
+    ]);
+  });
+
+  it('purges the orphaned host startup locks when this was the last team', async () => {
+    const result = await releaseSharedRuntimeResourcesAfterStop({
+      teamName: 'fixteam',
+      otherAliveTeams: [],
+      purgeHostStartupLocks: () =>
+        Promise.resolve({
+          locksDir: '/locks',
+          scanned: 4,
+          removed: 3,
+          kept: 1,
+          diagnostics: ['host-2.lock: Error: EIO'],
+        }),
+    });
+
+    expect(result.diagnostics).toEqual([
+      'Purged 3 stale OpenCode host startup lock(s)',
+      'lock purge: host-2.lock: Error: EIO',
+    ]);
+  });
+
+  // The port carries no upstream default: with no port handed in there is no
+  // release step at all, and the result must be the lock purge and nothing else.
+  it('has no shared-runtime step when no release port is supplied', async () => {
+    const result = await releaseSharedRuntimeResourcesAfterStop({
+      teamName: 'fixteam',
+      otherAliveTeams: [],
+      purgeHostStartupLocks: purgedNothing,
+    });
+
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('runs the supplied release port and reports it', async () => {
+    const releaseSharedLocalRuntime = vi.fn(() => Promise.resolve());
+
+    const result = await releaseSharedRuntimeResourcesAfterStop({
+      teamName: 'fixteam',
+      otherAliveTeams: [],
+      purgeHostStartupLocks: purgedNothing,
+      releaseSharedLocalRuntime,
+    });
+
+    expect(releaseSharedLocalRuntime).toHaveBeenCalledTimes(1);
+    expect(result.diagnostics).toEqual(['Released the shared runtime held for this team']);
+  });
+
+  it('never throws: a failing purge or release is reported, not raised', async () => {
+    const result = await releaseSharedRuntimeResourcesAfterStop({
+      teamName: 'fixteam',
+      otherAliveTeams: [],
+      purgeHostStartupLocks: () => Promise.reject(new Error('lock dir gone')),
+      releaseSharedLocalRuntime: () => Promise.reject(new Error('runtime unreachable')),
+    });
+
+    expect(result.diagnostics).toEqual([
+      'lock purge failed: lock dir gone',
+      'Shared runtime release failed: runtime unreachable',
+    ]);
   });
 });

--- a/test/main/utils/persistentAppLog.test.ts
+++ b/test/main/utils/persistentAppLog.test.ts
@@ -76,4 +76,40 @@ describe('persistentAppLog', () => {
       await rm(directory, { recursive: true, force: true });
     }
   });
+
+  it('persists diagnostic entries that never reached the console', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'agent-teams-persistent-log-'));
+    const warnOutput = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const handle = installPersistentAppLog({
+      directory,
+      appVersion: '2.9.1-test',
+      platform: 'darwin',
+    });
+
+    try {
+      createLogger('Service:TeamProvisioning').diagnostic(
+        '[alpha] opencode_launch_prompt_queued lead=lead messageId=m-1 chars=12'
+      );
+      await handle.flush();
+
+      const records = (await readFile(handle.filePath, 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        v: 1,
+        level: 'diagnostic',
+        process: 'main',
+        namespace: 'Service:TeamProvisioning',
+      });
+      expect(String(records[0]?.message)).toContain('opencode_launch_prompt_queued');
+      expect(warnOutput).toHaveBeenCalledTimes(0);
+    } finally {
+      handle.dispose();
+      warnOutput.mockRestore();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Stacked on #577 (fix(team): a stop is final: the stop marker, run-scoped reconcile writes, and a Stop that finishes on evidence); review the top 21 commits. That PR makes a stopped team stay stopped: the stop marker, run-scoped reconcile writes, a Stop that finishes the moment the recorded runtime hosts are gone, and the `cleanupOutcome` a force stop reports when hard cleanup cannot be confirmed.

## Problem

Seven defects, all hit on live OpenCode and mixed-provider runs during the earlier campaign. The first three are about processes and lock files this app leaves behind; the last four are about a launch that reports success without a usable lead.

**1. Leftover startup locks made every launch wait.** The orchestrator serialises host startups with lock files under its data directory, and a host that goes away without releasing its lock leaves the file behind. The next launch readiness probe waits on each leftover in turn, so a launch that follows a few stopped runs sits in "spawning" for minutes over files that guard nothing. Nothing removed them at the two moments that matter: the force path's hard cleanup reports itself incomplete and signals nothing, so neither a confirmed stop nor an escalated one released a lock, and a launch had no purge of its own.

**2. The startup sweep could kill the host it had just made.** The app reaps leftover managed hosts a few seconds after start. The orchestrator's own registry sweep is executed without a project path, which boots a managed host in the app's process directory; that host then owns the loopback port the runtime proxy is pinned to, so every lane launched afterwards was routed through it (wrong workspace, wrong profile, none of the user's MCP servers), and nothing reaped it because it was not in the registry the sweep had just cleaned. Reaping it means killing a host this instance started seconds ago, and the reap is fire-and-forget, so a team launched inside its window lost its own readiness-probe host and was refused before its first state-changing bridge command, with no cause the user could see.

**3. Orphans from a previous instance held the ports.** An `opencode serve` host orphaned by the last app instance keeps the fixed loopback ports a new host needs, and whoever claims a port first keeps it. Two such orphans were invisible to the scan: the orchestrator's own serve binary was never a candidate, and on Windows a host launched from a PATH-resolved runtime carries neither the managed install path in its command line nor a readable environment.

**4. A team with no usable lead was promoted to `ready`.** An aggregate OpenCode launch summarises its lanes and then asks whether some lane still holds a retainable member. The primary lane was one voice in that count, so two healthy side lanes were enough to promote a team whose lead held no runtime session: progress went to `ready`, the message read "OpenCode team is running with unavailable members", `configReady` stayed true, and the user's launch prompt was handed to a lead that could not receive it. A team with no usable lead has nobody to route work through; nothing about it is running. This was the "everything green, nothing happens" launch.

**5. The launch snapshot dropped the lead on read-back.** `normalizePersistedMemberState` discarded every member whose name reads as the lead. That is right for a native lead, which is the orchestrator process, and wrong for a pure-OpenCode team, where the lead owns the primary lane and is written into the snapshot like any other member. The snapshot was written with the lead and read back without it, so a team whose lead was dead still reported `teamLaunchState: 'clean_success'` and the lead card had no liveness at all.

**6. A blocked primary lane produced no output at all.** A primary lane that never reached session bootstrap said nothing anyone could act on: the commit loop skipped an uncommittable member with a bare `continue`, and the call that destroys a lane's session store was silent when it succeeded. The first sign was a "No stored OpenCode session record" relay failure minutes later, after the evidence had already been deleted.

**7. The committed-evidence promotion gate ran per lane, and for secondary lanes only.** `hasRuntimeEvidenceOnDisk` is a lane flag: it flips as soon as one member commits. On a multi-member primary lane a teammate's session record therefore vouched for a lead that had none, and the primary lane's lead, the one member whose absence makes a team useless, was the single member the gate never saw.

## Fix

Numbering follows the defects above.

1. **Stale locks purged where they are provably orphans.** Three purges on top of the periodic one #577 added, all in `OpenCodeHostStartupLockCleanup.ts`. After a stop on both paths, through a new optional `releaseSharedRuntimeResources` port on `TeamForceStopFlowPorts` that the stop flow calls once the team is down: after a stop that confirmed on its own, and after the escalated path finished its cleanup, never before it, because a lock a live host still holds open cannot be unlinked. Both entry points wire it to `releaseSharedRuntimeResourcesAfterStop` (`handleStopTeam` and `handleForceStopTeam` in `src/main/ipc/teams.ts`, and the two routes in `src/main/http/teams/teamLifecycleRoutes.ts`), and it does nothing at all while another team is alive, because nothing here can attribute a lock to a team. It applies the same `PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS` floor the pre-launch purge does, for the same reason: the alive-team list is read when the release starts, so a launch beginning during the scan owns a lock this purge can already see, and without the floor an unheld one would be unlinked out from under a host that is still booting. `releaseSharedLocalRuntime` inside it is an injected optional port with no upstream default: a deployment whose members share a runtime this app can ask to stand down hands one in, and everywhere else the step does not exist rather than being a no-op branch the app carries around. Before every create and every launch, through an optional `beforeStart` hook on `bindTeamProvisioningStartApi`: `bindOpenCodeStartPreparation` calls `purgeStaleOpenCodeHostStartupLocksBeforeLaunch`, which drops locks older than `PRE_LAUNCH_STALE_LOCK_MIN_AGE_MS` (two minutes) and declines entirely while another team is alive. The hook is preparation, never a precondition: a failure is swallowed and recorded, so nothing it does can be the reason a team fails to start. And at startup once the reap has run, in `cleanupOpenCodeHostsForLifecycle`, with a half-minute floor that keeps a host starting right now out of scope. The purge deliberately does not live inside the hard-cleanup step, where the wave this came from put it: that step is a stub that signals nothing, and the existing cleanup tests would delete a developer's live orchestrator locks (real data directory, no minimum age) unless the whole suite stubbed the data home.

2. **The startup sweep never kills its own instance's processes.** `OpenCodeStartupRuntimeSweep.ts` adds `runOpenCodeStartupRuntimeSweepTail`, which reaps the sweep host fenced by `sweepCommandSettledAtMs`, the instant the registry sweep command returned. App start would make the reap a guaranteed no-op, since the sweep host is younger by construction, and so would the instant the command was issued, since the host that command boots is younger than that too; the settled instant is the one that separates a host the sweep left behind from a host an in-flight launch owns. The tail also carries this app instance's own ownership markers, the same pair the shutdown sweep passes: the environment marker off Windows and the app-scoped loopback config marker on it. The sweep host inherits the bridge environment that carries them, so it stays reachable, while a host this instance did not start is kept however old it is - which matters because this is the one reap that runs in `force` mode with no lineage check. The tail never throws: the stale-lock purge runs on the line after it, and a process table that could not be read must not take that purge with it. `OpenCodeStartupSweepGate.ts` lets a start serialise behind the sweep instead of racing it: `beginOpenCodeStartupRuntimeSweep` is armed before the scheduling delay and released from a `finally`, so a throwing sweep cannot park launches forever, and `whenOpenCodeStartupRuntimeSweepSettled` is bounded by `OPEN_CODE_STARTUP_SWEEP_WAIT_TIMEOUT_MS` (60 s), so a hanging sweep costs one launch a minute rather than every launch its life. A start that cannot produce an `opencode serve` host never waits (`startRequestMayRaceOpenCodeStartupSweep`), and a start that does park reports the wait as a `validating` progress entry instead of freezing silently. The fence reads `readProcessStartTimeMs` from `src/main/utils/processStartTime.ts`, which landed on `main` in #539, forces `LC_ALL=C` on POSIX and answers `null` on any failure; `OpenCodeManagedHostProcessCleanup.ts` drops its two private copies for it. The reap is the scan `cleanupManagedOpenCodeServeProcesses` already performs for the startup cleanup on `main`, injected as `OpenCodeManagedHostSweep` so the fence can be tested without a process table. It reaches a process only because that process's own command line names an app-managed runtime or the orchestrator binary, and kills it only because its own environment carries strings this app wrote; there is no path here to a host this app merely recorded a pid for.

3. **Orphan managed hosts are reaped before the runtime registry exists.** `reapOrphanedOpenCodeHostsBeforeRuntimeRegistry` runs inside `initializeServices`, awaited, before the runtime adapter registry is built, in `orphaned` mode and fenced by this instance's start, so it only reaches a host that is both older than this app and no longer parented by anything alive. The scan also recognises the orchestrator's own serve command (`isOrchestratorServeCommand`) and, on Windows, falls back to asking the host over loopback for its effective config and matching strings only this app writes (`isManagedOpenCodeServeHostConfig`); silence, or a config this app did not write, reads as "not ours". It never throws, because an app that cannot clean up first still has to start.

4. **The lead is a veto, not a vote.** `TeamProvisioningOpenCodeAggregateLaunchPromotion.ts` resolves the lead's own bootstrap state before the aggregate state is summarised (`resolveOpenCodeAggregatePrimaryLeadBootstrap`, `classifyOpenCodePrimaryLeadBootstrap`) and lets it override the summary in both directions (`resolveOpenCodeAggregateLaunchStateForLeadBootstrap`). A `failed` lead forces `partial_failure` and can never be a partial success. A `pending` lead turns a `clean_success` into `partial_pending`, which keeps the run active instead of finishing it, because the lane can hold a live runtime handle or sit on an unanswered permission prompt before its session record commits. A `confirmed` lead changes nothing. `buildOpenCodeAggregateFinalProgress` stops reporting "running with unavailable members" while the lead is unconfirmed and sets `configReady: input.leadBootstrap !== 'failed'`, which is the one user-visible change to the launch dialog's contract and the assertion most likely to be questioned. The committed-session read is the same disk read the delivery path performs later, wired in `TeamProvisioningOpenCodeLaunchWiring.ts` as `hasCommittedOpenCodePrimaryLeadSessionEvidence`; it may only downgrade, so an explicit `false` is proof while a throw or an unwired reader means "cannot disprove". Deliberately not the existing `hasDeliverableOpenCodeRuntimeBootstrapSessionEvidence` helper, which swallows its store read and answers `false`: a manifest lock held by a concurrent bootstrap check-in would then tear a healthy team down. The direct read had the same hole one level down, because `readCommittedOpenCodeBootstrapSessionEvidence` reports a store it could not read as an empty session list rather than rejecting, so `requireAnsweredOpenCodeCommittedBootstrapSessionEvidence` now stands between the two: `healthy`, `missing` and `quarantined` are answers a gate may act on, and a manifest out of reach or a store between its write and its commit is raised for the caller to read as "cannot disprove".

5. **A lane-owned lead survives the read-back.** `TeamPersistedOpenCodeLaneMemberPolicy.ts` keeps a lead on read-back when, and only when, the persisted record carries the three fields the OpenCode lane writer stamps: `providerId: 'opencode'`, `laneOwnerProviderId: 'opencode'` and a primary lane kind (`isPersistedOpenCodePrimaryLaneLeadMember`, with a legacy allowance for a record that carries `laneId: 'primary'` and no `laneKind`), so a lead on any other provider can never match by accident. The lead lands in `members`, where `teamLaunchState` and the member diagnostics finally see it, and deliberately not in the snapshot's own `expectedMembers`, which is the teammate roster the UI renders; `summarizePersistedLaunchMembers` unions both, so the summarised member spawn statuses do name the lead. The JSON-reason recovery helpers move to `TeamLaunchFailureReasonText.ts` (`extractMessageSendRoutingReason`) to make the room.

6. **A blocked primary lane reports why.** `TeamProvisioningOpenCodeBlockedLaunchReporting.ts` builds four kinds of named report (a blocked primary launch, an uncommittable member session, a cleared lane storage, a launch prompt withheld or deferred), each carrying run, lane and reason. Every export is a pure function of the launch result and takes no ports, so a report cannot change what a launch does. Every free-form field a report quotes - the lane diagnostics, a member's hard-failure reason, the lead's runtime diagnostic - passes through `normalizeOpenCodeFailureMessage` first, the same redaction the member-facing failure text applies to the same strings, because these lines reach the durable sink and a runtime that failed while starting prints the command line it was given. The sinks are optional `logDiagnostic` ports beside the existing `logWarning`: `launchOpenCodeAggregatePrimaryLane` reports a `partial_failure` launch and a successful evidence wipe, `commitOpenCodeRuntimeAdapterLaunchSessionEvidence` replaces the bare `continue` with a per-member diagnostic on the primary lane only, and `runOpenCodeWorktreeRootAggregateLaunch` refuses to burn the launch prompt on a lead the lane holds no runtime evidence for and names the deferral when the lead is merely pending.

7. **Promotion requires per-member committed evidence.** `guardCommittedOpenCodeLaneEvidence` in `TeamProvisioningLaunchStateReconciliation.ts` takes a list of member names instead of one, reads the committed record per member through the new optional `hasCommittedOpenCodeLaneMemberSessionEvidence` port, and downgrades exactly the members whose record is missing, each carrying only its own `buildMissingOpenCodeSessionRecordDiagnostic` line. It is lane-kind agnostic, and the primary lane now calls it with every expected member through the optional `guardCommittedOpenCodeLaneEvidence` port on `LaunchOpenCodeAggregatePrimaryLanePorts`; the guarded result is what reaches persistence. `guardCommittedOpenCodeSecondaryLaneEvidence` stays as the single-member entry point it always was and delegates. The per-member check reads the COMMITTED result rather than the one that came in: the commit promotes a matching app-managed bootstrap candidate to confirmed, and reading the pre-commit result skipped exactly those members, so the one promotion this gate creates went unverified. Without a per-member reader the gate falls back to the lane flag, so a caller that wires nothing sees no change, and a read that throws resolves to "committed", never to "missing".

Two things dropped from the wave this came from, on purpose: a relaunch ladder for a failed lead bootstrap that its own comment described as deliberately not wired by default, and a pre-launch-gate retry seam labelled as a test seam. An optional port no production code supplies is a test-only parameter, so neither is here. The one optional port left here that no upstream caller supplies is `releaseSharedLocalRuntime`, and it is what the commit title is about: a deployment whose members share a runtime this app can ask to stand down hands one in. If you would rather not carry an extension point with no caller in-tree, it comes out on a word - the lock purge beside it is the half that fixes the slow launch.

Five things for your judgement rather than mine. The two startup reaps have no configuration surface: they are gated on the ownership proof rather than on a switch, and an env opt-out is a few lines if you would rather have one. The Windows ownership fallback issues one bounded loopback request to a process the app is about to kill, and a stricter signal would be welcome if you know one. `OPEN_CODE_STARTUP_SWEEP_HOST_SETTLE_MS` (8 s) is spent whether or not the orchestrator booted a sweep host, off the critical path but real, and the awaited preflight reap adds a process-table scan plus per-candidate start-time probes to every cold start, which is the point of the change but is a cost. The lock purge derives the orchestrator's data directory itself, and that derivation is worth confirming against the orchestrator's own. And a `pending` lead has no upper bound here; if you want one, the value is your call.

**Design changes in this revision.** This branch was written before #568 landed and has been re-expressed on the merged code.

- The force stop no longer sweeps managed hosts, and this PR does not bring that back. #568 reduced `killRetainedOpenCodeRuntimeProcessesForTeam` to a step that reports its own limit and deleted the managed-host sweep port, on the ground that a persisted pid - or even a matching process command - is not exclusive ownership of a host other teams may share. The earlier shape of `88c4087fb` and `e2151b3c0` relocated that port and extended it; both hunks are dropped. `teamForceStopFlow.ts` gains only the release port from this PR, and everything that port does acts on files.
- The two startup reaps stay, because neither claims a host by pid. A process becomes a candidate only because its own command line names an app-managed OpenCode runtime or the orchestrator binary, and is only signalled because its own environment - or, where Windows forbids reading that, its own answer over loopback - carries strings this app wrote. Both are fenced by a start time, and the pre-registry one additionally requires a parent that is already gone.
- The sweep is injected as a plain function (`OpenCodeManagedHostSweep`) instead of a port with an `isEnabled()` switch. With the unattributed kill gone there is nothing left for a deployment to switch off, so the two "touches nothing when the sweep port is disabled" cases went with it; what carries the rule now are the cases about what the scan refuses to claim, in `OpenCodeManagedHostProcessCleanup.test.ts`.
- Nothing here moves the force-stop cancellation ordering #568 and #577 established. The release step runs after the stop and after whatever cleanup that stop triggered, never before either.
- Rebased onto #599. It touches two files this branch also changes, and both additions are additive seams rather than changes to what this branch reads: `TeamProvisioningOpenCodeBootstrapEvidence.ts` gains an optional `onBootstrapSessionCommitted` port fired outside the lane lock after a verified commit, and `createTeamProvisioningOpenCodeLaunchWiring` gains an optional `onRuntimeRegistered` callback beside `setAliveRunId`. Neither meets the gate this PR adds: `hasCommittedOpenCodePrimaryLeadSessionEvidence` only ever reads, so it supplies no commit callback, and #599's own suites (bootstrap commit wake, bootstrap delivery during provisioning, launch wiring, runtime check-in) pass unchanged at the tip alongside this branch's.

## Tests

Negative controls, each its own test and each mutation-checked (the rule was broken, the named tests went red, the rule restored).

- `test/main/services/team/OpenCodeStartupRuntimeSweep.test.ts` (new): "fences the reap by the moment the sweep command settled"; "carries the ownership markers of this app instance into the reap"; "waits out the settle window before it reaps anything"; "records the kill count durably without writing to the console"; "reports what the sweep could not do without failing the startup"; "reports a failing reap instead of aborting the cleanup that follows it". For the pre-registry reap, "reaps only what predates this instance and is no longer parented" and "reports a failing sweep instead of failing the startup", which also pins that a scan which could not run reports no count. The gate: "resolves at once when no sweep is pending", "parks a caller until the pending sweep settles, and reports the wait", "releases waiters when the sweep it fronts fails", "gives up after the bound rather than parking a launch forever".
- `test/main/services/team/OpenCodeHostStartupLockCleanup.test.ts` (extended): "purges the locks an earlier run left behind and reports the count durably", "keeps a lock younger than the pre-launch threshold", "does not purge at all while another team is alive", "treats the launching team's own liveness as no obstacle", "answers null instead of throwing when the purge itself fails".
- `test/main/services/team/teamForceStopFlow.test.ts` (extended): "releases after a stop that confirmed on its own, before the stopped state is written", "releases after the kill step on the force path", "behaves exactly as before when no caller supplies the port", "records a failed release as a diagnostic and still writes the stopped state"; and over the helper itself, "releases nothing at all while another team is alive", "has no shared-runtime step when no release port is supplied", "keeps the startup lock of a host that is starting right now", "never throws: a failing purge or release is reported, not raised". `test/main/ipc/teams/teamStopEscalationSharedFlow.test.ts` pins that both stop entry points supply the release port and build the same alive-team filter for it.
- `test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts` (extended): "recognises the orchestrator serve host, which only this app runs", "recognises a managed host by its effective config when the environment is unreadable", "keeps a fenced managed process whose start time cannot be read at all", "claims a Windows host whose loopback config carries this app instance", and its inverse "leaves a Windows host alone when its loopback config belongs to somebody else". The existing marker guard still keeps a standalone `opencode serve` out of every path.
- `src/main/services/team/contracts/__tests__/TeamProvisioningApis.test.ts` (extended): "runs the pre-start step before every create and every launch" pins the order across both, "starts the team anyway when the pre-start step fails", "does not wait for the startup sweep when no member can be an OpenCode host", and an `it.each` over an OpenCode start, a start whose provider is resolved later and a mixed team with one OpenCode member, each of which waits and reports the wait.
- `src/main/services/team/runtime/__tests__/OpenCodeLaunchGateResult.test.ts` (extended): "resolves a blocked runtime store to its readiness diagnostic", beside the existing "reports a non-readiness reason verbatim instead of mining the diagnostics" which pins the other side of the same branch.
- `src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeBootstrapEvidence.test.ts` and `TeamProvisioningOpenCodeSecondaryLaneEvidencePortsFactory.test.ts` (both extended): "raises for every state that is not an answered store", "raises for a store that is between its write and its commit", "passes an answered store through untouched, sessions or none", "raises rather than answering false when the committed store did not answer", "answers false when the store answered and holds no record for the member".
- `src/shared/utils/__tests__/logger.test.ts` and `test/main/utils/persistentAppLog.test.ts`: "persists a diagnostic entry without writing to the console", with every console method asserted called zero times, and "persists diagnostic entries that never reached the console".
- `src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregateLaunchPromotion.test.ts` (new, unit) and `TeamProvisioningOpenCodeAggregateRun.leadVeto.test.ts` (new, end to end): "keeps a confirmed lead with two failed side lanes a partial success" is the first case in both suites, because the veto is not a blanket fail. Then "fails the launch when the lead has no committed session, even with two healthy side lanes"; "keeps the run active and still queues the prompt while the lead is pending"; "queues the prompt exactly once whether the lead commits before or after the branch"; "waits for a permission-blocked lead instead of tearing the team down"; "still fails a permission-blocked lead the lane reported as a hard failure"; "leaves a launch with no committed-session reader completely unchanged". The "cannot disprove" contract has three of its own: "confirms when the committed-session read answers null", "treats a failing disk read as \"cannot disprove\", never as failure", "confirms when no committed-session reader is wired".
- `TeamProvisioningOpenCodeBlockedLaunchReporting.test.ts` and `TeamProvisioningOpenCodeAggregateLaunchPersistence.uncommittableSession.test.ts` (both new): "produces reports from the result alone, with no ports and no writes"; "reports nothing at all for a healthy lead"; "leaves the aggregate launch state exactly as it found it"; "returns the same result with and without a report sink"; "says nothing for the same shape on a secondary lane"; "redacts secrets out of the member reason and the lane diagnostics"; "redacts the reason it quotes from the lead evidence". In the run suite, "produces the same launch outcome with and without a report sink" deep-equals the whole progress log.
- `test/main/services/team/TeamLaunchStateEvaluator.openCodeLead.test.ts` (new): "stops reporting clean_success for a team whose lead is dead", "keeps a healthy lane-owned lead without changing the aggregate state", and three inverses: "leaves a lead that is not lane-owned dropped exactly as before", "leaves an OpenCode lead on a foreign-owned lane dropped exactly as before", "does not misclassify a secondary-lane member named team-lead as the primary lead"; plus "accepts a legacy lane member that carries laneId but no laneKind".
- `test/main/services/team/TeamProvisioningLaunchStateReconciliation.laneEvidence.test.ts` and `TeamProvisioningOpenCodeAggregateLaunchPersistence.primaryLaneGate.test.ts` (both new): "downgrades a lead a committed teammate was masking"; "names only the member it is about in that member evidence"; "leaves every member alone when the per-member read throws"; "falls back to the lane flag when no per-member reader is wired"; "checks a member the commit itself promoted"; "ignores members that are not named in the guard call"; "delegates to the lane guard with exactly one member name"; "names the primary lane and every expected member, and persists the guarded result"; "persists the adapter result unchanged when no gate is wired".

Three end-to-end expectations changed, all in `test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts`, and all three are what the source change is about: a pending count of 1 becomes 2, a failed count of 1 becomes 2, and `expectedMembers` gains `team-lead` after a restart. One expectation in `test/main/services/team/TeamProvisioningService.test.ts` moves from an exact error match to `stringContaining` plus a `team-lead` assertion, because the failure artifact now leads with the lead reason and keeps the underlying root cause behind it.

At the tip: `pnpm typecheck`, the source-file size guard, the team-provisioning architecture guard, `eslint` (0 errors, no new warning on any line this branch adds), the announcements content check, and targeted vitest over every test file this branch touches plus the tests covering every changed module - 74 files, 1860 passed, 1 skipped, 0 failed. `prettier --check` is clean on every file this branch changes, `src/main/index.ts` included: the announcements initialiser that used to report unformatted on `main` was reformatted upstream in #599, so the exception this section carried in the previous revision is gone. The full suite is run over the restacked stack as a whole. One flake worth naming: `test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts` failed once under parallel load on an unexpected `console.warn` - `TeamConfigReader`'s slow-read diagnostic firing on a 664 ms config read - in a case this branch does not touch and from a module it does not change; the file is green on its own, 342 of 342.

## Commits

**Groundwork**

- `2c0a5a995` feat(logging): a durable diagnostic level that never writes to the console
- `731931e83` refactor(opencode): extract the launch gate result from the runtime adapter

**Host lifecycle: locks, sweeps and orphans**

- `88c4087fb` fix(opencode): a confirmed stop releases the shared runtime and stale host locks are purged before a launch
- `e2151b3c0` fix(opencode): the startup sweep never kills the processes of its own instance
- `172f3ba76` fix(opencode): orphan managed hosts are reaped before the runtime registry exists

**Aggregate launch promotion**

- `96bad4d0c` refactor(team): extract the OpenCode aggregate primary-lane stop helpers
- `fc4aa5d40` refactor(team): extract the primary-lane wiring from the aggregate primary facade
- `9ad5f55ca` fix(team): a lane-owned OpenCode lead survives the launch-snapshot read-back
- `f530a7436` fix(team): the lead is a veto, not a vote, in aggregate launch promotion
- `6a6eb7b6b` fix(team): a blocked primary lane reports why, instead of failing silently
- `ddf2c5c54` fix(team): promotion requires per-member committed session evidence

**Review round**

- `de70f1ac7` fix(opencode): the post-stop lock purge spares a host that is starting
- `3edb22582` fix(opencode): a failed startup reap no longer takes the lock purge with it
- `5c49a5b82` fix(opencode): the startup reap reaches the sweep host and nothing else
- `fce38e07a` fix(team): a store that did not answer cannot disprove a session record
- `9d39dcb72` fix(team): the blocked-launch report redacts what it quotes
- `a5b180565` fix(opencode): a blocked runtime store reports which store is blocked
- `890620744` fix(team): the promotion gate reads the members the commit just promoted
- `fbc866c26` test(team): pin the shared-runtime release port at both stop entry points

**Review round 2**

- `26c8e98d3` fix(opencode): a startup lock purge cannot outlive the refusal that protects it
- `67744692d` fix(opencode): a startup sweep that could not run at all is reported as a failure

## Notes

**Three extractions, each made to fit under the size guard, none of them behavioural.**

`731931e83` moves `blockedLaunchResult` and its message helpers out of `OpenCodeTeamRuntimeAdapter.ts` (1429 to 1316, cap 1591) into `OpenCodeLaunchGateResult.ts`, which #557 added to `main` for the gate marker: the gate marker and the result it is attached to are one decision. Verified with `--color-moved`; of the 121 lines leaving the adapter the only six not reproduced character for character are the five declarations that gain `export` and the adapter's old one-line import, which widens to name what it now pulls in. `isGenericOpenCodeFailureMessage` moves with them and stays module-private. It carries, unchanged, the `'OpenCode is temporarily unavailable. Retry the launch.'` clause that #557 (merged) added: that reassurance text is prepended ahead of the real readiness diagnostic, and without the clause it wins as the first displayable message and permanently hides the diagnostic behind it. The clause sits at `OpenCodeLaunchGateResult.ts:180` at the tip and at `OpenCodeTeamRuntimeAdapter.ts:1269` on the base, so it is moved, not new. The launch-gate unit test gains the cases previously reachable only through a full adapter launch. One behavioural correction rides with the extraction: `runtime_store_blocked` was missing from the readiness-failure set, so that one state reached the member card as the bare code while the other five resolved to their readiness diagnostic.

`96bad4d0c` moves the two primary-lane stop paths out of `TeamProvisioningOpenCodeAggregatePrimaryFacade.ts`, which sat exactly on the 800 default, into `OpenCodeAggregatePrimaryLaneStopHelpers.ts` behind a ports object (`stopUnretainableOpenCodePrimaryLane`, `stopFailedOpenCodeAggregatePrimaryRelaunchCandidate`); the facade drops to 724. Not a byte-identical move by `--color-moved`, because the helpers read their state through `ports.getRuntimeOwner(...)` instead of the facade's private map. `fc4aa5d40` then moves the mapping from that private state to the helpers' ports into `TeamProvisioningOpenCodeAggregatePrimaryLaneWiring.ts` (`createOpenCodeAggregatePrimaryLaneStopPorts`). It grows the facade by six lines rather than shrinking it, and says so: the facade's state is private, so only the mapping can leave, and the point of the module is that later primary-lane work has a home for its own ports without pushing the facade back over the cap.

**A shared commit.** `2c0a5a995` "feat(logging): a durable diagnostic level that never writes to the console" is also carried, byte-identical (same `git patch-id`), by #575; the two can land in either order, and whichever goes first the other drops it on rebase. It is load-bearing here: `test/setup.ts` fails any test on an unexpected `console.warn`, and every startup, sweep, lock-purge and launch-report event this PR adds would otherwise need an allowlist entry. They go through `logger.diagnostic` instead (12 call sites in `src/main` at the tip), and `test/setup.ts` is untouched.

**Round 2: the startup floor and the channel a failed sweep reports on.** The startup lock purge removed any lock older than thirty seconds with no owner or liveness check. Nothing identifies an owner in those files - the orchestrator writes them and this app only reads names and mtimes - so what protects a live host's lock is the OS refusing the unlink, which is a Windows property this module stated as a portable one. On POSIX an open lock unlinks cleanly, so the floor was the whole guard and it sat below this module's own bound for a startup still in progress. The floor is now the one the platform can defend: half a minute where the OS refuses the unlink, and the pre-launch floor where it does not. Separately, both startup sweeps caught their own failure and reported it through the same port as their per-host diagnostics. A caught failure means the sweep did not run at all, and `logger.warn` reaches the durable sinks but is filtered off a production console while `logger.error` is not, so both sweeps now take a `logError` port for their catch blocks and keep the per-host diagnostics on `logWarning`.

**Sizes.** `src/main/ipc/teams.ts` 5627/5661, `TeamLaunchStateEvaluator.ts` 1022/1059, `src/main/index.ts` 3712/3719, `TeamProvisioningOpenCodeAggregatePrimaryFacade.ts` 730/800, `TeamProvisioningLaunchStateReconciliation.ts` 725/800, `contracts/TeamProvisioningApis.ts` 631/800, `lifecycle/teamForceStopFlow.ts` 643/800, `TeamProvisioningOpenCodeBootstrapEvidence.ts` 615/800, `TeamProvisioningOpenCodeAggregateLaunchPersistence.ts` 606/800, `OpenCodeManagedHostProcessCleanup.ts` 569/800, `OpenCodeTeamRuntimeAdapter.ts` 1316/1591, `OpenCodeLaunchGateResult.ts` 198/800, `OpenCodeHostStartupLockCleanup.ts` 266/800, `teamLifecycleRoutes.ts` 219/800, `OpenCodeStartupRuntimeSweep.ts` 179/800, `TeamProvisioningOpenCodeBlockedLaunchReporting.ts` 165/800, `TeamProvisioningOpenCodeSecondaryLaneEvidencePortsFactory.ts` 79/800; the other new modules are 244, 145, 97, 58, 43 and 41 lines. `OpenCodeRuntimeManifestEvidenceReader.ts` stays at its frozen 1087. `scripts/ci/source-file-size-baseline.json` and `test/setup.ts` are untouched.

## Tested on

Windows 11 Pro, from source, against `origin/main @ 192560997` plus the branch of #577. Every defect above was hit on live runs during the earlier campaign: launches parked in "spawning" behind stale locks, a team routed through the sweep's own host, a previous instance's orphan holding the loopback port, and the "ready with an unavailable lead" launch on pure-OpenCode teams. With this in place a launch after several stops starts at once, a team launched inside the sweep window keeps its host, a cold start reaps last session's orphans before the registry is built, the same failing launch reports the lead's failure and keeps `configReady` false, and a lead on a permission prompt holds the run pending instead of finishing it. The Windows ownership fallback and the process-table reader have POSIX branches covered by test only; not run on macOS or Linux here.

**Authorship & provenance:** All code in this PR was written by **Claude (Fable 5)**, directed and live-verified on Windows by me. As with anything under AGPL-3.0, it is offered **as-is, without warranty of any kind** - use, adapt, or reject freely.

Base: main @ 192560997


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Team stopping now completes cleanup more reliably, including retained runtime processes, pending prompts, stopped-state tracking, and shared resource release.
  * Stop results now distinguish successfully stopped teams from runtimes that were already offline.
  * OpenCode launches better detect failed, pending, blocked, or uncommitted lead sessions and report clearer status details.
  * Restoring stopped teams no longer revives stale launch state.

* **Improvements**
  * Added startup cleanup for orphaned OpenCode hosts and stale startup locks.
  * Added durable diagnostic logging without unnecessary console output.
  * Improved backup manifest handling and launch-state protection during concurrent operations.
  * OpenCode runtime stops now handle multiple lanes more efficiently and verify process shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->