### PR TITLE
fix(team): restore provider preflight details

### DIFF
--- a/src/renderer/components/common/ProviderActivityStatusStrip.tsx
+++ b/src/renderer/components/common/ProviderActivityStatusStrip.tsx
@@ -38,6 +38,7 @@ interface ProviderActivityStatusStripProps {
   readonly layout?: 'inline' | 'stacked';
   readonly showReadyProviders?: boolean;
   readonly readyStatusText?: string;
+  readonly showDetailMessages?: boolean;
 }
 
 function getActivityToneStyles(tone: 'loading' | 'checked' | 'error'): {
@@ -260,6 +261,7 @@ export const ProviderActivityStatusStrip = ({
   layout = 'inline',
   showReadyProviders = false,
   readyStatusText,
+  showDetailMessages = false,
 }: ProviderActivityStatusStripProps): React.JSX.Element | null => {
   const { t } = useAppTranslation('settings');
   const { t: teamT } = useAppTranslation('team');
@@ -289,6 +291,13 @@ export const ProviderActivityStatusStrip = ({
     layout === 'stacked'
       ? 'flex min-w-0 w-full flex-wrap items-center gap-1.5'
       : 'flex min-w-0 flex-1 flex-wrap items-center gap-2';
+  const detailMessages = showDetailMessages
+    ? displayProviderIds.flatMap((providerId) => {
+        const provider = providerStateMap.get(providerId)?.provider;
+        const message = provider?.statusMessage?.trim() || provider?.detailMessage?.trim();
+        return provider && message ? [{ providerId, provider, message }] : [];
+      })
+    : [];
 
   return (
     <div className={rootClassName}>
@@ -354,6 +363,16 @@ export const ProviderActivityStatusStrip = ({
           );
         })}
       </div>
+      {detailMessages.length > 0 ? (
+        <div className="space-y-0.5 text-[10px] leading-relaxed text-[var(--color-text-muted)]">
+          {detailMessages.map(({ providerId, provider, message }) => (
+            <p key={providerId} data-testid={`provider-activity-detail-${providerId}`}>
+              {detailMessages.length > 1 ? `${provider.displayName}: ` : ''}
+              {message}
+            </p>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -2923,6 +2923,7 @@ export const CreateTeamDialog = ({
                   effectivePrepare.state === 'idle' || effectivePrepare.state === 'loading'
                 }
                 readyStatusText={t('create.prepare.readyStatus')}
+                showDetailMessages={effectivePrepare.state === 'idle'}
               />
             ) : null}
             {canCreate && launchTeam && prepareState === 'loading' ? (

--- a/test/renderer/components/common/ProviderActivityStatusStrip.test.ts
+++ b/test/renderer/components/common/ProviderActivityStatusStrip.test.ts
@@ -218,6 +218,44 @@ describe('ProviderActivityStatusStrip', () => {
     await act(async () => root.unmount());
   });
 
+  it('shows concise provider details only when requested', async () => {
+    const provider = createProvider({
+      providerId: 'codex',
+      displayName: 'Codex',
+      authenticated: true,
+      statusCheckOutcome: 'authoritative',
+      modelCatalogRefreshState: 'ready',
+      statusMessage: 'Codex native runtime ready',
+    });
+    provider.modelCatalog = {
+      schemaVersion: 1,
+      providerId: 'codex',
+      source: 'app-server',
+      status: 'ready',
+      fetchedAt: '2020-01-01T00:00:00.000Z',
+      staleAt: '2100-01-01T00:00:00.000Z',
+      defaultModelId: 'model',
+      defaultLaunchModel: 'model',
+      diagnostics: { configReadState: 'ready', appServerState: 'healthy' },
+      models: [],
+    };
+    const host = document.createElement('div');
+    let root!: ReturnType<typeof createRoot>;
+
+    await act(async () => {
+      root = renderStrip(host, {
+        cliStatus: createMultimodelStatus([provider]),
+        showReadyProviders: true,
+        showDetailMessages: true,
+      });
+    });
+
+    expect(host.querySelector('[data-testid="provider-activity-detail-codex"]')?.textContent).toBe(
+      'Codex native runtime ready'
+    );
+    await act(async () => root.unmount());
+  });
+
   beforeEach(() => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
   });


### PR DESCRIPTION
## Summary
- show the provider runtime detail directly below Selected providers while create-team preflight is idle
- keep deep/model probes confirmation-gated so opening the dialog cannot run project code
- hide the passive detail once the real preflight starts, avoiding duplicate copy

## Verification
- pnpm vitest run test/renderer/components/common/ProviderActivityStatusStrip.test.ts test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts --reporter=dot
- pnpm typecheck
- pnpm lint:fast:files -- src/renderer/components/common/ProviderActivityStatusStrip.tsx src/renderer/components/team/dialogs/CreateTeamDialog.tsx test/renderer/components/common/ProviderActivityStatusStrip.test.ts
- pnpm guard:source-file-size
- pnpm guard:team-provisioning-architecture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional provider detail messages to the activity status display.
  - Detail messages appear in the create-team dialog when preparation is idle.

- **Tests**
  - Added coverage confirming detail messages are shown only when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->