### PR TITLE
fix(team): settle OpenCode scoped preflight

### DIFF
--- a/src/renderer/components/team/dialogs/memberModelScope.test.ts
+++ b/src/renderer/components/team/dialogs/memberModelScope.test.ts
@@ -218,7 +218,7 @@ describe('getDialogTeamModelValidationError', () => {
     ).toEqual({ members: [{ ...savedMember, model: '' }], changed: true });
   });
 
-  it('settles model-only preparation only with every selected scoped catalog fresh', () => {
+  it('settles non-authoritative OpenCode preparation only with every selected scoped catalog fresh', () => {
     const passive = {
       ...createOpenCodeProviderStatus(),
       models: [],
@@ -260,6 +260,39 @@ describe('getDialogTeamModelValidationError', () => {
     expect(isTeamProviderRuntimeStatusLoading('opencode', passive, false, evidence)).toBe(false);
     expect(
       createLaunchGuard(['opencode'], new Map([['opencode', passive]]), evidence).blocked(true)
+    ).toBe(false);
+
+    for (const fallback of [
+      {
+        statusCheckOutcome: 'pending' as const,
+        statusCheckErrorCode: 'partial_response' as const,
+      },
+      {
+        statusCheckOutcome: 'transient_error' as const,
+        statusCheckErrorCode: 'runtime_missing' as const,
+      },
+    ]) {
+      const fallbackStatus = { ...passive, ...fallback };
+      expect(hasSettledOpenCodeScopedPreparation(fallbackStatus, evidence)).toBe(true);
+      expect(isTeamProviderRuntimeStatusLoading('opencode', fallbackStatus, false, evidence)).toBe(
+        false
+      );
+      expect(
+        createLaunchGuard(['opencode'], new Map([['opencode', fallbackStatus]]), evidence).blocked(
+          true
+        )
+      ).toBe(false);
+    }
+
+    expect(
+      hasSettledOpenCodeScopedPreparation(
+        {
+          ...passive,
+          statusCheckOutcome: 'transient_error',
+          statusCheckErrorCode: 'timeout',
+        },
+        evidence
+      )
     ).toBe(false);
 
     const failedScoped = {

--- a/src/renderer/components/team/dialogs/memberModelScope.test.ts
+++ b/src/renderer/components/team/dialogs/memberModelScope.test.ts
@@ -8,7 +8,7 @@ import {
   clearInheritedMemberModelsUnavailableForProvider,
   getDialogTeamModelValidationError,
 } from './memberModelScope';
-import { createLaunchGuard } from './providerLaunchAuthority';
+import { canResolveOpenCodeLaunchBlockers, createLaunchGuard } from './providerLaunchAuthority';
 
 import type { MemberDraft } from '@renderer/components/team/members/membersEditorTypes';
 import type { CliProviderStatus, TeamProviderId } from '@shared/types';
@@ -282,17 +282,31 @@ describe('getDialogTeamModelValidationError', () => {
           true
         )
       ).toBe(false);
+      expect(
+        canResolveOpenCodeLaunchBlockers([
+          {
+            providerId: 'opencode',
+            providerStatus: fallbackStatus,
+            detail: 'Passive status is still settling.',
+          },
+        ])
+      ).toBe(true);
     }
 
+    const timedOut = {
+      ...passive,
+      statusCheckOutcome: 'transient_error' as const,
+      statusCheckErrorCode: 'timeout' as const,
+    };
+    expect(hasSettledOpenCodeScopedPreparation(timedOut, evidence)).toBe(false);
     expect(
-      hasSettledOpenCodeScopedPreparation(
+      canResolveOpenCodeLaunchBlockers([
         {
-          ...passive,
-          statusCheckOutcome: 'transient_error',
-          statusCheckErrorCode: 'timeout',
+          providerId: 'opencode',
+          providerStatus: timedOut,
+          detail: 'Provider status timed out.',
         },
-        evidence
-      )
+      ])
     ).toBe(false);
 
     const failedScoped = {

--- a/src/renderer/components/team/dialogs/providerLaunchAuthority.ts
+++ b/src/renderer/components/team/dialogs/providerLaunchAuthority.ts
@@ -7,6 +7,7 @@ import {
 } from '@renderer/hooks/useEffectiveCliProviderStatus';
 import { getProviderLaunchReadinessDetail } from '@renderer/utils/providerReadiness';
 import {
+  canSettleOpenCodeStatusWithScopedPreparation,
   getOpenCodeScopedPreparationFailure,
   hasSettledOpenCodeScopedPreparation,
   type OpenCodeScopedPreparationEvidence,
@@ -35,10 +36,7 @@ export function canResolveOpenCodeLaunchBlockers(
     blockers.length > 0 &&
     blockers.every(
       ({ providerId, providerStatus }) =>
-        providerId === 'opencode' &&
-        (providerStatus?.statusCheckOutcome === 'model_only' ||
-          (providerStatus?.statusCheckOutcome === 'pending' &&
-            providerStatus.statusCheckErrorCode === 'partial_response'))
+        providerId === 'opencode' && canSettleOpenCodeStatusWithScopedPreparation(providerStatus)
     )
   );
 }
@@ -67,8 +65,8 @@ export function createLaunchGuard(
       const provider = runtimeProviderStatusById.get(providerId) ?? null;
       if (
         providerId === 'opencode' &&
-        provider?.statusCheckOutcome === 'model_only' &&
-        provider.runtimeCapabilities?.modelCatalog?.source === 'app-server' &&
+        canSettleOpenCodeStatusWithScopedPreparation(provider) &&
+        provider?.runtimeCapabilities?.modelCatalog?.source === 'app-server' &&
         hasSettledOpenCodeScopedPreparation(provider, openCodeEvidence, now)
       ) {
         // Passive status cannot authorize a launch. The strict OpenCode launch

--- a/src/renderer/utils/teamProviderRuntimeStatusLoading.ts
+++ b/src/renderer/utils/teamProviderRuntimeStatusLoading.ts
@@ -18,6 +18,18 @@ export interface OpenCodeScopedPreparationEvidence {
   localProviderLookupAuthoritative?: boolean;
 }
 
+export function canSettleOpenCodeStatusWithScopedPreparation(
+  providerStatus: CliProviderStatus | null | undefined
+): boolean {
+  return Boolean(
+    providerStatus?.statusCheckOutcome === 'model_only' ||
+    (providerStatus?.statusCheckOutcome === 'pending' &&
+      providerStatus.statusCheckErrorCode === 'partial_response') ||
+    (providerStatus?.statusCheckOutcome === 'transient_error' &&
+      providerStatus.statusCheckErrorCode === 'runtime_missing')
+  );
+}
+
 export function getOpenCodeScopedPreparationFailure(
   evidence: OpenCodeScopedPreparationEvidence | undefined
 ): CliProviderStatus | null {
@@ -37,7 +49,7 @@ export function hasSettledOpenCodeScopedPreparation(
   now = Date.now()
 ): boolean {
   if (
-    providerStatus?.statusCheckOutcome !== 'model_only' ||
+    !canSettleOpenCodeStatusWithScopedPreparation(providerStatus) ||
     !evidence ||
     evidence.selectedModels.length === 0
   ) {
@@ -47,10 +59,7 @@ export function hasSettledOpenCodeScopedPreparation(
   return evidence.selectedModels.every((model) => {
     const sourceId = parseOpenCodeQualifiedModelRef(model)?.sourceId?.trim().toLowerCase();
     if (!sourceId) return false;
-    if (
-      isOpenCodeLocalProviderId(sourceId) ||
-      evidence.localSourceIds?.has(sourceId) === true
-    ) {
+    if (isOpenCodeLocalProviderId(sourceId) || evidence.localSourceIds?.has(sourceId) === true) {
       return true;
     }
     const scopedStatus = evidence.scopedStatusBySourceId.get(sourceId);
@@ -69,10 +78,7 @@ export function isTeamProviderRuntimeStatusLoading(
   }
 
   if (isTeamProviderModelVerificationPending(providerId, providerStatus)) {
-    if (
-      providerId === 'opencode' &&
-      getOpenCodeScopedPreparationFailure(openCodeEvidence)
-    ) {
+    if (providerId === 'opencode' && getOpenCodeScopedPreparationFailure(openCodeEvidence)) {
       return false;
     }
     if (

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -464,7 +464,8 @@ vi.mock('@renderer/utils/teamModelAvailability', async (importOriginal) => ({
   normalizeExplicitTeamModelForUi: vi.fn((_providerId: string, model: string) => model),
 }));
 
-vi.mock('@renderer/utils/teamProviderRuntimeStatusLoading', () => ({
+vi.mock('@renderer/utils/teamProviderRuntimeStatusLoading', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@renderer/utils/teamProviderRuntimeStatusLoading')>()),
   getOpenCodeScopedPreparationFailure: vi.fn(() => null),
   hasSettledOpenCodeScopedPreparation: vi.fn(() => false),
   isTeamProviderRuntimeStatusLoading: vi.fn(() => false),


### PR DESCRIPTION
## Summary
- let fresh project-scoped OpenCode model proof settle cold passive `pending/partial_response` and `runtime_missing` status
- reuse the same eligibility rule for loading, launch-authority handoff, and Create preflight blocker resolution
- keep timeout and missing/stale scoped evidence fail-closed

## Verification
- `pnpm vitest run src/renderer/components/team/dialogs/memberModelScope.test.ts test/renderer/components/team/dialogs/providerLaunchAuthority.test.ts test/renderer/utils/teamModelAvailability.test.ts` (52/52)
- `pnpm typecheck`
- focused fast lint
- live `dev:mcp` mixed-team E2E on a disposable sandbox using fresh orchestrator `main`/v0.0.78: Anthropic Haiku 4.5, Codex 5.6-luna, and OpenCode big-pickle all joined and completed distinct evidence-file tasks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider launch readiness handling for scoped model catalogs.
  * Launches can now proceed when preparation reports partial responses or missing runtime information, rather than remaining blocked or appearing to load indefinitely.
  * Timeout-related preparation errors continue to prevent launch until resolved.
  * Improved handling when provider information is unavailable during launch checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->