### PR TITLE
fix(team): retry OpenCode lanes without phantom stop

### DIFF
--- a/src/main/services/team/provisioning/TeamProvisioningHasOpenCodeMemberRuntimeEvidenceForControlledRelaunchUseCase.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningHasOpenCodeMemberRuntimeEvidenceForControlledRelaunchUseCase.ts
@@ -44,7 +44,7 @@ export function createHasOpenCodeMemberRuntimeEvidenceForControlledRelaunchUseCa
       return true;
     }
 
-    const persistedSnapshot = await ports.readLaunchStateSnapshot(input.teamName).catch(() => null);
+    const persistedSnapshot = await ports.readLaunchStateSnapshot(input.teamName);
     const persistedMember =
       persistedSnapshot?.members[input.memberName] ??
       Object.values(persistedSnapshot?.members ?? {}).find(
@@ -57,9 +57,7 @@ export function createHasOpenCodeMemberRuntimeEvidenceForControlledRelaunchUseCa
       return true;
     }
 
-    const liveRuntimeByMember = await ports
-      .getLiveTeamAgentRuntimeMetadata(input.teamName)
-      .catch(() => new Map<string, LiveTeamAgentRuntimeMetadata>());
+    const liveRuntimeByMember = await ports.getLiveTeamAgentRuntimeMetadata(input.teamName);
     const liveRuntimeMember =
       liveRuntimeByMember.get(input.memberName) ??
       [...liveRuntimeByMember.entries()].find(([candidateName]) =>

--- a/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
@@ -2574,7 +2574,7 @@ export class TeamProvisioningMemberLifecycleController {
     });
     this.assertRunStillCurrentAndAlive(run, teamName);
 
-    if (existingLane) {
+    if (existingLane && hasRuntimeEvidence) {
       await this.stopSingleMixedSecondaryRuntimeLane(run, existingLane, 'relaunch');
       this.assertRunStillCurrentAndAlive(run, teamName);
     }

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningHasOpenCodeMemberRuntimeEvidenceForControlledRelaunchUseCase.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningHasOpenCodeMemberRuntimeEvidenceForControlledRelaunchUseCase.test.ts
@@ -157,4 +157,40 @@ describe('TeamProvisioningHasOpenCodeMemberRuntimeEvidenceForControlledRelaunchU
       })
     ).resolves.toBe(false);
   });
+
+  it('fails closed when persisted runtime evidence cannot be read', async () => {
+    const useCase = createHasOpenCodeMemberRuntimeEvidenceForControlledRelaunchUseCase({
+      readLaunchStateSnapshot: vi.fn(async () => {
+        throw new Error('launch state unavailable');
+      }),
+      getLiveTeamAgentRuntimeMetadata: vi.fn(async () => new Map()),
+    });
+
+    await expect(
+      useCase({
+        teamName: 'team-a',
+        memberName: 'Worker',
+        laneId: 'secondary:opencode:worker',
+        existingLane: null,
+      })
+    ).rejects.toThrow('launch state unavailable');
+  });
+
+  it('fails closed when live runtime evidence cannot be read', async () => {
+    const useCase = createHasOpenCodeMemberRuntimeEvidenceForControlledRelaunchUseCase({
+      readLaunchStateSnapshot: vi.fn(async () => null),
+      getLiveTeamAgentRuntimeMetadata: vi.fn(async () => {
+        throw new Error('runtime metadata unavailable');
+      }),
+    });
+
+    await expect(
+      useCase({
+        teamName: 'team-a',
+        memberName: 'Worker',
+        laneId: 'secondary:opencode:worker',
+        existingLane: null,
+      })
+    ).rejects.toThrow('runtime metadata unavailable');
+  });
 });

--- a/test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts
+++ b/test/main/services/team/TeamAgentLaunchMatrix.safe-e2e.test.ts
@@ -19484,7 +19484,7 @@ describe(
       });
     });
 
-    it('fresh relaunches a failed mixed OpenCode teammate without runtime evidence', async () => {
+    it('fresh relaunches an existing failed mixed OpenCode lane without runtime evidence', async () => {
       const teamName = 'mixed-opencode-fresh-relaunch-no-runtime-evidence-safe-e2e';
       await writeMixedTeamConfig({ teamName, projectPath });
       await writeTeamMeta(teamName, projectPath);
@@ -19496,9 +19496,16 @@ describe(
       const svc = new TeamProvisioningService();
       svc.setRuntimeAdapterRegistry(new TeamRuntimeAdapterRegistry([adapter]));
       const run = createMixedLiveRun({ teamName, projectPath });
-      run.mixedSecondaryLanes = run.mixedSecondaryLanes.filter(
-        (lane: { member: { name: string } }) => lane.member.name !== 'bob'
+      const failedLane = run.mixedSecondaryLanes.find(
+        (lane: { member: { name: string } }) => lane.member.name === 'bob'
       );
+      expect(failedLane).toBeDefined();
+      Object.assign(failedLane!, {
+        state: 'finished',
+        runId: null,
+        result: null,
+        diagnostics: ['OpenCode bridge handshake failed: provider startup lock timed out'],
+      });
       run.memberSpawnStatuses.set('bob', {
         status: 'error',
         launchState: 'failed_to_start',


### PR DESCRIPTION
## Summary
- skip a stop call when a failed OpenCode lane has no runtime evidence
- fail closed if persisted or live runtime evidence cannot be read
- cover the exact failed-before-session retry path with a safe E2E regression test

## Verification
- pnpm typecheck
- focused runtime evidence tests: 6/6
- focused safe E2E retry test
- source size and provisioning architecture guards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved controlled relaunch handling when runtime evidence is unavailable, preserving existing lanes instead of stopping them unnecessarily.
  - Relaunch checks now surface errors when persisted or live runtime information cannot be read, preventing the system from continuing with incomplete evidence.
  - Updated mixed-lane relaunch behavior to correctly handle lanes in a finished state without an active run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->