### PR TITLE
fix(team): settle OpenCode dialog readiness

### DIFF
--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeProviderModelCatalog.test.ts
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeProviderModelCatalog.test.ts
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { MODEL_CATALOG_FRESHNESS_MS } from './loadOpenCodeScopedCatalog';
 import {
   normalizeModelResponseDiagnostics,
   useOpenCodeProviderModelCatalog,
@@ -57,6 +58,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
   document.body.innerHTML = '';
 });
@@ -79,8 +81,8 @@ describe('useOpenCodeProviderModelCatalog', () => {
     const root = createRoot(host);
     const nextRefresh = new Promise<never>(() => undefined);
     const observed: Array<{ revision: number; status: string; catalogState: string | null }> = [];
-    const observe = (revision: number) =>
-      (result: ReturnType<typeof useOpenCodeProviderModelCatalog>) => {
+    const observe =
+      (revision: number) => (result: ReturnType<typeof useOpenCodeProviderModelCatalog>) => {
         observed.push({
           revision,
           status: result.status,
@@ -112,6 +114,36 @@ describe('useOpenCodeProviderModelCatalog', () => {
       catalogState: 'fresh',
     });
     expect(observed.at(-1)).toMatchObject({ revision: 1, status: 'loading' });
+    await act(async () => root.unmount());
+  });
+
+  it('refreshes a scoped catalog when its freshness window expires', async () => {
+    vi.useFakeTimers();
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const observed: Array<{ status: string; catalogState: string | null }> = [];
+    apiMock.runtimeProviderManagement.loadModels.mockResolvedValue(
+      modelCatalogResponse('automatic refresh')
+    );
+
+    await act(async () => {
+      root.render(
+        React.createElement(HookProbe, {
+          onResult: (result) =>
+            observed.push({ status: result.status, catalogState: result.catalogState }),
+        })
+      );
+    });
+    expect(apiMock.runtimeProviderManagement.loadModels).toHaveBeenCalledOnce();
+    expect(observed.at(-1)).toEqual({ status: 'ready', catalogState: 'fresh' });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(MODEL_CATALOG_FRESHNESS_MS);
+    });
+
+    expect(apiMock.runtimeProviderManagement.loadModels).toHaveBeenCalledTimes(2);
+    expect(observed.at(-1)).toEqual({ status: 'ready', catalogState: 'fresh' });
     await act(async () => root.unmount());
   });
 });

