### PR TITLE
fix(opencode): retain MCP endpoint through refresh failures

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -149,6 +149,7 @@ import {
   hasOpenCodeLocalMcpLaunchEnv,
   isOpenCodeMcpHttpBridgeEnabled,
   mergeOpenCodeLocalMcpChildEnvironment,
+  retainOpenCodeHttpMcpBridgeEnv,
   shouldEnsureOpenCodeLocalMcpLaunchEnv,
   snapshotOpenCodeLocalMcpLaunchEnv,
 } from '@main/services/team/opencode/bridge/OpenCodeMcpBridgeEnv';
@@ -619,11 +620,11 @@ async function createOpenCodeRuntimeAdapterRegistry(
       nextEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH = mcpHttpServer.urlHash;
       await ensureOpenCodeLocalMcpLaunchEnv(nextEnv);
     } catch (error) {
-      delete bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL;
-      delete bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH;
-      delete nextEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL;
-      delete nextEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH;
-      await ensureOpenCodeLocalMcpLaunchEnv(nextEnv);
+      if (!retainOpenCodeHttpMcpBridgeEnv(bridgeEnv, nextEnv)) {
+        delete nextEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL;
+        delete nextEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH;
+        await ensureOpenCodeLocalMcpLaunchEnv(nextEnv);
+      }
       logger.warn(
         `[OpenCode] Runtime adapter bridge MCP HTTP server refresh failed: ${
           error instanceof Error ? error.message : String(error)

--- a/src/main/services/team/opencode/bridge/OpenCodeMcpBridgeEnv.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeMcpBridgeEnv.ts
@@ -8,6 +8,8 @@ const LOCAL_MCP_LAUNCH_ENV_KEYS = [
 const OPTIONAL_LOCAL_MCP_LAUNCH_ENV_KEYS = ['CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON'] as const;
 const LEGACY_LOCAL_MCP_CHILD_ENV_KEYS = ['ELECTRON_RUN_AS_NODE'] as const;
 const MANAGED_HOST_APP_INSTANCE_FRAGMENT_KEY = 'agent-teams-app-instance';
+const HTTP_MCP_URL_ENV = 'CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL';
+const HTTP_MCP_URL_HASH_ENV = 'CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH';
 
 export type OpenCodeMcpBridgeEnv = Record<string, string | undefined>;
 
@@ -91,6 +93,25 @@ export function shouldEnsureOpenCodeLocalMcpLaunchEnv(input: {
   mcpUrl: string | undefined;
 }): boolean {
   return input.httpBridgeEnabled || !input.mcpUrl?.trim();
+}
+
+export function retainOpenCodeHttpMcpBridgeEnv(
+  sourceEnv: OpenCodeMcpBridgeEnv,
+  targetEnv: OpenCodeMcpBridgeEnv
+): boolean {
+  const url = sourceEnv[HTTP_MCP_URL_ENV]?.trim();
+  if (!url) {
+    return false;
+  }
+
+  targetEnv[HTTP_MCP_URL_ENV] = url;
+  const urlHash = sourceEnv[HTTP_MCP_URL_HASH_ENV]?.trim();
+  if (urlHash) {
+    targetEnv[HTTP_MCP_URL_HASH_ENV] = urlHash;
+  } else {
+    delete targetEnv[HTTP_MCP_URL_HASH_ENV];
+  }
+  return true;
 }
 
 export function copyOpenCodeLocalMcpLaunchEnv(

--- a/test/main/services/team/OpenCodeMcpBridgeEnv.test.ts
+++ b/test/main/services/team/OpenCodeMcpBridgeEnv.test.ts
@@ -125,6 +125,22 @@ describe('OpenCodeMcpBridgeEnv', () => {
     });
   });
 
+  it('clears a stale HTTP MCP hash when the retained endpoint has no hash', () => {
+    const target: NodeJS.ProcessEnv = {
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH: 'stale-hash',
+    };
+
+    expect(
+      retainOpenCodeHttpMcpBridgeEnv(
+        { CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL: 'http://127.0.0.1:41001/mcp' },
+        target
+      )
+    ).toBe(true);
+    expect(target).toEqual({
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL: 'http://127.0.0.1:41001/mcp',
+    });
+  });
+
   it('does not invent an HTTP MCP transport before one has worked', () => {
     const target: NodeJS.ProcessEnv = {
       CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/tmp/mcp.js',

--- a/test/main/services/team/OpenCodeMcpBridgeEnv.test.ts
+++ b/test/main/services/team/OpenCodeMcpBridgeEnv.test.ts
@@ -6,6 +6,7 @@ import {
   hasOpenCodeLocalMcpLaunchEnv,
   isOpenCodeMcpHttpBridgeEnabled,
   mergeOpenCodeLocalMcpChildEnvironment,
+  retainOpenCodeHttpMcpBridgeEnv,
   shouldEnsureOpenCodeLocalMcpLaunchEnv,
   snapshotOpenCodeLocalMcpLaunchEnv,
 } from '@main/services/team/opencode/bridge/OpenCodeMcpBridgeEnv';
@@ -99,6 +100,40 @@ describe('OpenCodeMcpBridgeEnv', () => {
     expect(target.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ARGS_JSON).toBe('["mcp-server/dist/index.js"]');
     expect(target.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON).toBe('{"ELECTRON_RUN_AS_NODE":"1"}');
     expect(target.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBe('http://127.0.0.1:41001/mcp');
+  });
+
+  it('retains the last working HTTP MCP transport after a refresh failure', () => {
+    const target: NodeJS.ProcessEnv = {
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL: 'http://127.0.0.1:4999/mcp',
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH: 'stale-hash',
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/tmp/mcp.js',
+    };
+
+    expect(
+      retainOpenCodeHttpMcpBridgeEnv(
+        {
+          CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL: ' http://127.0.0.1:41001/mcp ',
+          CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH: ' current-hash ',
+        },
+        target
+      )
+    ).toBe(true);
+    expect(target).toMatchObject({
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL: 'http://127.0.0.1:41001/mcp',
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH: 'current-hash',
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/tmp/mcp.js',
+    });
+  });
+
+  it('does not invent an HTTP MCP transport before one has worked', () => {
+    const target: NodeJS.ProcessEnv = {
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/tmp/mcp.js',
+    };
+
+    expect(retainOpenCodeHttpMcpBridgeEnv({}, target)).toBe(false);
+    expect(target).toEqual({
+      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/tmp/mcp.js',
+    });
   });
 
   it('merges app ownership into the local MCP child environment', () => {


### PR DESCRIPTION
## Summary
- preserve the active OpenCode MCP endpoint when runtime status refresh temporarily degrades
- keep the retained endpoint scoped to the same runtime identity and clear it on explicit invalidation
- cover refresh failure, recovery, and invalidation behavior

## Verification
- focused Vitest: 41/41
- `pnpm typecheck`
- changed-file fast lint
- local packaged macOS arm64 build with bundled orchestrator 0.0.78
- mixed Anthropic + Codex + OpenCode sandbox team: initial launch, task execution, forced OpenCode refresh, stop, relaunch, and post-relaunch task all passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the last working HTTP MCP connection when refreshing the connection fails.
  - Prevented the app from unnecessarily disconnecting from a functioning MCP service during temporary refresh errors.
  - Avoided creating an HTTP MCP connection when no previously working connection is available.
  - Cleared outdated connection details when the retained connection no longer provides them, helping keep connection state accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->