### PR TITLE
fix(opencode): retain dashboard models during refresh

### DIFF
--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
@@ -34,16 +34,18 @@ const passive = {
 } as unknown as CliProviderStatus;
 let observed: ReturnType<typeof useOpenCodeConnectedModelCatalog>;
 const Probe = ({
+  enabled = true,
   projectPath = '/sandbox/a',
   refreshRevision,
   periodic = false,
 }: {
+  enabled?: boolean;
   projectPath?: string;
   refreshRevision?: number;
   periodic?: boolean;
 }) => {
   observed = useOpenCodeConnectedModelCatalog({
-    enabled: true,
+    enabled,
     projectPath,
     passiveProviderStatus: passive,
     refreshRevision,
@@ -149,6 +151,17 @@ describe('connected OpenCode dashboard catalog', () => {
       'opencode/model-1',
       'openrouter/model-0',
     ]);
+  });
+  it('keeps the scoped catalog visible while provider refresh pauses catalog I/O', async () => {
+    await act(async () => root.render(<Probe />));
+    expect(observed.providerStatus?.models).toEqual(['opencode/model-0', 'openrouter/model-0']);
+
+    await act(async () => root.render(<Probe enabled={false} />));
+    expect(observed.providerStatus?.models).toEqual(['opencode/model-0', 'openrouter/model-0']);
+    expect(observed.providerStatus?.modelCatalogRefreshState).toBe('ready');
+
+    await act(async () => root.render(<Probe enabled={false} projectPath="/sandbox/b" />));
+    expect(observed.providerStatus).toBe(passive);
   });
   it.each(['not-connected', 'available', 'ignored'])(
     'includes built-in OpenCode models in %s state without granting readiness',

--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.ts
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.ts
@@ -191,8 +191,12 @@ export function useOpenCodeConnectedModelCatalog(input: {
 
   const providerStatus = useMemo(() => {
     const passive = input.passiveProviderStatus;
-    if (!passive || !input.enabled) return passive;
-    const active = state.scope === scope ? state : { loading: true, models: [], errors: [] };
+    const hasScopedState = state.scope === scope;
+    if (!passive || (!input.enabled && !hasScopedState)) return passive;
+    // A provider re-check temporarily pauses catalog I/O to avoid contending on
+    // the OpenCode profile. Keep rendering the last-good catalog for this scope
+    // while that pause is active instead of flashing an empty/loading summary.
+    const active = hasScopedState ? state : { loading: true, models: [], errors: [] };
     const models = [
       ...new Map(
         active.models.flatMap((model) => {


### PR DESCRIPTION
## Summary
- keep the last completed OpenCode model catalog visible while provider refresh temporarily pauses catalog I/O
- keep the cache scoped to the selected project so models never leak across projects
- cover the provider refresh pause with a focused hook regression test

## Verification
- `pnpm exec vitest run src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx` (13/13)
- `pnpm typecheck`
- focused fast lint
- source size and team provisioning architecture guards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Previously loaded model catalogs now remain visible when provider refresh is disabled.
  * Switching project paths while refresh is disabled correctly shows the provider’s passive status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->