### PR TITLE
fix(team): keep provider preflight details visible

### DIFF
--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -2412,7 +2412,7 @@ export const CreateTeamDialog = ({
         }
       }}
     >
-      <DialogContent className="max-w-[52rem]">
+      <DialogContent className="max-h-[calc(100vh-2rem)] max-w-[52rem]">
         <ScopedCatalogLoaders configuration={openCodeCatalogLoaderConfiguration} />
         <DialogHeader>
           <DialogTitle className="text-sm">


### PR DESCRIPTION
## Summary
- let Create Team use the full viewport-safe dialog height
- keep provider preflight detail messages visible instead of clipping them below the fold

## Verification
- dev:mcp visual check on a disposable sandbox project
- provider detail bounds are inside the visible dialog viewport
- focused Vitest: 5 passed
- typecheck
- fast lint for the changed file
- source-size and Team Provisioning architecture guards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the create-team dialog layout by limiting its height to fit within the viewport, helping prevent content from extending beyond the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->