### PR TITLE
fix(codex): surface dynamic Astra model updates

### DIFF
--- a/src/features/codex-model-catalog/core/domain/__tests__/normalizeCodexAppServerModel.test.ts
+++ b/src/features/codex-model-catalog/core/domain/__tests__/normalizeCodexAppServerModel.test.ts
@@ -39,6 +39,21 @@ describe('normalizeCodexAppServerModels', () => {
     ]);
   });
 
+  it('maps the authoritative availability NUX to a new-model hint and status message', () => {
+    const result = normalizeCodexAppServerModels([
+      {
+        id: 'gpt-6-astra',
+        availabilityNux: { message: ' A new generation of intelligence. ' },
+      },
+    ]);
+
+    expect(result.models[0]).toMatchObject({
+      id: 'gpt-6-astra',
+      statusMessage: 'A new generation of intelligence.',
+      metadata: { recentlyReleased: true },
+    });
+  });
+
   it('filters hidden models unless the caller explicitly asks for them', () => {
     const result = normalizeCodexAppServerModels([
       { id: 'gpt-visible', hidden: false },

--- a/src/features/codex-model-catalog/core/domain/__tests__/normalizeCodexAppServerModel.test.ts
+++ b/src/features/codex-model-catalog/core/domain/__tests__/normalizeCodexAppServerModel.test.ts
@@ -54,6 +54,15 @@ describe('normalizeCodexAppServerModels', () => {
     });
   });
 
+  it.each([null, { message: '   ' }, { message: 42 }])(
+    'ignores missing or malformed availability NUX messages: %j',
+    (availabilityNux) => {
+      const result = normalizeCodexAppServerModels([{ id: 'gpt-model', availabilityNux }]);
+
+      expect(result.models[0]).toMatchObject({ statusMessage: null, metadata: null });
+    }
+  );
+
   it('filters hidden models unless the caller explicitly asks for them', () => {
     const result = normalizeCodexAppServerModels([
       { id: 'gpt-visible', hidden: false },

--- a/src/features/codex-model-catalog/core/domain/normalizeCodexAppServerModel.ts
+++ b/src/features/codex-model-catalog/core/domain/normalizeCodexAppServerModel.ts
@@ -17,6 +17,7 @@ export interface CodexAppServerModelLike {
   supportsPersonality?: boolean;
   isDefault?: boolean;
   upgrade?: unknown;
+  availabilityNux?: { message?: string | null } | null;
 }
 
 export interface NormalizedCodexModelCatalogResult {
@@ -183,6 +184,7 @@ export function normalizeCodexAppServerModels(
     seenLaunchModels.add(launchModel);
 
     const supportedReasoningEfforts = normalizeEfforts(model);
+    const availabilityNuxMessage = model.availabilityNux?.message?.trim() || null;
     normalizedModels.push({
       id,
       launchModel,
@@ -200,6 +202,8 @@ export function normalizeCodexAppServerModels(
       upgrade: Boolean(model.upgrade),
       source: 'app-server',
       badgeLabel: asBadgeLabel(id),
+      statusMessage: availabilityNuxMessage,
+      metadata: availabilityNuxMessage ? { recentlyReleased: true } : null,
     });
   }
 

--- a/src/features/codex-model-catalog/core/domain/normalizeCodexAppServerModel.ts
+++ b/src/features/codex-model-catalog/core/domain/normalizeCodexAppServerModel.ts
@@ -17,7 +17,7 @@ export interface CodexAppServerModelLike {
   supportsPersonality?: boolean;
   isDefault?: boolean;
   upgrade?: unknown;
-  availabilityNux?: { message?: string | null } | null;
+  availabilityNux?: unknown;
 }
 
 export interface NormalizedCodexModelCatalogResult {
@@ -147,6 +147,14 @@ function asBadgeLabel(modelId: string): string {
   return modelId.replace(/^gpt-/, '');
 }
 
+function normalizeAvailabilityNuxMessage(value: unknown): string | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  const message = (value as { message?: unknown }).message;
+  return typeof message === 'string' ? message.trim() || null : null;
+}
+
 export function normalizeCodexAppServerModels(
   models: readonly CodexAppServerModelLike[] | undefined,
   options: {
@@ -184,7 +192,7 @@ export function normalizeCodexAppServerModels(
     seenLaunchModels.add(launchModel);
 
     const supportedReasoningEfforts = normalizeEfforts(model);
-    const availabilityNuxMessage = model.availabilityNux?.message?.trim() || null;
+    const availabilityNuxMessage = normalizeAvailabilityNuxMessage(model.availabilityNux);
     normalizedModels.push({
       id,
       launchModel,

--- a/src/features/codex-runtime-installer/main/infrastructure/CodexRuntimeInstallerService.ts
+++ b/src/features/codex-runtime-installer/main/infrastructure/CodexRuntimeInstallerService.ts
@@ -32,7 +32,11 @@ const NPM_REGISTRY_BASE_URL = 'https://registry.npmjs.org';
 const CURRENT_MANIFEST_SCHEMA_VERSION = 1;
 const MAX_TARBALL_BYTES = 160 * 1024 * 1024;
 const MAX_UNPACKED_BYTES = 650 * 1024 * 1024;
-const FETCH_TIMEOUT_MS = 60_000;
+const METADATA_FETCH_TIMEOUT_MS = 60_000;
+// The platform package can approach MAX_TARBALL_BYTES. A one-minute wall-clock
+// deadline aborts healthy downloads on ordinary slower connections, so package
+// downloads time out only after a full minute without network progress.
+const PACKAGE_DOWNLOAD_IDLE_TIMEOUT_MS = 60_000;
 const LATEST_VERSION_TIMEOUT_MS = 8_000;
 const VERSION_TIMEOUT_MS = 10_000;
 
@@ -234,7 +238,7 @@ export function getCodexRuntimePlatformCandidates(
   throw new Error(`Codex app install is not supported on ${platform}/${arch}`);
 }
 
-async function fetchText(url: string, timeoutMs = FETCH_TIMEOUT_MS): Promise<string> {
+async function fetchText(url: string, timeoutMs = METADATA_FETCH_TIMEOUT_MS): Promise<string> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
@@ -251,7 +255,7 @@ async function fetchText(url: string, timeoutMs = FETCH_TIMEOUT_MS): Promise<str
 async function fetchPackageMetadata(
   packageName: string,
   version = 'latest',
-  timeoutMs = FETCH_TIMEOUT_MS
+  timeoutMs = METADATA_FETCH_TIMEOUT_MS
 ): Promise<NpmPackageMetadata> {
   const url = `${NPM_REGISTRY_BASE_URL}/${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`;
   const raw = await fetchText(url, timeoutMs);
@@ -291,7 +295,12 @@ async function downloadTarball(
   onProgress: (progress: CodexRuntimeInstallProgress) => void
 ): Promise<Buffer> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const resetIdleTimeout = (): void => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => controller.abort(), PACKAGE_DOWNLOAD_IDLE_TIMEOUT_MS);
+  };
+  resetIdleTimeout();
   try {
     const response = await fetch(url, { signal: controller.signal });
     if (!response.ok || !response.body) {
@@ -311,6 +320,7 @@ async function downloadTarball(
       if (done) {
         break;
       }
+      resetIdleTimeout();
       const chunk = Buffer.from(value);
       downloadedBytes += chunk.length;
       if (downloadedBytes > MAX_TARBALL_BYTES) {
@@ -331,7 +341,7 @@ async function downloadTarball(
     }
     return Buffer.concat(chunks, downloadedBytes);
   } finally {
-    clearTimeout(timer);
+    if (timer) clearTimeout(timer);
   }
 }
 

--- a/src/features/codex-runtime-installer/renderer/ui/CodexRuntimeUpdateDialog.tsx
+++ b/src/features/codex-runtime-installer/renderer/ui/CodexRuntimeUpdateDialog.tsx
@@ -63,16 +63,18 @@ export const CodexRuntimeUpdateDialog = ({
     return dashboardT('cliStatus.runtimeInstall.install');
   }, [dashboardT, status?.latestVersion, status?.state, status?.updateAvailable]);
   const versionSummary =
-    status?.version && status.latestVersion
-      ? settingsT('cliStatus.versionUpgrade', {
-          current: normalizeVersion(status.version),
-          latest: status.latestVersion,
-        })
-      : status?.latestVersion
-        ? `v${status.latestVersion}`
-        : status?.version
-          ? status.version
-          : null;
+    completed && status?.version
+      ? `v${normalizeVersion(status.version)}`
+      : status?.version && status.latestVersion
+        ? settingsT('cliStatus.versionUpgrade', {
+            current: normalizeVersion(status.version),
+            latest: status.latestVersion,
+          })
+        : status?.latestVersion
+          ? `v${status.latestVersion}`
+          : status?.version
+            ? status.version
+            : null;
   const detail = status?.progress?.detail ?? error ?? status?.error ?? null;
 
   return (

--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
@@ -126,6 +126,30 @@ describe('connected OpenCode dashboard catalog', () => {
       vi.useRealTimers();
     }
   });
+  it('keeps the last completed catalog visible while the same scope refreshes', async () => {
+    await act(async () => root.render(<Probe />));
+    expect(observed.providerStatus?.models).toEqual(['opencode/model-0', 'openrouter/model-0']);
+
+    let completeRefresh!: (value: unknown) => void;
+    mocks.models.mockImplementation(
+      ({ providerId }) =>
+        new Promise((resolve) => {
+          if (providerId === 'opencode') completeRefresh = resolve;
+          else resolve(models(providerId));
+        })
+    );
+    await act(async () => observed.refresh());
+
+    expect(observed.providerStatus?.modelCatalogRefreshState).toBe('loading');
+    expect(observed.providerStatus?.models).toEqual(['opencode/model-0', 'openrouter/model-0']);
+
+    await act(async () => completeRefresh(models('opencode', 2)));
+    expect(observed.providerStatus?.models).toEqual([
+      'opencode/model-0',
+      'opencode/model-1',
+      'openrouter/model-0',
+    ]);
+  });
   it.each(['not-connected', 'available', 'ignored'])(
     'includes built-in OpenCode models in %s state without granting readiness',
     async (state) => {
@@ -193,6 +217,8 @@ describe('connected OpenCode dashboard catalog', () => {
       completions.get('opencode')?.(models('opencode'));
       await vi.waitFor(() => expect(mocks.models).toHaveBeenCalledTimes(2));
     });
+    expect(observed.providerStatus?.models).toEqual(['opencode/model-0']);
+    expect(observed.providerStatus?.modelCatalogRefreshState).toBe('loading');
     expect(mocks.models.mock.calls[1]?.[0].providerId).toBe('openrouter');
 
     await act(async () => {

--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.ts
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.ts
@@ -45,13 +45,15 @@ export function useOpenCodeConnectedModelCatalog(input: {
 }) {
   const [revision, setRevision] = useState(0);
   const lastRefresh = useRef({ revision, external: input.refreshRevision });
-  const scope = JSON.stringify([input.projectPath, revision, input.refreshRevision]);
+  const scope = JSON.stringify([input.projectPath]);
   const [state, setState] = useState<CatalogState>({
     scope: '',
     loading: false,
     models: [],
     errors: [],
   });
+  const stateRef = useRef(state);
+  stateRef.current = state;
   const sequence = useRef(0);
   const refresh = useCallback(() => setRevision((value) => value + 1), []);
 
@@ -66,8 +68,11 @@ export function useOpenCodeConnectedModelCatalog(input: {
     const activeGroups = new Set<string>();
     let cancelled = false;
     const current = () => !cancelled && request === sequence.current;
-    setState({ scope, loading: true, models: [], errors: [] });
+    const retainedModels = stateRef.current.scope === scope ? stateRef.current.models : [];
+    setState({ scope, loading: true, models: retainedModels, errors: [] });
     void (async () => {
+      const loadedModels: RuntimeProviderModelDto[] = [];
+      const loadErrors: string[] = [];
       const entries: RuntimeProviderDirectoryEntryDto[] = [];
       const cursors = new Set<string>();
       let cursor: string | null = null;
@@ -125,23 +130,23 @@ export function useOpenCodeConnectedModelCatalog(input: {
               refreshRequested
             );
             if (!current()) return;
-            setState((previous) => ({
-              ...previous,
-              models: [...previous.models, ...catalog.models],
-              errors:
-                catalog.catalogState === 'stale'
-                  ? [...previous.errors, `${source}: cached models are stale.`]
-                  : previous.errors,
-            }));
+            loadedModels.push(...catalog.models);
+            if (catalog.catalogState === 'stale') {
+              loadErrors.push(`${source}: cached models are stale.`);
+            }
+            if (retainedModels.length === 0 && current()) {
+              setState({
+                scope,
+                loading: true,
+                models: [...loadedModels],
+                errors: [...loadErrors],
+              });
+            }
           } catch (error) {
             if (!current()) return;
-            setState((previous) => ({
-              ...previous,
-              errors: [
-                ...previous.errors,
-                `${source}: ${error instanceof Error ? error.message : 'Model catalog request failed.'}`,
-              ],
-            }));
+            loadErrors.push(
+              `${source}: ${error instanceof Error ? error.message : 'Model catalog request failed.'}`
+            );
           } finally {
             activeGroups.delete(sourceRequestGroup);
           }
@@ -150,6 +155,15 @@ export function useOpenCodeConnectedModelCatalog(input: {
       await Promise.all(
         Array.from({ length: Math.min(CONCURRENT_SOURCE_LOADS, sources.length) }, loadNext)
       );
+      if (current()) {
+        setState({
+          scope,
+          loading: true,
+          models:
+            loadedModels.length > 0 || loadErrors.length === 0 ? loadedModels : retainedModels,
+          errors: loadErrors,
+        });
+      }
     })()
       .catch((error: unknown) => {
         if (current())

--- a/src/main/services/infrastructure/CliInstallerService.backgroundStatus.test.ts
+++ b/src/main/services/infrastructure/CliInstallerService.backgroundStatus.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { createDefaultProviderStatus } from '../runtime/providerStatusCheckContract';
+
+import { CliInstallerService } from './CliInstallerService';
+
+import type { CliInstallationStatus, CliProviderId, CliProviderStatus } from '@shared/types';
+
+interface CliInstallerServiceInternals {
+  statusGatherGeneration: number;
+  latestStatusSnapshot: CliInstallationStatus | null;
+  multimodelBridgeService: {
+    getProviderStatuses: (
+      binaryPath: string,
+      onUpdate?: (providers: CliProviderStatus[], providerId?: CliProviderId) => void
+    ) => Promise<CliProviderStatus[]>;
+  };
+  createInitialStatus: () => CliInstallationStatus;
+  checkAuthStatus: (
+    binaryPath: string,
+    result: CliInstallationStatus,
+    diag: Record<string, unknown>,
+    generation: number
+  ) => Promise<void>;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('CliInstallerService background provider status', () => {
+  test('publishes provider completion after the initial status budget expires', async () => {
+    vi.useFakeTimers();
+    const internals = new CliInstallerService() as unknown as CliInstallerServiceInternals;
+    const result = internals.createInitialStatus();
+    result.installed = true;
+    result.binaryPath = '/fake/runtime';
+    internals.latestStatusSnapshot = result;
+
+    let resolveProviders!: (providers: CliProviderStatus[]) => void;
+    let publishProviderUpdate:
+      | ((providers: CliProviderStatus[], providerId?: CliProviderId) => void)
+      | undefined;
+    const providersPromise = new Promise<CliProviderStatus[]>((resolve) => {
+      resolveProviders = resolve;
+    });
+    vi.spyOn(internals.multimodelBridgeService, 'getProviderStatuses').mockImplementation(
+      (_binaryPath, onUpdate) => {
+        publishProviderUpdate = onUpdate;
+        return providersPromise;
+      }
+    );
+
+    const checkPromise = internals.checkAuthStatus(
+      result.binaryPath,
+      result,
+      { authTimedOut: false },
+      internals.statusGatherGeneration
+    );
+    await vi.advanceTimersByTimeAsync(1_500);
+    await checkPromise;
+
+    const codex = createDefaultProviderStatus('codex');
+    codex.supported = true;
+    codex.authenticated = true;
+    codex.authMethod = 'oauth_token';
+    codex.verificationState = 'verified';
+    codex.statusCheckOutcome = 'authoritative';
+    codex.statusCheckErrorCode = undefined;
+    codex.capabilities = { ...codex.capabilities, teamLaunch: true, oneShot: true };
+    publishProviderUpdate?.([codex], 'codex');
+
+    expect(
+      internals.latestStatusSnapshot?.providers.find((provider) => provider.providerId === 'codex')
+    ).toMatchObject({
+      authenticated: true,
+      authMethod: 'oauth_token',
+      verificationState: 'verified',
+    });
+
+    resolveProviders([codex]);
+    await providersPromise;
+    await Promise.resolve();
+  });
+});

--- a/src/main/services/infrastructure/CliInstallerService.ts
+++ b/src/main/services/infrastructure/CliInstallerService.ts
@@ -1221,14 +1221,13 @@ export class CliInstallerService {
   ): Promise<void> {
     if (result.flavor === 'agent_teams_orchestrator') {
       result.authStatusChecking = true;
-      let acceptsHydrationUpdates = true;
       const hydratedProviderIds = new Set<CliProviderId>();
       const applyProviders = (
         providersSnapshot: CliProviderStatus[],
         final: boolean,
         updatedProviderId?: CliProviderId
       ): void => {
-        if (!acceptsHydrationUpdates || generation !== this.statusGatherGeneration) {
+        if (generation !== this.statusGatherGeneration) {
           return;
         }
         const publication = mergeProviderStatusPublication(
@@ -1255,7 +1254,7 @@ export class CliInstallerService {
           applyProviders(providers, true);
         })
         .catch((error) => {
-          if (!acceptsHydrationUpdates || generation !== this.statusGatherGeneration) {
+          if (generation !== this.statusGatherGeneration) {
             return;
           }
           const msg = getErrorMessage(error);
@@ -1268,7 +1267,6 @@ export class CliInstallerService {
       let timer: ReturnType<typeof setTimeout> | null = null;
       const timeout = new Promise<'timeout'>((resolve) => {
         timer = setTimeout(() => {
-          acceptsHydrationUpdates = false;
           result.authStatusChecking = false;
           resolve('timeout');
         }, MULTIMODEL_PROVIDER_STATUS_INITIAL_TIMEOUT_MS);

--- a/src/main/services/infrastructure/codexAppServer/protocol.ts
+++ b/src/main/services/infrastructure/codexAppServer/protocol.ts
@@ -134,6 +134,10 @@ export interface CodexAppServerReasoningEffortOption {
   description?: string | null;
 }
 
+export interface CodexAppServerAvailabilityNux {
+  message?: string | null;
+}
+
 export interface CodexAppServerModel {
   id?: string;
   model?: string;
@@ -150,6 +154,7 @@ export interface CodexAppServerModel {
   isDefault?: boolean;
   upgrade?: boolean | string | null;
   upgradeInfo?: unknown;
+  availabilityNux?: CodexAppServerAvailabilityNux | null;
 }
 
 export interface CodexAppServerListModelsParams {

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -173,6 +173,7 @@ describe('ClaudeMultimodelBridgeService runtime status mapping', () => {
               limits: null,
               free: false,
               releaseDate: '2026-05-20',
+              recentlyReleased: true,
               opencode: {
                 providerId: 'llama.cpp',
                 modelId: 'qwen-test:0.5b',
@@ -204,6 +205,7 @@ describe('ClaudeMultimodelBridgeService runtime status mapping', () => {
       reason: 'Execution proof required',
     });
     expect(provider.modelCatalog?.models[0]?.metadata?.releaseDate).toBe('2026-05-20');
+    expect(provider.modelCatalog?.models[0]?.metadata?.recentlyReleased).toBe(true);
     expect(provider.modelCatalog?.models[0]?.supportedReasoningEfforts).toEqual(['high', 'ultra']);
     expect(provider.modelCatalog?.models[0]?.defaultReasoningEffort).toBe('ultra');
   });

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -15,6 +15,23 @@ interface RuntimeStatusMapper {
   mergeOpenCodeVerification: (provider: CliProviderStatus, snapshot: unknown) => CliProviderStatus;
 }
 
+interface RuntimeStatusHydrationInternals {
+  beginProviderStatusHydration: (
+    binaryPath: string,
+    providerIds: readonly CliProviderId[],
+    projectPath?: string | null
+  ) => number;
+  getProviderStatusHydrationKey: (
+    binaryPath: string,
+    providerId: CliProviderId,
+    projectPath?: string | null
+  ) => string;
+  providerStatusHydrationInFlight: Map<
+    string,
+    { readonly generation: number; readonly promise: Promise<CliProviderStatus> }
+  >;
+}
+
 function mapRuntimeProviderStatus(
   providerId: CliProviderId,
   runtimeStatus: unknown
@@ -294,6 +311,23 @@ describe('ClaudeMultimodelBridgeService runtime status mapping', () => {
       summary: false,
       projectPath: path.resolve(projectPath),
     });
+  });
+
+  test('reuses an active single-provider catalog hydration generation', () => {
+    const internals =
+      new ClaudeMultimodelBridgeService() as unknown as RuntimeStatusHydrationInternals;
+    const binaryPath = '/fake/cli';
+    const generation = internals.beginProviderStatusHydration(binaryPath, ['codex']);
+    const hydrationKey = internals.getProviderStatusHydrationKey(binaryPath, 'codex', null);
+    internals.providerStatusHydrationInFlight.set(hydrationKey, {
+      generation,
+      promise: Promise.resolve(mapRuntimeProviderStatus('codex', {})),
+    });
+
+    expect(internals.beginProviderStatusHydration(binaryPath, ['codex'])).toBe(generation);
+    expect(
+      internals.beginProviderStatusHydration(binaryPath, ['codex'], '/tmp/another-project')
+    ).not.toBe(generation);
   });
 });
 

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
@@ -486,6 +486,7 @@ function mapRuntimeProviderModelMetadata(
     limits: metadata.limits ?? null,
     free: metadata.free === true,
     releaseDate: typeof releaseDate === 'string' ? releaseDate : null,
+    recentlyReleased: metadata.recentlyReleased === true,
     ...(opencode ? { opencode } : {}),
   };
 }

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
@@ -677,6 +677,21 @@ export class ClaudeMultimodelBridgeService {
     providerIds: readonly CliProviderId[],
     projectPath?: string | null
   ): number {
+    if (providerIds.length === 1) {
+      const hydrationKey = this.getProviderStatusHydrationKey(
+        binaryPath,
+        providerIds[0]!,
+        projectPath
+      );
+      const currentGeneration = this.providerStatusHydrationGenerations.get(hydrationKey);
+      if (
+        currentGeneration !== undefined &&
+        this.providerStatusHydrationInFlight.has(hydrationKey)
+      ) {
+        return currentGeneration;
+      }
+    }
+
     const generation = ++this.providerStatusHydrationGeneration;
     for (const providerId of providerIds) {
       this.providerStatusHydrationGenerations.set(

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
@@ -680,7 +680,7 @@ export class ClaudeMultimodelBridgeService {
     if (providerIds.length === 1) {
       const hydrationKey = this.getProviderStatusHydrationKey(
         binaryPath,
-        providerIds[0]!,
+        providerIds[0],
         projectPath
       );
       const currentGeneration = this.providerStatusHydrationGenerations.get(hydrationKey);

--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -1162,22 +1162,27 @@ const InstalledBanner = ({
                 ? getVisibleTeamProviderModels(provider.providerId, provider.models, provider)
                     .length > 0
                 : provider.models.length > 0;
-            const statusText = showSkeleton
+            const statusText: string | null = showSkeleton
               ? t('cliStatus.actions.checking')
-              : isPassiveOpenCodeModelSummary
-                ? hasProviderModels
-                  ? settingsT('providerRuntime.connectionUi.status.modelsAvailable')
-                  : provider.modelCatalogRefreshState === 'error'
-                    ? settingsT('providerRuntime.connectionUi.status.unableToVerify')
-                    : provider.modelCatalogRefreshState === 'ready'
-                      ? 'No models from connected providers'
-                      : t('cliStatus.actions.checking')
-                : openCodeRuntimeContradictsMissingMetadata
-                  ? t('cliStatus.quickConnect.connected')
-                  : formatProviderStatusText(provider, settingsT);
+              : provider.providerId === 'opencode' &&
+                  hasProviderModels &&
+                  isProviderInventoryOnlyFallback(provider)
+                ? null
+                : isPassiveOpenCodeModelSummary
+                  ? hasProviderModels
+                    ? null
+                    : provider.modelCatalogRefreshState === 'error'
+                      ? settingsT('providerRuntime.connectionUi.status.unableToVerify')
+                      : provider.modelCatalogRefreshState === 'ready'
+                        ? 'No models from connected providers'
+                        : t('cliStatus.actions.checking')
+                  : openCodeRuntimeContradictsMissingMetadata
+                    ? t('cliStatus.quickConnect.connected')
+                    : formatProviderStatusText(provider, settingsT);
             const modelCatalogLoading =
-              provider.modelCatalogRefreshState === 'loading' ||
-              (!isPassiveOpenCodeModelSummary && isOpenCodeCatalogHydrating(provider));
+              !(provider.providerId === 'opencode' && hasProviderModels) &&
+              (provider.modelCatalogRefreshState === 'loading' ||
+                (!isPassiveOpenCodeModelSummary && isOpenCodeCatalogHydrating(provider)));
             const showProviderModels = shouldShowLoadedProviderModels(provider, hasProviderModels);
             const openCodeDashboardChips = getOpenCodeDashboardChips(provider, t);
             const hasDetailContent = Boolean(
@@ -1222,14 +1227,16 @@ const InstalledBanner = ({
                           </span>
                         ))}
                       </span>
-                      <span
-                        className="whitespace-nowrap text-xs"
-                        style={{
-                          color: getProviderStatusColor(statusText, provider.authenticated),
-                        }}
-                      >
-                        {statusText}
-                      </span>
+                      {statusText ? (
+                        <span
+                          className="whitespace-nowrap text-xs"
+                          style={{
+                            color: getProviderStatusColor(statusText, provider.authenticated),
+                          }}
+                        >
+                          {statusText}
+                        </span>
+                      ) : null}
                     </div>
                     {showSkeleton ? (
                       <ProviderDetailSkeleton />

--- a/src/renderer/components/runtime/ProviderModelBadges.tsx
+++ b/src/renderer/components/runtime/ProviderModelBadges.tsx
@@ -2,6 +2,7 @@ import { useLayoutEffect, useRef, useState } from 'react';
 
 import { useAppTranslation } from '@features/localization/renderer';
 import { cn } from '@renderer/lib/utils';
+import { isRecentlyReleasedModel } from '@renderer/utils/modelReleaseFreshness';
 import {
   getTeamModelBadgeLabel,
   getVisibleTeamProviderModels,
@@ -203,7 +204,11 @@ export const ProviderModelBadges = ({
     const availabilityStatus = getAvailabilityStatus(model, displayModelAvailability);
     const availabilityReason = getAvailabilityReason(model, displayModelAvailability);
     const availabilityChip = getAvailabilityChip(availabilityStatus, t);
-    const modelLabel = formatModelBadgeLabel(providerId, model);
+    const catalogModel = providerStatus?.modelCatalog?.models.find(
+      (item) => item.launchModel === model || item.id === model
+    );
+    const modelLabel = catalogModel?.badgeLabel?.trim() || formatModelBadgeLabel(providerId, model);
+    const recentlyReleased = isRecentlyReleasedModel(catalogModel);
     const catalogModelIsFree = isCatalogModelFree(model, providerStatus);
     const hasFollowingModel = index < displayedModels.length - 1;
     const title = [
@@ -216,6 +221,11 @@ export const ProviderModelBadges = ({
     return (
       <span key={`${model}-${index}`} className={modelClassName} title={title || undefined}>
         <span>{modelLabel}</span>
+        {recentlyReleased ? (
+          <span className="ml-1 rounded bg-sky-400/15 px-1 py-0 text-[9px] font-medium uppercase tracking-[0.06em] text-sky-200">
+            New
+          </span>
+        ) : null}
         {catalogModelIsFree ? (
           <span className="ml-1 rounded bg-[rgba(34,197,94,0.14)] px-1 py-0 text-[9px] font-medium uppercase tracking-[0.06em] text-[rgb(74,222,128)]">
             {t('providerModelBadges.free')}

--- a/src/renderer/components/runtime/ProviderModelBadges.tsx
+++ b/src/renderer/components/runtime/ProviderModelBadges.tsx
@@ -4,7 +4,7 @@ import { useAppTranslation } from '@features/localization/renderer';
 import { cn } from '@renderer/lib/utils';
 import { isRecentlyReleasedModel } from '@renderer/utils/modelReleaseFreshness';
 import {
-  getTeamModelBadgeLabel,
+  getRuntimeAwareTeamModelBadgeLabel,
   getVisibleTeamProviderModels,
 } from '@renderer/utils/teamModelCatalog';
 import { isOpenCodeModelExplicitlyFree } from '@shared/utils/opencodeModelRoute';
@@ -18,7 +18,7 @@ import type {
 } from '@shared/types';
 
 function formatModelBadgeLabel(providerId: CliProviderId, model: string): string {
-  return getTeamModelBadgeLabel(providerId, model) ?? model;
+  return getRuntimeAwareTeamModelBadgeLabel(providerId, model) ?? model;
 }
 
 function getAvailabilityStatus(
@@ -207,7 +207,9 @@ export const ProviderModelBadges = ({
     const catalogModel = providerStatus?.modelCatalog?.models.find(
       (item) => item.launchModel === model || item.id === model
     );
-    const modelLabel = catalogModel?.badgeLabel?.trim() || formatModelBadgeLabel(providerId, model);
+    const modelLabel =
+      getRuntimeAwareTeamModelBadgeLabel(providerId, model, providerStatus) ??
+      formatModelBadgeLabel(providerId, model);
     const recentlyReleased = isRecentlyReleasedModel(catalogModel);
     const catalogModelIsFree = isCatalogModelFree(model, providerStatus);
     const hasFollowingModel = index < displayedModels.length - 1;

--- a/src/renderer/components/team/dialogs/TeamModelSelector.test.ts
+++ b/src/renderer/components/team/dialogs/TeamModelSelector.test.ts
@@ -1,11 +1,71 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  addCodexAstraUpdatePreview,
   resolveTeamModelSelectorValue,
   shouldElevateOpenCodeVirtualRow,
   shouldShowOpenCodeNeedsTestBadge,
   shouldShowOpenCodeOverviewStatus,
 } from './teamModelSelectorUi';
+
+const CODEX_RUNTIME_WITH_ASTRA_UPDATE = {
+  installed: true,
+  version: 'codex-cli 0.152.0',
+  latestVersion: '0.153.4',
+  updateAvailable: true,
+};
+
+describe('addCodexAstraUpdatePreview', () => {
+  const defaultOption = { value: '', label: 'Default' };
+  const solOption = { value: 'gpt-5.6-sol', label: '5.6 Sol' };
+
+  it('adds an unavailable Astra card after Default for an older updatable Codex runtime', () => {
+    expect(
+      addCodexAstraUpdatePreview(
+        'codex',
+        [defaultOption, solOption],
+        CODEX_RUNTIME_WITH_ASTRA_UPDATE
+      )
+    ).toEqual([
+      defaultOption,
+      expect.objectContaining({
+        value: 'gpt-6-astra',
+        availabilityStatus: 'unavailable',
+        availabilityReason: expect.stringContaining('Update Codex'),
+      }),
+      solOption,
+    ]);
+  });
+
+  it('does not add a duplicate when the live catalog already exposes Astra', () => {
+    const astraOption = { value: 'gpt-6-astra', label: 'GPT-6 Astra' };
+    expect(
+      addCodexAstraUpdatePreview(
+        'codex',
+        [defaultOption, astraOption],
+        CODEX_RUNTIME_WITH_ASTRA_UPDATE
+      )
+    ).toEqual([defaultOption, astraOption]);
+  });
+
+  it('does not advertise Astra when the available update cannot provide it', () => {
+    expect(
+      addCodexAstraUpdatePreview('codex', [defaultOption, solOption], {
+        ...CODEX_RUNTIME_WITH_ASTRA_UPDATE,
+        latestVersion: '0.153.3',
+      })
+    ).toEqual([defaultOption, solOption]);
+  });
+
+  it('does not add the update preview once the installed runtime supports Astra', () => {
+    expect(
+      addCodexAstraUpdatePreview('codex', [defaultOption, solOption], {
+        ...CODEX_RUNTIME_WITH_ASTRA_UPDATE,
+        version: 'codex-cli 0.153.4',
+      })
+    ).toEqual([defaultOption, solOption]);
+  });
+});
 
 describe('resolveTeamModelSelectorValue', () => {
   it('preserves an explicit local OpenCode route outside the current catalog and overlay', () => {

--- a/src/renderer/components/team/dialogs/TeamModelSelector.test.ts
+++ b/src/renderer/components/team/dialogs/TeamModelSelector.test.ts
@@ -37,7 +37,7 @@ describe('addCodexAstraUpdatePreview', () => {
     ]);
   });
 
-  it('does not add a duplicate when the live catalog already exposes Astra', () => {
+  it('marks live-catalog Astra as update-required without adding a duplicate', () => {
     const astraOption = { value: 'gpt-6-astra', label: 'GPT-6 Astra' };
     expect(
       addCodexAstraUpdatePreview(
@@ -45,7 +45,14 @@ describe('addCodexAstraUpdatePreview', () => {
         [defaultOption, astraOption],
         CODEX_RUNTIME_WITH_ASTRA_UPDATE
       )
-    ).toEqual([defaultOption, astraOption]);
+    ).toEqual([
+      defaultOption,
+      expect.objectContaining({
+        ...astraOption,
+        availabilityStatus: 'unavailable',
+        availabilityReason: expect.stringContaining('Update Codex'),
+      }),
+    ]);
   });
 
   it('does not advertise Astra when the available update cannot provide it', () => {

--- a/src/renderer/components/team/dialogs/TeamModelSelector.tsx
+++ b/src/renderer/components/team/dialogs/TeamModelSelector.tsx
@@ -2898,7 +2898,7 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
           !modelDisabledReason && !activeProviderSelectable && 'pointer-events-none'
         )}
         onClick={() => {
-          if (codexModelCanUpdate) return setCodexRuntimeDialogOpen(true);
+          if (codexModelCanUpdate) return void setCodexRuntimeDialogOpen(true);
           if (localModelCanAdd && localModelDescriptor) {
             const target: OpenCodeLocalModelSetupTarget = {
               providerId: localModelDescriptor.providerId,

--- a/src/renderer/components/team/dialogs/TeamModelSelector.tsx
+++ b/src/renderer/components/team/dialogs/TeamModelSelector.tsx
@@ -110,11 +110,13 @@ import {
 } from './openCodeRuntimeStatusUi';
 import { compareModelFreshness, isRecentlyReleasedModel } from './teamModelFreshness';
 import {
+  addCodexAstraUpdatePreview,
   deriveOpenCodeSelectionAuthorityState,
   getActiveOpenCodeStickyHeadingIndex,
   getOpenCodeModelGridColumnCount,
   getOpenCodeSelectionAuthorityScopeKey,
   getOpenCodeSourceInfo,
+  isCodexAstraUpdatePreview,
   type OpenCodeSelectionScopeAssociation,
   resolveTeamModelSelectorValue,
   shouldElevateOpenCodeVirtualRow,
@@ -1744,7 +1746,6 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
     shouldDeferModelNormalization,
     value,
   ]);
-
   const modelOptions = useMemo(() => {
     if (shouldAwaitRuntimeModelList) {
       const pendingOptions: TeamRuntimeModelOption[] = [
@@ -1777,19 +1778,21 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
               openCodeLocalModelOverlay.modelIds.has(option.value)
           )
         : unscopedRuntimeOptions;
-    const presentedRuntimeOptions =
+    const presentedRuntimeOptions = addCodexAstraUpdatePreview(
+      effectiveProviderId,
       effectiveProviderId === 'opencode'
         ? runtimeOptions.map((option) =>
             option.value.trim() ? option : { ...option, label: openCodeDefaultOptionLabel }
           )
-        : runtimeOptions;
+        : runtimeOptions,
+      codexRuntimeStatus
+    );
     if (
       effectiveProviderId !== 'opencode' ||
       (openCodeLocalModelOverlay.options.length === 0 && !selectedLocalModelFallbackOption)
     ) {
       return presentedRuntimeOptions;
     }
-
     const optionByValue = new Map(presentedRuntimeOptions.map((option) => [option.value, option]));
     if (
       selectedLocalModelFallbackOption &&
@@ -1802,6 +1805,7 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
     }
     return Array.from(optionByValue.values());
   }, [
+    codexRuntimeStatus,
     effectiveProviderId,
     openCodeLocalProviderLookupAuthoritative,
     openCodeDefaultOptionLabel,
@@ -1853,7 +1857,6 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
         }
       }
     }
-
     if (effectiveProviderId === 'opencode') {
       for (const model of openCodeLocalModelOverlay.catalogModels) {
         const runtimeModel = modelById.get(model.launchModel) ?? modelById.get(model.id);
@@ -1863,7 +1866,6 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
         modelById.set(model.id, scopedModel);
       }
     }
-
     return modelById;
   }, [
     effectiveProviderId,
@@ -1876,7 +1878,6 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
     if (effectiveProviderId !== 'opencode') {
       return [];
     }
-
     return modelOptions.map((option, index) => {
       const recommendation = getTeamModelRecommendation(effectiveProviderId, option.value);
       const catalogModel = runtimeCatalogModelById.get(option.value) ?? null;
@@ -1901,7 +1902,6 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
         option.value,
         knownOpenCodeLocalSourceIds
       );
-
       return {
         option,
         index,
@@ -1974,7 +1974,6 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
       }
       counts.set(metadata.routeTag, (counts.get(metadata.routeTag) ?? 0) + 1);
     }
-
     return OPEN_CODE_ROUTE_FILTER_TAG_ORDER.flatMap((routeTag) => {
       const count = counts.get(routeTag) ?? 0;
       return count > 0
@@ -1998,7 +1997,6 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
       autoFocusedOpenCodeSourceRef.current = null;
       return;
     }
-
     const selectedModel = normalizedValue.trim();
     if (!selectedModel) {
       if (autoFocusedOpenCodeSourceRef.current) {
@@ -2012,12 +2010,10 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
     if (lastAutoFocusedOpenCodeModelRef.current === selectedModel) {
       return;
     }
-
     const selectedMetadata = openCodeModelMetadataByValue.get(selectedModel);
     if (!selectedMetadata) {
       return;
     }
-
     if (selectedMetadata.routeTag === 'local') {
       lastAutoFocusedOpenCodeModelRef.current = selectedModel;
       autoFocusedOpenCodeSourceRef.current = OPENCODE_LOCAL_MODELS_TAB_ID;
@@ -2758,6 +2754,7 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
             runtimeProviderStatus
           ) ??
           runtimeUnavailableReason);
+    const codexModelCanUpdate = isCodexAstraUpdatePreview(opt);
     const openCodeMetadata =
       effectiveProviderId === 'opencode' ? openCodeModelMetadataByValue.get(opt.value) : null;
     let modelRecommendation: ReturnType<typeof getTeamModelRecommendation> = null;
@@ -2822,7 +2819,7 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
         ? true
         : !modelUnavailableReason &&
           (opt.value === '' || availabilityStatus == null || availabilityStatus === 'available'));
-    const modelInteractable = modelSelectable || localModelCanAdd;
+    const modelInteractable = modelSelectable || localModelCanAdd || codexModelCanUpdate;
     const localModelStatusHint =
       localModelPresentation?.status === 'needs_verification'
         ? t('modelSelector.localModels.needsVerificationHint')
@@ -2851,7 +2848,6 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
     const isFlatOpenCodeCell = effectiveProviderId === 'opencode';
     const flatCellBackgroundClass =
       'bg-[color-mix(in_srgb,var(--color-surface-raised)_58%,var(--color-surface)_42%)]';
-
     return (
       <button
         key={opt.value || '__default__'}
@@ -2884,22 +2880,25 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
                     : cn(flatCellBackgroundClass, 'text-[var(--color-text-muted)]')
             : hasBlockingModelIssue && isSelectedModel
               ? 'border-red-500/60 bg-red-500/10 text-red-100 shadow-sm'
-              : hasBlockingModelIssue
-                ? 'border-red-500/40 bg-red-500/5 text-red-200 hover:border-red-400/60 hover:bg-red-500/10 hover:text-red-100'
-                : hasModelAdvisory && isSelectedModel
-                  ? 'border-amber-300/55 bg-amber-300/10 text-amber-100 shadow-sm'
-                  : hasModelAdvisory
-                    ? 'border-amber-300/35 bg-amber-300/5 text-amber-200 hover:border-amber-300/55 hover:bg-amber-300/10 hover:text-amber-100'
-                    : isSelectedModel
-                      ? 'border-[var(--color-border-emphasis)] bg-[var(--color-surface-raised)] text-[var(--color-text)] shadow-sm'
-                      : modelInteractable
-                        ? 'border-[var(--color-border-subtle)] text-[var(--color-text-muted)] hover:border-[var(--color-border-emphasis)] hover:bg-[color-mix(in_srgb,var(--color-surface-raised)_62%,var(--color-surface)_38%)] hover:text-[var(--color-text-secondary)] hover:shadow-sm'
-                        : 'border-[var(--color-border-subtle)] text-[var(--color-text-muted)]',
+              : codexModelCanUpdate
+                ? 'border-sky-300/35 bg-sky-300/5 text-sky-200 hover:border-sky-300/60 hover:bg-sky-300/10 hover:text-sky-100'
+                : hasBlockingModelIssue
+                  ? 'border-red-500/40 bg-red-500/5 text-red-200 hover:border-red-400/60 hover:bg-red-500/10 hover:text-red-100'
+                  : hasModelAdvisory && isSelectedModel
+                    ? 'border-amber-300/55 bg-amber-300/10 text-amber-100 shadow-sm'
+                    : hasModelAdvisory
+                      ? 'border-amber-300/35 bg-amber-300/5 text-amber-200 hover:border-amber-300/55 hover:bg-amber-300/10 hover:text-amber-100'
+                      : isSelectedModel
+                        ? 'border-[var(--color-border-emphasis)] bg-[var(--color-surface-raised)] text-[var(--color-text)] shadow-sm'
+                        : modelInteractable
+                          ? 'border-[var(--color-border-subtle)] text-[var(--color-text-muted)] hover:border-[var(--color-border-emphasis)] hover:bg-[color-mix(in_srgb,var(--color-surface-raised)_62%,var(--color-surface)_38%)] hover:text-[var(--color-text-secondary)] hover:shadow-sm'
+                          : 'border-[var(--color-border-subtle)] text-[var(--color-text-muted)]',
           isFlatOpenCodeCell && isSelectedModel && 'z-[1] ring-1 ring-inset ring-emerald-300',
           !modelInteractable && 'cursor-not-allowed',
           !modelDisabledReason && !activeProviderSelectable && 'pointer-events-none'
         )}
         onClick={() => {
+          if (codexModelCanUpdate) return setCodexRuntimeDialogOpen(true);
           if (localModelCanAdd && localModelDescriptor) {
             const target: OpenCodeLocalModelSetupTarget = {
               providerId: localModelDescriptor.providerId,
@@ -3038,12 +3037,14 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
             </span>
           ) : null}
           {hasBlockingModelIssue && !localModelDescriptor ? (
-            <span className="flex items-center justify-center gap-1 text-[10px] font-normal text-red-300">
+            <span className="flex items-center justify-center gap-1 text-[10px] font-normal text-current">
               <AlertTriangle className="size-3 shrink-0" />
               <span>
-                {modelUnavailableReason
-                  ? t('modelSelector.badges.unavailable')
-                  : t('modelSelector.badges.issue')}
+                {codexModelCanUpdate
+                  ? 'Update Codex'
+                  : modelUnavailableReason
+                    ? t('modelSelector.badges.unavailable')
+                    : t('modelSelector.badges.issue')}
               </span>
               {modelStatusMessage ? (
                 <ModelInfoTooltip

--- a/src/renderer/components/team/dialogs/teamModelFreshness.ts
+++ b/src/renderer/components/team/dialogs/teamModelFreshness.ts
@@ -1,48 +1,22 @@
+import {
+  compareModelReleaseFreshness,
+  isRecentlyReleasedModel,
+} from '@renderer/utils/modelReleaseFreshness';
 import { compareTeamModelVersionsDescending } from '@renderer/utils/teamModelCatalog';
 
 import type { TeamRuntimeModelOption } from '@renderer/utils/teamModelAvailability';
 import type { CliProviderStatus } from '@shared/types';
 
 type ProviderModelCatalogItem = NonNullable<CliProviderStatus['modelCatalog']>['models'][number];
-const NEW_MODEL_BADGE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 
-function getModelReleaseTimestamp(
-  catalogModel: ProviderModelCatalogItem | null | undefined
-): number | null {
-  const releaseDate = catalogModel?.metadata?.releaseDate?.trim();
-  if (!releaseDate) return null;
-  const timestamp = Date.parse(releaseDate);
-  return Number.isFinite(timestamp) ? timestamp : null;
-}
-
-export function isRecentlyReleasedModel(
-  catalogModel: ProviderModelCatalogItem | null | undefined,
-  nowMs = Date.now()
-): boolean {
-  const releasedAt = getModelReleaseTimestamp(catalogModel);
-  if (releasedAt === null) return false;
-  const ageMs = nowMs - releasedAt;
-  return ageMs >= 0 && ageMs <= NEW_MODEL_BADGE_WINDOW_MS;
-}
-
-function compareModelReleaseDates(
-  left: { catalogModel: ProviderModelCatalogItem | null },
-  right: { catalogModel: ProviderModelCatalogItem | null }
-): number {
-  const leftReleasedAt = getModelReleaseTimestamp(left.catalogModel);
-  const rightReleasedAt = getModelReleaseTimestamp(right.catalogModel);
-  if (leftReleasedAt === rightReleasedAt) return 0;
-  if (leftReleasedAt === null) return 1;
-  if (rightReleasedAt === null) return -1;
-  return rightReleasedAt - leftReleasedAt;
-}
+export { isRecentlyReleasedModel };
 
 export function compareModelFreshness(
   left: { option: TeamRuntimeModelOption; catalogModel: ProviderModelCatalogItem | null },
   right: { option: TeamRuntimeModelOption; catalogModel: ProviderModelCatalogItem | null }
 ): number {
   return (
-    compareModelReleaseDates(left, right) ||
+    compareModelReleaseFreshness(left.catalogModel, right.catalogModel) ||
     compareTeamModelVersionsDescending(left.option.value, right.option.value)
   );
 }

--- a/src/renderer/components/team/dialogs/teamModelSelectorUi.ts
+++ b/src/renderer/components/team/dialogs/teamModelSelectorUi.ts
@@ -33,10 +33,22 @@ export function addCodexAstraUpdatePreview(
     !runtimeStatus.latestVersion ||
     !currentVersion ||
     compareVersions(currentVersion, MINIMUM_CODEX_ASTRA_VERSION) >= 0 ||
-    compareVersions(runtimeStatus.latestVersion, MINIMUM_CODEX_ASTRA_VERSION) < 0 ||
-    options.some((option) => option.value === CODEX_ASTRA_MODEL_ID)
+    compareVersions(runtimeStatus.latestVersion, MINIMUM_CODEX_ASTRA_VERSION) < 0
   ) {
     return [...options];
+  }
+
+  const existingAstraIndex = options.findIndex((option) => option.value === CODEX_ASTRA_MODEL_ID);
+  if (existingAstraIndex >= 0) {
+    return options.map((option, index) =>
+      index === existingAstraIndex
+        ? {
+            ...option,
+            availabilityStatus: 'unavailable',
+            availabilityReason: CODEX_ASTRA_UPDATE_REQUIRED_REASON,
+          }
+        : option
+    );
   }
 
   const preview: TeamRuntimeModelOption = {

--- a/src/renderer/components/team/dialogs/teamModelSelectorUi.ts
+++ b/src/renderer/components/team/dialogs/teamModelSelectorUi.ts
@@ -1,11 +1,62 @@
 import { getTeamModelSourceBadgeLabel } from '@renderer/utils/teamModelCatalog';
 import { parseOpenCodeQualifiedModelRef } from '@shared/utils/opencodeModelRef';
+import { compareVersions } from '@shared/utils/version';
+
+import type { TeamRuntimeModelOption } from '@renderer/utils/teamModelAvailability';
 
 const OPENCODE_SOURCES_WITHOUT_NEEDS_TEST_BADGE = new Set(['cursor-acp']);
 const OPENCODE_ROUTE_KINDS_WITHOUT_NEEDS_TEST_BADGE = new Set(['configured_local']);
 const OPENCODE_MODEL_GRID_MIN_CARD_WIDTH_PX = 140;
 const OPENCODE_MODEL_GRID_GAP_PX = 6;
 const OPENCODE_NO_REMOTE_CATALOG_AUTHORITY = '$no-remote-catalog';
+export const CODEX_ASTRA_MODEL_ID = 'gpt-6-astra';
+export const MINIMUM_CODEX_ASTRA_VERSION = '0.153.4';
+export const CODEX_ASTRA_UPDATE_REQUIRED_REASON = `Update Codex to ${MINIMUM_CODEX_ASTRA_VERSION} or newer to use GPT-6 Astra.`;
+
+interface CodexRuntimeUpdatePreviewStatus {
+  installed: boolean;
+  version?: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+}
+
+export function addCodexAstraUpdatePreview(
+  providerId: string,
+  options: readonly TeamRuntimeModelOption[],
+  runtimeStatus: CodexRuntimeUpdatePreviewStatus | null | undefined
+): TeamRuntimeModelOption[] {
+  const currentVersion = runtimeStatus?.version?.trim();
+  if (
+    providerId !== 'codex' ||
+    !runtimeStatus?.installed ||
+    !runtimeStatus.updateAvailable ||
+    !runtimeStatus.latestVersion ||
+    !currentVersion ||
+    compareVersions(currentVersion, MINIMUM_CODEX_ASTRA_VERSION) >= 0 ||
+    compareVersions(runtimeStatus.latestVersion, MINIMUM_CODEX_ASTRA_VERSION) < 0 ||
+    options.some((option) => option.value === CODEX_ASTRA_MODEL_ID)
+  ) {
+    return [...options];
+  }
+
+  const preview: TeamRuntimeModelOption = {
+    value: CODEX_ASTRA_MODEL_ID,
+    label: 'GPT-6 Astra',
+    badgeLabel: '6-astra',
+    availabilityStatus: 'unavailable',
+    availabilityReason: CODEX_ASTRA_UPDATE_REQUIRED_REASON,
+  };
+  const defaultIndex = options.findIndex((option) => option.value === '');
+  const insertionIndex = defaultIndex < 0 ? 0 : defaultIndex + 1;
+  return [...options.slice(0, insertionIndex), preview, ...options.slice(insertionIndex)];
+}
+
+export function isCodexAstraUpdatePreview(option: TeamRuntimeModelOption): boolean {
+  return (
+    option.value === CODEX_ASTRA_MODEL_ID &&
+    option.availabilityReason === CODEX_ASTRA_UPDATE_REQUIRED_REASON
+  );
+}
 
 export interface OpenCodeSelectionScopeAssociation {
   readonly value: string;
@@ -61,8 +112,7 @@ export function deriveOpenCodeSelectionAuthorityState(input: {
       input.currentAuthorityConfirmsSelection && current.scopeKey !== input.scopeKey
         ? { value: input.value, scopeKey: input.scopeKey }
         : current,
-    awaitingLocalAuthority:
-      input.localAuthorityLoading && current.scopeKey !== input.scopeKey,
+    awaitingLocalAuthority: input.localAuthorityLoading && current.scopeKey !== input.scopeKey,
   };
 }
 

--- a/src/renderer/utils/__tests__/modelReleaseFreshness.test.ts
+++ b/src/renderer/utils/__tests__/modelReleaseFreshness.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  compareModelReleaseFreshness,
+  getModelReleaseTimestamp,
+  isRecentlyReleasedModel,
+  NEW_MODEL_BADGE_WINDOW_MS,
+} from '../modelReleaseFreshness';
+
+import type { CliProviderModelCatalogItem } from '@shared/types';
+
+const NOW_MS = Date.parse('2026-09-05T12:00:00.000Z');
+
+function buildModel(options: {
+  id: string;
+  releaseDate?: string | null;
+  recentlyReleased?: boolean;
+}): CliProviderModelCatalogItem {
+  return {
+    id: options.id,
+    launchModel: options.id,
+    displayName: options.id,
+    hidden: false,
+    supportedReasoningEfforts: ['medium'],
+    defaultReasoningEffort: 'medium',
+    inputModalities: ['text'],
+    supportsPersonality: false,
+    isDefault: false,
+    upgrade: false,
+    source: 'app-server',
+    metadata: {
+      releaseDate: options.releaseDate ?? null,
+      recentlyReleased: options.recentlyReleased === true,
+    },
+  };
+}
+
+describe('model release freshness', () => {
+  it('uses an inclusive fourteen-day window', () => {
+    const boundary = new Date(NOW_MS - NEW_MODEL_BADGE_WINDOW_MS).toISOString();
+    const expired = new Date(NOW_MS - NEW_MODEL_BADGE_WINDOW_MS - 1).toISOString();
+
+    expect(
+      isRecentlyReleasedModel(buildModel({ id: 'boundary', releaseDate: boundary }), NOW_MS)
+    ).toBe(true);
+    expect(
+      isRecentlyReleasedModel(buildModel({ id: 'expired', releaseDate: expired }), NOW_MS)
+    ).toBe(false);
+  });
+
+  it('rejects invalid and future release dates', () => {
+    expect(
+      getModelReleaseTimestamp(buildModel({ id: 'invalid', releaseDate: 'not-a-date' }), NOW_MS)
+    ).toBeNull();
+    expect(
+      getModelReleaseTimestamp(
+        buildModel({ id: 'future', releaseDate: '2026-09-06T12:00:00.000Z' }),
+        NOW_MS
+      )
+    ).toBeNull();
+  });
+
+  it('honors the runtime new-model hint when no release date is available', () => {
+    expect(
+      isRecentlyReleasedModel(buildModel({ id: 'astra', recentlyReleased: true }), NOW_MS)
+    ).toBe(true);
+  });
+
+  it('sorts recent runtime hints first, then known release dates newest-first', () => {
+    const hinted = buildModel({ id: 'hinted', recentlyReleased: true });
+    const newer = buildModel({ id: 'newer', releaseDate: '2026-08-01T00:00:00.000Z' });
+    const older = buildModel({ id: 'older', releaseDate: '2026-07-01T00:00:00.000Z' });
+
+    expect(compareModelReleaseFreshness(hinted, newer, NOW_MS)).toBeLessThan(0);
+    expect(compareModelReleaseFreshness(newer, older, NOW_MS)).toBeLessThan(0);
+  });
+});

--- a/src/renderer/utils/__tests__/teamModelCatalog.dynamicCatalog.test.ts
+++ b/src/renderer/utils/__tests__/teamModelCatalog.dynamicCatalog.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { getVisibleTeamProviderModels } from '../teamModelCatalog';
+import {
+  getRuntimeAwareTeamModelBadgeLabel,
+  getVisibleTeamProviderModels,
+} from '../teamModelCatalog';
 
 import type { CliProviderStatus } from '@shared/types';
 
@@ -91,5 +94,37 @@ describe('dynamic Codex dashboard model catalog', () => {
       'gpt-6-astra',
       'gpt-5.6-sol',
     ]);
+  });
+});
+
+describe('dynamic OpenCode dashboard model labels', () => {
+  it('uses each model display name instead of repeating the provider source badge', () => {
+    const provider = {
+      providerId: 'opencode',
+      modelCatalog: {
+        providerId: 'opencode',
+        models: [
+          {
+            id: 'opencode/big-pickle',
+            launchModel: 'opencode/big-pickle',
+            displayName: 'Big Pickle',
+            badgeLabel: 'OpenCode Zen',
+          },
+          {
+            id: 'opencode/kimi-k2.5-free',
+            launchModel: 'opencode/kimi-k2.5-free',
+            displayName: 'Kimi K2.5 Free',
+            badgeLabel: 'OpenCode Zen',
+          },
+        ],
+      },
+    } as CliProviderStatus;
+
+    expect(getRuntimeAwareTeamModelBadgeLabel('opencode', 'opencode/big-pickle', provider)).toBe(
+      'Big Pickle'
+    );
+    expect(
+      getRuntimeAwareTeamModelBadgeLabel('opencode', 'opencode/kimi-k2.5-free', provider)
+    ).toBe('Kimi K2.5 Free');
   });
 });

--- a/src/renderer/utils/__tests__/teamModelCatalog.dynamicCatalog.test.ts
+++ b/src/renderer/utils/__tests__/teamModelCatalog.dynamicCatalog.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { getVisibleTeamProviderModels } from '../teamModelCatalog';
+
+import type { CliProviderStatus } from '@shared/types';
+
+function buildCodexStatus(): CliProviderStatus {
+  return {
+    providerId: 'codex',
+    displayName: 'Codex',
+    supported: true,
+    authenticated: true,
+    authMethod: 'chatgpt',
+    verificationState: 'verified',
+    models: ['gpt-5.6-sol'],
+    capabilities: {
+      teamLaunch: true,
+      oneShot: false,
+      extensions: {
+        plugins: { status: 'supported', ownership: 'shared' },
+        mcp: { status: 'supported', ownership: 'shared' },
+        skills: { status: 'supported', ownership: 'shared' },
+        apiKeys: { status: 'supported', ownership: 'shared' },
+      },
+    },
+    modelAvailability: [],
+    modelCatalogRefreshState: 'ready',
+    runtimeCapabilities: {
+      modelCatalog: { dynamic: true, source: 'app-server' },
+      reasoningEffort: {
+        supported: true,
+        values: ['medium'],
+        configPassthrough: false,
+      },
+    },
+    canLoginFromUi: true,
+    modelCatalog: {
+      schemaVersion: 1,
+      providerId: 'codex',
+      source: 'app-server',
+      status: 'ready',
+      fetchedAt: '2026-09-05T12:00:00.000Z',
+      staleAt: '2026-09-05T12:10:00.000Z',
+      defaultModelId: 'gpt-6-astra',
+      defaultLaunchModel: 'gpt-6-astra',
+      models: [
+        {
+          id: 'gpt-6-astra',
+          launchModel: 'gpt-6-astra',
+          displayName: 'GPT-6-Astra',
+          hidden: false,
+          supportedReasoningEfforts: ['medium'],
+          defaultReasoningEffort: 'medium',
+          inputModalities: ['text', 'image'],
+          supportsPersonality: false,
+          isDefault: true,
+          upgrade: false,
+          source: 'app-server',
+          badgeLabel: '6-astra',
+          metadata: { recentlyReleased: true },
+        },
+        {
+          id: 'gpt-5.6-sol',
+          launchModel: 'gpt-5.6-sol',
+          displayName: 'GPT-5.6-Sol',
+          hidden: false,
+          supportedReasoningEfforts: ['medium'],
+          defaultReasoningEffort: 'medium',
+          inputModalities: ['text', 'image'],
+          supportsPersonality: false,
+          isDefault: false,
+          upgrade: false,
+          source: 'app-server',
+          badgeLabel: '5.6-sol',
+          metadata: null,
+        },
+      ],
+      diagnostics: {
+        configReadState: 'ready',
+        appServerState: 'healthy',
+      },
+    },
+  };
+}
+
+describe('dynamic Codex dashboard model catalog', () => {
+  it('adds catalog-only models and keeps newest models first', () => {
+    const provider = buildCodexStatus();
+
+    expect(getVisibleTeamProviderModels('codex', provider.models, provider)).toEqual([
+      'gpt-6-astra',
+      'gpt-5.6-sol',
+    ]);
+  });
+});

--- a/src/renderer/utils/modelReleaseFreshness.ts
+++ b/src/renderer/utils/modelReleaseFreshness.ts
@@ -1,0 +1,38 @@
+import type { CliProviderModelCatalogItem } from '@shared/types';
+
+export const NEW_MODEL_BADGE_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
+
+export function getModelReleaseTimestamp(
+  catalogModel: CliProviderModelCatalogItem | null | undefined,
+  nowMs = Date.now()
+): number | null {
+  const releaseDate = catalogModel?.metadata?.releaseDate?.trim();
+  if (!releaseDate) return null;
+  const timestamp = Date.parse(releaseDate);
+  return Number.isFinite(timestamp) && timestamp <= nowMs ? timestamp : null;
+}
+
+export function isRecentlyReleasedModel(
+  catalogModel: CliProviderModelCatalogItem | null | undefined,
+  nowMs = Date.now()
+): boolean {
+  if (catalogModel?.metadata?.recentlyReleased === true) return true;
+  const releasedAt = getModelReleaseTimestamp(catalogModel, nowMs);
+  return releasedAt !== null && nowMs - releasedAt <= NEW_MODEL_BADGE_WINDOW_MS;
+}
+
+export function compareModelReleaseFreshness(
+  left: CliProviderModelCatalogItem | null | undefined,
+  right: CliProviderModelCatalogItem | null | undefined,
+  nowMs = Date.now()
+): number {
+  const leftIsRecent = isRecentlyReleasedModel(left, nowMs);
+  const rightIsRecent = isRecentlyReleasedModel(right, nowMs);
+  if (leftIsRecent !== rightIsRecent) return leftIsRecent ? -1 : 1;
+  const leftReleasedAt = getModelReleaseTimestamp(left, nowMs);
+  const rightReleasedAt = getModelReleaseTimestamp(right, nowMs);
+  if (leftReleasedAt === rightReleasedAt) return 0;
+  if (leftReleasedAt === null) return 1;
+  if (rightReleasedAt === null) return -1;
+  return rightReleasedAt - leftReleasedAt;
+}

--- a/src/renderer/utils/teamModelCatalog.ts
+++ b/src/renderer/utils/teamModelCatalog.ts
@@ -561,13 +561,16 @@ export function getRuntimeAwareTeamModelBadgeLabel(
   const trimmed = model?.trim();
   const runtimeModel = getRuntimeCatalogModel(providerId, model, providerStatus);
   if (providerId === 'opencode') {
-    return runtimeModel?.displayName?.trim() || getTeamModelBadgeLabel(providerId, trimmed);
+    const runtimeLabel = runtimeModel?.displayName?.trim();
+    return runtimeLabel
+      ? getProviderScopedTeamModelLabel(providerId, runtimeLabel)
+      : getTeamModelBadgeLabel(providerId, trimmed);
   }
   const safeAnthropicAliasLabel =
     providerId === 'anthropic'
       ? getRuntimeSafeAnthropicAliasLabel({
           model: trimmed,
-          runtimeLabel: runtimeModel?.badgeLabel?.trim() || runtimeModel?.displayName?.trim(),
+          runtimeLabel: runtimeModel?.displayName?.trim(),
           fallbackLabel: getTeamModelBadgeLabel(providerId, trimmed),
         })
       : null;
@@ -575,7 +578,7 @@ export function getRuntimeAwareTeamModelBadgeLabel(
     return safeAnthropicAliasLabel;
   }
 
-  if (runtimeModel?.badgeLabel?.trim()) {
+  if (providerId === 'codex' && runtimeModel?.badgeLabel?.trim()) {
     return runtimeModel.badgeLabel.trim();
   }
 

--- a/src/renderer/utils/teamModelCatalog.ts
+++ b/src/renderer/utils/teamModelCatalog.ts
@@ -7,6 +7,7 @@ import {
 import { isOpenCodeModelExplicitlyFree } from '@shared/utils/opencodeModelRoute';
 import { filterVisibleProviderRuntimeModels } from '@shared/utils/providerModelVisibility';
 
+import { compareModelReleaseFreshness } from './modelReleaseFreshness';
 import { getCodexChatGptModeUiDisabledReason } from './teamModelCatalogChatGptGate';
 
 import type { CliProviderId, CliProviderStatus, TeamProviderId } from '@shared/types';
@@ -615,6 +616,7 @@ export function sortTeamProviderModels(
     return true;
   });
   const order = TEAM_PROVIDER_MODEL_ORDER[providerId];
+  const nowMs = Date.now();
 
   const sorted = [...deduped].sort((left, right) => {
     const leftLabel =
@@ -622,6 +624,14 @@ export function sortTeamProviderModels(
     const rightLabel =
       providerId === 'anthropic' ? (getTeamModelBadgeLabel(providerId, right) ?? right) : right;
     if (providerId !== 'opencode') {
+      const releaseDateOrder = compareModelReleaseFreshness(
+        getRuntimeCatalogModel(providerId, left, providerStatus),
+        getRuntimeCatalogModel(providerId, right, providerStatus),
+        nowMs
+      );
+      if (releaseDateOrder !== 0) {
+        return releaseDateOrder;
+      }
       const versionOrder = compareTeamModelVersionsDescending(leftLabel, rightLabel);
       if (versionOrder !== 0) {
         return versionOrder;
@@ -752,15 +762,16 @@ export function getVisibleTeamProviderModels(
 ): string[] {
   const expandOpenCodeSummaryCatalog = options.expandOpenCodeSummaryCatalog ?? true;
   const hasExplicitModels = models.some((model) => model.trim().length > 0);
-  const catalogModels =
-    providerId === 'opencode' ? getRuntimeCatalogLaunchModels(providerId, providerStatus) : null;
+  const catalogModels = getRuntimeCatalogLaunchModels(providerId, providerStatus);
   const sourceModels =
     providerId === 'opencode' &&
     catalogModels &&
     (!hasExplicitModels ||
       (expandOpenCodeSummaryCatalog && isOpenCodeSummaryOnlyModelList(models, providerStatus)))
       ? mergeModelLists(catalogModels, models)
-      : models;
+      : providerId === 'codex' && catalogModels
+        ? mergeModelLists(catalogModels, models)
+        : models;
 
   return sortTeamProviderModels(
     providerId,

--- a/src/renderer/utils/teamModelCatalog.ts
+++ b/src/renderer/utils/teamModelCatalog.ts
@@ -566,6 +566,13 @@ export function getRuntimeAwareTeamModelBadgeLabel(
       ? getProviderScopedTeamModelLabel(providerId, runtimeLabel)
       : getTeamModelBadgeLabel(providerId, trimmed);
   }
+  if (
+    providerId === 'anthropic' &&
+    providerStatus?.modelCatalog?.source === 'anthropic-compatible-api' &&
+    runtimeModel?.badgeLabel?.trim()
+  ) {
+    return runtimeModel.badgeLabel.trim();
+  }
   const safeAnthropicAliasLabel =
     providerId === 'anthropic'
       ? getRuntimeSafeAnthropicAliasLabel({

--- a/src/renderer/utils/teamModelCatalog.ts
+++ b/src/renderer/utils/teamModelCatalog.ts
@@ -560,6 +560,9 @@ export function getRuntimeAwareTeamModelBadgeLabel(
 ): string | undefined {
   const trimmed = model?.trim();
   const runtimeModel = getRuntimeCatalogModel(providerId, model, providerStatus);
+  if (providerId === 'opencode') {
+    return runtimeModel?.displayName?.trim() || getTeamModelBadgeLabel(providerId, trimmed);
+  }
   const safeAnthropicAliasLabel =
     providerId === 'anthropic'
       ? getRuntimeSafeAnthropicAliasLabel({

--- a/src/shared/types/cliInstaller.ts
+++ b/src/shared/types/cliInstaller.ts
@@ -200,6 +200,8 @@ export interface CliProviderModelCatalogItem {
     limits?: unknown;
     free?: boolean;
     releaseDate?: string | null;
+    /** Authoritative runtime hint that the model is in its new-model announcement window. */
+    recentlyReleased?: boolean;
     opencode?: OpenCodeModelRouteMetadata | null;
   } | null;
 }

--- a/test/main/services/infrastructure/CliInstallerService.test.ts
+++ b/test/main/services/infrastructure/CliInstallerService.test.ts
@@ -1725,7 +1725,7 @@ describe('CliInstallerService', () => {
       expect(status.authMethod).toBe('api_key');
     });
 
-    it('does not publish provider authority after the initial hydration wait times out', async () => {
+    it('publishes provider authority when background hydration finishes after the initial wait', async () => {
       allowConsoleLogs();
       vi.useFakeTimers();
 
@@ -1768,8 +1768,14 @@ describe('CliInstallerService', () => {
 
       const latest = service.getLatestStatusSnapshot();
       expect(latest?.authStatusChecking).toBe(false);
-      expect(latest?.authLoggedIn).toBe(false);
-      expect(latest?.authMethod).toBeNull();
+      expect(latest?.authLoggedIn).toBe(true);
+      expect(latest?.authMethod).toBe('oauth_token');
+      expect(
+        latest?.providers.find((provider) => provider.providerId === 'anthropic')
+      ).toMatchObject({
+        authenticated: true,
+        authMethod: 'oauth_token',
+      });
       expect(status.authStatusChecking).toBe(false);
       expect(status.authLoggedIn).toBe(false);
       expect(status.providers.every((provider) => provider.statusMessage === 'Checking...')).toBe(

--- a/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -2022,7 +2022,7 @@ describe('ClaudeMultimodelBridgeService', () => {
     ).toBe(90_000);
   });
 
-  it('queues fresh single-provider catalog hydration behind an in-flight one', async () => {
+  it('coalesces repeated single-provider catalog hydration while one is in flight', async () => {
     let resolveHydration!: (value: { stdout: string; stderr: string; exitCode: number }) => void;
     const hydration = new Promise<{ stdout: string; stderr: string; exitCode: number }>(
       (resolve) => {
@@ -2162,16 +2162,16 @@ describe('ClaudeMultimodelBridgeService', () => {
     await vi.waitFor(() => {
       expect(secondUpdate).toHaveBeenCalledTimes(1);
     });
-    expect(fullStatusCalls).toBe(2);
-    expect(firstUpdate).not.toHaveBeenCalled();
+    expect(fullStatusCalls).toBe(1);
+    expect(firstUpdate).toHaveBeenCalledTimes(1);
     expect(secondUpdate.mock.calls[0]?.[0]).toMatchObject({
       authenticated: false,
       authMethod: null,
-      statusMessage: 'Fresh full status',
+      statusMessage: 'Full status reports logged out',
       capabilities: { teamLaunch: false },
       modelCatalogRefreshState: 'error',
       modelCatalog: {
-        defaultModelId: 'fresh-model',
+        defaultModelId: 'gpt-5.4',
         status: 'stale',
       },
     });

--- a/test/renderer/components/cli/CliStatusVisibility.test.ts
+++ b/test/renderer/components/cli/CliStatusVisibility.test.ts
@@ -982,7 +982,7 @@ describe('CLI status visibility during completed install state', () => {
     expect(host.textContent).toContain('OpenCode');
     expect(host.textContent).toContain('Ready to run agents');
     expect(host.textContent).toContain('Providers: 10 connected');
-    expect(host.textContent).toContain('Models available');
+    expect(host.textContent).not.toContain('Models available');
     expect(host.textContent).toContain('big-pickle');
     expect(host.textContent).not.toContain('Checking...');
     expect(host.textContent).not.toContain('Provider status unavailable');
@@ -1775,7 +1775,7 @@ describe('CLI status visibility during completed install state', () => {
       await Promise.resolve();
     });
 
-    expect(host.textContent).toContain('Models available');
+    expect(host.textContent).not.toContain('Models available');
     expect(host.textContent).toContain('Runtime: OpenCode CLI');
     expect(host.textContent).not.toContain('Loading models...');
     expect(host.textContent).not.toContain('Models unavailable for this runtime build');


### PR DESCRIPTION
## Summary
- merge the authoritative Codex app-server catalog into dashboard and team model lists
- sort new models first and show the runtime-backed New marker, with a 14-day release-date fallback
- show an update action for GPT-6 Astra when Codex is older than the first verified supporting runtime, 0.153.4
- make large Codex package downloads time out on network inactivity instead of total elapsed time

## Verification
- targeted Vitest: 36 tests passed
- pnpm typecheck
- focused fast lint
- source-file-size and provisioning architecture guards
- manual model/list proof: 0.152.0 omits gpt-6-astra; 0.153.4 returns it as default with availability NUX

Local packaged-app and mixed-team E2E verification will be attached after CI integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “New” badges and release-aware sorting for recently released models.
  - Codex catalogs now include dynamically available launch models.
  - Added a GPT-6 Astra update preview with a direct “Update Codex” action.
  - Model availability notices now appear as status messages.
  - OpenCode models now display individual model names in badges.

- **Bug Fixes**
  - Package downloads remain active while network data continues arriving.
  - Provider model metadata now preserves recently released indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->