### PR TITLE
fix(opencode): retain active MCP transport

### DIFF
--- a/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
@@ -186,6 +186,8 @@ export class OpenCodeBridgeCommandClient {
   private readonly clock: () => Date;
   private readonly env: NodeJS.ProcessEnv;
   private readonly envProvider: (() => NodeJS.ProcessEnv | Promise<NodeJS.ProcessEnv>) | null;
+  private lastKnownMcpUrl: string | null;
+  private lastKnownMcpUrlHash: string | null;
   private readonly keepInputFile: boolean;
   private readonly ensureWindowsNodeModulesJunction: (
     profileId: string,
@@ -203,6 +205,8 @@ export class OpenCodeBridgeCommandClient {
     this.clock = options.clock ?? (() => new Date());
     this.env = applyOpenCodeAutoUpdatePolicy(options.env ?? process.env);
     this.envProvider = options.envProvider ?? null;
+    this.lastKnownMcpUrl = this.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL?.trim() || null;
+    this.lastKnownMcpUrlHash = this.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH?.trim() || null;
     this.keepInputFile = options.keepInputFile ?? false;
     this.ensureWindowsNodeModulesJunction =
       options.ensureWindowsNodeModulesJunction ?? ensureOpenCodeProfileNodeModulesJunction;
@@ -459,16 +463,19 @@ export class OpenCodeBridgeCommandClient {
       return this.env;
     }
     const resolved = applyOpenCodeAutoUpdatePolicy(await this.envProvider());
-    const initialMcpUrl = this.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL?.trim();
-    if (!resolved.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL?.trim() && initialMcpUrl) {
+    const resolvedMcpUrl = resolved.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL?.trim();
+    if (resolvedMcpUrl) {
+      this.lastKnownMcpUrl = resolvedMcpUrl;
+      this.lastKnownMcpUrlHash =
+        resolved.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH?.trim() || null;
+    } else if (this.lastKnownMcpUrl) {
       // A transient HTTP MCP refresh failure must not silently switch an active
       // OpenCode launch from its sealed remote transport to the local fallback.
       // The next command can recover the endpoint, while changing transport
       // here would invalidate every already-running selected session.
-      resolved.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL = initialMcpUrl;
-      const initialMcpUrlHash = this.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH?.trim();
-      if (initialMcpUrlHash) {
-        resolved.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH = initialMcpUrlHash;
+      resolved.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL = this.lastKnownMcpUrl;
+      if (this.lastKnownMcpUrlHash) {
+        resolved.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH = this.lastKnownMcpUrlHash;
       }
     }
     return resolved;

--- a/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
+++ b/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
@@ -747,6 +747,50 @@ describe('OpenCodeBridgeCommandClient', () => {
     });
   });
 
+  it('retains an HTTP MCP transport first discovered by the lazy env provider', async () => {
+    runner.nextResult = {
+      stdout: `${JSON.stringify(bridgeSuccess({ data: { runId: 'run-1' } }))}\n`,
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+    };
+    let envVersion = 0;
+    const client = createClient({
+      envProvider: () => {
+        envVersion += 1;
+        return envVersion === 1
+          ? {
+              PATH: '/usr/bin',
+              CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL: 'http://127.0.0.1:5001/mcp',
+              CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH: 'url-hash-1',
+            }
+          : {
+              PATH: '/usr/bin',
+              CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND: '/usr/bin/node',
+              CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/tmp/mcp.js',
+              CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ARGS_JSON: '[]',
+            };
+      },
+    });
+
+    for (const runId of ['run-1', 'run-2']) {
+      await client.execute(
+        'opencode.launchTeam',
+        { runId },
+        {
+          cwd: '/tmp/project',
+          timeoutMs: 10_000,
+        }
+      );
+    }
+
+    expect(runner.calls[1].env).toMatchObject({
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL: 'http://127.0.0.1:5001/mcp',
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH: 'url-hash-1',
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/tmp/mcp.js',
+    });
+  });
+
   it('runs Windows batch launchers from their launcher directory while preserving envelope cwd', async () => {
     runner.nextResult = {
       stdout: `${JSON.stringify(bridgeSuccess({ data: { runId: 'run-1' } }))}\n`,


### PR DESCRIPTION
## Summary
- remember the last successful Agent Teams HTTP MCP endpoint discovered by the lazy bridge environment
- keep using that sealed transport during a transient endpoint refresh fallback
- cover the launch-success then local-fallback sequence that previously changed the OpenCode session fingerprint

## Verification
- pnpm vitest run test/main/services/team/OpenCodeBridgeCommandClient.test.ts
- pnpm typecheck
- pnpm lint:fast:files -- src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts test/main/services/team/OpenCodeBridgeCommandClient.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the active remote connection when a temporary environment refresh does not return the remote URL.
  - Continued using the previously valid remote transport alongside newly discovered local connections.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->