### PR TITLE
fix(models): expire new badges from release dates

### DIFF
--- a/src/renderer/utils/__tests__/modelReleaseFreshness.test.ts
+++ b/src/renderer/utils/__tests__/modelReleaseFreshness.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import {
   compareModelReleaseFreshness,
-  getModelReleaseTimestamp,
   isRecentlyReleasedModel,
   NEW_MODEL_BADGE_WINDOW_MS,
 } from '../modelReleaseFreshness';
@@ -36,33 +35,54 @@ function buildModel(options: {
 }
 
 describe('model release freshness', () => {
-  it('uses an inclusive fourteen-day window', () => {
+  it('uses a strict fourteen-day window', () => {
     const boundary = new Date(NOW_MS - NEW_MODEL_BADGE_WINDOW_MS).toISOString();
-    const expired = new Date(NOW_MS - NEW_MODEL_BADGE_WINDOW_MS - 1).toISOString();
+    const inside = new Date(NOW_MS - NEW_MODEL_BADGE_WINDOW_MS + 1).toISOString();
 
     expect(
       isRecentlyReleasedModel(buildModel({ id: 'boundary', releaseDate: boundary }), NOW_MS)
-    ).toBe(true);
+    ).toBe(false);
+    expect(isRecentlyReleasedModel(buildModel({ id: 'inside', releaseDate: inside }), NOW_MS)).toBe(
+      true
+    );
+  });
+
+  it('treats non-empty old, future, and invalid dates as authoritative over the runtime hint', () => {
+    const old = new Date(NOW_MS - NEW_MODEL_BADGE_WINDOW_MS - 1).toISOString();
+
     expect(
-      isRecentlyReleasedModel(buildModel({ id: 'expired', releaseDate: expired }), NOW_MS)
+      isRecentlyReleasedModel(
+        buildModel({ id: 'old', releaseDate: old, recentlyReleased: true }),
+        NOW_MS
+      )
+    ).toBe(false);
+    expect(
+      isRecentlyReleasedModel(
+        buildModel({ id: 'invalid', releaseDate: 'not-a-date', recentlyReleased: true }),
+        NOW_MS
+      )
+    ).toBe(false);
+    expect(
+      isRecentlyReleasedModel(
+        buildModel({
+          id: 'future',
+          releaseDate: '2026-09-06T12:00:00.000Z',
+          recentlyReleased: true,
+        }),
+        NOW_MS
+      )
     ).toBe(false);
   });
 
-  it('rejects invalid and future release dates', () => {
-    expect(
-      getModelReleaseTimestamp(buildModel({ id: 'invalid', releaseDate: 'not-a-date' }), NOW_MS)
-    ).toBeNull();
-    expect(
-      getModelReleaseTimestamp(
-        buildModel({ id: 'future', releaseDate: '2026-09-06T12:00:00.000Z' }),
-        NOW_MS
-      )
-    ).toBeNull();
-  });
-
-  it('honors the runtime new-model hint when no release date is available', () => {
+  it('honors the runtime hint only when the release date is absent or blank', () => {
     expect(
       isRecentlyReleasedModel(buildModel({ id: 'astra', recentlyReleased: true }), NOW_MS)
+    ).toBe(true);
+    expect(
+      isRecentlyReleasedModel(
+        buildModel({ id: 'blank-date', releaseDate: '   ', recentlyReleased: true }),
+        NOW_MS
+      )
     ).toBe(true);
   });
 

--- a/src/renderer/utils/modelReleaseFreshness.ts
+++ b/src/renderer/utils/modelReleaseFreshness.ts
@@ -16,9 +16,10 @@ export function isRecentlyReleasedModel(
   catalogModel: CliProviderModelCatalogItem | null | undefined,
   nowMs = Date.now()
 ): boolean {
-  if (catalogModel?.metadata?.recentlyReleased === true) return true;
+  const releaseDate = catalogModel?.metadata?.releaseDate?.trim();
+  if (!releaseDate) return catalogModel?.metadata?.recentlyReleased === true;
   const releasedAt = getModelReleaseTimestamp(catalogModel, nowMs);
-  return releasedAt !== null && nowMs - releasedAt <= NEW_MODEL_BADGE_WINDOW_MS;
+  return releasedAt !== null && nowMs - releasedAt < NEW_MODEL_BADGE_WINDOW_MS;
 }
 
 export function compareModelReleaseFreshness(

--- a/test/renderer/components/runtime/ProviderModelBadgesFreshness.test.tsx
+++ b/test/renderer/components/runtime/ProviderModelBadgesFreshness.test.tsx
@@ -1,0 +1,146 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { ProviderModelBadges } from '@renderer/components/runtime/ProviderModelBadges';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CliProviderId, CliProviderModelCatalogItem, CliProviderStatus } from '@shared/types';
+
+const NOW = new Date('2026-09-05T12:00:00.000Z');
+const roots: Root[] = [];
+
+function buildCatalogModel(
+  id: string,
+  displayName: string,
+  metadata: CliProviderModelCatalogItem['metadata']
+): CliProviderModelCatalogItem {
+  return {
+    id,
+    launchModel: id,
+    displayName,
+    hidden: false,
+    supportedReasoningEfforts: ['medium'],
+    defaultReasoningEffort: 'medium',
+    inputModalities: ['text'],
+    supportsPersonality: false,
+    isDefault: true,
+    upgrade: false,
+    source: 'app-server',
+    metadata,
+  };
+}
+
+function buildProviderStatus(
+  providerId: CliProviderId,
+  model: CliProviderModelCatalogItem
+): Pick<CliProviderStatus, 'providerId' | 'authMethod' | 'backend' | 'modelCatalog'> {
+  return {
+    providerId,
+    authMethod: providerId === 'anthropic' ? 'oauth_token' : 'chatgpt',
+    backend:
+      providerId === 'anthropic'
+        ? { kind: 'anthropic', label: 'Anthropic' }
+        : { kind: 'codex-native', label: 'Codex native' },
+    modelCatalog: {
+      schemaVersion: 1,
+      providerId,
+      source: 'app-server',
+      status: 'ready',
+      fetchedAt: NOW.toISOString(),
+      staleAt: new Date(NOW.getTime() + 60_000).toISOString(),
+      defaultModelId: model.id,
+      defaultLaunchModel: model.launchModel,
+      models: [model],
+      diagnostics: { configReadState: 'ready', appServerState: 'healthy' },
+    },
+  };
+}
+
+function renderModel(
+  providerId: CliProviderId,
+  model: CliProviderModelCatalogItem
+): HTMLDivElement {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  roots.push(root);
+  act(() => {
+    root.render(
+      <ProviderModelBadges
+        providerId={providerId}
+        models={[model.launchModel]}
+        providerStatus={buildProviderStatus(providerId, model)}
+      />
+    );
+  });
+  return host;
+}
+
+function getNewBadges(host: HTMLElement): HTMLElement[] {
+  return Array.from(host.querySelectorAll('span')).filter(
+    (element): element is HTMLElement =>
+      element instanceof HTMLElement && element.textContent === 'New'
+  );
+}
+
+describe('ProviderModelBadges release freshness', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    act(() => {
+      roots.splice(0).forEach((root) => root.unmount());
+    });
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('renders identical New badges for recent Anthropic and Codex release dates', () => {
+    const releaseDate = '2026-09-01T12:00:00.000Z';
+    const anthropicHost = renderModel(
+      'anthropic',
+      buildCatalogModel('claude-fable-5-1', 'Fable 5.1', { releaseDate })
+    );
+    const codexHost = renderModel(
+      'codex',
+      buildCatalogModel('gpt-6-astra', 'GPT-6 Astra', { releaseDate })
+    );
+    const anthropicBadges = getNewBadges(anthropicHost);
+    const codexBadges = getNewBadges(codexHost);
+
+    expect(anthropicBadges).toHaveLength(1);
+    expect(codexBadges).toHaveLength(1);
+    expect(anthropicBadges[0]?.className).toBe(codexBadges[0]?.className);
+  });
+
+  it.each([
+    ['anthropic', 'claude-fable-5-1', 'Fable 5.1'],
+    ['codex', 'gpt-6-astra', 'GPT-6 Astra'],
+  ] as const)(
+    'expires the %s New badge when its dated release is old despite a hint',
+    (providerId, id, displayName) => {
+      const host = renderModel(
+        providerId,
+        buildCatalogModel(id, displayName, {
+          releaseDate: '2026-08-01T12:00:00.000Z',
+          recentlyReleased: true,
+        })
+      );
+
+      expect(getNewBadges(host)).toHaveLength(0);
+    }
+  );
+
+  it('keeps the Codex runtime hint when no release date is supplied', () => {
+    const host = renderModel(
+      'codex',
+      buildCatalogModel('gpt-6-astra', 'GPT-6 Astra', { recentlyReleased: true })
+    );
+
+    expect(getNewBadges(host)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
A model with a known release date could keep its New badge indefinitely when the runtime also supplied `recentlyReleased: true`. Make the release date authoritative and use a strict window of less than 14 days in the shared freshness helper. Preserve the runtime hint fallback when no date is available.

Anthropic Fable 5.1 and Codex Astra use the same badge logic and styling. Fixed-clock tests cover the boundary, expired/future/invalid dates overriding hints, and matching badges for both providers.

Validation: 112 focused frontend tests passed across freshness, badges, sorting, the runtime metadata bridge, and the model selector. Frontend typecheck, focused lint, and the source-size guard passed.

Companion producer fix: https://github.com/777genius/agent_teams_orchestrator/pull/58. Shipping Anthropic dates to installed apps requires a subsequent runtime release and runtime lock update; this PR safely handles both existing and updated catalogs.

Independent code review of `ba896e25cd6665e7e8e0be6055c2b66958eae384` found no actionable defects. ReviewRouter could not complete its review because the configured provider account has exhausted its usage quota; it reported no code findings. The independent review covered the exact diff, metadata boundary, shared consumers, and regression tests. CI results are tracked separately in the checks below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - “New” model badges now expire exactly when the freshness window ends.
  - Valid release dates take precedence over runtime freshness hints, preventing outdated models from displaying a “New” badge.
  - Models without a release date continue to use available freshness metadata.
  - Release-date freshness behavior is now consistent across supported provider model badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->