--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeProviderModelCatalog.ts
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeProviderModelCatalog.ts
@@ -496,14 +496,7 @@ export function useOpenCodeProviderModelCatalog(input: {
       Math.max(0, Date.parse(state.freshUntil) - Date.now())
     );
     const timer = window.setTimeout(() => {
-      setState((current) =>
-        current.scopeKey === state.scopeKey &&
-        current.refreshRevision === state.refreshRevision &&
-        current.completedAt === state.completedAt &&
-        current.catalogState === 'fresh'
-          ? { ...current, catalogState: 'stale' }
-          : current
-      );
+      setRefreshSequence((sequence) => sequence + 1);
     }, delay);
     return () => window.clearTimeout(timer);
   }, [

--- a/src/renderer/components/common/ProviderActivityStatusStrip.tsx
+++ b/src/renderer/components/common/ProviderActivityStatusStrip.tsx
@@ -6,7 +6,11 @@ import { shouldMaskCodexNegativeBootstrapState } from '@renderer/components/runt
 import { createLoadingMultimodelCliStatus } from '@renderer/store/slices/cliInstallerSlice';
 import { filterMainScreenCliProviders } from '@renderer/utils/geminiUiFreeze';
 import { hasEffectiveProviderLaunchAuthority } from '@renderer/utils/providerReadiness';
-import { isTeamProviderModelVerificationPending } from '@renderer/utils/teamModelAvailability';
+import {
+  hasSettledOpenCodeScopedPreparation,
+  isTeamProviderRuntimeStatusLoading,
+  type OpenCodeScopedPreparationEvidence,
+} from '@renderer/utils/teamProviderRuntimeStatusLoading';
 import { AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react';
 
 import { ProviderBrandLogo } from './ProviderBrandLogo';
@@ -27,16 +31,13 @@ interface ProviderActivityStatusStripProps {
   readonly cliProviderStatusLoading: Partial<Record<CliProviderId, boolean>>;
   readonly multimodelEnabled: boolean;
   readonly codexSnapshotPending?: boolean;
+  readonly openCodePreparationEvidence?: OpenCodeScopedPreparationEvidence;
   readonly providerIds?: readonly CliProviderId[];
   readonly className?: string;
   readonly label?: string | null;
   readonly layout?: 'inline' | 'stacked';
   readonly showReadyProviders?: boolean;
   readonly readyStatusText?: string;
-}
-
-function isProviderCardLoading(provider: CliProviderStatus, providerLoading: boolean): boolean {
-  return providerLoading || isTeamProviderModelVerificationPending(provider.providerId, provider);
 }
 
 function getActivityToneStyles(tone: 'loading' | 'checked' | 'error'): {
@@ -83,6 +84,7 @@ function useProviderActivityDisplay({
   cliProviderStatusLoading,
   multimodelEnabled,
   codexSnapshotPending = false,
+  openCodePreparationEvidence,
   providerIds,
   showReadyProviders,
 }: Pick<
@@ -94,6 +96,7 @@ function useProviderActivityDisplay({
   | 'cliProviderStatusLoading'
   | 'multimodelEnabled'
   | 'codexSnapshotPending'
+  | 'openCodePreparationEvidence'
   | 'providerIds'
   | 'showReadyProviders'
 >): {
@@ -130,24 +133,30 @@ function useProviderActivityDisplay({
       const provider = overridden ? providerStatusOverride : globalProvider;
       const sourceProvider = sourceProviderMap.get(provider.providerId) ?? null;
       const loading =
-        isProviderCardLoading(
+        isTeamProviderRuntimeStatusLoading(
+          provider.providerId,
           provider,
-          !overridden && cliProviderStatusLoading[provider.providerId] === true
+          !overridden && cliProviderStatusLoading[provider.providerId] === true,
+          openCodePreparationEvidence
         ) ||
         (provider.providerId === 'codex' && codexSnapshotPending) ||
         shouldMaskCodexNegativeBootstrapState(sourceProvider, provider, {
           providerLoading: cliProviderStatusLoading[provider.providerId] === true,
         });
+      const scopedOpenCodeReady =
+        provider.providerId === 'opencode' &&
+        hasSettledOpenCodeScopedPreparation(provider, openCodePreparationEvidence);
 
       return {
         provider,
         loading,
-        error: !loading && !hasEffectiveProviderLaunchAuthority(provider),
+        error: !loading && !scopedOpenCodeReady && !hasEffectiveProviderLaunchAuthority(provider),
       };
     });
   }, [
     cliProviderStatusLoading,
     codexSnapshotPending,
+    openCodePreparationEvidence,
     providerIdSet,
     renderCliStatus?.providers,
     sourceProviderMap,
@@ -244,6 +253,7 @@ export const ProviderActivityStatusStrip = ({
   cliProviderStatusLoading,
   multimodelEnabled,
   codexSnapshotPending = false,
+  openCodePreparationEvidence,
   providerIds,
   className = '',
   label,
@@ -262,6 +272,7 @@ export const ProviderActivityStatusStrip = ({
     cliProviderStatusLoading,
     multimodelEnabled,
     codexSnapshotPending,
+    openCodePreparationEvidence,
     providerIds,
     showReadyProviders,
   });

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -2914,6 +2914,7 @@ export const CreateTeamDialog = ({
                 cliProviderStatusLoading={cliProviderStatusLoading}
                 multimodelEnabled={multimodelEnabled}
                 codexSnapshotPending={codexSnapshotPending}
+                openCodePreparationEvidence={openCodePreparationEvidence}
                 providerIds={selectedMemberProviders}
                 className="mb-2"
                 label={t('create.prepare.selectedProvidersLabel')}

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -3139,6 +3139,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                 cliProviderStatusLoading={cliProviderStatusLoading}
                 multimodelEnabled={multimodelEnabled}
                 codexSnapshotPending={codexSnapshotPending}
+                openCodePreparationEvidence={openCodePreparationEvidence}
                 providerIds={selectedMemberProviders}
                 label="Selected providers"
                 layout="stacked"

--- a/test/renderer/components/common/ProviderActivityStatusStrip.test.ts
+++ b/test/renderer/components/common/ProviderActivityStatusStrip.test.ts
@@ -151,6 +151,73 @@ describe('ProviderActivityStatusStrip', () => {
     }
   );
 
+  it('shows OpenCode ready when selected scoped catalogs settle passive discovery', async () => {
+    const passiveProvider = createProvider({
+      providerId: 'opencode',
+      displayName: 'OpenCode',
+      authenticated: false,
+      verificationState: 'unknown',
+      statusCheckOutcome: 'model_only',
+      statusCheckErrorCode: 'partial_response',
+      modelCatalogRefreshState: 'loading',
+    });
+    passiveProvider.capabilities.teamLaunch = false;
+    const scopedProvider = createProvider({
+      providerId: 'opencode',
+      displayName: 'OpenCode',
+      authenticated: true,
+      statusCheckOutcome: 'authoritative',
+      modelCatalogRefreshState: 'ready',
+    });
+    scopedProvider.modelCatalog = {
+      schemaVersion: 1,
+      providerId: 'opencode',
+      source: 'app-server',
+      status: 'ready',
+      fetchedAt: '2020-01-01T00:00:00.000Z',
+      staleAt: '2100-01-01T00:00:00.000Z',
+      defaultModelId: 'openrouter/auto',
+      defaultLaunchModel: 'openrouter/auto',
+      diagnostics: { configReadState: 'ready', appServerState: 'healthy' },
+      models: [
+        {
+          id: 'openrouter/auto',
+          launchModel: 'openrouter/auto',
+          displayName: 'Auto',
+          hidden: false,
+          supportedReasoningEfforts: [],
+          defaultReasoningEffort: null,
+          inputModalities: ['text'],
+          supportsPersonality: false,
+          isDefault: true,
+          upgrade: false,
+          source: 'app-server',
+        },
+      ],
+    };
+    const host = document.createElement('div');
+    let root!: ReturnType<typeof createRoot>;
+
+    await act(async () => {
+      root = renderStrip(host, {
+        cliStatus: createMultimodelStatus([passiveProvider]),
+        providerStatusOverride: passiveProvider,
+        openCodePreparationEvidence: {
+          selectedModels: ['openrouter/auto'],
+          scopedStatusBySourceId: new Map([['openrouter', scopedProvider]]),
+        },
+        showReadyProviders: true,
+        readyStatusText: 'Ready',
+      });
+    });
+
+    expect(host.textContent).toContain('OpenCode');
+    expect(host.textContent).toContain('Ready');
+    expect(host.textContent).not.toContain('Checking...');
+    expect(host.textContent).not.toContain('Needs attention');
+    await act(async () => root.unmount());
+  });
+
   beforeEach(() => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
   });

--- a/test/renderer/features/runtime-provider-management/useOpenCodeProviderModelCatalog.test.tsx
+++ b/test/renderer/features/runtime-provider-management/useOpenCodeProviderModelCatalog.test.tsx
@@ -799,7 +799,7 @@ describe('useOpenCodeProviderModelCatalog', () => {
     });
   });
 
-  it('ages synthetic fresh authority to stale while retaining display models', async () => {
+  it('automatically refreshes synthetic authority at expiry while retaining display models', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-09-01T00:00:00.000Z'));
     apiMocks.loadModels.mockResolvedValue(
@@ -838,15 +838,19 @@ describe('useOpenCodeProviderModelCatalog', () => {
       await Promise.resolve();
     });
 
-    expect(observed?.catalogState).toBe('stale');
-    expect(observed?.freshModelCount).toBeNull();
+    expect(observed?.catalogState).toBe('fresh');
+    expect(observed?.freshModelCount).toBe(1);
     expect(observed?.providerStatus?.models).toEqual(['deepinfra/retained-model']);
     expect(observed?.providerStatus?.modelCatalog).toMatchObject({
-      status: 'stale',
-      fetchedAt: refreshedFetchedAt,
-      staleAt: refreshedStaleAt,
+      status: 'ready',
     });
-    expect(apiMocks.loadModels).toHaveBeenCalledTimes(2);
+    expect(Date.parse(observed?.providerStatus?.modelCatalog?.fetchedAt ?? '')).toBeGreaterThan(
+      Date.parse(refreshedFetchedAt)
+    );
+    expect(Date.parse(observed?.providerStatus?.modelCatalog?.staleAt ?? '')).toBeGreaterThan(
+      Date.parse(refreshedStaleAt)
+    );
+    expect(apiMocks.loadModels).toHaveBeenCalledTimes(3);
   });
 
   it('reports fresh scoped zero-model authority without treating stale data as authoritative', async () => {


### PR DESCRIPTION
## Summary
- make Create/Relaunch provider cards use the same scoped OpenCode readiness evidence as launch guards
- refresh scoped model catalogs when their two-minute authority window expires instead of leaving them stale forever
- keep optional skip available only while a real refresh/preflight remains unresolved

## Verification
- 15 focused readiness/catalog tests
- 67 Create/Relaunch/scoped-catalog tests
- TypeScript typecheck
- fast lint on changed files (one existing LaunchTeamDialog hook warning)
- source file size guard
- Prettier and git diff checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Provider status now displays OpenCode as **Ready** once scoped model discovery settles, avoiding misleading loading or error states.
  - Expired model catalogs now refresh automatically, keeping available models current instead of remaining marked as stale.

- **Tests**
  - Added coverage for automatic catalog refresh after the freshness period expires.
  - Added coverage confirming accurate OpenCode readiness messaging after scoped provider discovery settles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->