### PR TITLE
chore(release): refresh v2.13.0 candidate

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,33 +34,36 @@ Target branch: `main`.
 
 Runtime gate:
 
-- Agent Teams runtime: `v0.0.76`.
+- Agent Teams runtime: `v0.0.78`.
 - Terminal Platform runtime: `v0.3.3`.
 
 Draft body source for GitHub release:
 
 <!-- RELEASE_BODY_START v2.13.0 -->
-Edit teammate and lead runtime settings without restarting the whole team. This release also strengthens provider launch checks, worktree safety, and team coordination.
+Edit live agent settings, stop teams from either team view, and review product news without leaving the app. Provider checks and mixed-team relaunches are now more reliable.
 
 ### What's New
 
 - Edit teammate provider, model, effort, workflow, worktree, and MCP settings directly from their cards.
 - Change supported lead models and reasoning effort without relaunching healthy teammates.
+- Review product news in the app and dismiss announcements permanently across restarts.
+- Stop a team from Team List or Team Details with one shared progress state.
 - See task attachment mosaics on Kanban cards, with previews that refresh after changes.
 
 ### Improvements
 
-- Browse project- and provider-scoped OpenCode catalogs with pagination, freshness indicators, and safer refreshes.
+- Browse models from every connected OpenCode provider with pagination, freshness indicators, and safer refreshes.
 - Check provider readiness when launching, with clearer blockers and connection guidance.
+- See first-launch project trust warnings only when Anthropic or Codex needs them.
 - Reuse existing worktrees without resetting branches or local changes, with branch details shown before launch.
 - Team leads now coordinate delegated tasks instead of duplicating their teammates' work.
 
 ### Bug Fixes
 
-- Codex ChatGPT logins no longer enter refresh-token revocation loops during team launch.
+- Codex teammates launch with ChatGPT or API-key authentication without refresh-token loops.
 - ChatGPT-incompatible Codex models are blocked before launch with a clear explanation.
-- Codex API-key teammates now launch correctly under non-Codex leads.
-- Launch dialog edits no longer revert while saved settings or live status refresh.
+- Failed or superseded launches no longer leave teams stuck on `Launching...` or overwrite newer attempts.
+- Mixed Anthropic, Codex, and OpenCode teams recover from stale provider and session state.
 - Windows OpenCode teammates no longer flash console windows during tool calls.
 - Replayed agent turns no longer duplicate tasks, deleted-task notices, or final messages.
 

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,39 +1,39 @@
 {
-  "version": "0.0.77",
-  "sourceRef": "v0.0.77",
+  "version": "0.0.78",
+  "sourceRef": "v0.0.78",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator_binaries",
-  "releaseTag": "runtime-v0.0.77",
+  "releaseTag": "runtime-v0.0.78",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.77.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.78.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "9b3491234084c26f743fa75a2f12eabee851354e0969676cc71948e56b2a5a4d"
+      "sha256": "8d78198ccde5c2fa6ab99706f721d79b22fbe703c8424ea1d3481c2c5cd4d033"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.77.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.78.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "99bb23b0b876871689e45e7a23afa71ebed5d97156d178403d04a00993d5e4c8"
+      "sha256": "6bfeed94ac3e73a16cb5f220db43b56769e29c28e2b2fcd128c5a2f66096c05a"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.77.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.78.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "0aa5827e8d8e7ea07230cbcf89f9452f7fd6545402f2bb7b6126ffe88f428503"
+      "sha256": "b2d3eb0a3b9def66705c319045ba947e88de15f911f632049bd4f19d8b97ac1e"
     },
     "win32-arm64": {
-      "file": "agent-teams-runtime-win32-arm64-v0.0.77.zip",
+      "file": "agent-teams-runtime-win32-arm64-v0.0.78.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "7c19f4674fe80d0ab3359361acc8121ad11e61f6988f2cebd4a3eb58053f126a"
+      "sha256": "a8ac0addada8539833ea8db28bd1fd795b90eca9b85bbfdcf2cb8c4ca5bf9571"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.77.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.78.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "3a6f87ecec76ff07984ca112d238e6027a5af78d2d99d0152edf02e59b807ec5"
+      "sha256": "f171d83e7e9863e3877282d387d8dcdc3a094d14085d4e2c679d87e9fc36ca8e"
     }
   }
 }


### PR DESCRIPTION
## Summary

- pin the published Agent Teams runtime 0.0.78 with verified checksums for all five platforms
- refresh v2.13.0 notes for announcements, unified Stop controls, provider trust, mixed-team recovery, and failed-launch cleanup

## Verification

- runtime 0.0.78 release workflow and anonymous public bootstrap
- `pnpm typecheck`
- source-file-size and provisioning architecture guards
- 270 focused launch, trust, Stop, and state tests
- production Electron build
- announcement content validation against current main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Review product news directly in the app, with an option to permanently dismiss it.
  - Stop teams from either team view and see shared progress while they shut down.
- **Improvements**
  - Project trust warnings now appear on first launch only when required by Anthropic or Codex.
  - Updated the OpenCode catalog information.
- **Bug Fixes**
  - Improved Codex authentication to prevent refresh-token loops.
  - Blocked incompatible models and improved recovery from failed launches and stale mixed-team states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->