### PR TITLE
fix(team): restore automatic preflight and early mixed-team delivery

### DIFF
--- a/.github/workflows/runtime-bootstrap-smoke.yml
+++ b/.github/workflows/runtime-bootstrap-smoke.yml
@@ -10,6 +10,7 @@ on:
       - 'scripts/ci/verify-public-runtime-bootstrap.mjs'
       - 'scripts/ci/verify-runtime-lock.mjs'
       - 'scripts/lib/github-release-download-error.mjs'
+      - 'scripts/lib/runtime-cli-version.mjs'
       - '.github/workflows/runtime-bootstrap-smoke.yml'
   pull_request:
     paths:
@@ -18,6 +19,7 @@ on:
       - 'scripts/ci/verify-public-runtime-bootstrap.mjs'
       - 'scripts/ci/verify-runtime-lock.mjs'
       - 'scripts/lib/github-release-download-error.mjs'
+      - 'scripts/lib/runtime-cli-version.mjs'
       - '.github/workflows/runtime-bootstrap-smoke.yml'
 
 permissions:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,7 +34,7 @@ Target branch: `main`.
 
 Runtime gate:
 
-- Agent Teams runtime: `v0.0.81`.
+- Agent Teams runtime: `v0.0.82`.
 - Terminal Platform runtime: `v0.3.3`.
 
 Draft body source for GitHub release:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,7 +34,7 @@ Target branch: `main`.
 
 Runtime gate:
 
-- Agent Teams runtime: `v0.0.78`.
+- Agent Teams runtime: `v0.0.79`.
 - Terminal Platform runtime: `v0.3.3`.
 
 Draft body source for GitHub release:
@@ -53,7 +53,7 @@ Edit live agent settings, stop teams from either team view, and review product n
 ### Improvements
 
 - Browse models from every connected OpenCode provider with pagination, freshness indicators, and safer refreshes.
-- Check provider readiness when launching, with clearer blockers and connection guidance.
+- See automatic preflight progress for each selected model before creating or relaunching a team.
 - See first-launch project trust warnings only when Anthropic or Codex needs them.
 - Reuse existing worktrees without resetting branches or local changes, with branch details shown before launch.
 - Team leads now coordinate delegated tasks instead of duplicating their teammates' work.
@@ -63,7 +63,7 @@ Edit live agent settings, stop teams from either team view, and review product n
 - Codex teammates launch with ChatGPT or API-key authentication without refresh-token loops.
 - ChatGPT-incompatible Codex models are blocked before launch with a clear explanation.
 - Failed or superseded launches no longer leave teams stuck on `Launching...` or overwrite newer attempts.
-- Mixed Anthropic, Codex, and OpenCode teams recover from stale provider and session state.
+- Mixed-team assignments arrive during startup, and relaunch instructions run without needing another message.
 - Windows OpenCode teammates no longer flash console windows during tool calls.
 - Replayed agent turns no longer duplicate tasks, deleted-task notices, or final messages.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,7 +34,7 @@ Target branch: `main`.
 
 Runtime gate:
 
-- Agent Teams runtime: `v0.0.80`.
+- Agent Teams runtime: `v0.0.81`.
 - Terminal Platform runtime: `v0.3.3`.
 
 Draft body source for GitHub release:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,7 +34,7 @@ Target branch: `main`.
 
 Runtime gate:
 
-- Agent Teams runtime: `v0.0.79`.
+- Agent Teams runtime: `v0.0.80`.
 - Terminal Platform runtime: `v0.3.3`.
 
 Draft body source for GitHub release:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -970,6 +970,9 @@ gh run watch <RUN_ID> --repo 777genius/agent_teams_orchestrator
 After the runtime workflow succeeds, update this repo's `runtime.lock.json`:
 
 - `version`: the new runtime version, for example `0.0.52`
+- `cliVersion`: the exact first token of the released binary's `--version` output,
+  for example `2.1.251`. This can differ from the runtime release version for
+  Claude compatibility; when omitted, bootstrap expects `version`.
 - `sourceRef`: the matching runtime tag, for example `v0.0.52`
 - `releaseRepository`: the public repository that hosts runtime assets,
   `777genius/agent_teams_orchestrator_binaries`

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,39 +1,39 @@
 {
-  "version": "0.0.78",
-  "sourceRef": "v0.0.78",
+  "version": "0.0.79",
+  "sourceRef": "v0.0.79",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator_binaries",
-  "releaseTag": "runtime-v0.0.78",
+  "releaseTag": "runtime-v0.0.79",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.78.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.79.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "8d78198ccde5c2fa6ab99706f721d79b22fbe703c8424ea1d3481c2c5cd4d033"
+      "sha256": "fa56a9b9c7cd2ef2a908a47ba49813f1a1878e0bd21072bfc2fbcc2808e7f8e9"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.78.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.79.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "6bfeed94ac3e73a16cb5f220db43b56769e29c28e2b2fcd128c5a2f66096c05a"
+      "sha256": "c501605cd2034611f61484479f6cde0aaa1c9b1760976240a8be94e007a26800"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.78.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.79.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "b2d3eb0a3b9def66705c319045ba947e88de15f911f632049bd4f19d8b97ac1e"
+      "sha256": "59c8986d21834fa90c6e4abfaa09d0e83f6d94a8f23824bbfbbb42cd70ac81f4"
     },
     "win32-arm64": {
-      "file": "agent-teams-runtime-win32-arm64-v0.0.78.zip",
+      "file": "agent-teams-runtime-win32-arm64-v0.0.79.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "a8ac0addada8539833ea8db28bd1fd795b90eca9b85bbfdcf2cb8c4ca5bf9571"
+      "sha256": "c8173a0b74ee98f2f6bde870b70ac672771345a3f43d6133447428236695b979"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.78.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.79.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "f171d83e7e9863e3877282d387d8dcdc3a094d14085d4e2c679d87e9fc36ca8e"
+      "sha256": "0022ca9b58705ed84c3b0a1420917031f3aaa148440fba0cf047a9dc7e87bf9a"
     }
   }
 }

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,40 +1,40 @@
 {
-  "version": "0.0.81",
+  "version": "0.0.82",
   "cliVersion": "2.1.251",
-  "sourceRef": "v0.0.81",
+  "sourceRef": "v0.0.82",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator_binaries",
-  "releaseTag": "runtime-v0.0.81",
+  "releaseTag": "runtime-v0.0.82",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.81.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.82.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "bd7ced69552a3eebc6f2e9355e521dd0a13d0c8f3bc64779ec53034bd828b225"
+      "sha256": "e5f0c05a5625bb16bbd292b1a968f046df47ffb2809171d7243f708a8fbb8a31"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.81.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.82.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "6f89a045b1e31044f09dec8945fd2ee0c529f805ee667cf993cec81e338cadd1"
+      "sha256": "c7b6343e1621706d7ea3d1b5a15a82709875bb70262ecc113d03d271900197e3"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.81.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.82.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "0b7d97c4d3450cc7830cca26088dfde92f0ae38fbeb0d51d9d0a1589c739ac2c"
+      "sha256": "b52b1bb94d21cfd6af1123145ac32dd015350f33f4af3dd4c6f520f9e77fb8ec"
     },
     "win32-arm64": {
-      "file": "agent-teams-runtime-win32-arm64-v0.0.81.zip",
+      "file": "agent-teams-runtime-win32-arm64-v0.0.82.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "7d0acd88b1304b2394eb29d8922206c96f1b614b488d1039f80d1317fb8d3c29"
+      "sha256": "756ed9bf2887c0f5579e156327e8ee8fe52df52503bc7956bdb16c36587f6be5"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.81.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.82.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "781b69b42be9de3e9cec51b7ac66b9581f9821ab2f4cbc8616c4dfa5d063a84e"
+      "sha256": "f94ccc9c34d03c565ed0af60099e7710d8005d787da378560c3f30b6e102b1fd"
     }
   }
 }

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,40 +1,40 @@
 {
-  "version": "0.0.79",
+  "version": "0.0.80",
   "cliVersion": "2.1.251",
-  "sourceRef": "v0.0.79",
+  "sourceRef": "v0.0.80",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator_binaries",
-  "releaseTag": "runtime-v0.0.79",
+  "releaseTag": "runtime-v0.0.80",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.79.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.80.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "fa56a9b9c7cd2ef2a908a47ba49813f1a1878e0bd21072bfc2fbcc2808e7f8e9"
+      "sha256": "835ee00803da6909998cc31463545baef48c846bb9c64d5f84a042fa484ae4bf"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.79.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.80.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "c501605cd2034611f61484479f6cde0aaa1c9b1760976240a8be94e007a26800"
+      "sha256": "5d7a415a321f4ab04325cf8882dff88af9a9db23bd5b869ff7ad4488f13c16f3"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.79.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.80.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "59c8986d21834fa90c6e4abfaa09d0e83f6d94a8f23824bbfbbb42cd70ac81f4"
+      "sha256": "488cc1220610a1af172c763219a4e57db0bf6c21bb17d8e55e2a44baa32a4395"
     },
     "win32-arm64": {
-      "file": "agent-teams-runtime-win32-arm64-v0.0.79.zip",
+      "file": "agent-teams-runtime-win32-arm64-v0.0.80.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "c8173a0b74ee98f2f6bde870b70ac672771345a3f43d6133447428236695b979"
+      "sha256": "663a33d073b8a8e552b187807c609acf55f1b64b48ccb9bc33d5c1e2d3ea9a5d"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.79.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.80.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "0022ca9b58705ed84c3b0a1420917031f3aaa148440fba0cf047a9dc7e87bf9a"
+      "sha256": "8cc7dd1e6caa18a5d9770cd8bef2ddfb536f9f1e9e83df6077491f221ee03646"
     }
   }
 }

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,40 +1,40 @@
 {
-  "version": "0.0.80",
+  "version": "0.0.81",
   "cliVersion": "2.1.251",
-  "sourceRef": "v0.0.80",
+  "sourceRef": "v0.0.81",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator_binaries",
-  "releaseTag": "runtime-v0.0.80",
+  "releaseTag": "runtime-v0.0.81",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.80.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.81.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "835ee00803da6909998cc31463545baef48c846bb9c64d5f84a042fa484ae4bf"
+      "sha256": "bd7ced69552a3eebc6f2e9355e521dd0a13d0c8f3bc64779ec53034bd828b225"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.80.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.81.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "5d7a415a321f4ab04325cf8882dff88af9a9db23bd5b869ff7ad4488f13c16f3"
+      "sha256": "6f89a045b1e31044f09dec8945fd2ee0c529f805ee667cf993cec81e338cadd1"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.80.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.81.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "488cc1220610a1af172c763219a4e57db0bf6c21bb17d8e55e2a44baa32a4395"
+      "sha256": "0b7d97c4d3450cc7830cca26088dfde92f0ae38fbeb0d51d9d0a1589c739ac2c"
     },
     "win32-arm64": {
-      "file": "agent-teams-runtime-win32-arm64-v0.0.80.zip",
+      "file": "agent-teams-runtime-win32-arm64-v0.0.81.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "663a33d073b8a8e552b187807c609acf55f1b64b48ccb9bc33d5c1e2d3ea9a5d"
+      "sha256": "7d0acd88b1304b2394eb29d8922206c96f1b614b488d1039f80d1317fb8d3c29"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.80.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.81.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "8cc7dd1e6caa18a5d9770cd8bef2ddfb536f9f1e9e83df6077491f221ee03646"
+      "sha256": "781b69b42be9de3e9cec51b7ac66b9581f9821ab2f4cbc8616c4dfa5d063a84e"
     }
   }
 }

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,5 +1,6 @@
 {
   "version": "0.0.79",
+  "cliVersion": "2.1.251",
   "sourceRef": "v0.0.79",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator_binaries",

--- a/scripts/ci/verify-public-runtime-bootstrap.mjs
+++ b/scripts/ci/verify-public-runtime-bootstrap.mjs
@@ -7,9 +7,15 @@ import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
+import {
+  getExpectedRuntimeCliVersion,
+  matchesRuntimeCliVersion,
+} from '../lib/runtime-cli-version.mjs';
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..', '..');
 const runtimeLock = JSON.parse(fs.readFileSync(path.join(repoRoot, 'runtime.lock.json'), 'utf8'));
+const expectedCliVersion = getExpectedRuntimeCliVersion(runtimeLock);
 const cacheRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-teams-public-runtime-e2e-'));
 const platformKey = `${process.platform}-${process.arch}`;
 
@@ -86,9 +92,13 @@ try {
     maxBuffer: 1024 * 1024,
   });
   const versionText = `${version.stdout ?? ''}\n${version.stderr ?? ''}`.trim();
-  if (version.error || version.status !== 0 || !versionText.includes(runtimeLock.version)) {
+  if (
+    version.error ||
+    version.status !== 0 ||
+    !matchesRuntimeCliVersion(version.stdout, expectedCliVersion)
+  ) {
     fail(
-      `expected executable runtime ${runtimeLock.version}, got ${versionText || version.error?.message || `exit ${version.status}`}`,
+      `expected executable runtime ${runtimeLock.version} with CLI version ${expectedCliVersion}, got ${versionText || version.error?.message || `exit ${version.status}`}`,
       version
     );
   }

--- a/scripts/ci/verify-runtime-lock.mjs
+++ b/scripts/ci/verify-runtime-lock.mjs
@@ -4,6 +4,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { getExpectedRuntimeCliVersion } from '../lib/runtime-cli-version.mjs';
+
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..', '..');
 const runtimeLockPath = path.join(repoRoot, 'runtime.lock.json');
@@ -30,6 +32,12 @@ const publicRuntimeReleaseRepository = '777genius/agent_teams_orchestrator_binar
 
 if (!version) {
   fail('version is required');
+}
+
+try {
+  getExpectedRuntimeCliVersion(lock);
+} catch (error) {
+  fail(error.message);
 }
 
 if (!sourceRef || sourceRef !== `v${version}`) {

--- a/scripts/dev-with-runtime.mjs
+++ b/scripts/dev-with-runtime.mjs
@@ -13,6 +13,10 @@ import { fileURLToPath } from 'node:url';
 import { formatGitHubReleaseDownloadError } from './lib/github-release-download-error.mjs';
 import { ensureMinimumNodeOldSpaceEnv } from './lib/node-options.mjs';
 import { verifyRuntimeArchiveChecksum } from './lib/runtime-archive-checksum.mjs';
+import {
+  getExpectedRuntimeCliVersion,
+  matchesRuntimeCliVersion,
+} from './lib/runtime-cli-version.mjs';
 import { spawnSyncWithWindowsShell } from './lib/windows-shell-spawn.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
@@ -409,7 +413,7 @@ function isCachedBinaryValid(binaryPath, expectedVersion) {
   }
 
   try {
-    return readBinaryVersion(binaryPath).includes(expectedVersion);
+    return matchesRuntimeCliVersion(readBinaryVersion(binaryPath), expectedVersion);
   } catch {
     return false;
   }
@@ -618,6 +622,7 @@ async function acquireBootstrapLock(lockPath) {
 
 async function ensureBootstrappedRuntime() {
   const runtimeLock = readRuntimeLock();
+  const expectedCliVersion = getExpectedRuntimeCliVersion(runtimeLock);
   const platformKey = getPlatformAssetKey();
   const asset = runtimeLock.assets[platformKey];
   if (!asset) {
@@ -627,7 +632,7 @@ async function ensureBootstrappedRuntime() {
   const cacheDir = path.join(runtimeCacheRoot, runtimeLock.version, platformKey);
   const cachedBinaryPath = path.join(cacheDir, asset.binaryName);
 
-  if (isCachedBinaryValid(cachedBinaryPath, runtimeLock.version)) {
+  if (isCachedBinaryValid(cachedBinaryPath, expectedCliVersion)) {
     return {
       binaryPath: cachedBinaryPath,
       versionText: readBinaryVersion(cachedBinaryPath),
@@ -641,7 +646,7 @@ async function ensureBootstrappedRuntime() {
   const lockHandle = await acquireBootstrapLock(path.join(cacheDir, '.bootstrap.lock'));
 
   try {
-    if (isCachedBinaryValid(cachedBinaryPath, runtimeLock.version)) {
+    if (isCachedBinaryValid(cachedBinaryPath, expectedCliVersion)) {
       return {
         binaryPath: cachedBinaryPath,
         versionText: readBinaryVersion(cachedBinaryPath),
@@ -679,10 +684,10 @@ async function ensureBootstrappedRuntime() {
         await fs.promises.rename(nextBinaryPath, cachedBinaryPath);
 
         const versionText = readBinaryVersion(cachedBinaryPath);
-        if (!versionText.includes(runtimeLock.version)) {
+        if (!matchesRuntimeCliVersion(versionText, expectedCliVersion)) {
           await fs.promises.rm(cachedBinaryPath, { force: true });
           throw new Error(
-            `Bootstrapped runtime version mismatch. Expected ${runtimeLock.version}, got: ${versionText}`
+            `Bootstrapped runtime CLI version mismatch for release ${runtimeLock.version}. Expected ${expectedCliVersion}, got: ${versionText}`
           );
         }
 

--- a/scripts/dev-with-runtime.mjs
+++ b/scripts/dev-with-runtime.mjs
@@ -14,6 +14,7 @@ import { formatGitHubReleaseDownloadError } from './lib/github-release-download-
 import { ensureMinimumNodeOldSpaceEnv } from './lib/node-options.mjs';
 import { verifyRuntimeArchiveChecksum } from './lib/runtime-archive-checksum.mjs';
 import {
+  formatRuntimeVersionForDisplay,
   getExpectedRuntimeCliVersion,
   matchesRuntimeCliVersion,
 } from './lib/runtime-cli-version.mjs';
@@ -33,7 +34,6 @@ const runtimeCacheRoot = process.env.CLAUDE_DEV_RUNTIME_CACHE_ROOT?.trim()
 const scriptArgs = process.argv.slice(2);
 const shouldPrintRuntimePath = scriptArgs.includes('--print-runtime-path');
 const electronViteArgs = scriptArgs.filter((arg) => arg !== '--print-runtime-path' && arg !== '--');
-const runtimeDisplayName = 'teams orchestrator';
 const remoteDebuggingPortArg = '--remoteDebuggingPort';
 const terminalPlatformRootEnv = 'CLAUDE_TERMINAL_PLATFORM_ROOT';
 const legacyTerminalPlatformRootEnv = 'TERMINAL_PLATFORM_ROOT';
@@ -378,16 +378,6 @@ async function resolveElectronViteArgs(args) {
 
 function readBinaryVersion(binaryPath) {
   return runAndCapture(binaryPath, ['--version']);
-}
-
-function formatRuntimeVersionForDisplay(versionText) {
-  const trimmed = versionText.trim();
-  if (!trimmed) {
-    return runtimeDisplayName;
-  }
-
-  const versionOnly = trimmed.replace(/\s*\([^)]*\)\s*$/, '');
-  return `${versionOnly} (${runtimeDisplayName})`;
 }
 
 function isExecutable(filePath) {

--- a/scripts/lib/runtime-cli-version.mjs
+++ b/scripts/lib/runtime-cli-version.mjs
@@ -1,5 +1,12 @@
 const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
 
+export function formatRuntimeVersionForDisplay(versionText) {
+  const trimmed = versionText.trim();
+  if (!trimmed) return 'teams orchestrator';
+  const versionOnly = trimmed.replace(/\s*\([^)]*\)\s*$/, '');
+  return `${versionOnly} (teams orchestrator)`;
+}
+
 /**
  * Release identity remains lock.version plus the pinned archive checksum.
  * --version may report a separate Claude compatibility version.

--- a/scripts/lib/runtime-cli-version.mjs
+++ b/scripts/lib/runtime-cli-version.mjs
@@ -1,0 +1,20 @@
+const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u;
+
+/**
+ * Release identity remains lock.version plus the pinned archive checksum.
+ * --version may report a separate Claude compatibility version.
+ */
+export function getExpectedRuntimeCliVersion(runtimeLock) {
+  const field = Object.hasOwn(runtimeLock, 'cliVersion') ? 'cliVersion' : 'version';
+  const value = runtimeLock[field];
+  if (typeof value !== 'string' || !VERSION_PATTERN.test(value.trim())) {
+    throw new Error(`runtime.lock.json ${field} must be a version such as 0.0.79 or 2.1.251`);
+  }
+  return value.trim();
+}
+
+export function matchesRuntimeCliVersion(versionText, expectedVersion) {
+  return (
+    typeof versionText === 'string' && versionText.trim().split(/\s+/u, 1)[0] === expectedVersion
+  );
+}

--- a/src/features/codex-runtime-installer/main/infrastructure/CodexRuntimeInstallerService.ts
+++ b/src/features/codex-runtime-installer/main/infrastructure/CodexRuntimeInstallerService.ts
@@ -17,6 +17,11 @@ import { promises as fsp, readFileSync } from 'fs';
 import path from 'path';
 import { gunzipSync } from 'zlib';
 
+import {
+  CODEX_RUNTIME_VERSION_TIMEOUT_MS as VERSION_TIMEOUT_MS,
+  probeManagedCodexVersion,
+} from './probeManagedCodexVersion';
+
 import type { CodexRuntimeInstallerPort } from '../../core/application/ports/CodexRuntimeInstallerPort';
 import type {
   CodexRuntimeInstallProgress,
@@ -38,7 +43,6 @@ const METADATA_FETCH_TIMEOUT_MS = 60_000;
 // downloads time out only after a full minute without network progress.
 const PACKAGE_DOWNLOAD_IDLE_TIMEOUT_MS = 60_000;
 const LATEST_VERSION_TIMEOUT_MS = 8_000;
-const VERSION_TIMEOUT_MS = 10_000;
 
 interface NpmPackageMetadata {
   name?: string;
@@ -120,10 +124,7 @@ export async function resolveVerifiedAppManagedCodexRuntimeBinaryPath(): Promise
     return null;
   }
   try {
-    await execCli(binaryPath, ['--version'], {
-      timeout: VERSION_TIMEOUT_MS,
-      windowsHide: true,
-    });
+    await probeManagedCodexVersion(binaryPath);
     return binaryPath;
   } catch {
     return null;
@@ -599,10 +600,7 @@ export class CodexRuntimeInstallerService implements CodexRuntimeInstallerPort {
       };
     }
     try {
-      const { stdout } = await execCli(manifest.binaryPath, ['--version'], {
-        timeout: VERSION_TIMEOUT_MS,
-        windowsHide: true,
-      });
+      const stdout = await probeManagedCodexVersion(manifest.binaryPath);
       return {
         installed: true,
         binaryPath: manifest.binaryPath,

--- a/src/features/codex-runtime-installer/main/infrastructure/probeManagedCodexVersion.ts
+++ b/src/features/codex-runtime-installer/main/infrastructure/probeManagedCodexVersion.ts
@@ -1,0 +1,40 @@
+import { execCli } from '@main/utils/childProcess';
+import { createLogger } from '@shared/utils/logger';
+
+export const CODEX_RUNTIME_VERSION_TIMEOUT_MS = 10_000;
+
+const logger = createLogger('CodexRuntimeInstallerService');
+
+export async function probeManagedCodexVersion(binaryPath: string): Promise<string> {
+  const probe = async (attempt: number): Promise<string> => {
+    try {
+      const { stdout } = await execCli(binaryPath, ['--version'], {
+        timeout: CODEX_RUNTIME_VERSION_TIMEOUT_MS,
+        windowsHide: true,
+      });
+      return stdout;
+    } catch (error) {
+      const failure = error as { code?: string | number; signal?: string } | null;
+      const timedOut =
+        failure?.code === 'ETIMEDOUT' ||
+        (error instanceof Error &&
+          error.message ===
+            `Command timed out after ${CODEX_RUNTIME_VERSION_TIMEOUT_MS}ms: ${binaryPath} --version`);
+      const retrying = attempt === 1 && timedOut;
+      // Raw errors can include child output; diagnostics deliberately record metadata only.
+      logger.warn('Managed Codex version probe failed', {
+        binaryPath,
+        attempt,
+        timedOut,
+        code: failure?.code,
+        signal: failure?.signal,
+        retrying,
+      });
+      if (!retrying) {
+        throw error;
+      }
+      return probe(2);
+    }
+  };
+  return probe(1);
+}

--- a/src/features/runtime-provider-management/main/infrastructure/AgentTeamsRuntimeProviderManagementCliClient.test.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/AgentTeamsRuntimeProviderManagementCliClient.test.ts
@@ -21,9 +21,9 @@ vi.mock('@main/services/runtime/providerAwareCliEnv', () => ({
   buildProviderAwareCliEnv: vi.fn(async () => ({ env: {} })),
 }));
 
-import {
-  AgentTeamsRuntimeProviderManagementCliClient,
-} from './AgentTeamsRuntimeProviderManagementCliClient';
+import { AgentTeamsRuntimeProviderManagementCliClient } from './AgentTeamsRuntimeProviderManagementCliClient';
+
+import type { RuntimeProviderManagementDirectoryResponse } from '../../contracts';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -58,9 +58,7 @@ describe('AgentTeamsRuntimeProviderManagementCliClient model refresh generations
   it('does not join a pre-refresh in-flight request or cache its response as fresh', async () => {
     const oldRequest = deferred<{ stdout: string; stderr: string }>();
     const refreshRequest = deferred<{ stdout: string; stderr: string }>();
-    execCliMock
-      .mockReturnValueOnce(oldRequest.promise)
-      .mockReturnValueOnce(refreshRequest.promise);
+    execCliMock.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(refreshRequest.promise);
     const client = new AgentTeamsRuntimeProviderManagementCliClient();
     const input = {
       runtimeId: 'opencode' as const,
@@ -98,9 +96,7 @@ describe('AgentTeamsRuntimeProviderManagementCliClient model refresh generations
   it('fences recovered model JSON from a superseded generation', async () => {
     const oldRequest = deferred<{ stdout: string; stderr: string }>();
     const refreshRequest = deferred<{ stdout: string; stderr: string }>();
-    execCliMock
-      .mockReturnValueOnce(oldRequest.promise)
-      .mockReturnValueOnce(refreshRequest.promise);
+    execCliMock.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(refreshRequest.promise);
     const client = new AgentTeamsRuntimeProviderManagementCliClient();
     const input = {
       runtimeId: 'opencode' as const,
@@ -134,6 +130,239 @@ describe('AgentTeamsRuntimeProviderManagementCliClient model refresh generations
     await expect(client.loadModels(input)).resolves.toMatchObject({
       models: { diagnostics: ['fresh'], catalogState: 'fresh' },
     });
+    expect(execCliMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+const inventoryTimeout =
+  'OpenCode inventory probe timed out after 8000ms during prepare managed OpenCode profile: reconcile managed auth stores';
+const directoryInput = {
+  runtimeId: 'opencode' as const,
+  projectPath: '/test/project',
+  summary: true,
+  query: null,
+  filter: 'all' as const,
+  limit: 100,
+  cursor: null,
+};
+
+function directoryResponse(fallback = false): RuntimeProviderManagementDirectoryResponse {
+  return {
+    schemaVersion: 1,
+    runtimeId: 'opencode',
+    directory: {
+      runtimeId: 'opencode',
+      totalCount: 1,
+      returnedCount: 1,
+      query: null,
+      filter: 'all',
+      limit: 100,
+      cursor: null,
+      nextCursor: null,
+      fetchedAt: '2026-09-06T00:00:00.000Z',
+      diagnostics: fallback ? [inventoryTimeout] : [],
+      entries: [
+        {
+          providerId: 'openrouter',
+          displayName: 'OpenRouter',
+          state: fallback ? 'not-connected' : 'connected',
+          setupKind: 'connect-api-key',
+          ownership: [],
+          recommended: false,
+          modelCount: fallback ? null : 505,
+          authMethods: [],
+          defaultModelId: null,
+          sources: fallback ? ['seed'] : ['opencode-provider'],
+          sourceLabel: null,
+          providerSource: null,
+          detail: null,
+          actions: [],
+          metadata: {
+            hasKnownModels: !fallback,
+            requiresManualConfig: false,
+            supportedInlineAuth: true,
+            configuredAuthless: false,
+          },
+        },
+      ],
+    },
+  };
+}
+
+const directoryOutput = (response: RuntimeProviderManagementDirectoryResponse) => ({
+  stdout: JSON.stringify(response),
+  stderr: '',
+});
+
+describe('AgentTeamsRuntimeProviderManagementCliClient passive directory timeout', () => {
+  beforeEach(() => {
+    execCliMock.mockReset();
+  });
+
+  it('returns a recoverable error without retrying or caching the seed-only timeout', async () => {
+    execCliMock.mockResolvedValue(directoryOutput(directoryResponse(true)));
+    const client = new AgentTeamsRuntimeProviderManagementCliClient();
+    const response = await client.loadProviderDirectory(directoryInput);
+    expect(response.directory).toBeUndefined();
+    expect(response.error).toMatchObject({ code: 'runtime-unhealthy', recoverable: true });
+    expect(response.error!.message).toContain(inventoryTimeout);
+    expect(execCliMock).toHaveBeenCalledTimes(1);
+    await client.loadProviderDirectory(directoryInput);
+    expect(execCliMock).toHaveBeenCalledTimes(2);
+    for (const [, args] of execCliMock.mock.calls) expect(args).toContain('--summary');
+  });
+
+  it('keeps the previous catalog on a failed refresh without caching the error', async () => {
+    const good = directoryResponse();
+    execCliMock
+      .mockResolvedValueOnce(directoryOutput(good))
+      .mockResolvedValueOnce(directoryOutput(directoryResponse(true)))
+      .mockResolvedValueOnce(directoryOutput(good));
+    const client = new AgentTeamsRuntimeProviderManagementCliClient();
+    await client.loadProviderDirectory(directoryInput);
+    const failure = await client.loadProviderDirectory({ ...directoryInput, refresh: true });
+    expect(failure.directory).toEqual(good.directory);
+    expect(failure.error?.code).toBe('runtime-unhealthy');
+    expect(execCliMock).toHaveBeenCalledTimes(2);
+    expect((await client.loadProviderDirectory(directoryInput)).error).toBeUndefined();
+    expect(execCliMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('never borrows a previous directory from another project, filter or page', async () => {
+    execCliMock
+      .mockResolvedValueOnce(directoryOutput(directoryResponse()))
+      .mockResolvedValue(directoryOutput(directoryResponse(true)));
+    const client = new AgentTeamsRuntimeProviderManagementCliClient();
+    await client.loadProviderDirectory(directoryInput);
+    for (const scope of [
+      { projectPath: '/test/other' },
+      { filter: 'connected' as const },
+      { cursor: '100' },
+    ]) {
+      const response = await client.loadProviderDirectory({ ...directoryInput, ...scope });
+      expect(response.directory).toBeUndefined();
+      expect(response.error?.code).toBe('runtime-unhealthy');
+    }
+  });
+
+  it('handles an empty filtered timeout result as unknown rather than no connected providers', async () => {
+    const response = directoryResponse(true);
+    response.directory!.entries = [];
+    response.directory!.totalCount = 0;
+    response.directory!.returnedCount = 0;
+    execCliMock.mockResolvedValue(directoryOutput(response));
+    expect(
+      (
+        await new AgentTeamsRuntimeProviderManagementCliClient().loadProviderDirectory({
+          ...directoryInput,
+          filter: 'connected',
+        })
+      ).error?.code
+    ).toBe('runtime-unhealthy');
+    expect(execCliMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { label: 'no diagnostic', diagnostics: [] },
+    {
+      label: 'profile-scope warning',
+      diagnostics: ['OpenCode profile scope auth evidence is invalid'],
+    },
+    { label: 'other timeout', diagnostics: ['OpenCode host startup timed out'] },
+  ])('preserves legitimate seed-only results with $label', async ({ diagnostics }) => {
+    const response = directoryResponse(true);
+    response.directory!.diagnostics = diagnostics;
+    execCliMock.mockResolvedValue(directoryOutput(response));
+    const client = new AgentTeamsRuntimeProviderManagementCliClient();
+    expect(await client.loadProviderDirectory(directoryInput)).toEqual(response);
+    expect(await client.loadProviderDirectory(directoryInput)).toEqual(response);
+    expect(execCliMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['connected', 'configured-authless', 'inventory-source'] as const)(
+    'does not discard %s evidence when a timeout warning accompanies it',
+    async (evidence) => {
+      const response = directoryResponse(true);
+      const entry = response.directory!.entries[0];
+      if (evidence === 'connected') entry.state = 'connected';
+      if (evidence === 'configured-authless') entry.metadata.configuredAuthless = true;
+      if (evidence === 'inventory-source') entry.sources = ['seed', 'inventory'];
+      execCliMock.mockResolvedValue(directoryOutput(response));
+      expect(
+        await new AgentTeamsRuntimeProviderManagementCliClient().loadProviderDirectory(
+          directoryInput
+        )
+      ).toEqual(response);
+      expect(execCliMock).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('leaves explicit non-summary calls unchanged', async () => {
+    const response = directoryResponse(true);
+    execCliMock.mockResolvedValue(directoryOutput(response));
+    expect(
+      await new AgentTeamsRuntimeProviderManagementCliClient().loadProviderDirectory({
+        ...directoryInput,
+        summary: false,
+      })
+    ).toEqual(response);
+    expect(execCliMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the existing in-flight request without adding a timeout retry', async () => {
+    const pending = deferred<ReturnType<typeof directoryOutput>>();
+    execCliMock.mockReturnValueOnce(pending.promise);
+    const client = new AgentTeamsRuntimeProviderManagementCliClient();
+    const first = client.loadProviderDirectory(directoryInput);
+    const joined = client.loadProviderDirectory(directoryInput);
+    await vi.waitFor(() => expect(execCliMock).toHaveBeenCalledTimes(1));
+    pending.resolve(directoryOutput(directoryResponse(true)));
+    const [left, right] = await Promise.all([first, joined]);
+    expect(left).toEqual(right);
+    expect(left.error?.code).toBe('runtime-unhealthy');
+    expect(execCliMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes timeout JSON recovered from a failed command without caching it', async () => {
+    execCliMock.mockRejectedValue(
+      Object.assign(new Error('Command failed after JSON'), {
+        stdout: JSON.stringify(directoryResponse(true)),
+      })
+    );
+    const client = new AgentTeamsRuntimeProviderManagementCliClient();
+    expect((await client.loadProviderDirectory(directoryInput)).error?.code).toBe(
+      'runtime-unhealthy'
+    );
+    await client.loadProviderDirectory(directoryInput);
+    expect(execCliMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves the no-cache policy for successful JSON recovered from a failed command', async () => {
+    execCliMock.mockRejectedValue(
+      Object.assign(new Error('Command failed after JSON'), {
+        stdout: JSON.stringify(directoryResponse()),
+      })
+    );
+    const client = new AgentTeamsRuntimeProviderManagementCliClient();
+    await client.loadProviderDirectory(directoryInput);
+    await client.loadProviderDirectory(directoryInput);
+    expect(execCliMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let a late timeout overwrite a newer successful refresh', async () => {
+    const stale = deferred<ReturnType<typeof directoryOutput>>();
+    execCliMock
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValueOnce(directoryOutput(directoryResponse()));
+    const client = new AgentTeamsRuntimeProviderManagementCliClient();
+    const old = client.loadProviderDirectory(directoryInput);
+    await vi.waitFor(() => expect(execCliMock).toHaveBeenCalledTimes(1));
+    await client.loadProviderDirectory({ ...directoryInput, refresh: true });
+    stale.resolve(directoryOutput(directoryResponse(true)));
+    expect((await old).error?.code).toBe('runtime-unhealthy');
+    expect((await client.loadProviderDirectory(directoryInput)).directory?.entries[0].state).toBe(
+      'connected'
+    );
     expect(execCliMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/features/runtime-provider-management/main/infrastructure/AgentTeamsRuntimeProviderManagementCliClient.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/AgentTeamsRuntimeProviderManagementCliClient.ts
@@ -32,6 +32,7 @@ import {
   sanitizeCommandErrorMessage,
   truncateCommandErrorDetail,
 } from './runtimeProviderCommandPresentation';
+import { normalizeRuntimeProviderDirectoryResponse } from './runtimeProviderDirectoryResponse';
 import { RuntimeProviderModelRequestTracker } from './runtimeProviderModelRequestTracker';
 import {
   RUNTIME_PROVIDER_MODEL_PROBE_COMMAND_TIMEOUT_MS,
@@ -1606,6 +1607,7 @@ export class AgentTeamsRuntimeProviderManagementCliClient implements RuntimeProv
   ): Promise<RuntimeProviderManagementDirectoryResponse> {
     const projectPath = normalizeProjectPath(input.projectPath);
     const cacheKey = this.getDirectoryResponseCacheKey(input, projectPath);
+    const previous = this.directoryResponseCache.get(cacheKey)?.response;
     const refreshInFlightKey = `refresh:${cacheKey}`;
     const cachedInFlightKey = `cached:${cacheKey}`;
     if (input.refresh) {
@@ -1634,12 +1636,17 @@ export class AgentTeamsRuntimeProviderManagementCliClient implements RuntimeProv
       return existingRequest;
     }
 
-    const request = this.loadProviderDirectoryUncached(
-      input,
-      projectPath,
-      cacheKey,
-      this.directoryResponseCacheGeneration
-    );
+    const generation = this.directoryResponseCacheGeneration;
+    const normalize = (response: RuntimeProviderManagementDirectoryResponse) =>
+      normalizeRuntimeProviderDirectoryResponse(response, input.summary === true, previous);
+    const request = this.loadProviderDirectoryUncached(input, projectPath, (response) =>
+      this.writeDirectoryResponseCache(
+        cacheKey,
+        normalize(response),
+        this.getDirectoryResponseCacheTtlMs(input),
+        generation
+      )
+    ).then(normalize);
     this.directoryResponseInFlight.set(inFlightKey, request);
     try {
       return await request;
@@ -1653,8 +1660,9 @@ export class AgentTeamsRuntimeProviderManagementCliClient implements RuntimeProv
   private async loadProviderDirectoryUncached(
     input: RuntimeProviderManagementLoadDirectoryInput,
     projectPath: string | null,
-    cacheKey: string,
-    cacheGeneration: number
+    onSuccess: (
+      response: RuntimeProviderManagementDirectoryResponse
+    ) => RuntimeProviderManagementDirectoryResponse
   ): Promise<RuntimeProviderManagementDirectoryResponse> {
     const { binaryPath, env } = await resolveCliEnv();
     if (!binaryPath) {
@@ -1665,9 +1673,7 @@ export class AgentTeamsRuntimeProviderManagementCliClient implements RuntimeProv
     }
 
     const args = ['runtime', 'providers', 'directory', '--runtime', input.runtimeId, '--json'];
-    if (input.summary === true) {
-      args.push('--summary');
-    }
+    if (input.summary === true) args.push('--summary');
     appendOptionalArg(args, '--project-path', projectPath);
     appendOptionalArg(args, '--query', input.query ?? null);
     appendOptionalArg(args, '--filter', input.filter ?? null);
@@ -1693,15 +1699,12 @@ export class AgentTeamsRuntimeProviderManagementCliClient implements RuntimeProv
         args,
         runtimeProviderCommandOptions({ env, timeout: COMMAND_TIMEOUT_MS }, projectPath)
       );
-      return this.writeDirectoryResponseCache(
-        cacheKey,
+      return onSuccess(
         extractJsonObjectWithContext<RuntimeProviderManagementDirectoryResponse>(
           stdout,
           context,
           stderr
-        ),
-        this.getDirectoryResponseCacheTtlMs(input),
-        cacheGeneration
+        )
       );
     } catch (error) {
       const failure = normalizeCommandFailure(error, context);
@@ -1720,15 +1723,12 @@ export class AgentTeamsRuntimeProviderManagementCliClient implements RuntimeProv
                 args,
                 runtimeProviderCommandOptions({ env, timeout: COMMAND_TIMEOUT_MS }, projectPath)
               );
-              return this.writeDirectoryResponseCache(
-                cacheKey,
+              return onSuccess(
                 extractJsonObjectWithContext<RuntimeProviderManagementDirectoryResponse>(
                   retryResult.stdout,
                   context,
                   retryResult.stderr
-                ),
-                this.getDirectoryResponseCacheTtlMs(input),
-                cacheGeneration
+                )
               );
             } catch {
               // Retry also failed; fall through to return the original error.

--- a/src/features/runtime-provider-management/main/infrastructure/runtimeProviderDirectoryResponse.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/runtimeProviderDirectoryResponse.ts
@@ -1,0 +1,39 @@
+import type { RuntimeProviderManagementDirectoryResponse } from '../../contracts';
+
+/** A timed-out passive inventory is unknown, not evidence that every provider disconnected. */
+export function normalizeRuntimeProviderDirectoryResponse(
+  response: RuntimeProviderManagementDirectoryResponse,
+  summary: boolean,
+  previous?: RuntimeProviderManagementDirectoryResponse
+): RuntimeProviderManagementDirectoryResponse {
+  if (!summary || response.runtimeId !== 'opencode') return response;
+  const directory = response.directory;
+  const timeout = directory?.diagnostics.find((message) =>
+    /^OpenCode inventory probe timed out after \d+ms(?: during |$)/u.test(message)
+  );
+  if (
+    !response.error &&
+    timeout &&
+    directory &&
+    directory.entries.every(
+      (entry) =>
+        entry.state !== 'connected' &&
+        !entry.metadata?.configuredAuthless &&
+        entry.sources.length > 0 &&
+        entry.sources.every((source) => source === 'seed')
+    )
+  ) {
+    response = {
+      schemaVersion: response.schemaVersion,
+      runtimeId: response.runtimeId,
+      error: {
+        code: 'runtime-unhealthy',
+        message: `OpenCode provider directory could not be loaded. ${timeout.slice(0, 500)}`,
+        recoverable: true,
+      },
+    };
+  }
+  return response.error && previous?.directory
+    ? { ...response, directory: previous.directory }
+    : response;
+}

--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
@@ -42,14 +42,17 @@ const Probe = ({
   projectPath = '/sandbox/a',
   refreshRevision,
   periodic = false,
+  statusChecking = false,
 }: {
   enabled?: boolean;
   projectPath?: string;
   refreshRevision?: number;
   periodic?: boolean;
+  statusChecking?: boolean;
 }) => {
   observed = useOpenCodeConnectedModelCatalog({
     enabled,
+    statusChecking,
     projectPath,
     passiveProviderStatus: passive,
     refreshRevision,
@@ -110,6 +113,111 @@ afterEach(async () => {
 });
 
 describe('connected OpenCode dashboard catalog', () => {
+  it('waits for initial status to settle before reading the directory', async () => {
+    await act(async () => root.render(<Probe statusChecking />));
+    expect(mocks.directory).not.toHaveBeenCalled();
+    expect(mocks.models).not.toHaveBeenCalled();
+    await act(async () => root.render(<Probe />));
+    expect(mocks.directory).toHaveBeenCalledTimes(1);
+    expect(observed.providerStatus?.models).toEqual(['opencode/model-0', 'openrouter/model-0']);
+  });
+
+  it('finishes an in-flight source during status checking, then resumes the next source once', async () => {
+    let completeFirst!: (value: unknown) => void;
+    mocks.models.mockImplementation(({ providerId }) =>
+      providerId === 'opencode'
+        ? new Promise((resolve) => {
+            completeFirst = resolve;
+          })
+        : Promise.resolve(models(providerId))
+    );
+    await act(async () => root.render(<Probe />));
+    await act(async () => root.render(<Probe statusChecking />));
+    expect(mocks.cancel).not.toHaveBeenCalled();
+    await act(async () => completeFirst(models('opencode', 7)));
+    expect(mocks.models).toHaveBeenCalledTimes(1);
+    expect(observed.providerStatus?.models).toHaveLength(7);
+    expect(observed.providerStatus?.modelCatalogRefreshState).toBe('loading');
+    await act(async () => root.render(<Probe />));
+    expect(mocks.directory).toHaveBeenCalledTimes(1);
+    expect(mocks.models.mock.calls.map(([input]) => input.providerId)).toEqual([
+      'opencode',
+      'openrouter',
+    ]);
+    expect(observed.providerStatus?.models).toHaveLength(8);
+    expect(observed.providerStatus?.modelCatalogRefreshState).toBe('ready');
+    expect(mocks.cancel).not.toHaveBeenCalled();
+    await act(async () => root.render(<Probe statusChecking />));
+    await act(async () => root.render(<Probe />));
+    expect(mocks.models).toHaveBeenCalledTimes(2);
+    expect(observed.providerStatus?.modelCatalogRefreshState).toBe('ready');
+  });
+
+  it('cancels an active old scope and never paints its completion while the new scope is paused', async () => {
+    let completeOld!: (value: unknown) => void;
+    mocks.models.mockImplementation(({ providerId, projectPath }) =>
+      projectPath === '/sandbox/a'
+        ? new Promise((resolve) => {
+            completeOld = resolve;
+          })
+        : Promise.resolve(models(providerId))
+    );
+    await act(async () => root.render(<Probe />));
+    const oldGroup = mocks.models.mock.calls[0][0].requestGroupId;
+    await act(async () => root.render(<Probe projectPath="/sandbox/b" statusChecking />));
+    expect(mocks.cancel).toHaveBeenCalledWith({ requestGroupId: oldGroup });
+    await act(async () => completeOld(models('opencode', 7)));
+    expect(observed.providerStatus?.models).toEqual([]);
+    expect(mocks.directory).toHaveBeenCalledTimes(1);
+    await act(async () => root.render(<Probe projectPath="/sandbox/b" />));
+    expect(mocks.directory).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.models.mock.calls.slice(1).every(([input]) => input.projectPath === '/sandbox/b')
+    ).toBe(true);
+    expect(observed.providerStatus?.models).toHaveLength(2);
+  });
+
+  it.each(['disable', 'unmount'] as const)(
+    'releases an initial status wait on hard %s',
+    async (action) => {
+      await act(async () => root.render(<Probe statusChecking />));
+      await act(async () => root.render(action === 'unmount' ? null : <Probe enabled={false} />));
+      expect(mocks.directory).not.toHaveBeenCalled();
+      expect(mocks.models).not.toHaveBeenCalled();
+      await act(async () => root.render(<Probe />));
+      expect(mocks.directory).toHaveBeenCalledTimes(1);
+      expect(mocks.models).toHaveBeenCalledTimes(2);
+      expect(observed.providerStatus?.modelCatalogRefreshState).toBe('ready');
+    }
+  );
+
+  it('supersedes a source on explicit refresh but waits for status before starting the replacement', async () => {
+    let completeOld!: (value: unknown) => void;
+    mocks.models.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          completeOld = resolve;
+        })
+    );
+    await act(async () => root.render(<Probe />));
+    const oldGroup = mocks.models.mock.calls[0][0].requestGroupId;
+    await act(async () => root.render(<Probe statusChecking />));
+    await act(async () => observed.refresh());
+    expect(mocks.cancel).toHaveBeenCalledWith({ requestGroupId: oldGroup });
+    await act(async () => completeOld(models('opencode', 7)));
+    expect(mocks.directory).toHaveBeenCalledTimes(1);
+    expect(observed.providerStatus?.models).toEqual([]);
+    await act(async () => root.render(<Probe />));
+    expect(mocks.directory).toHaveBeenCalledTimes(2);
+    expect(mocks.directory).toHaveBeenLastCalledWith(expect.objectContaining({ refresh: true }));
+    expect(mocks.models.mock.calls.slice(1).map(([input]) => input.providerId)).toEqual([
+      'opencode',
+      'openrouter',
+    ]);
+    expect(mocks.models.mock.calls[1][0].requestGroupId).not.toBe(oldGroup);
+    expect(observed.providerStatus?.models).toHaveLength(2);
+  });
+
   it('loads built-in free models before slower connected sources', () => {
     expect(
       connectedCatalogSourceIds(

--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
@@ -1,4 +1,4 @@
-import React, { act, startTransition, Suspense } from 'react';
+import React, { act, startTransition, Suspense, use } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 import { useDashboardStatusRefresh } from '@renderer/components/dashboard/useDashboardStatusRefresh';
@@ -134,7 +134,7 @@ describe('connected OpenCode dashboard catalog', () => {
       });
       if (checking) {
         suspendedRender();
-        throw suspended;
+        use(suspended);
       }
       return null;
     };

--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
@@ -1,4 +1,4 @@
-import React, { act } from 'react';
+import React, { act, startTransition, Suspense } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 import { useDashboardStatusRefresh } from '@renderer/components/dashboard/useDashboardStatusRefresh';
@@ -113,6 +113,64 @@ afterEach(async () => {
 });
 
 describe('connected OpenCode dashboard catalog', () => {
+  it('does not pause catalog I/O for an abandoned status-checking render', async () => {
+    let completeDirectory!: (value: ReturnType<typeof directory>) => void;
+    mocks.directory.mockReturnValue(
+      new Promise((resolve) => {
+        completeDirectory = resolve;
+      })
+    );
+    let finishSuspension!: () => void;
+    const suspended = new Promise<void>((resolve) => {
+      finishSuspension = resolve;
+    });
+    const suspendedRender = vi.fn();
+    const SuspendedProbe = ({ checking }: { checking: boolean }) => {
+      observed = useOpenCodeConnectedModelCatalog({
+        enabled: true,
+        statusChecking: checking,
+        projectPath: '/sandbox/abandoned-render',
+        passiveProviderStatus: passive,
+      });
+      if (checking) {
+        suspendedRender();
+        throw suspended;
+      }
+      return null;
+    };
+    const render = (checking: boolean) =>
+      root.render(
+        <Suspense fallback={null}>
+          <SuspendedProbe checking={checking} />
+        </Suspense>
+      );
+    await act(async () => {
+      render(false);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      startTransition(() => render(true));
+      await Promise.resolve();
+    });
+    expect(suspendedRender).toHaveBeenCalled();
+    await act(async () => {
+      completeDirectory(directory());
+      await Promise.resolve();
+    });
+    await act(async () => {
+      render(false);
+      finishSuspension();
+      await Promise.resolve();
+    });
+    expect(mocks.directory).toHaveBeenCalledTimes(1);
+    expect(mocks.models.mock.calls.map(([input]) => input.providerId)).toEqual([
+      'opencode',
+      'openrouter',
+    ]);
+    expect(observed.providerStatus?.modelCatalogRefreshState).toBe('ready');
+    expect(mocks.cancel).not.toHaveBeenCalled();
+  });
+
   it('waits for initial status to settle before reading the directory', async () => {
     await act(async () => root.render(<Probe statusChecking />));
     expect(mocks.directory).not.toHaveBeenCalled();

--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.ts
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.ts
@@ -43,6 +43,7 @@ interface CatalogState {
 /** Dashboard display only: connected sources, never a full model inventory or launch proof. */
 export function useOpenCodeConnectedModelCatalog(input: {
   enabled: boolean;
+  statusChecking?: boolean;
   projectPath: string | null;
   passiveProviderStatus: CliProviderStatus | null;
   refreshRevision?: number;
@@ -59,7 +60,17 @@ export function useOpenCodeConnectedModelCatalog(input: {
   const stateRef = useRef(state);
   stateRef.current = state;
   const sequence = useRef(0);
+  const statusChecking = useRef(input.statusChecking === true);
+  statusChecking.current = input.statusChecking === true;
+  const statusWaiter = useRef<(() => void) | null>(null);
   const refresh = useCallback(() => setRevision((value) => value + 1), []);
+
+  useEffect(() => {
+    if (input.statusChecking !== true) {
+      statusWaiter.current?.();
+      statusWaiter.current = null;
+    }
+  }, [input.statusChecking]);
 
   useEffect(() => {
     if (!input.enabled) return;
@@ -72,6 +83,16 @@ export function useOpenCodeConnectedModelCatalog(input: {
     const activeGroups = new Set<string>();
     let cancelled = false;
     const current = () => !cancelled && request === sequence.current;
+    // One sequential catalog lane: status checks pause its next read without
+    // aborting the current source or discarding already collected models.
+    const waitForStatus = async () => {
+      while (current() && statusChecking.current) {
+        await new Promise<void>((resolve) => {
+          statusWaiter.current = resolve;
+        });
+      }
+      return current();
+    };
     const retainedModels = stateRef.current.scope === scope ? stateRef.current.models : [];
     setState({ scope, loading: true, models: retainedModels, errors: [] });
     void (async () => {
@@ -82,6 +103,7 @@ export function useOpenCodeConnectedModelCatalog(input: {
       let cursor: string | null = null;
       let total: number | null = null;
       for (let page = 0; page < 20; page += 1) {
+        if (!(await waitForStatus())) return;
         const response = await api.runtimeProviderManagement.loadProviderDirectory({
           runtimeId: 'opencode',
           projectPath: input.projectPath,
@@ -122,6 +144,7 @@ export function useOpenCodeConnectedModelCatalog(input: {
       let sourceIndex = 0;
       const loadNext = async () => {
         while (current() && sourceIndex < sources.length) {
+          if (!(await waitForStatus())) return;
           const source = sources[sourceIndex++];
           const sourceRequestGroup = `${requestGroupId}:${source}`;
           activeGroups.add(sourceRequestGroup);
@@ -184,6 +207,8 @@ export function useOpenCodeConnectedModelCatalog(input: {
       });
     return () => {
       cancelled = true;
+      statusWaiter.current?.();
+      statusWaiter.current = null;
       if (isElectronMode()) {
         for (const group of activeGroups)
           void api.runtimeProviderManagement
@@ -197,9 +222,8 @@ export function useOpenCodeConnectedModelCatalog(input: {
     const passive = input.passiveProviderStatus;
     const hasScopedState = state.scope === scope;
     if (!passive || (!input.enabled && !hasScopedState)) return passive;
-    // A provider re-check temporarily pauses catalog I/O to avoid contending on
-    // the OpenCode profile. Keep rendering the last-good catalog for this scope
-    // while that pause is active instead of flashing an empty/loading summary.
+    // Keep the last-good catalog for this scope while reads or status checks
+    // are in flight. Catalog discovery never grants launch authority.
     const active = hasScopedState ? state : { loading: true, models: [], errors: [] };
     const models = [
       ...new Map(

--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.ts
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.ts
@@ -61,11 +61,11 @@ export function useOpenCodeConnectedModelCatalog(input: {
   stateRef.current = state;
   const sequence = useRef(0);
   const statusChecking = useRef(input.statusChecking === true);
-  statusChecking.current = input.statusChecking === true;
   const statusWaiter = useRef<(() => void) | null>(null);
   const refresh = useCallback(() => setRevision((value) => value + 1), []);
 
   useEffect(() => {
+    statusChecking.current = input.statusChecking === true;
     if (input.statusChecking !== true) {
       statusWaiter.current?.();
       statusWaiter.current = null;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1751,11 +1751,10 @@ function wireFileWatcherEvents(context: ServiceContext): void {
   };
   context.fileWatcher.on('team-change', teamChangeHandler);
 
-  // Scope team-root/task file watching to alive + UI-engaged teams, and scope
-  // inbox watching to live teams only. Idle historical teams cannot produce
-  // immediate runtime inbox activity, so their inbox files do not need live fd
-  // watchers; when a team launches, target reconciliation backfills existing
-  // inbox files before live delivery resumes.
+  // Scope artifacts and inboxes to alive + recently engaged teams. Provisioning
+  // can assign work before final readiness, so its engaged window must include
+  // inbox delivery too. The bounded TTL excludes historical idle teams;
+  // reconciliation backfills assignments written before watcher readiness.
   setAliveTeamsProvider(() => teamProvisioningService.getAliveTeamNames());
   setTeamWatchScopeChangeListener(() => {
     void context.fileWatcher.refreshTeamWatchScope();
@@ -1866,15 +1865,17 @@ function reconfigureLocalContextForClaudeRoot(): void {
 const announcementsLifecycle = new AnnouncementsLifecycle();
 
 async function initializeServices(): Promise<void> {
-  void announcementsLifecycle.initialize({
-    userDataPath: app.getPath('userData'),
-    profile: earlyAnnouncementsProfile,
-    production: app.isPackaged,
-    isolatedProfile:
-      !!earlyElectronDevPathOverrideResult.userDataDir &&
-      !!earlyElectronDevPathOverrideResult.claudeRoot,
-    sourceOverride: process.env.AGENT_TEAMS_ANNOUNCEMENTS_FEED_URL,
-  }).catch((error: unknown) => logger.warn('Announcements initialization unavailable', error));
+  void announcementsLifecycle
+    .initialize({
+      userDataPath: app.getPath('userData'),
+      profile: earlyAnnouncementsProfile,
+      production: app.isPackaged,
+      isolatedProfile:
+        !!earlyElectronDevPathOverrideResult.userDataDir &&
+        !!earlyElectronDevPathOverrideResult.claudeRoot,
+      sourceOverride: process.env.AGENT_TEAMS_ANNOUNCEMENTS_FEED_URL,
+    })
+    .catch((error: unknown) => logger.warn('Announcements initialization unavailable', error));
   logger.info('Initializing services...');
   publishStartupStatus({
     phase: 'services',

--- a/src/main/services/infrastructure/teamWatchScope.ts
+++ b/src/main/services/infrastructure/teamWatchScope.ts
@@ -2,10 +2,10 @@
  * Decides which team artifacts should be file-watched.
  *
  * Team root/task scope is (teams with a live runtime run) + (teams recently
- * engaged in the UI). Inbox scope is stricter: only teams with a live runtime
- * run. That keeps the expensive per-inbox file watchers tied to teams that can
- * actually produce live runtime activity, while opened idle teams still get
- * their root/task artifacts watched for UI refreshes.
+ * engaged in the UI). Inbox scope uses the same bounded set. A newly launched
+ * team can start assigning work before provisioning publishes final `ready`,
+ * so excluding the engaged launch window would lose those inbox events and can
+ * deadlock an OpenCode teammate waiting for its first task.
  *
  * Module-level state mirrors the existing IPC/registry singletons in this layer.
  */
@@ -66,14 +66,13 @@ export function computeTeamWatchScope(nowMs: number = Date.now()): ReadonlySet<s
 }
 
 /**
- * Current set of teams whose inboxes should be watched live. Inbox writes only
- * need immediate watcher delivery while a runtime is alive; otherwise the next
- * launch or explicit team read can catch up from disk without holding one fd per
- * inbox file for every historical team.
+ * Current bounded set of teams whose inboxes should be watched for live
+ * delivery. Recently engaged teams are included because create/launch can
+ * produce actionable inbox messages before the run is promoted to `ready`.
+ * The engagement TTL still keeps historical idle teams out of the watch set.
  */
-export function computeLiveTeamWatchScope(): ReadonlySet<string> | null {
-  const scope = new Set<string>();
-  return collectAliveTeams(scope) ? scope : null;
+export function computeLiveTeamWatchScope(nowMs: number = Date.now()): ReadonlySet<string> | null {
+  return computeTeamWatchScope(nowMs);
 }
 
 /**

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -62,6 +62,35 @@ function verifiedOpenCodeProvider(): CliProviderStatus {
 }
 
 describe('ClaudeMultimodelBridgeService runtime status mapping', () => {
+  test.each([true, false])(
+    'mints refresh provenance only from raw affirmative teamLaunch=%s, ignoring injected markers',
+    (teamLaunch) => {
+      const provider = mapRuntimeProviderStatus('anthropic', {
+        providerId: 'anthropic',
+        supported: true,
+        authenticated: true,
+        authMethod: 'claude.ai',
+        verificationState: 'verified',
+        statusCheckOutcome: 'authoritative',
+        capabilities: { teamLaunch, oneShot: true, extensions: {} },
+        canLoginFromUi: true,
+        selectedBackendId: null,
+        resolvedBackendId: null,
+        availableBackends: [],
+        externalRuntimeDiagnostics: [],
+        backend: null,
+        statusMessage: null,
+        detailMessage: null,
+        models: ['haiku'],
+        runtimeCapabilities: { modelCatalog: { dynamic: true } },
+        teamLaunchAuthorityRestriction: 'catalog-refresh',
+      });
+      expect(provider.capabilities.teamLaunch).toBe(false);
+      expect(provider.teamLaunchAuthorityRestriction).toBe(
+        teamLaunch ? 'catalog-refresh' : undefined
+      );
+    }
+  );
   test('maps Anthropic subscription rate limits from orchestrator runtime status', () => {
     const provider = mapRuntimeProviderStatus('anthropic', {
       supported: true,

--- a/src/main/services/runtime/ProviderConnectionService.ts
+++ b/src/main/services/runtime/ProviderConnectionService.ts
@@ -347,9 +347,10 @@ function createCodexCustomProviderCatalog(
 
 function applyCodexRuntimeContextEnv(
   env: NodeJS.ProcessEnv,
-  snapshot: CodexAccountSnapshotDto
+  snapshot: CodexAccountSnapshotDto,
+  binaryPathOverride?: string
 ): void {
-  const binaryPath = snapshot.runtimeContext?.binaryPath?.trim();
+  const binaryPath = binaryPathOverride?.trim() || snapshot.runtimeContext?.binaryPath?.trim();
   if (binaryPath) {
     env[CODEX_CLI_PATH_ENV_VAR] = binaryPath;
   }
@@ -826,7 +827,7 @@ export class ProviderConnectionService {
     if (!snapshot) {
       return env;
     }
-    applyCodexRuntimeContextEnv(env, snapshot);
+    applyCodexRuntimeContextEnv(env, snapshot, env[CODEX_CLI_PATH_ENV_VAR]);
     const readiness = evaluateCodexLaunchReadiness({
       preferredAuthMode: snapshot.preferredAuthMode,
       managedAccount: snapshot.managedAccount,

--- a/src/main/services/runtime/providerAwareCliEnv.ts
+++ b/src/main/services/runtime/providerAwareCliEnv.ts
@@ -1,4 +1,7 @@
-import { resolveVerifiedAppManagedCodexRuntimeBinaryPath } from '@features/codex-runtime-installer/main';
+import {
+  resolveAppManagedCodexRuntimeBinaryPath,
+  resolveVerifiedAppManagedCodexRuntimeBinaryPath,
+} from '@features/codex-runtime-installer/main';
 import { getCachedShellEnv } from '@main/utils/shellEnv';
 
 import {
@@ -91,6 +94,12 @@ export function buildPassiveProviderStatusCliEnv(
       delete env[OPENCODE_LEGACY_BINARY_PATH_ENV];
     }
     applyOpenCodeRuntimeBinaryEnv(env, explicitOpenCodeBinary ?? knownOpenCodeBinary);
+  }
+  if (!options.providerId || options.providerId === 'codex') {
+    const appManagedCodexBinary = resolveAppManagedCodexRuntimeBinaryPath();
+    if (appManagedCodexBinary && !env.CODEX_CLI_PATH) {
+      env.CODEX_CLI_PATH = appManagedCodexBinary;
+    }
   }
   removeGlobalElectronRunAsNodeEnv(env);
   return { env, connectionIssues: {}, providerArgs: [] };

--- a/src/main/services/runtime/providerStatusCheckContract.ts
+++ b/src/main/services/runtime/providerStatusCheckContract.ts
@@ -4,6 +4,7 @@ import {
   createLegacyRuntimeFallbackCliExtensionCapabilities,
 } from '@shared/utils/providerExtensionCapabilities';
 import {
+  hasAnthropicCatalogRefreshLaunchSupport,
   hasAuthoritativeProviderLaunchEvidence,
   hasAuthoritativeProviderStatusEvidence,
   isProviderModelCatalogExactReady,
@@ -218,6 +219,7 @@ export function createDegradedProviderStatus(
   const degraded = createRuntimeStatusErrorProviderStatus(previous.providerId, error);
   return {
     ...previous,
+    teamLaunchAuthorityRestriction: undefined,
     verificationState: degraded.verificationState,
     statusCheckOutcome: degraded.statusCheckOutcome,
     statusCheckErrorCode: degraded.statusCheckErrorCode,
@@ -267,6 +269,9 @@ export function mergeProviderStatusDisplayEvidence(
 
   return {
     ...incoming,
+    teamLaunchAuthorityRestriction: hasAnthropicCatalogRefreshLaunchSupport(incoming)
+      ? 'catalog-refresh'
+      : undefined,
     supported: incoming.supported,
     authenticated: hasAuthoritativeStatusEvidence ? incoming.authenticated : false,
     authMethod: hasAuthoritativeStatusEvidence ? incoming.authMethod : null,

--- a/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator.ts
@@ -97,6 +97,11 @@ export interface OpenCodePromptDeliveryWatchdogCoordinatorPorts {
   resolveMembersForRuntimeLane(teamName: string, laneId: string): Promise<string[]>;
   getInboxMessages(teamName: string, memberName: string): Promise<InboxMessage[]>;
   resolveCurrentRuntimeRunId(teamName: string, laneId: string): Promise<string | null>;
+  resolveTrackedBootstrapRunId(input: {
+    teamName: string;
+    laneId: string;
+    runId: string;
+  }): string | null;
   hasCommittedBootstrapSession(input: {
     teamName: string;
     laneId: string;
@@ -553,9 +558,23 @@ export class OpenCodePromptDeliveryWatchdogCoordinator {
     memberName: string;
   }): Promise<number> {
     if (!this.ports.watchdogScheduler.isEnabled()) return 0;
-    const isCurrentRun = async (): Promise<boolean> =>
-      (await this.ports.resolveCurrentRuntimeRunId(input.teamName, input.laneId)) === input.runId &&
-      this.ports.canDeliverToTeamRuntime(input.teamName);
+    const bootstrapOwner = this.ports.resolveTrackedBootstrapRunId(input);
+    const isCurrentRun = async (): Promise<boolean> => {
+      if (
+        (await this.ports.resolveCurrentRuntimeRunId(input.teamName, input.laneId)) !== input.runId
+      )
+        return false;
+      if (bootstrapOwner && this.ports.resolveTrackedBootstrapRunId(input) !== bootstrapOwner)
+        return false;
+      if (this.ports.canDeliverToTeamRuntime(input.teamName)) return true;
+      // A confirmed lane can work while its owning lead is still finalizing.
+      // This schedules only; the watchdog retains its existing recovery/Stop checks.
+      return (
+        bootstrapOwner !== null &&
+        (await this.ports.hasCommittedBootstrapSession(input)) &&
+        this.ports.resolveTrackedBootstrapRunId(input) === bootstrapOwner
+      );
+    };
     if (!(await isCurrentRun())) return 0;
     const messages = await this.ports.getInboxMessages(input.teamName, input.memberName);
     // Stop/relaunch may race either read. Never wake a replacement generation.
@@ -716,6 +735,7 @@ export function createOpenCodePromptDeliveryWatchdogCoordinator(
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     getErrorMessage: defaultGetErrorMessage,
     hasCommittedBootstrapSession: async () => false,
+    resolveTrackedBootstrapRunId: () => null,
     ...ports,
   });
 }

--- a/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator.ts
@@ -97,6 +97,12 @@ export interface OpenCodePromptDeliveryWatchdogCoordinatorPorts {
   resolveMembersForRuntimeLane(teamName: string, laneId: string): Promise<string[]>;
   getInboxMessages(teamName: string, memberName: string): Promise<InboxMessage[]>;
   resolveCurrentRuntimeRunId(teamName: string, laneId: string): Promise<string | null>;
+  hasCommittedBootstrapSession(input: {
+    teamName: string;
+    laneId: string;
+    runId: string;
+    memberName: string;
+  }): Promise<boolean>;
   hasStableInboxMessageId(message: InboxMessage): message is InboxMessage & { messageId: string };
   logPromptDeliveryEvent(
     event: string,
@@ -521,6 +527,55 @@ export class OpenCodePromptDeliveryWatchdogCoordinator {
     return await this.scanActiveLanes(teamName, activeLaneIds);
   }
 
+  async wakeAfterRuntimeRegistration(input: { teamName: string; runId: string }): Promise<void> {
+    const isCurrentPrimary = async (): Promise<boolean> =>
+      (await this.ports.resolveCurrentRuntimeRunId(input.teamName, 'primary')) === input.runId;
+    if (!(await isCurrentPrimary()) || !this.ports.canDeliverToTeamRuntime(input.teamName)) return;
+    for (const laneId of (await this.ports.readActiveRuntimeLaneIds(input.teamName)) ?? []) {
+      const runId = await this.ports.resolveCurrentRuntimeRunId(input.teamName, laneId);
+      if (!runId) continue;
+      for (const memberName of await this.ports.resolveMembersForRuntimeLane(
+        input.teamName,
+        laneId
+      )) {
+        const member = { teamName: input.teamName, laneId, runId, memberName };
+        if (!(await this.ports.hasCommittedBootstrapSession(member))) continue;
+        if (!(await isCurrentPrimary())) return;
+        await this.wakeAfterBootstrapCommit(member);
+      }
+    }
+  }
+
+  async wakeAfterBootstrapCommit(input: {
+    teamName: string;
+    laneId: string;
+    runId: string;
+    memberName: string;
+  }): Promise<number> {
+    if (!this.ports.watchdogScheduler.isEnabled()) return 0;
+    const isCurrentRun = async (): Promise<boolean> =>
+      (await this.ports.resolveCurrentRuntimeRunId(input.teamName, input.laneId)) === input.runId &&
+      this.ports.canDeliverToTeamRuntime(input.teamName);
+    if (!(await isCurrentRun())) return 0;
+    const messages = await this.ports.getInboxMessages(input.teamName, input.memberName);
+    // Stop/relaunch may race either read. Never wake a replacement generation.
+    if (!(await isCurrentRun())) return 0;
+    let scheduled = 0;
+    for (const message of messages) {
+      if (message.read || !message.text?.trim() || !this.ports.hasStableInboxMessageId(message)) {
+        continue;
+      }
+      this.schedule({
+        teamName: input.teamName,
+        memberName: input.memberName,
+        messageId: message.messageId,
+        delayMs: 500,
+      });
+      scheduled += 1;
+    }
+    return scheduled;
+  }
+
   async scanActiveLanes(teamName: string, laneIds: string[]): Promise<number> {
     if (!this.ports.watchdogScheduler.isEnabled()) {
       return 0;
@@ -660,6 +715,7 @@ export function createOpenCodePromptDeliveryWatchdogCoordinator(
     nowIso: () => new Date().toISOString(),
     sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     getErrorMessage: defaultGetErrorMessage,
+    hasCommittedBootstrapSession: async () => false,
     ...ports,
   });
 }

--- a/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator.ts
@@ -559,6 +559,8 @@ export class OpenCodePromptDeliveryWatchdogCoordinator {
   }): Promise<number> {
     if (!this.ports.watchdogScheduler.isEnabled()) return 0;
     const bootstrapOwner = this.ports.resolveTrackedBootstrapRunId(input);
+    // A primary can be standalone; a secondary must still belong to its tracked root.
+    if (input.laneId !== 'primary' && bootstrapOwner === null) return 0;
     const isCurrentRun = async (): Promise<boolean> => {
       if (
         (await this.ports.resolveCurrentRuntimeRunId(input.teamName, input.laneId)) !== input.runId

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryWatchdogCoordinator.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryWatchdogCoordinator.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { getTrackedOpenCodeBootstrapWakeRunId } from '../../../provisioning/TeamProvisioningSecondaryRuntimeRuns';
 import { createOpenCodePromptDeliveryWatchdogCoordinator } from '../OpenCodePromptDeliveryWatchdogCoordinator';
 import { OpenCodePromptDeliveryWatchdogScheduler } from '../OpenCodePromptDeliveryWatchdogScheduler';
 
@@ -100,6 +101,11 @@ function makeCoordinator(
     resolveCurrentRuntimeRunId?: (teamName: string, laneId: string) => Promise<string | null>;
     resolveMembersForRuntimeLane?: (teamName: string, laneId: string) => Promise<string[]>;
     hasCommittedBootstrapSession?: (input: { memberName: string }) => Promise<boolean>;
+    resolveTrackedBootstrapRunId?: (input: {
+      teamName: string;
+      laneId: string;
+      runId: string;
+    }) => string | null;
     getInboxMessages?: () => Promise<InboxMessage[]>;
   } = {}
 ) {
@@ -139,6 +145,9 @@ function makeCoordinator(
       overrides.getInboxMessages ?? vi.fn(async () => overrides.inboxMessages ?? []),
     resolveCurrentRuntimeRunId: overrides.resolveCurrentRuntimeRunId ?? vi.fn(async () => 'run-1'),
     hasCommittedBootstrapSession: overrides.hasCommittedBootstrapSession ?? vi.fn(async () => true),
+    resolveTrackedBootstrapRunId:
+      overrides.resolveTrackedBootstrapRunId ??
+      ((input) => (input.laneId === 'primary' ? input.runId : 'root-run-1')),
     hasStableInboxMessageId: (message): message is InboxMessage & { messageId: string } =>
       typeof message.messageId === 'string' && message.messageId.trim().length > 0,
     logPromptDeliveryEvent: overrides.logPromptDeliveryEvent ?? vi.fn(),
@@ -165,6 +174,92 @@ describe('OpenCodePromptDeliveryWatchdogCoordinator', () => {
       isStaleError: vi.fn(async () => false),
     });
 
+    it.each(['bootstrap commit', 'runtime registration'])(
+      'does not wake an orphan active secondary lane from %s while the current primary is ready',
+      async (entryPoint) => {
+        const scheduler = makeScheduler();
+        const secondary = { ...input, laneId: 'secondary:opencode:alice', runId: 'orphan-run' };
+        const coordinator = makeCoordinator({
+          scheduler,
+          inboxMessages: [unread],
+          activeLaneIds: ['primary', secondary.laneId],
+          resolveCurrentRuntimeRunId: async (_team, lane) =>
+            lane === 'primary' ? 'current-root' : secondary.runId,
+          resolveMembersForRuntimeLane: async (_team, lane) =>
+            lane === 'primary' ? ['team-lead'] : ['alice'],
+          resolveTrackedBootstrapRunId: (member) =>
+            getTrackedOpenCodeBootstrapWakeRunId(member, {
+              runTracking: { resolveDeliverableTrackedRuntimeRunId: () => 'current-root' },
+              runs: new Map([['current-root', { mixedSecondaryLanes: [] }]]),
+            }),
+        });
+        if (entryPoint === 'bootstrap commit') {
+          await expect(coordinator.wakeAfterBootstrapCommit(secondary)).resolves.toBe(0);
+          expect(scheduler.schedule).not.toHaveBeenCalled();
+        } else {
+          await coordinator.wakeAfterRuntimeRegistration({
+            teamName: 'team',
+            runId: 'current-root',
+          });
+          expect(scheduler.schedule).toHaveBeenCalledExactlyOnceWith({
+            teamName: 'team',
+            memberName: 'team-lead',
+            messageId: 'msg-1',
+            delayMs: 500,
+          });
+        }
+      }
+    );
+
+    it.each([true, false])('revalidates owned secondary lanes with ready=%s', async (ready) => {
+      const scheduler = makeScheduler();
+      const lane = { laneId: input.laneId, runId: input.runId };
+      const root = { mixedSecondaryLanes: [lane] };
+      let removeOwnerDuringRead = false;
+      const coordinator = makeCoordinator({
+        scheduler,
+        canDeliverToTeamRuntime: () => ready,
+        resolveTrackedBootstrapRunId: (member) =>
+          getTrackedOpenCodeBootstrapWakeRunId(member, {
+            runTracking: { resolveDeliverableTrackedRuntimeRunId: () => 'root-run-1' },
+            runs: new Map([['root-run-1', root]]),
+          }),
+        getInboxMessages: async () => {
+          if (removeOwnerDuringRead) root.mixedSecondaryLanes = [];
+          return [unread];
+        },
+      });
+      await expect(coordinator.wakeAfterBootstrapCommit(input)).resolves.toBe(1);
+      scheduler.schedule.mockClear();
+      removeOwnerDuringRead = true;
+      await expect(coordinator.wakeAfterBootstrapCommit(input)).resolves.toBe(0);
+      expect(scheduler.schedule).not.toHaveBeenCalled();
+    });
+
+    it('preserves a ready standalone primary without an aggregate owner and rechecks its runtime ID', async () => {
+      const scheduler = makeScheduler();
+      let currentRun = input.runId;
+      let replaceDuringRead = false;
+      const coordinator = makeCoordinator({
+        scheduler,
+        resolveTrackedBootstrapRunId: () => null,
+        resolveCurrentRuntimeRunId: async () => currentRun,
+        getInboxMessages: async () => {
+          if (replaceDuringRead) currentRun = 'new-primary-run';
+          return [unread];
+        },
+      });
+      await expect(
+        coordinator.wakeAfterBootstrapCommit({ ...input, laneId: 'primary' })
+      ).resolves.toBe(1);
+      scheduler.schedule.mockClear();
+      replaceDuringRead = true;
+      await expect(
+        coordinator.wakeAfterBootstrapCommit({ ...input, laneId: 'primary' })
+      ).resolves.toBe(0);
+      expect(scheduler.schedule).not.toHaveBeenCalled();
+    });
+
     it('replays verified primary and secondary bootstrap wakes after fresh runtime registration', async () => {
       const scheduler = makeScheduler();
       let registered = false;
@@ -173,6 +268,7 @@ describe('OpenCodePromptDeliveryWatchdogCoordinator', () => {
         inboxMessages: [unread],
         activeLaneIds: ['primary', 'secondary'],
         canDeliverToTeamRuntime: () => registered,
+        resolveTrackedBootstrapRunId: () => (registered ? 'run-1' : null),
         resolveCurrentRuntimeRunId: async (_team, lane) =>
           lane === 'primary' ? 'run-1' : 'lane-run-1',
         resolveMembersForRuntimeLane: async (_team, lane) =>
@@ -199,6 +295,7 @@ describe('OpenCodePromptDeliveryWatchdogCoordinator', () => {
           inboxMessages: [unread],
           activeLaneIds: ['primary'],
           canDeliverToTeamRuntime: () => scenario !== 'stopped',
+          resolveTrackedBootstrapRunId: () => (scenario === 'stopped' ? null : 'root-run-1'),
           resolveCurrentRuntimeRunId: async () => primaryRun,
           hasCommittedBootstrapSession: async () => {
             if (scenario === 'replacement during proof') primaryRun = 'run-2';
@@ -239,6 +336,7 @@ describe('OpenCodePromptDeliveryWatchdogCoordinator', () => {
           scheduler,
           inboxMessages: scenario === 'empty inbox' ? [] : [unread],
           canDeliverToTeamRuntime: () => scenario !== 'stopped',
+          resolveTrackedBootstrapRunId: () => (scenario === 'stopped' ? null : 'root-run-1'),
           resolveCurrentRuntimeRunId: async () => (scenario === 'stale run' ? 'run-2' : 'run-1'),
         });
         await expect(coordinator.wakeAfterBootstrapCommit(input)).resolves.toBe(0);
@@ -253,6 +351,7 @@ describe('OpenCodePromptDeliveryWatchdogCoordinator', () => {
       const coordinator = makeCoordinator({
         scheduler,
         canDeliverToTeamRuntime: () => active,
+        resolveTrackedBootstrapRunId: () => (active ? 'root-run-1' : null),
         resolveCurrentRuntimeRunId: async () => currentRun,
         getInboxMessages: async () => {
           if (transition === 'stop') active = false;

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryWatchdogCoordinator.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodePromptDeliveryWatchdogCoordinator.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createOpenCodePromptDeliveryWatchdogCoordinator } from '../OpenCodePromptDeliveryWatchdogCoordinator';
+import { OpenCodePromptDeliveryWatchdogScheduler } from '../OpenCodePromptDeliveryWatchdogScheduler';
 
 import type {
   OpenCodePromptDeliveryLedgerRecord,
   OpenCodePromptDeliveryLedgerStore,
 } from '../OpenCodePromptDeliveryLedger';
-import type { OpenCodePromptDeliveryWatchdogScheduler } from '../OpenCodePromptDeliveryWatchdogScheduler';
 import type { OpenCodeVisibleReplyProofService } from '../OpenCodeVisibleReplyProofService';
 import type { InboxMessage, TaskRef } from '@shared/types/team';
 
@@ -96,6 +96,11 @@ function makeCoordinator(
     members?: string[];
     logPromptDeliveryEvent?: ReturnType<typeof vi.fn>;
     notifyLeadTurnActivity?: ReturnType<typeof vi.fn>;
+    canDeliverToTeamRuntime?: () => boolean;
+    resolveCurrentRuntimeRunId?: (teamName: string, laneId: string) => Promise<string | null>;
+    resolveMembersForRuntimeLane?: (teamName: string, laneId: string) => Promise<string[]>;
+    hasCommittedBootstrapSession?: (input: { memberName: string }) => Promise<boolean>;
+    getInboxMessages?: () => Promise<InboxMessage[]>;
   } = {}
 ) {
   const scheduler =
@@ -123,14 +128,17 @@ function makeCoordinator(
     maybeSyncRuntimePermissionsAfterDelivery: vi.fn(async () => undefined),
     rememberRuntimePidFromBridge: vi.fn(async () => undefined),
     watchdogScheduler: scheduler,
-    canDeliverToTeamRuntime: vi.fn(() => true),
+    canDeliverToTeamRuntime: overrides.canDeliverToTeamRuntime ?? vi.fn(() => true),
     recoverRuntimeLanesForWatchdog: vi.fn(async () => []),
     stopRuntimeLanesForStoppedTeam: vi.fn(async () => undefined),
     readActiveRuntimeLaneIds: vi.fn(async () => overrides.activeLaneIds ?? ['lane-1']),
     createLedger: vi.fn(() => overrides.ledger ?? ({} as OpenCodePromptDeliveryLedgerStore)),
-    resolveMembersForRuntimeLane: vi.fn(async () => overrides.members ?? ['alice']),
-    getInboxMessages: vi.fn(async () => overrides.inboxMessages ?? []),
-    resolveCurrentRuntimeRunId: vi.fn(async () => 'run-1'),
+    resolveMembersForRuntimeLane:
+      overrides.resolveMembersForRuntimeLane ?? vi.fn(async () => overrides.members ?? ['alice']),
+    getInboxMessages:
+      overrides.getInboxMessages ?? vi.fn(async () => overrides.inboxMessages ?? []),
+    resolveCurrentRuntimeRunId: overrides.resolveCurrentRuntimeRunId ?? vi.fn(async () => 'run-1'),
+    hasCommittedBootstrapSession: overrides.hasCommittedBootstrapSession ?? vi.fn(async () => true),
     hasStableInboxMessageId: (message): message is InboxMessage & { messageId: string } =>
       typeof message.messageId === 'string' && message.messageId.trim().length > 0,
     logPromptDeliveryEvent: overrides.logPromptDeliveryEvent ?? vi.fn(),
@@ -141,6 +149,155 @@ function makeCoordinator(
 }
 
 describe('OpenCodePromptDeliveryWatchdogCoordinator', () => {
+  describe('committed bootstrap inbox wake', () => {
+    const input = { teamName: 'team', laneId: 'lane-1', runId: 'run-1', memberName: 'alice' };
+    const unread: InboxMessage = {
+      from: 'team-lead',
+      to: 'alice',
+      text: 'Assigned task',
+      timestamp: ISO,
+      read: false,
+      messageId: 'msg-1',
+    };
+    const makeScheduler = () => ({
+      isEnabled: vi.fn(() => true),
+      schedule: vi.fn(),
+      isStaleError: vi.fn(async () => false),
+    });
+
+    it('replays verified primary and secondary bootstrap wakes after fresh runtime registration', async () => {
+      const scheduler = makeScheduler();
+      let registered = false;
+      const coordinator = makeCoordinator({
+        scheduler,
+        inboxMessages: [unread],
+        activeLaneIds: ['primary', 'secondary'],
+        canDeliverToTeamRuntime: () => registered,
+        resolveCurrentRuntimeRunId: async (_team, lane) =>
+          lane === 'primary' ? 'run-1' : 'lane-run-1',
+        resolveMembersForRuntimeLane: async (_team, lane) =>
+          lane === 'primary' ? ['alice', 'not-confirmed'] : ['bob'],
+        hasCommittedBootstrapSession: async ({ memberName }) => memberName !== 'not-confirmed',
+      });
+      await coordinator.wakeAfterBootstrapCommit({ ...input, laneId: 'primary' });
+      expect(scheduler.schedule).not.toHaveBeenCalled();
+      registered = true;
+      await coordinator.wakeAfterRuntimeRegistration({ teamName: 'team', runId: 'run-1' });
+      expect(scheduler.schedule.mock.calls.map(([wake]) => wake.memberName)).toEqual([
+        'alice',
+        'bob',
+      ]);
+    });
+
+    it.each(['stopped', 'stale primary', 'replacement during proof'])(
+      'suppresses registration wake after %s',
+      async (scenario) => {
+        const scheduler = makeScheduler();
+        let primaryRun = scenario === 'stale primary' ? 'run-2' : 'run-1';
+        const coordinator = makeCoordinator({
+          scheduler,
+          inboxMessages: [unread],
+          activeLaneIds: ['primary'],
+          canDeliverToTeamRuntime: () => scenario !== 'stopped',
+          resolveCurrentRuntimeRunId: async () => primaryRun,
+          hasCommittedBootstrapSession: async () => {
+            if (scenario === 'replacement during proof') primaryRun = 'run-2';
+            return true;
+          },
+        });
+        await coordinator.wakeAfterRuntimeRegistration({ teamName: 'team', runId: 'run-1' });
+        expect(scheduler.schedule).not.toHaveBeenCalled();
+      }
+    );
+
+    it('wakes only substantive unread stable messages without waiting for team ready or delivery', async () => {
+      const scheduler = makeScheduler();
+      const coordinator = makeCoordinator({
+        scheduler,
+        inboxMessages: [
+          unread,
+          { ...unread, messageId: 'read', read: true },
+          { ...unread, messageId: 'empty', text: ' ' },
+          { ...unread, messageId: undefined },
+        ],
+      });
+      await expect(coordinator.wakeAfterBootstrapCommit(input)).resolves.toBe(1);
+      expect(scheduler.schedule).toHaveBeenCalledExactlyOnceWith({
+        teamName: 'team',
+        memberName: 'alice',
+        messageId: 'msg-1',
+        delayMs: 500,
+      });
+    });
+
+    it.each(['empty inbox', 'disabled', 'stopped', 'stale run'])(
+      'does not wake for %s',
+      async (scenario) => {
+        const scheduler = makeScheduler();
+        scheduler.isEnabled.mockReturnValue(scenario !== 'disabled');
+        const coordinator = makeCoordinator({
+          scheduler,
+          inboxMessages: scenario === 'empty inbox' ? [] : [unread],
+          canDeliverToTeamRuntime: () => scenario !== 'stopped',
+          resolveCurrentRuntimeRunId: async () => (scenario === 'stale run' ? 'run-2' : 'run-1'),
+        });
+        await expect(coordinator.wakeAfterBootstrapCommit(input)).resolves.toBe(0);
+        expect(scheduler.schedule).not.toHaveBeenCalled();
+      }
+    );
+
+    it.each(['stop', 'relaunch'])('rechecks %s after reading the inbox', async (transition) => {
+      const scheduler = makeScheduler();
+      let currentRun = 'run-1';
+      let active = true;
+      const coordinator = makeCoordinator({
+        scheduler,
+        canDeliverToTeamRuntime: () => active,
+        resolveCurrentRuntimeRunId: async () => currentRun,
+        getInboxMessages: async () => {
+          if (transition === 'stop') active = false;
+          else currentRun = 'run-2';
+          return [unread];
+        },
+      });
+      await expect(coordinator.wakeAfterBootstrapCommit(input)).resolves.toBe(0);
+      expect(scheduler.schedule).not.toHaveBeenCalled();
+    });
+
+    it('coalesces repeated commits through the existing scheduler and cancels on Stop', async () => {
+      vi.useFakeTimers();
+      const relay = vi.fn(async () => undefined);
+      const scheduler = new OpenCodePromptDeliveryWatchdogScheduler({
+        canDeliverToTeamRuntime: () => true,
+        recoverBeforeDelivery: async () => false,
+        relay,
+        getInboxMessages: async () => [unread],
+        resolveIdentity: async () => ({ ok: true, laneId: 'lane-1' }),
+        isLaneActive: async () => true,
+        isRecordNotFoundError: () => false,
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+        getErrorMessage: String,
+      });
+      try {
+        const coordinator = makeCoordinator({ scheduler, inboxMessages: [unread] });
+        await coordinator.wakeAfterBootstrapCommit(input);
+        await coordinator.wakeAfterBootstrapCommit(input);
+        expect(vi.getTimerCount()).toBe(1);
+        await vi.advanceTimersByTimeAsync(500);
+        expect(relay).toHaveBeenCalledTimes(1);
+        await coordinator.wakeAfterBootstrapCommit(input);
+        scheduler.cancelTeam('team');
+        await vi.advanceTimersByTimeAsync(500);
+        expect(relay).toHaveBeenCalledTimes(1);
+      } finally {
+        scheduler.cancelTeam('team');
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it('keeps read commits pending when visible replies miss required task refs', async () => {
     const coordinator = makeCoordinator();
 

--- a/src/main/services/team/provisioning/TeamProvisioningBootstrapEvidenceFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningBootstrapEvidenceFacade.ts
@@ -43,10 +43,12 @@ export interface TeamProvisioningBootstrapEvidenceFacadeDeps {
   getTeamsBasePath?: () => string;
   nowIso(): string;
   warn(message: string): void;
+  onBootstrapSessionCommitted?: OpenCodeRuntimeBootstrapEvidencePorts['onBootstrapSessionCommitted'];
   openCodeSecondaryEvidenceOverlayPorts?: OpenCodeSecondaryEvidenceOverlayPorts;
   createOpenCodeRuntimeBootstrapEvidencePorts?: (input: {
     teamsBasePath: string;
     warn(message: string): void;
+    onBootstrapSessionCommitted?: OpenCodeRuntimeBootstrapEvidencePorts['onBootstrapSessionCommitted'];
   }) => OpenCodeRuntimeBootstrapEvidencePorts;
 }
 
@@ -59,6 +61,7 @@ export interface TeamProvisioningBootstrapEvidenceFacadeServiceHostOptions {
   getTeamsBasePath?: () => string;
   nowIso(): string;
   warn(message: string): void;
+  onBootstrapSessionCommitted?: OpenCodeRuntimeBootstrapEvidencePorts['onBootstrapSessionCommitted'];
 }
 
 export function createTeamProvisioningBootstrapEvidenceFacadeDepsFromService(
@@ -71,6 +74,7 @@ export function createTeamProvisioningBootstrapEvidenceFacadeDepsFromService(
     getTeamsBasePath: options.getTeamsBasePath,
     nowIso: options.nowIso,
     warn: options.warn,
+    onBootstrapSessionCommitted: options.onBootstrapSessionCommitted,
   };
 }
 
@@ -119,6 +123,7 @@ export class TeamProvisioningBootstrapEvidenceFacade {
     return this.createOpenCodeRuntimeBootstrapEvidencePortsForInput({
       teamsBasePath: this.getTeamsBasePath(),
       warn: (message) => this.deps.warn(message),
+      onBootstrapSessionCommitted: this.deps.onBootstrapSessionCommitted,
     });
   }
 

--- a/src/main/services/team/provisioning/TeamProvisioningCompatibilityFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningCompatibilityFacade.ts
@@ -34,6 +34,7 @@ export interface TeamProvisioningCompatibilityDelegation<
     | 'persistMembersMeta'
     | 'resolveLaunchExpectedMembers'
     | 'updateConfigPostLaunch'
+    | 'materializeLaunchRoster'
   >;
   configTaskActivityBoundary: Pick<
     TeamProvisioningConfigTaskActivityBoundary<TRun>,

--- a/src/main/services/team/provisioning/TeamProvisioningConfigFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningConfigFacade.ts
@@ -20,6 +20,7 @@ import {
   type TeamProvisioningLaunchExpectedMembersPorts,
 } from './TeamProvisioningLaunchExpectedMembers';
 import { createTeamProvisioningLaunchExpectedMembersPorts } from './TeamProvisioningLaunchExpectedMembersPortsFactory';
+import { type TeamProvisioningLaunchRosterInput } from './TeamProvisioningLaunchRosterMaterialization';
 import {
   listPersistedTeamNames as listPersistedTeamNamesHelper,
   type PersistedTeamConfigCacheEntry,
@@ -92,7 +93,8 @@ export class TeamProvisioningConfigFacade {
         getTeamsBasePath,
         getProjectsBasePath,
         readRegularFileUtf8: options.readRegularFileUtf8,
-        writeFileUtf8: (filePath, contents) => atomicWriteAsync(filePath, contents),
+        writeFileUtf8: (filePath, contents, options) =>
+          atomicWriteAsync(filePath, contents, options),
         unlink: (filePath) => fs.promises.unlink(filePath),
         readDir: (dirPath) => fs.promises.readdir(dirPath),
         stat: (filePath) => fs.promises.stat(filePath),
@@ -142,6 +144,10 @@ export class TeamProvisioningConfigFacade {
 
   updateConfigProjectPath(teamName: string, cwd: string): Promise<void> {
     return this.configMaintenance.updateConfigProjectPath(teamName, cwd);
+  }
+
+  materializeLaunchRoster(input: TeamProvisioningLaunchRosterInput): Promise<boolean> {
+    return this.configMaintenance.materializeLaunchRoster(input);
   }
 
   updateConfigPostLaunch(

--- a/src/main/services/team/provisioning/TeamProvisioningConfigMaintenance.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningConfigMaintenance.ts
@@ -17,6 +17,10 @@ import {
   updateTeamConfigPostLaunch,
 } from './TeamProvisioningConfigMaterialization';
 import { mergeAndRemoveDuplicateInboxes } from './TeamProvisioningInboxDuplicateMerge';
+import {
+  materializeTeamProvisioningLaunchRoster,
+  type TeamProvisioningLaunchRosterInput,
+} from './TeamProvisioningLaunchRosterMaterialization';
 
 import type { TeamCreateRequest, TeamMember } from '@shared/types';
 
@@ -41,7 +45,11 @@ export interface TeamProvisioningConfigMaintenancePorts {
     filePath: string,
     options: TeamProvisioningConfigMaintenanceReadOptions
   ): Promise<string | null | undefined>;
-  writeFileUtf8(filePath: string, contents: string): Promise<void>;
+  writeFileUtf8(
+    filePath: string,
+    contents: string,
+    options?: { beforeCommit: () => Promise<void> }
+  ): Promise<void>;
   unlink(filePath: string): Promise<void>;
   readDir(dirPath: string): Promise<string[]>;
   stat(filePath: string): Promise<{ isFile(): boolean; mtimeMs: number }>;
@@ -79,6 +87,18 @@ export interface TeamProvisioningConfigMaintenanceOptions {
 
 export class TeamProvisioningConfigMaintenance {
   constructor(private readonly options: TeamProvisioningConfigMaintenanceOptions) {}
+
+  materializeLaunchRoster(input: TeamProvisioningLaunchRosterInput): Promise<boolean> {
+    const configPath = this.getConfigPath(input.teamName);
+    return materializeTeamProvisioningLaunchRoster(input, {
+      readConfig: () => this.readTeamConfig(configPath),
+      readMetaMembers: () => this.options.ports.membersMetaStore.getMembers(input.teamName),
+      writeConfig: (raw, beforeCommit) =>
+        this.options.ports.writeFileUtf8(configPath, raw, { beforeCommit }),
+      invalidateTeam: (teamName) => this.options.ports.invalidateTeam(teamName),
+      now: () => this.options.ports.now(),
+    });
+  }
 
   /**
    * Immediately update projectPath in config.json at launch start, before CLI spawn.

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchDeterministicSpawnFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchDeterministicSpawnFlow.ts
@@ -505,6 +505,7 @@ export async function runDeterministicLaunchSpawnFlow<TRun extends Deterministic
         request,
         run,
         effectiveMemberSpecs,
+        allEffectiveMemberSpecs,
         controlApiBaseUrl: provisioningEnv.env.CLAUDE_TEAM_CONTROL_URL,
         isValidationCancelled: () =>
           isDeterministicLaunchSpawnCancelled({

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchRosterMaterialization.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchRosterMaterialization.ts
@@ -1,0 +1,80 @@
+import { normalizeOptionalTeamProviderId } from '@shared/utils/teamProvider';
+
+import { buildOpenCodeConfigMemberFromLaunchMember } from './TeamProvisioningConfigMaterialization';
+
+import type { TeamCreateRequest, TeamMember } from '@shared/types';
+
+export interface TeamProvisioningLaunchRosterInput {
+  teamName: string;
+  members: TeamCreateRequest['members'];
+  isCurrentRun(): boolean;
+}
+
+export interface TeamProvisioningLaunchRosterPorts {
+  readConfig(): Promise<string | null>;
+  readMetaMembers(): Promise<readonly TeamMember[]>;
+  writeConfig(raw: string, beforeCommit: () => Promise<void>): Promise<void>;
+  invalidateTeam(teamName: string): void;
+  now(): number;
+}
+
+/** Publish side-lane identities before runtime startup, independently of the lead's first turn. */
+export async function materializeTeamProvisioningLaunchRoster(
+  input: TeamProvisioningLaunchRosterInput,
+  ports: TeamProvisioningLaunchRosterPorts
+): Promise<boolean> {
+  if (!input.isCurrentRun()) return false;
+  const members = input.members.filter(
+    (member) => normalizeOptionalTeamProviderId(member.providerId) === 'opencode'
+  );
+  if (members.length === 0) return true;
+
+  const raw = await ports.readConfig();
+  if (!input.isCurrentRun()) return false;
+  if (!raw) throw new Error('Cannot prepare secondary launch: config.json unreadable');
+  const config = JSON.parse(raw) as Record<string, unknown>;
+  if (!Array.isArray(config.members)) {
+    throw new Error('Cannot prepare secondary launch: config members missing');
+  }
+  const configMembers = config.members as TeamMember[];
+  const names = new Set(members.map((member) => member.name.trim().toLowerCase()));
+  const hasRemovedMember = (roster: readonly TeamMember[]): boolean =>
+    roster.some(
+      (member) =>
+        member &&
+        typeof member.name === 'string' &&
+        names.has(member.name.trim().toLowerCase()) &&
+        member.removedAt != null
+    );
+  const metaMembers = await ports.readMetaMembers();
+  if (!input.isCurrentRun() || hasRemovedMember(configMembers) || hasRemovedMember(metaMembers)) {
+    return false;
+  }
+
+  const existingNames = new Set(
+    configMembers.map((member) => member?.name?.trim().toLowerCase()).filter(Boolean)
+  );
+  const previousMemberCount = configMembers.length;
+  for (const member of members) {
+    const name = member.name.trim().toLowerCase();
+    if (existingNames.has(name)) continue;
+    config.members.push(
+      buildOpenCodeConfigMemberFromLaunchMember(input.teamName, member, { now: ports.now })
+    );
+    existingNames.add(name);
+  }
+  const nextRaw = JSON.stringify(config, null, 2);
+  if (configMembers.length === previousMemberCount) {
+    return input.isCurrentRun();
+  }
+
+  await ports.writeConfig(nextRaw, async () => {
+    const currentRaw = await ports.readConfig();
+    const currentMeta = await ports.readMetaMembers();
+    if (!input.isCurrentRun() || currentRaw !== raw || hasRemovedMember(currentMeta)) {
+      throw new Error('Secondary launch roster changed before config commit');
+    }
+  });
+  ports.invalidateTeam(input.teamName);
+  return input.isCurrentRun();
+}

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchTeamFlow.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchTeamFlow.ts
@@ -72,6 +72,7 @@ export interface MaterializeDeterministicLaunchBootstrapFilesInput<
   request: TeamLaunchRequest;
   run: TRun;
   effectiveMemberSpecs: TeamCreateRequest['members'];
+  allEffectiveMemberSpecs: TeamCreateRequest['members'];
   controlApiBaseUrl?: string;
   isValidationCancelled(): boolean;
 }
@@ -406,7 +407,7 @@ export async function materializeDeterministicLaunchBootstrapFiles<
 
   const prompt = ports.buildDeterministicLaunchHydrationPrompt(
     request,
-    effectiveMemberSpecs,
+    input.allEffectiveMemberSpecs,
     existingTasks,
     false
   );

--- a/src/main/services/team/provisioning/TeamProvisioningLeadActivity.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLeadActivity.ts
@@ -6,6 +6,7 @@ export interface LeadActivityRunLike {
   teamName: string;
   runId: string;
   leadActivityState: LeadActivityState;
+  leadActivityPublished?: boolean;
 }
 
 export interface LeadActivityAccessorRunLike extends LeadActivityRunLike {
@@ -40,14 +41,17 @@ export interface LeadTaskActivityIntervalPorts<TRun extends LeadActivityRunLike>
   ): { failed?: boolean };
 }
 
-export interface SetLeadActivityPorts<TRun extends LeadActivityRunLike>
-  extends LeadTaskActivityIntervalPorts<TRun> {
+export interface SetLeadActivityPorts<
+  TRun extends LeadActivityRunLike,
+> extends LeadTaskActivityIntervalPorts<TRun> {
   isCurrentTrackedRun(run: TRun): boolean;
   nowIso(): string;
   emitTeamChange(event: TeamChangeEvent): void;
 }
 
-export function getLeadTaskActivityRunKey(run: Pick<LeadActivityRunLike, 'teamName' | 'runId'>): string {
+export function getLeadTaskActivityRunKey(
+  run: Pick<LeadActivityRunLike, 'teamName' | 'runId'>
+): string {
   return `${run.teamName}\u0000${run.runId}`;
 }
 
@@ -87,7 +91,11 @@ export function syncLeadTaskActivityForState<TRun extends LeadActivityRunLike>(
   const key = getLeadTaskActivityRunKey(run);
   if (state === 'active') {
     if (ports.syncedRunKeys.has(key)) return;
-    const result = ports.resumeActiveIntervalsForMember(run.teamName, ports.getRunLeadName(run), at);
+    const result = ports.resumeActiveIntervalsForMember(
+      run.teamName,
+      ports.getRunLeadName(run),
+      at
+    );
     if (result.failed) return;
     ports.syncedRunKeys.add(key);
     return;
@@ -115,9 +123,10 @@ export function setLeadActivity<TRun extends LeadActivityRunLike>(
   } else {
     ports.syncedRunKeys.delete(getLeadTaskActivityRunKey(run));
   }
-  if (previousState === state) return;
+  if (previousState === state && run.leadActivityPublished) return;
   run.leadActivityState = state;
   if (!isCurrentRun) return;
+  run.leadActivityPublished = true;
   ports.emitTeamChange({
     type: 'lead-activity',
     teamName: run.teamName,

--- a/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaneLaunchSetup.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaneLaunchSetup.ts
@@ -20,6 +20,7 @@ export interface MixedSecondaryLaneLaunchSetupPorts<TRun extends MixedSecondaryL
   nowMs(): number;
   randomUuid(): string;
   teamsBasePath(): string;
+  isCurrentTrackedRun(run: TRun): boolean;
   isStoppingSecondaryRuntimeTeam(teamName: string): boolean;
   clearOpenCodeRuntimeLaneStorage(input: {
     teamsBasePath: string;
@@ -86,7 +87,10 @@ export async function setupMixedSecondaryLaneLaunch<TRun extends MixedSecondaryL
   const requestedDiagnostics = [...lane.diagnostics];
   const laneRunId = (lane.runId ??= ports.randomUuid());
   const shouldAbortLaunch = (): boolean =>
-    run.cancelRequested || run.processKilled || ports.isStoppingSecondaryRuntimeTeam(run.teamName);
+    run.cancelRequested ||
+    run.processKilled ||
+    !ports.isCurrentTrackedRun(run) ||
+    ports.isStoppingSecondaryRuntimeTeam(run.teamName);
   const finishCancelledLane = async (): Promise<void> => {
     await ports
       .clearOpenCodeRuntimeLaneStorage({

--- a/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaneWiring.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaneWiring.ts
@@ -114,6 +114,7 @@ export interface TeamProvisioningMixedSecondaryLaneWiringDeps<
   TRun extends TeamProvisioningMixedSecondaryLaneWiringRun,
 > {
   service: TeamProvisioningMixedSecondaryLaneWiringService<TRun>;
+  isCurrentTrackedRun(run: TRun): boolean;
   logger: MixedSecondaryLaunchQueuePorts<TRun>['logger'] &
     SingleMixedSecondaryRuntimeLaneStopPorts['logger'];
 }
@@ -165,6 +166,7 @@ export interface TeamProvisioningMixedSecondaryLaneWiringServiceHost<
 export interface TeamProvisioningMixedSecondaryLaneWiringServiceHostOptions<
   TRun extends TeamProvisioningMixedSecondaryLaneWiringRun,
 > {
+  isCurrentTrackedRun(run: TRun): boolean;
   logger: TeamProvisioningMixedSecondaryLaneWiringDeps<TRun>['logger'];
 }
 
@@ -203,6 +205,7 @@ export function createMixedSecondaryLaneLaunchFlowPorts<
   deps: TeamProvisioningMixedSecondaryLaneWiringDeps<TRun>
 ): MixedSecondaryLaneLaunchFlowPorts<TRun> {
   return {
+    isCurrentTrackedRun: deps.isCurrentTrackedRun,
     nowMs: () => Date.now(),
     randomUuid: () => randomUUID(),
     teamsBasePath: () => getTeamsBasePath(),
@@ -252,6 +255,7 @@ export function createMixedSecondaryLaunchQueuePorts<
   TRun extends TeamProvisioningMixedSecondaryLaneWiringRun,
 >(deps: TeamProvisioningMixedSecondaryLaneWiringDeps<TRun>): MixedSecondaryLaunchQueuePorts<TRun> {
   return {
+    isCurrentTrackedRun: deps.isCurrentTrackedRun,
     nowMs: () => Date.now(),
     randomUuid: () => randomUUID(),
     teamsBasePath: () => getTeamsBasePath(),
@@ -314,6 +318,7 @@ export function createTeamProvisioningMixedSecondaryLaneWiringDepsFromService<
   options: TeamProvisioningMixedSecondaryLaneWiringServiceHostOptions<TRun>
 ): TeamProvisioningMixedSecondaryLaneWiringDeps<TRun> {
   return {
+    isCurrentTrackedRun: options.isCurrentTrackedRun,
     service: {
       isStoppingSecondaryRuntimeTeam: (teamName) =>
         service.stoppingSecondaryRuntimeTeams.has(teamName),

--- a/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaunchQueue.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMixedSecondaryLaunchQueue.ts
@@ -33,6 +33,7 @@ export interface MixedSecondaryLaunchQueuePorts<TRun extends MixedSecondaryLaunc
   nowMs(): number;
   randomUuid(): string;
   teamsBasePath(): string;
+  isCurrentTrackedRun(run: TRun): boolean;
   clearOpenCodeRuntimeLaneStorage(input: {
     teamsBasePath: string;
     teamName: string;
@@ -102,10 +103,12 @@ export function launchQueuedMixedSecondaryLaneInBackground<
   lane.queuedAtMs = lane.queuedAtMs ?? ports.nowMs();
   lane.launchScheduled = true;
   const laneRunId = (lane.runId ??= ports.randomUuid());
+  const shouldAbortLaunch = (): boolean =>
+    run.cancelRequested || run.processKilled || !ports.isCurrentTrackedRun(run);
 
   const launch = async () => {
     try {
-      if (run.cancelRequested || run.processKilled) {
+      if (shouldAbortLaunch()) {
         // This queued lane has not acquired runtime storage or registry ownership.
         if (lane.runId === laneRunId) lane.state = 'finished';
         return;
@@ -129,11 +132,7 @@ export function launchQueuedMixedSecondaryLaneInBackground<
       }
       lane.state = 'launching';
       await ports.launchSingleMixedSecondaryLane(run, lane);
-      if (
-        shouldRetryTransientOpenCodeSharedRuntimeFailure(lane.result) &&
-        !run.cancelRequested &&
-        !run.processKilled
-      ) {
+      if (shouldRetryTransientOpenCodeSharedRuntimeFailure(lane.result) && !shouldAbortLaunch()) {
         // The pre-launch gate on the failed result proves the state-changing
         // bridge command never ran, so one in-place relaunch cannot duplicate a
         // host or a session.
@@ -148,7 +147,7 @@ export function launchQueuedMixedSecondaryLaneInBackground<
         // The backoff is a window in which the lane can change hands (a manual
         // lane retry or a relaunch assigns a new lane run id). Only the run that
         // observed the timeout may relaunch, mirroring the cancelled-lane fence.
-        if (!run.cancelRequested && !run.processKilled && lane.runId === laneRunId) {
+        if (!shouldAbortLaunch() && lane.runId === laneRunId) {
           lane.state = 'launching';
           lane.result = null;
           await ports.launchSingleMixedSecondaryLane(run, lane);
@@ -158,7 +157,7 @@ export function launchQueuedMixedSecondaryLaneInBackground<
         trackOpenCodeSharedRuntimeFailureFromResult(run, laneCwd, lane.result, ports.nowMs());
       }
     } catch (error) {
-      if (run.cancelRequested || run.processKilled) {
+      if (shouldAbortLaunch()) {
         await clearQueuedMixedSecondaryLaneStorage(run, lane, laneRunId, ports);
         if (lane.runId === laneRunId) lane.state = 'finished';
         return;
@@ -209,7 +208,9 @@ export async function launchMixedSecondaryLaneIfNeeded<TRun extends MixedSeconda
   ports: MixedSecondaryLaunchQueuePorts<TRun>,
   options: { waitForCompletion?: boolean } = {}
 ): Promise<PersistedTeamLaunchSnapshot | null> {
-  if (run.cancelRequested || run.processKilled) {
+  const shouldAbortLaunch = (): boolean =>
+    run.cancelRequested || run.processKilled || !ports.isCurrentTrackedRun(run);
+  if (shouldAbortLaunch()) {
     return ports.readLaunchState(run.teamName).catch(() => null);
   }
 
@@ -246,6 +247,7 @@ export async function launchMixedSecondaryLaneIfNeeded<TRun extends MixedSeconda
       };
       lane.diagnostics = lane.result.diagnostics;
       await ports.publishMixedSecondaryLaneStatusChange(run, lane);
+      if (shouldAbortLaunch()) return ports.readLaunchState(run.teamName).catch(() => null);
     }
     return ports.persistLaunchStateSnapshot(run, 'finished');
   }
@@ -256,7 +258,7 @@ export async function launchMixedSecondaryLaneIfNeeded<TRun extends MixedSeconda
 
   if (options.waitForCompletion) {
     await run.mixedSecondaryLaneLaunchQueue;
-    if (run.cancelRequested || run.processKilled) {
+    if (shouldAbortLaunch()) {
       return ports.readLaunchState(run.teamName).catch(() => null);
     }
   }

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeBootstrapEvidence.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeBootstrapEvidence.ts
@@ -50,11 +50,13 @@ export interface OpenCodeRuntimeBootstrapEvidencePorts {
   getCurrentAgentTeamsMcpHttpTransportEvidence(): AgentTeamsMcpHttpTransportEvidence | null;
   isFileLockTimeoutError(error: unknown): boolean;
   warn(message: string): void;
+  onBootstrapSessionCommitted?(input: CommitOpenCodeRuntimeBootstrapSessionEvidenceInput): void;
 }
 
 export function createDefaultOpenCodeRuntimeBootstrapEvidencePorts(input: {
   teamsBasePath: string;
   warn?: (message: string) => void;
+  onBootstrapSessionCommitted?: OpenCodeRuntimeBootstrapEvidencePorts['onBootstrapSessionCommitted'];
 }): OpenCodeRuntimeBootstrapEvidencePorts {
   return {
     teamsBasePath: input.teamsBasePath,
@@ -66,6 +68,7 @@ export function createDefaultOpenCodeRuntimeBootstrapEvidencePorts(input: {
     getCurrentAgentTeamsMcpHttpTransportEvidence,
     isFileLockTimeoutError,
     warn: input.warn ?? (() => undefined),
+    onBootstrapSessionCommitted: input.onBootstrapSessionCommitted,
   };
 }
 
@@ -276,10 +279,16 @@ export async function commitOpenCodeRuntimeBootstrapSessionEvidence(
   input: CommitOpenCodeRuntimeBootstrapSessionEvidenceInput,
   ports: OpenCodeRuntimeBootstrapEvidencePorts
 ): Promise<void> {
-  return withOpenCodeRuntimeLaneLifecycleLock(
-    { teamsBasePath: ports.teamsBasePath, ...input },
-    () => commitOpenCodeRuntimeBootstrapSessionEvidenceUnlocked(input, ports)
+  await withOpenCodeRuntimeLaneLifecycleLock({ teamsBasePath: ports.teamsBasePath, ...input }, () =>
+    commitOpenCodeRuntimeBootstrapSessionEvidenceUnlocked(input, ports)
   );
+  // Both app-managed bootstrap and runtime check-in reach this verified commit.
+  // Publish outside the lane lock; inbox delivery must not block launch/check-in.
+  try {
+    ports.onBootstrapSessionCommitted?.(input);
+  } catch (error) {
+    ports.warn(`OpenCode bootstrap inbox wake failed: ${getErrorMessage(error)}`);
+  }
 }
 
 async function commitOpenCodeRuntimeBootstrapSessionEvidenceUnlocked(

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeDeliveryComposition.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeDeliveryComposition.ts
@@ -1,4 +1,24 @@
+import { findDeliverableOpenCodeRuntimeBootstrapSessionEvidence } from './TeamProvisioningOpenCodeBootstrapEvidence';
+import { getTrackedOpenCodeBootstrapWakeRunId } from './TeamProvisioningSecondaryRuntimeRuns';
+
 import type { OpenCodePromptDeliveryWatchdogCoordinatorPorts } from '../opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator';
+import type { OpenCodeRuntimeBootstrapEvidencePorts } from './TeamProvisioningOpenCodeBootstrapEvidence';
+
+export function createOpenCodeBootstrapWakePorts(
+  runtime: Parameters<typeof getTrackedOpenCodeBootstrapWakeRunId>[1],
+  createEvidencePorts: () => OpenCodeRuntimeBootstrapEvidencePorts
+): Pick<
+  OpenCodePromptDeliveryWatchdogCoordinatorPorts,
+  'resolveTrackedBootstrapRunId' | 'hasCommittedBootstrapSession'
+> {
+  return {
+    resolveTrackedBootstrapRunId: (input) => getTrackedOpenCodeBootstrapWakeRunId(input, runtime),
+    hasCommittedBootstrapSession: async (input) =>
+      Boolean(
+        await findDeliverableOpenCodeRuntimeBootstrapSessionEvidence(input, createEvidencePorts())
+      ),
+  };
+}
 
 /**
  * Service-side ports the OpenCode prompt-delivery pipeline is composed from.

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeLaunchWiring.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeLaunchWiring.ts
@@ -287,7 +287,8 @@ export function createTeamProvisioningOpenCodeLaunchWiringHostFromService<Run>(
 }
 
 export function createTeamProvisioningOpenCodeLaunchWiring<Run>(
-  host: TeamProvisioningOpenCodeLaunchWiringHost<Run>
+  host: TeamProvisioningOpenCodeLaunchWiringHost<Run>,
+  onRuntimeRegistered?: (input: { teamName: string; runId: string }) => void
 ): TeamProvisioningOpenCodeLaunchWiring {
   // One OpenCode host serves every launch of a project, so the shared-runtime
   // records outlive a single team launch: a relaunch that hits the same timeout
@@ -365,6 +366,7 @@ export function createTeamProvisioningOpenCodeLaunchWiring<Run>(
             host.deliverOpenCodeLaunchPromptToLead(promptInput),
           setAliveRunId: (teamName, runId) => {
             host.runTracking.setAliveRunId(teamName, runId);
+            onRuntimeRegistered?.({ teamName, runId });
           },
           setRuntimeAdapterRun: (teamName, runtimeRun) => {
             host.runtimeAdapterRunByTeam.set(teamName, runtimeRun);
@@ -459,6 +461,7 @@ export function createTeamProvisioningOpenCodeLaunchWiring<Run>(
           },
           setAliveRunId: (teamName, runId) => {
             host.runTracking.setAliveRunId(teamName, runId);
+            onRuntimeRegistered?.({ teamName, runId });
           },
           invalidateRuntimeSnapshotCaches: (teamName) =>
             host.invalidateRuntimeSnapshotCaches(teamName),

--- a/src/main/services/team/provisioning/TeamProvisioningPromptBuilders.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningPromptBuilders.ts
@@ -1042,7 +1042,7 @@ export function buildDeterministicLaunchHydrationPrompt(
   const startupLabel = isResume ? 'resume/bootstrap' : 'launch/bootstrap';
   const headerModeLabel = isResume ? 'Deterministic resume' : 'Deterministic launch';
   const userPromptBlock = request.prompt?.trim()
-    ? `\nOriginal user instructions to apply after ${isResume ? 'resume' : 'startup'} is stable:\n${request.prompt.trim()}\n`
+    ? `\nOriginal user instructions to apply now:\n${request.prompt.trim()}\n`
     : '';
   const hasOriginalUserPrompt = Boolean(request.prompt?.trim());
   const taskBoardSnapshot = buildTaskBoardSnapshot(tasks);
@@ -1052,27 +1052,25 @@ export function buildDeterministicLaunchHydrationPrompt(
     isSolo,
     members,
   });
-  const nextSteps = isSolo
+  const nextSteps = hasOriginalUserPrompt
     ? `This ${startupLabel} step has already been completed deterministically by the runtime.
+Do NOT call TeamCreate.
+Do NOT use Agent to spawn or restore teammates.
+This is the first normal operating turn after bootstrap. Apply the original user instructions now; do not wait for another user message.
+${isSolo ? "Follow the user's requested action mode; answer read-only questions or carry out requested work and update the task board as appropriate." : "Follow the user's requested action mode, including read-only answers. Create or assign tasks only when the request calls for teammate work, using the exact roster below. If an owner is still joining, leave its assignment pending and wait for that owner; do not do its work yourself."}`
+    : isSolo
+      ? `This ${startupLabel} step has already been completed deterministically by the runtime.
 Do NOT call TeamCreate.
 Do NOT use Agent to spawn or restore teammates.
 Do NOT start implementation in this turn.
 Use this turn only to review the current board snapshot and confirm operational readiness.
-${
-  hasOriginalUserPrompt
-    ? 'Do NOT create or update any new task in this turn - wait for the next normal operating turn before translating those instructions into board work.'
-    : 'Do NOT create, assign, or delegate any new task in this turn. If the board is empty, stay silent and wait for a fresh user instruction.'
-}`
-    : `This ${startupLabel} step has already been completed deterministically by the runtime.
+Do NOT create, assign, or delegate any new task in this turn. If the board is empty, stay silent and wait for a fresh user instruction.`
+      : `This ${startupLabel} step has already been completed deterministically by the runtime.
 Do NOT call TeamCreate.
 Do NOT use Agent to spawn or restore teammates.
 Do NOT repeat the launch summary.
 Use this turn only to review the current board snapshot and teammate readiness.
-${
-  hasOriginalUserPrompt
-    ? 'Do NOT create or assign any new task in this turn - wait for the next normal operating turn before translating those instructions into board work.'
-    : 'Do NOT create, assign, or delegate any new task in this turn. If the board is empty, stay silent and wait for a fresh user instruction.'
-}
+Do NOT create, assign, or delegate any new task in this turn. If the board is empty, stay silent and wait for a fresh user instruction.
 Treat teammates whose bootstrap is still pending as not-yet-available for blocking assignments.`;
 
   return `${startLabel} [${headerModeLabel} | Team: "${request.teamName}" | Project: "${projectName}" | Lead: "${leadName}"]
@@ -1086,7 +1084,7 @@ ${nextSteps}
 ${taskBoardSnapshot}
 ${persistentContext}
 
-Reply with one concise user-facing team status line. Mention whether there is actionable board work and whether any teammate is still bootstrap-pending. Only report board readiness and teammate availability. Do not start work, create tasks, or delegate in this turn.`;
+${hasOriginalUserPrompt ? 'Carry out the requested operating turn once, then give the user a concise progress update.' : 'Reply with one concise user-facing team status line. Mention whether there is actionable board work and whether any teammate is still bootstrap-pending. Only report board readiness and teammate availability. Do not start work, create tasks, or delegate in this turn.'}`;
 }
 
 export function buildGeminiPostLaunchHydrationPrompt(

--- a/src/main/services/team/provisioning/TeamProvisioningRunModel.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningRunModel.ts
@@ -212,6 +212,7 @@ export interface ProvisioningRun {
   detectedSessionId: string | null;
   /** Lead process activity: 'active' during turn processing, 'idle' waiting for input, 'offline' after exit. */
   leadActivityState: LeadActivityState;
+  leadActivityPublished?: boolean;
   /** Whether an auth failure retry was already attempted for this run. */
   authFailureRetried: boolean;
   /** Set to true while auth-failure respawn is in progress to prevent duplicate handling. */

--- a/src/main/services/team/provisioning/TeamProvisioningRunModel.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningRunModel.ts
@@ -96,6 +96,8 @@ export interface ProvisioningRun {
   effectiveMembers: TeamCreateRequest['members'];
   launchIdentity: ProviderModelLaunchIdentity | null;
   mixedSecondaryLanes: MixedSecondaryRuntimeLaneState[];
+  /** Roster-only write barrier; does not wait for secondary runtime startup. */
+  mixedSecondaryRosterPreparation?: Promise<boolean>;
   /**
    * OpenCode secondary lanes share bridge state files. Launch them sequentially
    * per team run to avoid file-lock contention while keeping launch non-blocking.

--- a/src/main/services/team/provisioning/TeamProvisioningSecondaryRuntimeRuns.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningSecondaryRuntimeRuns.ts
@@ -304,6 +304,29 @@ export function createSecondaryRuntimeRunStore(input: {
   };
 }
 
+export function getTrackedOpenCodeBootstrapWakeRunId(
+  input: { teamName: string; laneId: string; runId: string },
+  ports: {
+    runTracking: { resolveDeliverableTrackedRuntimeRunId(teamName: string): string | null };
+    runs: {
+      get(
+        runId: string
+      ): { mixedSecondaryLanes?: readonly { laneId: string; runId: string | null }[] } | undefined;
+    };
+  }
+): string | null {
+  const trackedRunId = ports.runTracking.resolveDeliverableTrackedRuntimeRunId(input.teamName);
+  if (!trackedRunId) return null;
+  if (input.laneId === 'primary') return trackedRunId === input.runId ? trackedRunId : null;
+  return ports.runs
+    .get(trackedRunId)
+    ?.mixedSecondaryLanes?.some(
+      (lane) => lane.laneId === input.laneId && lane.runId === input.runId
+    )
+    ? trackedRunId
+    : null;
+}
+
 export function getCurrentOpenCodeRuntimeRunId(input: {
   teamName: string;
   laneId: string;

--- a/src/main/services/team/provisioning/TeamProvisioningServiceComposition.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningServiceComposition.ts
@@ -99,6 +99,7 @@ import {
   type TeamProvisioningMemberMcpLaunchConfigServiceHost,
 } from './TeamProvisioningMemberMcpLaunchConfig';
 import { createInitialMemberSpawnStatusEntry } from './TeamProvisioningMemberSpawnStatusPolicy';
+import { findDeliverableOpenCodeRuntimeBootstrapSessionEvidence } from './TeamProvisioningOpenCodeBootstrapEvidence';
 import { type TeamProvisioningOpenCodeDeliveryCompositionPorts } from './TeamProvisioningOpenCodeDeliveryComposition';
 import {
   createOpenCodePromptDeliveryWatchdogSchedulerFromService,
@@ -726,6 +727,13 @@ export function createTeamProvisioningServiceComposition(
           teamName,
           laneId
         ),
+      hasCommittedBootstrapSession: async (input) =>
+        Boolean(
+          await findDeliverableOpenCodeRuntimeBootstrapSessionEvidence(
+            input,
+            bootstrapEvidenceFacade.createOpenCodeRuntimeBootstrapEvidencePorts()
+          )
+        ),
       hasStableInboxMessageId,
       logPromptDeliveryEvent: (event, record, extra) =>
         servicePorts.logOpenCodePromptDeliveryEvent(event, record, extra),
@@ -753,6 +761,13 @@ export function createTeamProvisioningServiceComposition(
       getTeamsBasePath,
       nowIso,
       warn: (message) => logger.warn(message),
+      onBootstrapSessionCommitted: (input) => {
+        void openCodePromptDeliveryWatchdogCoordinator
+          .wakeAfterBootstrapCommit(input)
+          .catch((error) =>
+            logger.warn(`OpenCode bootstrap inbox wake failed: ${getErrorMessage(error)}`)
+          );
+      },
     }
   );
   assignCompositionPart(host.installTarget, 'bootstrapEvidenceFacade', bootstrapEvidenceFacade);

--- a/src/main/services/team/provisioning/TeamProvisioningServiceComposition.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningServiceComposition.ts
@@ -99,8 +99,10 @@ import {
   type TeamProvisioningMemberMcpLaunchConfigServiceHost,
 } from './TeamProvisioningMemberMcpLaunchConfig';
 import { createInitialMemberSpawnStatusEntry } from './TeamProvisioningMemberSpawnStatusPolicy';
-import { findDeliverableOpenCodeRuntimeBootstrapSessionEvidence } from './TeamProvisioningOpenCodeBootstrapEvidence';
-import { type TeamProvisioningOpenCodeDeliveryCompositionPorts } from './TeamProvisioningOpenCodeDeliveryComposition';
+import {
+  createOpenCodeBootstrapWakePorts,
+  type TeamProvisioningOpenCodeDeliveryCompositionPorts,
+} from './TeamProvisioningOpenCodeDeliveryComposition';
 import {
   createOpenCodePromptDeliveryWatchdogSchedulerFromService,
   type TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerServiceHost,
@@ -727,13 +729,9 @@ export function createTeamProvisioningServiceComposition(
           teamName,
           laneId
         ),
-      hasCommittedBootstrapSession: async (input) =>
-        Boolean(
-          await findDeliverableOpenCodeRuntimeBootstrapSessionEvidence(
-            input,
-            bootstrapEvidenceFacade.createOpenCodeRuntimeBootstrapEvidencePorts()
-          )
-        ),
+      ...createOpenCodeBootstrapWakePorts(openCodeRuntimeDeliveryBoundaryHost, () =>
+        bootstrapEvidenceFacade.createOpenCodeRuntimeBootstrapEvidencePorts()
+      ),
       hasStableInboxMessageId,
       logPromptDeliveryEvent: (event, record, extra) =>
         servicePorts.logOpenCodePromptDeliveryEvent(event, record, extra),

--- a/src/main/services/team/provisioning/TeamProvisioningServiceMemberLifecycleFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningServiceMemberLifecycleFacade.ts
@@ -355,7 +355,7 @@ export abstract class TeamProvisioningServiceMemberLifecycleFacade extends TeamP
     createTeamProvisioningMixedSecondaryLaneWiring<ProvisioningRun>(
       createTeamProvisioningMixedSecondaryLaneWiringDepsFromService(
         this as unknown as TeamProvisioningMixedSecondaryLaneWiringServiceHost<ProvisioningRun>,
-        { logger }
+        { logger, isCurrentTrackedRun: (run) => this.isCurrentTrackedRun(run) }
       )
     );
   protected readonly openCodeLaunchWiring =

--- a/src/main/services/team/provisioning/TeamProvisioningServiceMemberLifecycleFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningServiceMemberLifecycleFacade.ts
@@ -362,7 +362,14 @@ export abstract class TeamProvisioningServiceMemberLifecycleFacade extends TeamP
     createTeamProvisioningOpenCodeLaunchWiring<ProvisioningRun>(
       createTeamProvisioningOpenCodeLaunchWiringHostFromService(
         this as unknown as TeamProvisioningOpenCodeLaunchWiringServiceHost<ProvisioningRun>
-      )
+      ),
+      (input) => {
+        void this.openCodePromptDeliveryWatchdogCoordinator
+          .wakeAfterRuntimeRegistration(input)
+          .catch((error: unknown) =>
+            logger.warn(`OpenCode registered runtime inbox wake failed: ${String(error)}`)
+          );
+      }
     );
   protected readonly requestAdmissionBoundary!: TeamProvisioningServiceComposition['requestAdmissionBoundary'];
   protected readonly openCodeRuntimeDeliveryBoundaryHost!: TeamProvisioningOpenCodeRuntimeDeliveryBoundaryHost<ProvisioningRun>;

--- a/src/main/services/team/provisioning/TeamProvisioningStreamEventPortsFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStreamEventPortsFactory.ts
@@ -76,6 +76,7 @@ export interface TeamProvisioningStreamEventPortCallbacks<
   injectGeminiPostLaunchHydration: TeamProvisioningStreamEventPorts<TRun>['injectGeminiPostLaunchHydration'];
   completeProvisioningFromSuccessfulResult: TeamProvisioningStreamEventPorts<TRun>['completeProvisioningFromSuccessfulResult'];
   handleControlRequest: TeamProvisioningStreamEventPorts<TRun>['handleControlRequest'];
+  launchMixedSecondaryLaneIfNeeded: TeamProvisioningStreamEventPorts<TRun>['launchMixedSecondaryLaneIfNeeded'];
   handleProvisioningTurnComplete: TeamProvisioningStreamEventPorts<TRun>['handleProvisioningTurnComplete'];
   cleanupRun: TeamProvisioningStreamEventPorts<TRun>['cleanupRun'];
   emitApiErrorWarning: TeamProvisioningStreamEventPorts<TRun>['emitApiErrorWarning'];
@@ -115,6 +116,7 @@ type StreamEventServicePortKey =
   | 'injectGeminiPostLaunchHydration'
   | 'completeProvisioningFromSuccessfulResult'
   | 'handleControlRequest'
+  | 'launchMixedSecondaryLaneIfNeeded'
   | 'handleProvisioningTurnComplete'
   | 'cleanupRun'
   | 'setMemberSpawnStatus'
@@ -139,6 +141,7 @@ export interface TeamProvisioningStreamEventPortsBoundaryDeps<
   service: TeamProvisioningStreamEventServiceAdapter<TRun>;
   persistentRuntimeCleanup: TeamProvisioningStreamEventPersistentRuntimeCleanupAdapter<TRun>;
   outputRecovery: TeamProvisioningStreamEventOutputRecoveryAdapter<TRun>;
+  prepareMixedSecondaryLaunch(run: TRun): Promise<boolean>;
   updateProgress: TeamProvisioningStreamEventPorts<TRun>['updateProgress'];
   emitTeamChange?: TeamProvisioningStreamEventPorts<TRun>['emitTeamChange'];
 }
@@ -183,6 +186,12 @@ export function createTeamProvisioningStreamEventPortsBoundary<
     completeProvisioningFromSuccessfulResult: (run) =>
       deps.service.completeProvisioningFromSuccessfulResult(run),
     handleControlRequest: (run, msg) => deps.service.handleControlRequest(run, msg),
+    launchMixedSecondaryLaneIfNeeded: async (run) => {
+      if (run.cancelRequested || run.processKilled) return;
+      const prepared = await deps.prepareMixedSecondaryLaunch(run);
+      if (!prepared || run.cancelRequested || run.processKilled) return;
+      return deps.service.launchMixedSecondaryLaneIfNeeded(run);
+    },
     handleProvisioningTurnComplete: (run) => deps.service.handleProvisioningTurnComplete(run),
     cleanupRun: (run) => deps.service.cleanupRun(run),
     emitApiErrorWarning: (run, text) => deps.outputRecovery.emitApiErrorWarning(run, text),
@@ -239,6 +248,7 @@ export function createTeamProvisioningStreamEventPorts<
     injectGeminiPostLaunchHydration: callbacks.injectGeminiPostLaunchHydration,
     completeProvisioningFromSuccessfulResult: callbacks.completeProvisioningFromSuccessfulResult,
     handleControlRequest: callbacks.handleControlRequest,
+    launchMixedSecondaryLaneIfNeeded: callbacks.launchMixedSecondaryLaneIfNeeded,
     handleProvisioningTurnComplete: callbacks.handleProvisioningTurnComplete,
     cleanupRun: callbacks.cleanupRun,
     killTeamProcess,

--- a/src/main/services/team/provisioning/TeamProvisioningStreamEventPortsFactory.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStreamEventPortsFactory.ts
@@ -188,7 +188,8 @@ export function createTeamProvisioningStreamEventPortsBoundary<
     handleControlRequest: (run, msg) => deps.service.handleControlRequest(run, msg),
     launchMixedSecondaryLaneIfNeeded: async (run) => {
       if (run.cancelRequested || run.processKilled) return;
-      const prepared = await deps.prepareMixedSecondaryLaunch(run);
+      run.mixedSecondaryRosterPreparation ??= deps.prepareMixedSecondaryLaunch(run);
+      const prepared = await run.mixedSecondaryRosterPreparation;
       if (!prepared || run.cancelRequested || run.processKilled) return;
       return deps.service.launchMixedSecondaryLaneIfNeeded(run);
     },

--- a/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
@@ -777,6 +777,23 @@ export function handleTeamProvisioningStreamJsonMessage<TRun extends TeamProvisi
       }
     }
 
+    const hasObservedActivity =
+      textParts.some((text) => text.trim().length > 0) ||
+      content.some(
+        (block) =>
+          block.type === 'tool_use' &&
+          typeof block.name === 'string' &&
+          typeof block.id === 'string'
+      );
+    if (
+      hasObservedActivity &&
+      !run.processKilled &&
+      !run.cancelRequested &&
+      run.progress.state !== 'failed'
+    ) {
+      ports.setLeadActivity(run, 'active');
+    }
+
     for (const block of content) {
       if (
         block?.type === 'tool_use' &&

--- a/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
@@ -90,6 +90,7 @@ export interface TeamProvisioningStreamRun {
   provisioningOutputParts: string[];
   lastRetryAt: number;
   apiErrorWarningEmitted: boolean;
+  mixedSecondaryLanes?: readonly unknown[];
 }
 
 export interface TeamProvisioningStreamEventPorts<TRun extends TeamProvisioningStreamRun> {
@@ -162,6 +163,7 @@ export interface TeamProvisioningStreamEventPorts<TRun extends TeamProvisioningS
   injectGeminiPostLaunchHydration(run: TRun): Promise<void>;
   completeProvisioningFromSuccessfulResult(run: TRun): void;
   handleControlRequest(run: TRun, msg: Record<string, unknown>): void;
+  launchMixedSecondaryLaneIfNeeded(run: TRun): Promise<unknown>;
   handleProvisioningTurnComplete(run: TRun): Promise<void>;
   cleanupRun(run: TRun): void;
   killTeamProcess(child: ChildProcess | null | undefined): void;
@@ -572,6 +574,15 @@ export function handleDeterministicBootstrapEvent<TRun extends TeamProvisioningS
           reason || 'Deterministic bootstrap failed to spawn teammate.'
         );
       }
+    }
+    if ((run.mixedSecondaryLanes?.length ?? 0) > 0) {
+      void ports.launchMixedSecondaryLaneIfNeeded(run).catch((error: unknown) => {
+        logger.error(
+          `[${run.teamName}] mixed secondary launch after primary bootstrap failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      });
     }
     if (!run.requiresFirstRealTurnSuccess && !run.provisioningComplete && !run.cancelRequested) {
       void ports.handleProvisioningTurnComplete(run).catch((error: unknown) => {

--- a/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
@@ -91,6 +91,7 @@ export interface TeamProvisioningStreamRun {
   lastRetryAt: number;
   apiErrorWarningEmitted: boolean;
   mixedSecondaryLanes?: readonly unknown[];
+  mixedSecondaryRosterPreparation?: Promise<boolean>;
 }
 
 export interface TeamProvisioningStreamEventPorts<TRun extends TeamProvisioningStreamRun> {
@@ -575,7 +576,7 @@ export function handleDeterministicBootstrapEvent<TRun extends TeamProvisioningS
         );
       }
     }
-    if ((run.mixedSecondaryLanes?.length ?? 0) > 0) {
+    if (!run.provisioningComplete && (run.mixedSecondaryLanes?.length ?? 0) > 0) {
       void ports.launchMixedSecondaryLaneIfNeeded(run).catch((error: unknown) => {
         logger.error(
           `[${run.teamName}] mixed secondary launch after primary bootstrap failed: ${

--- a/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStreamEvents.ts
@@ -777,8 +777,9 @@ export function handleTeamProvisioningStreamJsonMessage<TRun extends TeamProvisi
       }
     }
 
+    const activityText = stripAgentBlocks(textParts.join('\n')).trim();
     const hasObservedActivity =
-      textParts.some((text) => text.trim().length > 0) ||
+      (activityText.length > 0 && !isTeamInternalControlMessageText(activityText)) ||
       content.some(
         (block) =>
           block.type === 'tool_use' &&

--- a/src/main/services/team/provisioning/TeamProvisioningStreamTurnCompatibilityFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningStreamTurnCompatibilityFacade.ts
@@ -136,6 +136,17 @@ export abstract class TeamProvisioningStreamTurnCompatibilityFacade<
       service: this as unknown as TeamProvisioningStreamEventServiceAdapter<TRun>,
       persistentRuntimeCleanup: this.persistentRuntimeCleanup,
       outputRecovery: this.outputRecoveryFacade,
+      prepareMixedSecondaryLaunch: (run) =>
+        this.compatibilityDelegation.configFacade.materializeLaunchRoster({
+          teamName: run.teamName,
+          members: run.allEffectiveMembers,
+          isCurrentRun: () =>
+            this.compatibilityDelegation.runs.get(run.runId) === run &&
+            this.runTracking.getTrackedRunId(run.teamName) === run.runId &&
+            !run.cancelRequested &&
+            !run.processKilled &&
+            run.progress.state !== 'failed',
+        }),
       updateProgress,
       emitTeamChange: (event) => this.teamChangeEmitter?.(event),
     });

--- a/src/main/services/team/provisioning/TeamProvisioningTurnComplete.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningTurnComplete.ts
@@ -59,6 +59,7 @@ export interface TeamProvisioningTurnCompleteRun {
   request: TeamCreateRequest;
   detectedSessionId: string | null;
   allEffectiveMembers: TeamCreateRequest['members'];
+  mixedSecondaryRosterPreparation?: Promise<boolean>;
   deterministicBootstrap: boolean;
   pendingGeminiPostLaunchHydration: boolean;
   geminiPostLaunchHydrationInFlight: boolean;
@@ -377,6 +378,11 @@ export async function handleTeamProvisioningTurnComplete<
   run: TRun,
   ports: TeamProvisioningTurnCompletePorts<TRun, TSecondaryLaunchResult>
 ): Promise<void> {
+  // Finish an eager roster write before post-launch metadata reads config.json.
+  // Failed preparation is already reported by the stream handler; completion can retry launch.
+  if (run.mixedSecondaryRosterPreparation) {
+    await run.mixedSecondaryRosterPreparation.catch(() => undefined);
+  }
   if (
     run.provisioningComplete ||
     run.cancelRequested ||

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningBootstrapEvidenceFacade.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningBootstrapEvidenceFacade.test.ts
@@ -58,6 +58,7 @@ describe('TeamProvisioningBootstrapEvidenceFacade', () => {
   it('builds facade deps from service-shaped dependencies', () => {
     const { facade: bootstrapTranscriptFacade } = transcriptFacade();
     const readPersistedRuntimeMembers = vi.fn(() => []);
+    const onBootstrapSessionCommitted = vi.fn();
     const service = {
       bootstrapTranscriptFacade,
       readPersistedRuntimeMembers,
@@ -67,6 +68,7 @@ describe('TeamProvisioningBootstrapEvidenceFacade', () => {
       getTeamsBasePath: () => '/teams',
       nowIso: () => NOW,
       warn: vi.fn(),
+      onBootstrapSessionCommitted,
     });
 
     expect(deps.bootstrapTranscriptFacade).toBe(bootstrapTranscriptFacade);
@@ -74,6 +76,7 @@ describe('TeamProvisioningBootstrapEvidenceFacade', () => {
     expect(readPersistedRuntimeMembers).toHaveBeenCalledWith('demo');
     expect(deps.getTeamsBasePath?.()).toBe('/teams');
     expect(deps.nowIso()).toBe(NOW);
+    expect(deps.onBootstrapSessionCommitted).toBe(onBootstrapSessionCommitted);
   });
 
   it('owns transcript, runtime proof, evidence port, and member log compatibility wrappers', async () => {
@@ -86,6 +89,7 @@ describe('TeamProvisioningBootstrapEvidenceFacade', () => {
       (input: { teamsBasePath: string; warn(message: string): void }) =>
         input as unknown as OpenCodeRuntimeBootstrapEvidencePorts
     );
+    const onBootstrapSessionCommitted = vi.fn();
     const facade = new TeamProvisioningBootstrapEvidenceFacade({
       bootstrapTranscriptFacade,
       readPersistedRuntimeMembers: vi.fn(() => []),
@@ -93,6 +97,7 @@ describe('TeamProvisioningBootstrapEvidenceFacade', () => {
       nowIso: () => NOW,
       warn: vi.fn(),
       createOpenCodeRuntimeBootstrapEvidencePorts,
+      onBootstrapSessionCommitted,
     });
 
     expect(facade.memberLogsFinder).toBe(memberLogsFinder);
@@ -112,11 +117,16 @@ describe('TeamProvisioningBootstrapEvidenceFacade', () => {
     ).resolves.toBe(null);
 
     const ports = facade.createOpenCodeRuntimeBootstrapEvidencePorts();
-    expect(ports).toEqual({ teamsBasePath: '/teams', warn: expect.any(Function) });
+    expect(ports).toEqual({
+      teamsBasePath: '/teams',
+      warn: expect.any(Function),
+      onBootstrapSessionCommitted,
+    });
     expect(setMemberLogsFinderForCompatibility).toHaveBeenCalledWith(nextMemberLogsFinder);
     expect(createOpenCodeRuntimeBootstrapEvidencePorts).toHaveBeenCalledWith({
       teamsBasePath: '/teams',
       warn: expect.any(Function),
+      onBootstrapSessionCommitted,
     });
   });
 

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningConfigMaintenance.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningConfigMaintenance.test.ts
@@ -57,7 +57,8 @@ function createHarness(
     getTeamsBasePath: () => TEAM_BASE,
     getProjectsBasePath: () => PROJECTS_BASE,
     readRegularFileUtf8: vi.fn(async (filePath) => files.get(filePath) ?? null),
-    writeFileUtf8: vi.fn(async (filePath, contents) => {
+    writeFileUtf8: vi.fn(async (filePath, contents, options) => {
+      await options?.beforeCommit();
       files.set(filePath, contents);
     }),
     unlink: vi.fn(async (filePath) => {
@@ -102,6 +103,32 @@ function createHarness(
 }
 
 describe('TeamProvisioningConfigMaintenance', () => {
+  it('publishes the early launch roster through a guarded write and invalidates config reads', async () => {
+    const configPath = path.join(TEAM_BASE, 'launch-team', 'config.json');
+    const { maintenance, ports, files, invalidatedTeams } = createHarness({
+      files: {
+        [configPath]: JSON.stringify({ members: [{ name: 'team-lead', agentType: 'team-lead' }] }),
+      },
+    });
+
+    await expect(
+      maintenance.materializeLaunchRoster({
+        teamName: 'launch-team',
+        members: [{ name: 'worker', role: 'Worker', providerId: 'opencode' }],
+        isCurrentRun: () => true,
+      })
+    ).resolves.toBe(true);
+    expect(ports.writeFileUtf8).toHaveBeenCalledWith(configPath, expect.any(String), {
+      beforeCommit: expect.any(Function),
+    });
+    expect(JSON.parse(files.get(configPath) ?? '{}').members).toEqual([
+      { name: 'team-lead', agentType: 'team-lead' },
+      expect.objectContaining({ name: 'worker', providerId: 'opencode', joinedAt: 123_456 }),
+    ]);
+    expect(invalidatedTeams).toEqual(['launch-team']);
+    expect(ports.scanForNewestProjectSession).not.toHaveBeenCalled();
+  });
+
   it('backs up and normalizes launch config, then merges duplicate inboxes using in-memory ports', async () => {
     const teamName = 'launch-team';
     const configPath = path.join(TEAM_BASE, teamName, 'config.json');

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchRosterMaterialization.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchRosterMaterialization.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  materializeTeamProvisioningLaunchRoster,
+  type TeamProvisioningLaunchRosterInput,
+  type TeamProvisioningLaunchRosterPorts,
+} from '../TeamProvisioningLaunchRosterMaterialization';
+import { resolveRuntimeRecipientProviderIdFromSources } from '../TeamProvisioningRuntimeRecipientResolution';
+
+import type { TeamConfig, TeamMember } from '@shared/types';
+
+function createHarness() {
+  const state = {
+    current: true,
+    raw: JSON.stringify({
+      leadSessionId: 'lead-session',
+      members: [
+        { name: 'team-lead', agentType: 'team-lead', providerId: 'anthropic' },
+        { name: 'haiku', providerId: 'anthropic', model: 'claude-haiku-4-5' },
+      ],
+    }),
+    meta: [{ name: 'opencode-worker', providerId: 'opencode' }] as TeamMember[],
+    beforeWrite: () => {},
+  };
+  const input: TeamProvisioningLaunchRosterInput = {
+    teamName: 'sandbox-mixed',
+    members: [
+      { name: 'haiku', role: 'Native', providerId: 'anthropic' },
+      { name: 'opencode-worker', role: 'Worker', providerId: 'opencode', model: 'openai/gpt-5' },
+    ],
+    isCurrentRun: () => state.current,
+  };
+  const ports: TeamProvisioningLaunchRosterPorts = {
+    readConfig: vi.fn(async () => state.raw),
+    readMetaMembers: vi.fn(async () => state.meta),
+    writeConfig: vi.fn(async (raw, beforeCommit) => {
+      state.beforeWrite();
+      await beforeCommit();
+      state.raw = raw;
+    }),
+    invalidateTeam: vi.fn(),
+    now: () => 123,
+  };
+  return { state, input, ports };
+}
+
+describe('TeamProvisioningLaunchRosterMaterialization', () => {
+  it('makes a bootstrap-complete mixed roster authoritative before the first lead result', async () => {
+    const { state, input, ports } = createHarness();
+    const resolve = () =>
+      resolveRuntimeRecipientProviderIdFromSources({
+        memberName: 'opencode-worker',
+        config: JSON.parse(state.raw) as TeamConfig,
+        metaMembers: state.meta,
+      });
+    expect(resolve).toThrow('no authoritative config identity');
+    expect(await materializeTeamProvisioningLaunchRoster(input, ports)).toBe(true);
+    expect(resolve()).toBe('opencode');
+    expect(JSON.parse(state.raw)).toMatchObject({
+      leadSessionId: 'lead-session',
+      members: [
+        { name: 'team-lead', providerId: 'anthropic' },
+        { name: 'haiku', providerId: 'anthropic', model: 'claude-haiku-4-5' },
+        {
+          name: 'opencode-worker',
+          agentId: 'opencode-worker@sandbox-mixed',
+          providerId: 'opencode',
+          model: 'openai/gpt-5',
+        },
+      ],
+    });
+    expect(ports.invalidateTeam).toHaveBeenCalledWith('sandbox-mixed');
+    expect(await materializeTeamProvisioningLaunchRoster(input, ports)).toBe(true);
+    expect(ports.writeConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('materializes create-team lanes even before members metadata is first persisted', async () => {
+    const { state, input, ports } = createHarness();
+    state.meta = [];
+    expect(await materializeTeamProvisioningLaunchRoster(input, ports)).toBe(true);
+    expect(JSON.parse(state.raw).members).toHaveLength(3);
+  });
+
+  it.each(['config', 'metadata'])('preserves a removed member tombstone in %s', async (source) => {
+    const { state, input, ports } = createHarness();
+    const removed = { name: 'OPENCODE-WORKER', removedAt: 456 };
+    if (source === 'metadata') state.meta.push(removed);
+    else {
+      const config = JSON.parse(state.raw);
+      config.members.push(removed);
+      state.raw = JSON.stringify(config);
+    }
+    const original = state.raw;
+    expect(await materializeTeamProvisioningLaunchRoster(input, ports)).toBe(false);
+    expect(state.raw).toBe(original);
+    expect(ports.writeConfig).not.toHaveBeenCalled();
+  });
+
+  it('does not read or write for an already cancelled or superseded run', async () => {
+    const { state, input, ports } = createHarness();
+    state.current = false;
+    expect(await materializeTeamProvisioningLaunchRoster(input, ports)).toBe(false);
+    expect(ports.readConfig).not.toHaveBeenCalled();
+    expect(ports.writeConfig).not.toHaveBeenCalled();
+  });
+
+  it.each(['cancelled', 'config-changed', 'removed'])(
+    'aborts atomic publication when the launch becomes %s during the write',
+    async (change) => {
+      const { state, input, ports } = createHarness();
+      state.beforeWrite = () => {
+        if (change === 'cancelled') state.current = false;
+        if (change === 'config-changed') state.raw = JSON.stringify({ members: [] });
+        if (change === 'removed') state.meta[0].removedAt = 456;
+      };
+      await expect(materializeTeamProvisioningLaunchRoster(input, ports)).rejects.toThrow(
+        'roster changed before config commit'
+      );
+      expect(JSON.parse(state.raw).members).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ agentId: 'opencode-worker@sandbox-mixed' }),
+        ])
+      );
+      expect(ports.invalidateTeam).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchTeamFlow.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchTeamFlow.test.ts
@@ -499,12 +499,17 @@ describe('TeamProvisioningLaunchTeamFlow', () => {
     const existingTasks = [{ id: 'task-1', title: 'Resume work' } as unknown as TeamTask];
     const isValidationCancelled = vi.fn(() => false);
     const validationOptionsRef: { current?: { isCancelled(): boolean } } = {};
+    const allEffectiveMemberSpecs: TeamCreateRequest['members'] = [
+      ...syntheticRequest.members,
+      { name: 'OpenCode', role: 'Developer', providerId: 'opencode' },
+    ];
 
     const result = await materializeDeterministicLaunchBootstrapFiles(
       {
         request: launchRequest,
         run,
         effectiveMemberSpecs: syntheticRequest.members,
+        allEffectiveMemberSpecs,
         controlApiBaseUrl: 'http://127.0.0.1:1234',
         isValidationCancelled,
       },
@@ -517,7 +522,7 @@ describe('TeamProvisioningLaunchTeamFlow', () => {
         buildDeterministicLaunchHydrationPrompt: vi.fn((request, members, tasks, includeLead) => {
           order.push(`prompt:${tasks.length}:${includeLead}`);
           expect(request).toBe(launchRequest);
-          expect(members).toBe(syntheticRequest.members);
+          expect(members).toBe(allEffectiveMemberSpecs);
           expect(tasks).toBe(existingTasks);
           return 'hydrate\nprompt';
         }),
@@ -526,6 +531,7 @@ describe('TeamProvisioningLaunchTeamFlow', () => {
           return { chars: 14, lines: 2 };
         }),
         buildNativeAppManagedBootstrapSpecsWithDiagnostics: vi.fn(async (input) => {
+          expect(input.members).toBe(syntheticRequest.members);
           order.push(`native:${input.teamName}:${input.members.length}`);
           return {
             specs: new Map([
@@ -637,6 +643,7 @@ describe('TeamProvisioningLaunchTeamFlow', () => {
         request: launchRequest,
         run,
         effectiveMemberSpecs: syntheticRequest.members,
+        allEffectiveMemberSpecs: syntheticRequest.members,
         isValidationCancelled: () => false,
       },
       {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadActivity.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadActivity.test.ts
@@ -180,4 +180,38 @@ describe('lead activity helpers', () => {
     expect(ports.emitTeamChange).not.toHaveBeenCalled();
     expect(syncedRunKeys.has(getLeadTaskActivityRunKey(run))).toBe(false);
   });
+
+  it('publishes initial observed activity once even when the run starts active', () => {
+    const run: LeadActivityRunLike = {
+      teamName: 'team-a',
+      runId: 'run-1',
+      leadActivityState: 'active',
+    };
+    const ports = createPorts();
+
+    setLeadActivity(run, 'active', ports);
+    setLeadActivity(run, 'active', ports);
+
+    expect(ports.emitTeamChange).toHaveBeenCalledExactlyOnceWith({
+      type: 'lead-activity',
+      teamName: 'team-a',
+      runId: 'run-1',
+      detail: 'active',
+    });
+    expect(run.leadActivityPublished).toBe(true);
+  });
+
+  it('does not publish initial observed activity from a stale run', () => {
+    const run: LeadActivityRunLike = {
+      teamName: 'team-a',
+      runId: 'old-run',
+      leadActivityState: 'active',
+    };
+    const ports = createPorts(new Set(), false);
+
+    setLeadActivity(run, 'active', ports);
+
+    expect(ports.emitTeamChange).not.toHaveBeenCalled();
+    expect(run.leadActivityPublished).not.toBe(true);
+  });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayCaptureTouch.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLeadRelayCaptureTouch.test.ts
@@ -74,6 +74,7 @@ function createPorts(): TeamProvisioningStreamEventPorts<TeamProvisioningStreamR
     appendProvisioningAssistantText: vi.fn(),
     boundProgressAssistantParts: vi.fn((parts: string[]) => parts),
     pushLiveLeadTextMessage: vi.fn(),
+    setLeadActivity: vi.fn(),
     captureTeamSpawnEvents: vi.fn(),
     captureSendMessages: vi.fn(),
     updateLeadContextUsageFromUsage: vi.fn(),
@@ -126,10 +127,12 @@ describe('lead relay capture activity proof', () => {
   it('touches the capture when the lead stream reports an assistant message', () => {
     const touch = vi.fn();
     const run = createRun({ leadRelayCapture: createCapture(touch) });
+    const ports = createPorts();
 
-    handleTeamProvisioningStreamJsonMessage(run, assistantMessage(), createPorts());
+    handleTeamProvisioningStreamJsonMessage(run, assistantMessage(), ports);
 
     expect(touch).toHaveBeenCalledTimes(1);
+    expect(ports.setLeadActivity).toHaveBeenCalledWith(run, 'active');
   });
 
   it.each(['processKilled', 'cancelRequested'] as const)(
@@ -146,6 +149,7 @@ describe('lead relay capture activity proof', () => {
       expect(ports.pushLiveLeadTextMessage).not.toHaveBeenCalled();
       expect(ports.captureSendMessages).not.toHaveBeenCalled();
       expect(ports.startRuntimeToolActivity).not.toHaveBeenCalled();
+      expect(ports.setLeadActivity).not.toHaveBeenCalled();
     }
   );
 

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaneLaunchFlow.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaneLaunchFlow.test.ts
@@ -123,6 +123,7 @@ function createPorts(
     nowMs: vi.fn<() => number>().mockReturnValueOnce(1000).mockReturnValue(1250),
     randomUuid: vi.fn<() => string>(() => 'lane-run-id'),
     teamsBasePath: vi.fn<() => string>(() => '/teams'),
+    isCurrentTrackedRun: vi.fn(() => true),
     isStoppingSecondaryRuntimeTeam: vi.fn<(teamName: string) => boolean>(() => false),
     clearOpenCodeRuntimeLaneStorage: vi.fn<
       MixedSecondaryLaneLaunchFlowPorts<TestRun>['clearOpenCodeRuntimeLaneStorage']
@@ -166,6 +167,59 @@ function createPorts(
 }
 
 describe('TeamProvisioningMixedSecondaryLaneLaunchFlow', () => {
+  it.each(['setup', 'generation', 'prompt'] as const)(
+    'does not launch when the tracked run changes as %s preparation resolves',
+    async (stage) => {
+      const run = createRun();
+      const lane = createLane({ runId: 'superseded-lane-run' });
+      let currentRun = run;
+      let markPrepared!: () => void;
+      let releasePreparation!: () => void;
+      const prepared = new Promise<void>((resolve) => (markPrepared = resolve));
+      const preparation = new Promise<void>((resolve) => (releasePreparation = resolve));
+      const waitForPreparation = async <T>(result: T): Promise<T> => {
+        markPrepared();
+        await preparation;
+        return result;
+      };
+      const adapter = createAdapter();
+      const ports = createPorts({
+        isCurrentTrackedRun: vi.fn((candidate) => candidate === currentRun),
+        getOpenCodeRuntimeAdapter: () => adapter,
+        ...(stage === 'setup'
+          ? { readLaunchState: () => waitForPreparation(createSnapshot()) }
+          : stage === 'generation'
+            ? {
+                prepareOpenCodeRuntimeLaneForLaunchGeneration: () =>
+                  waitForPreparation({ diagnostics: [] }),
+              }
+            : { buildOpenCodeSecondaryAppManagedLaunchPrompt: () => waitForPreparation('prompt') }),
+      });
+
+      const launching = launchSingleMixedSecondaryLaneWithPorts(run, lane, ports);
+      await prepared;
+      releasePreparation();
+      currentRun = createRun();
+      await launching;
+
+      expect(run).toMatchObject({ cancelRequested: false, processKilled: false });
+      expect(adapter.launch).not.toHaveBeenCalled();
+      expect(ports.clearOpenCodeRuntimeLaneStorage).toHaveBeenCalledWith({
+        teamsBasePath: '/teams',
+        teamName: run.teamName,
+        laneId: lane.laneId,
+        expectedRunId: 'superseded-lane-run',
+      });
+      expect(ports.deleteSecondaryRuntimeRunIfOwned).toHaveBeenCalledWith(
+        run.teamName,
+        lane.laneId,
+        'superseded-lane-run'
+      );
+      expect(ports.deleteSecondaryRuntimeRun).not.toHaveBeenCalled();
+      expect(lane).toMatchObject({ state: 'finished', result: null });
+    }
+  );
+
   it('resets stale launch generation state and retries a stale manifest launch failure', async () => {
     const staleMessage = 'Bridge server runtime manifest high watermark is stale';
     const launch = vi

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaneLaunchSetup.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaneLaunchSetup.test.ts
@@ -83,6 +83,7 @@ function createPorts(
     nowMs: vi.fn<() => number>(() => 1000),
     randomUuid: vi.fn<() => string>(() => 'generated-run-id'),
     teamsBasePath: vi.fn<() => string>(() => '/teams'),
+    isCurrentTrackedRun: vi.fn(() => true),
     isStoppingSecondaryRuntimeTeam: vi.fn<(teamName: string) => boolean>(() => false),
     clearOpenCodeRuntimeLaneStorage: vi.fn<
       MixedSecondaryLaneLaunchSetupPorts<TestRun>['clearOpenCodeRuntimeLaneStorage']

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaneWiring.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaneWiring.test.ts
@@ -123,6 +123,7 @@ function createDeps(
 ): TeamProvisioningMixedSecondaryLaneWiringDeps<TestRun> {
   return {
     service: createService(overrides),
+    isCurrentTrackedRun: vi.fn(() => true),
     logger: {
       warn: vi.fn(),
     },
@@ -137,6 +138,8 @@ describe('TeamProvisioningMixedSecondaryLaneWiring', () => {
     const lane = createLane();
     const launchResult = createLaunchResult();
 
+    expect(ports.isCurrentTrackedRun(run)).toBe(true);
+    expect(deps.isCurrentTrackedRun).toHaveBeenCalledWith(run);
     expect(ports.isStoppingSecondaryRuntimeTeam('atlas-hq')).toBe(false);
     ports.deleteSecondaryRuntimeRun('atlas-hq', lane.laneId);
     await ports.publishMixedSecondaryLaneStatusChange(run, lane);
@@ -309,14 +312,18 @@ describe('TeamProvisioningMixedSecondaryLaneWiring', () => {
       readPersistedTeamProjectPath: service.readPersistedTeamProjectPath,
       writeLaunchStateSnapshot: service.writeLaunchStateSnapshot,
     } satisfies TeamProvisioningMixedSecondaryLaneWiringServiceHost<TestRun>;
+    const isCurrentTrackedRun = vi.fn(() => false);
     const deps = createTeamProvisioningMixedSecondaryLaneWiringDepsFromService(host, {
       logger,
+      isCurrentTrackedRun,
     });
     const run = createRun();
     const lane = createLane();
     const snapshot = createSnapshot();
 
     expect(deps.logger).toBe(logger);
+    expect(deps.isCurrentTrackedRun(run)).toBe(false);
+    expect(isCurrentTrackedRun).toHaveBeenCalledWith(run);
     expect(deps.service.isStoppingSecondaryRuntimeTeam('atlas-hq')).toBe(true);
     deps.service.deleteSecondaryRuntimeRun('atlas-hq', lane.laneId);
     await deps.service.publishMixedSecondaryLaneStatusChange(run, lane);

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaunchQueue.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningMixedSecondaryLaunchQueue.test.ts
@@ -127,6 +127,7 @@ function createPorts(
     nowMs: vi.fn<() => number>(() => 1234),
     randomUuid: vi.fn<() => string>(() => 'generated-run-id'),
     teamsBasePath: vi.fn<() => string>(() => '/teams'),
+    isCurrentTrackedRun: vi.fn(() => true),
     clearOpenCodeRuntimeLaneStorage: vi.fn<
       MixedSecondaryLaunchQueuePorts<TestRun>['clearOpenCodeRuntimeLaneStorage']
     >(async () => undefined),
@@ -184,6 +185,54 @@ function createDeferred(): {
 }
 
 describe('TeamProvisioningMixedSecondaryLaunchQueue', () => {
+  it('rejects a run superseded after successful roster preparation before queue entry', async () => {
+    const lane = createLane();
+    const run = createRun({ mixedSecondaryLanes: [lane] });
+    let currentRun = run;
+    const ports = createPorts({
+      isCurrentTrackedRun: vi.fn((candidate) => candidate === currentRun),
+    });
+    const prepared = createDeferred();
+    const launching = (async () => {
+      await prepared.promise;
+      return launchMixedSecondaryLaneIfNeeded(run, ports);
+    })();
+
+    prepared.resolve();
+    currentRun = createRun();
+    await expect(launching).resolves.toEqual(createSnapshot('active'));
+
+    expect(ports.getOpenCodeRuntimeAdapter).not.toHaveBeenCalled();
+    expect(ports.launchSingleMixedSecondaryLane).not.toHaveBeenCalled();
+    expect(ports.persistLaunchStateSnapshot).not.toHaveBeenCalled();
+    expect(run.mixedSecondaryLaneLaunchQueue).toBeUndefined();
+    expect(lane).toMatchObject({ state: 'queued', runId: null });
+  });
+
+  it('does not launch or persist an old run after it is superseded while queued', async () => {
+    const lane = createLane();
+    const previous = createDeferred();
+    const run = createRun({
+      mixedSecondaryLanes: [lane],
+      mixedSecondaryLaneLaunchQueue: previous.promise,
+    });
+    let currentRun = run;
+    const ports = createPorts({
+      isCurrentTrackedRun: vi.fn((candidate) => candidate === currentRun),
+    });
+
+    const launching = launchMixedSecondaryLaneIfNeeded(run, ports, { waitForCompletion: true });
+    currentRun = createRun();
+    previous.resolve();
+    await launching;
+
+    expect(lane.state).toBe('finished');
+    expect(ports.launchSingleMixedSecondaryLane).not.toHaveBeenCalled();
+    expect(ports.persistLaunchStateSnapshot).not.toHaveBeenCalled();
+    expect(ports.clearOpenCodeRuntimeLaneStorage).not.toHaveBeenCalled();
+    expect(ports.deleteSecondaryRuntimeRunIfOwned).not.toHaveBeenCalled();
+  });
+
   it('no-ops queued launch guard for non-queued or already scheduled lanes', () => {
     const finishedLane = createLane({ state: 'finished' });
     const scheduledLane = createLane({ launchScheduled: true });
@@ -450,46 +499,52 @@ describe('TeamProvisioningMixedSecondaryLaunchQueue', () => {
     expect(ports.persistLaunchStateSnapshot).toHaveBeenCalledWith(run, 'active');
     expect(ports.launchSingleMixedSecondaryLane).toHaveBeenCalledTimes(2);
   });
-  it('fences late rejected launch cleanup to the generation captured when queued', async () => {
-    const lane = createLane({ runId: 'cancelled-run' });
-    const run = createRun({ mixedSecondaryLanes: [lane] });
-    let releaseLaunch!: () => void;
-    let markLaunchEntered!: () => void;
-    const launchEntered = new Promise<void>((resolve) => {
-      markLaunchEntered = resolve;
-    });
-    const launchReleased = new Promise<void>((resolve) => {
-      releaseLaunch = resolve;
-    });
-    const ports = createPorts({
-      launchSingleMixedSecondaryLane: vi.fn(async () => {
-        markLaunchEntered();
-        await launchReleased;
-        throw new Error('cancelled launch returned late');
-      }),
-    });
-    launchQueuedMixedSecondaryLaneInBackground(run, lane, ports);
-    await launchEntered;
-    run.cancelRequested = true;
-    lane.runId = 'fresh-run';
-    lane.state = 'launching';
-    releaseLaunch();
-    await run.mixedSecondaryLaneLaunchQueue;
+  it.each(['cancelled', 'superseded'])(
+    'fences late rejected %s launch cleanup to the generation captured when queued',
+    async (outcome) => {
+      const lane = createLane({ runId: 'cancelled-run' });
+      const run = createRun({ mixedSecondaryLanes: [lane] });
+      let currentRun = run;
+      let releaseLaunch!: () => void;
+      let markLaunchEntered!: () => void;
+      const launchEntered = new Promise<void>((resolve) => {
+        markLaunchEntered = resolve;
+      });
+      const launchReleased = new Promise<void>((resolve) => {
+        releaseLaunch = resolve;
+      });
+      const ports = createPorts({
+        isCurrentTrackedRun: vi.fn((candidate) => candidate === currentRun),
+        launchSingleMixedSecondaryLane: vi.fn(async () => {
+          markLaunchEntered();
+          await launchReleased;
+          throw new Error('cancelled launch returned late');
+        }),
+      });
+      launchQueuedMixedSecondaryLaneInBackground(run, lane, ports);
+      await launchEntered;
+      if (outcome === 'cancelled') run.cancelRequested = true;
+      else currentRun = createRun();
+      lane.runId = 'fresh-run';
+      lane.state = 'launching';
+      releaseLaunch();
+      await run.mixedSecondaryLaneLaunchQueue;
 
-    expect(ports.clearOpenCodeRuntimeLaneStorage).toHaveBeenCalledWith({
-      teamsBasePath: '/teams',
-      teamName: 'team-a',
-      laneId: lane.laneId,
-      expectedRunId: 'cancelled-run',
-    });
-    expect(ports.deleteSecondaryRuntimeRunIfOwned).toHaveBeenCalledWith(
-      'team-a',
-      lane.laneId,
-      'cancelled-run'
-    );
-    expect(ports.deleteSecondaryRuntimeRun).not.toHaveBeenCalled();
-    expect(lane).toMatchObject({ runId: 'fresh-run', state: 'launching' });
-  });
+      expect(ports.clearOpenCodeRuntimeLaneStorage).toHaveBeenCalledWith({
+        teamsBasePath: '/teams',
+        teamName: 'team-a',
+        laneId: lane.laneId,
+        expectedRunId: 'cancelled-run',
+      });
+      expect(ports.deleteSecondaryRuntimeRunIfOwned).toHaveBeenCalledWith(
+        'team-a',
+        lane.laneId,
+        'cancelled-run'
+      );
+      expect(ports.deleteSecondaryRuntimeRun).not.toHaveBeenCalled();
+      expect(lane).toMatchObject({ runId: 'fresh-run', state: 'launching' });
+    }
+  );
 
   const MODELS_QUERY_TIMEOUT =
     'Failed to query OpenCode models: OpenCode command timed out after 10000ms';
@@ -742,35 +797,43 @@ describe('TeamProvisioningMixedSecondaryLaunchQueue', () => {
     }
   });
 
-  it('does not relaunch after the backoff when the lane changed hands meanwhile', async () => {
-    vi.useFakeTimers();
-    try {
-      const lane = createLane();
-      const run = createRun({ mixedSecondaryLanes: [lane] });
-      const launchSingleMixedSecondaryLane = vi
-        .fn<MixedSecondaryLaunchQueuePorts<TestRun>['launchSingleMixedSecondaryLane']>()
-        .mockImplementationOnce(async (_run, launchedLane) => {
-          launchedLane.state = 'finished';
-          launchedLane.result = gatedFailureResult({
-            runId: launchedLane.runId!,
-            teamName: run.teamName,
-            memberName: launchedLane.member.name,
-            message: MODELS_QUERY_TIMEOUT,
+  it.each(['lane', 'tracked-run'])(
+    'does not relaunch after the backoff when the %s changed hands meanwhile',
+    async (owner) => {
+      vi.useFakeTimers();
+      try {
+        const lane = createLane();
+        const run = createRun({ mixedSecondaryLanes: [lane] });
+        let currentRun = run;
+        const launchSingleMixedSecondaryLane = vi
+          .fn<MixedSecondaryLaunchQueuePorts<TestRun>['launchSingleMixedSecondaryLane']>()
+          .mockImplementationOnce(async (_run, launchedLane) => {
+            launchedLane.state = 'finished';
+            launchedLane.result = gatedFailureResult({
+              runId: launchedLane.runId!,
+              teamName: run.teamName,
+              memberName: launchedLane.member.name,
+              message: MODELS_QUERY_TIMEOUT,
+            });
           });
+        const ports = createPorts({
+          launchSingleMixedSecondaryLane,
+          isCurrentTrackedRun: vi.fn((candidate) => candidate === currentRun),
         });
-      const ports = createPorts({ launchSingleMixedSecondaryLane });
 
-      launchQueuedMixedSecondaryLaneInBackground(run, lane, ports);
-      await vi.advanceTimersByTimeAsync(OPENCODE_TRANSIENT_SHARED_RUNTIME_RETRY_BACKOFF_MS - 1);
-      // A manual lane retry re-owned the lane while the backoff was still pending.
-      lane.runId = 'successor-run-id';
-      await drainTransientBackoff(run);
+        launchQueuedMixedSecondaryLaneInBackground(run, lane, ports);
+        await vi.advanceTimersByTimeAsync(OPENCODE_TRANSIENT_SHARED_RUNTIME_RETRY_BACKOFF_MS - 1);
+        // A manual lane retry re-owned the lane while the backoff was still pending.
+        if (owner === 'lane') lane.runId = 'successor-run-id';
+        else currentRun = createRun();
+        await drainTransientBackoff(run);
 
-      expect(launchSingleMixedSecondaryLane).toHaveBeenCalledTimes(1);
-      expect(lane.runId).toBe('successor-run-id');
-      expect(lane.result).toMatchObject({ teamLaunchState: 'partial_failure' });
-    } finally {
-      vi.useRealTimers();
+        expect(launchSingleMixedSecondaryLane).toHaveBeenCalledTimes(1);
+        expect(lane.runId).toBe(owner === 'lane' ? 'successor-run-id' : 'generated-run-id');
+        expect(lane.result).toMatchObject({ teamLaunchState: 'partial_failure' });
+      } finally {
+        vi.useRealTimers();
+      }
     }
-  });
+  );
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeBootstrapCommitWake.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeBootstrapCommitWake.test.ts
@@ -1,0 +1,103 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { setOpenCodeRuntimeActiveRunManifest } from '../../opencode/store/OpenCodeRuntimeManifestEvidenceReader';
+import {
+  commitOpenCodeRuntimeBootstrapSessionEvidence,
+  createDefaultOpenCodeRuntimeBootstrapEvidencePorts,
+  hasCommittedOpenCodeRuntimeBootstrapSessionEvidence,
+} from '../TeamProvisioningOpenCodeBootstrapEvidence';
+
+const input = {
+  teamName: 'bootstrap-wake-test',
+  laneId: 'secondary:opencode:alice',
+  runId: 'run-1',
+  memberName: 'alice',
+  runtimeSessionId: 'session-1',
+  observedAt: '2026-01-01T00:00:00.000Z',
+};
+const tempDirectories: string[] = [];
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true }))
+  );
+});
+
+async function setup() {
+  const teamsBasePath = await mkdtemp(join(tmpdir(), 'agent-teams-bootstrap-wake-test-'));
+  tempDirectories.push(teamsBasePath);
+  await setOpenCodeRuntimeActiveRunManifest({ teamsBasePath, ...input });
+  const onBootstrapSessionCommitted = vi.fn();
+  const ports = createDefaultOpenCodeRuntimeBootstrapEvidencePorts({
+    teamsBasePath,
+    onBootstrapSessionCommitted,
+  });
+  return { ports, onBootstrapSessionCommitted };
+}
+
+describe('OpenCode bootstrap committed wake', () => {
+  it.each(['app_managed_bootstrap', 'runtime_bootstrap_checkin'] as const)(
+    'publishes %s only after evidence verifies and releases the lane lock',
+    async (source) => {
+      const { ports, onBootstrapSessionCommitted } = await setup();
+      let verified = false;
+      let followup: Promise<void> | undefined;
+      onBootstrapSessionCommitted.mockImplementation((committed) => {
+        followup = (async () => {
+          verified = await hasCommittedOpenCodeRuntimeBootstrapSessionEvidence(committed, ports);
+          // Reacquiring this lock would deadlock if publication awaited delivery under it.
+          await setOpenCodeRuntimeActiveRunManifest({
+            teamsBasePath: ports.teamsBasePath,
+            ...input,
+          });
+        })();
+      });
+      await commitOpenCodeRuntimeBootstrapSessionEvidence({ ...input, source }, ports);
+      await followup;
+      expect(verified).toBe(true);
+      expect(onBootstrapSessionCommitted).toHaveBeenCalledExactlyOnceWith({ ...input, source });
+    }
+  );
+
+  it('does not publish when evidence commit fails', async () => {
+    const { ports, onBootstrapSessionCommitted } = await setup();
+    ports.mkdirRecursive = vi.fn(async () => {
+      throw new Error('commit failed');
+    });
+    await expect(commitOpenCodeRuntimeBootstrapSessionEvidence(input, ports)).rejects.toThrow(
+      'commit failed'
+    );
+    expect(onBootstrapSessionCommitted).not.toHaveBeenCalled();
+  });
+
+  it('does not publish when the committed evidence does not read back', async () => {
+    const { ports, onBootstrapSessionCommitted } = await setup();
+    ports.readCommittedBootstrapSessionEvidence = vi.fn(async () => ({
+      state: 'healthy' as const,
+      committed: false,
+      activeRunId: 'run-1',
+      sessions: [],
+      diagnostics: [],
+    }));
+    await expect(commitOpenCodeRuntimeBootstrapSessionEvidence(input, ports)).rejects.toThrow(
+      'did not verify'
+    );
+    expect(onBootstrapSessionCommitted).not.toHaveBeenCalled();
+  });
+
+  it('does not fail a verified bootstrap if the output callback fails', async () => {
+    const { ports, onBootstrapSessionCommitted } = await setup();
+    onBootstrapSessionCommitted.mockImplementation(() => {
+      throw new Error('wake failed');
+    });
+    ports.warn = vi.fn();
+    await expect(
+      commitOpenCodeRuntimeBootstrapSessionEvidence(input, ports)
+    ).resolves.toBeUndefined();
+    expect(ports.warn).toHaveBeenCalledWith('OpenCode bootstrap inbox wake failed: wake failed');
+    expect(await hasCommittedOpenCodeRuntimeBootstrapSessionEvidence(input, ports)).toBe(true);
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeBootstrapDeliveryDuringProvisioning.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeBootstrapDeliveryDuringProvisioning.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createOpenCodePromptDeliveryWatchdogCoordinator } from '../../opencode/delivery/OpenCodePromptDeliveryWatchdogCoordinator';
+import { createDefaultOpenCodeRuntimeBootstrapEvidencePorts } from '../TeamProvisioningOpenCodeBootstrapEvidence';
+import { createOpenCodeBootstrapWakePorts } from '../TeamProvisioningOpenCodeDeliveryComposition';
+import { createOpenCodePromptDeliveryWatchdogSchedulerFromService } from '../TeamProvisioningOpenCodePromptDeliveryWatchdogSchedulerFactory';
+import { tryRecoverOpenCodeRuntimeLaneForConfiguredMemberBeforeDelivery } from '../TeamProvisioningOpenCodeRuntimeRecoveryFlow';
+import { TeamProvisioningRunTrackingDeliveryHelper } from '../TeamProvisioningRunTrackingDelivery';
+
+import type { OpenCodeRuntimeLaneRecoveryPorts } from '../TeamProvisioningOpenCodeRuntimeRecoveryFlow';
+import type { TeamProvisioningProgress } from '@shared/types';
+
+const input = {
+  teamName: 'bootstrap-wake-test',
+  laneId: 'secondary:opencode:oc',
+  runId: 'lane-run-1',
+  memberName: 'oc',
+};
+const unread = {
+  from: 'team-lead',
+  to: 'oc',
+  text: 'Assigned task',
+  read: false,
+  messageId: 'assignment-1',
+  timestamp: '2026-09-06T15:14:25.748Z',
+};
+
+function createHarness() {
+  const run = {
+    processKilled: false,
+    cancelRequested: false,
+    progress: { state: 'verifying' as TeamProvisioningProgress['state'] },
+    mixedSecondaryLanes: [{ laneId: input.laneId, runId: input.runId }],
+  };
+  const runs = new Map([['root-run-1', run]]);
+  const provisioningRunByTeam = new Map([[input.teamName, 'root-run-1']]);
+  const runTracking = new TeamProvisioningRunTrackingDeliveryHelper({
+    state: {
+      runs,
+      provisioningRunByTeam,
+      aliveRunByTeam: new Map(),
+      runtimeAdapterRunByTeam: new Map(),
+      runtimeAdapterProgressByRunId: new Map(),
+      getRetainedProvisioningProgressMap: () => new Map(),
+    },
+    ports: {
+      isTeamAlive: () => false,
+      hasAlivePersistedTeamProcess: () => false,
+      hasOnlyExplicitlyStoppedPersistedTeamProcesses: () => false,
+      notifyTeamWatchScopeChanged: vi.fn(),
+      logDebug: vi.fn(),
+    },
+    liveRuntimeSnapshotCacheTtlMs: 2000,
+    persistedRuntimeSnapshotCacheTtlMs: 10000,
+  });
+  const runtimeProbe = vi.fn(async () => {
+    throw new Error('No runtime probe/host start is permitted');
+  });
+  const recoveryPorts = {
+    readOpenCodeMemberDirectory: vi.fn(async () => ({ config: null, metaMembers: [] })),
+    resolveOpenCodeMemberIdentityFromDirectory: () => ({ ok: true, laneId: input.laneId }),
+    readOpenCodeRuntimeLaneIndex: vi.fn(async () => ({
+      lanes: { [input.laneId]: { state: 'active' } },
+    })),
+    tryRecoverActiveOpenCodeSecondaryLaneFromRuntime: runtimeProbe,
+    tryRecoverMissingOpenCodeSecondaryLaneFromRuntime: runtimeProbe,
+    readLaunchState: runtimeProbe,
+  } as unknown as OpenCodeRuntimeLaneRecoveryPorts;
+  const recover = vi.fn((member: { teamName: string; memberName: string }) =>
+    tryRecoverOpenCodeRuntimeLaneForConfiguredMemberBeforeDelivery(member, recoveryPorts)
+  );
+  const relay = vi.fn(async () => ({
+    attempted: 1,
+    delivered: 1,
+    relayed: 1,
+    failed: 0,
+    skipped: 0,
+  }));
+  const logger = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+  const scheduler = createOpenCodePromptDeliveryWatchdogSchedulerFromService(
+    {
+      canDeliverToOpenCodeRuntimeForTeam: (teamName) =>
+        runTracking.canDeliverToOpenCodeRuntimeForTeam(teamName),
+      tryRecoverOpenCodeRuntimeLaneForConfiguredMemberBeforeDelivery: recover,
+      relayOpenCodeMemberInboxMessages: relay,
+      inboxReader: { getMessagesFor: async () => [unread] },
+      openCodeRuntimeRecoveryIdentity: {
+        resolveOpenCodeMemberDeliveryIdentity: async () => ({ ok: true, laneId: input.laneId }),
+        isOpenCodeRuntimeLaneIndexActive: async () => true,
+      },
+    },
+    { logger, getErrorMessage: String }
+  );
+  const evidencePorts = createDefaultOpenCodeRuntimeBootstrapEvidencePorts({
+    teamsBasePath: '/unused-test-only',
+  });
+  evidencePorts.readCommittedBootstrapSessionEvidence = vi.fn(async () => ({
+    state: 'healthy' as const,
+    committed: true,
+    activeRunId: input.runId,
+    diagnostics: [],
+    sessions: [
+      {
+        id: 'session-1',
+        ...input,
+        observedAt: unread.timestamp,
+        source: 'runtime_bootstrap_checkin' as const,
+      },
+    ],
+  }));
+  const getInboxMessages = vi.fn(async () => [unread]);
+  const coordinator = createOpenCodePromptDeliveryWatchdogCoordinator({
+    ...createOpenCodeBootstrapWakePorts({ runTracking, runs }, () => evidencePorts),
+    hasAcceptedMemberWorkSyncReport: async () => false,
+    taskRefsIncludeAll: () => true,
+    visibleReplyProofService: {
+      applyDestinationProof: vi.fn(),
+      materializePlainTextReplyIfNeeded: vi.fn(),
+    },
+    maybeSyncRuntimePermissionsAfterDelivery: async () => undefined,
+    rememberRuntimePidFromBridge: async () => undefined,
+    watchdogScheduler: scheduler,
+    canDeliverToTeamRuntime: (teamName) => runTracking.canDeliverToOpenCodeRuntimeForTeam(teamName),
+    recoverRuntimeLanesForWatchdog: async () => [],
+    stopRuntimeLanesForStoppedTeam: async () => 0,
+    readActiveRuntimeLaneIds: async () => [input.laneId],
+    createLedger: vi.fn(),
+    resolveMembersForRuntimeLane: async () => ['oc'],
+    getInboxMessages,
+    resolveCurrentRuntimeRunId: async () => input.runId,
+    hasStableInboxMessageId: (message): message is typeof message & { messageId: string } =>
+      Boolean(message.messageId),
+    logPromptDeliveryEvent: vi.fn(),
+  });
+  return {
+    coordinator,
+    scheduler,
+    runTracking,
+    run,
+    runs,
+    provisioningRunByTeam,
+    relay,
+    recover,
+    runtimeProbe,
+    evidencePorts,
+    getInboxMessages,
+  };
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe('OpenCode bootstrap delivery while the lead is finalizing', () => {
+  it('uses actual tracked-run admission and existing active-lane recovery without starting a host', async () => {
+    vi.useFakeTimers();
+    const h = createHarness();
+    expect(h.runTracking.canDeliverToOpenCodeRuntimeForTeam(input.teamName)).toBe(false);
+    expect(h.runTracking.resolveDeliverableTrackedRuntimeRunId(input.teamName)).toBe('root-run-1');
+    await expect(h.coordinator.wakeAfterBootstrapCommit(input)).resolves.toBe(1);
+    expect(h.relay).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(h.recover).toHaveBeenCalledExactlyOnceWith({
+      teamName: input.teamName,
+      memberName: 'oc',
+    });
+    expect(h.relay).toHaveBeenCalledExactlyOnceWith(input.teamName, 'oc', {
+      onlyMessageId: unread.messageId,
+      source: 'watchdog',
+    });
+    expect(h.runtimeProbe).not.toHaveBeenCalled();
+    expect(h.runTracking.canDeliverToOpenCodeRuntimeForTeam(input.teamName)).toBe(false);
+  });
+
+  it.each([
+    'cancelled',
+    'killed',
+    'failed',
+    'stale lane',
+    'new root with old lane index',
+    'missing proof',
+    'cancel during proof',
+    'cancel during inbox',
+  ])('does not schedule for %s', async (scenario) => {
+    const h = createHarness();
+    if (scenario === 'cancelled') h.run.cancelRequested = true;
+    if (scenario === 'killed') h.run.processKilled = true;
+    if (scenario === 'failed') h.run.progress.state = 'failed';
+    if (scenario === 'stale lane') h.run.mixedSecondaryLanes[0].runId = 'new-lane-run';
+    if (scenario === 'new root with old lane index') {
+      h.provisioningRunByTeam.set(input.teamName, 'root-run-2');
+      h.runs.set('root-run-2', { ...h.run, mixedSecondaryLanes: [] });
+    }
+    if (scenario === 'missing proof')
+      h.evidencePorts.readCommittedBootstrapSessionEvidence = vi.fn(async () => ({
+        state: 'healthy' as const,
+        committed: false,
+        activeRunId: input.runId,
+        sessions: [],
+        diagnostics: [],
+      }));
+    if (scenario === 'cancel during proof') {
+      const read = h.evidencePorts.readCommittedBootstrapSessionEvidence;
+      h.evidencePorts.readCommittedBootstrapSessionEvidence = async (params) => {
+        h.run.cancelRequested = true;
+        return read(params);
+      };
+    }
+    if (scenario === 'cancel during inbox')
+      h.getInboxMessages.mockImplementation(async () => {
+        h.run.cancelRequested = true;
+        return [unread];
+      });
+    await expect(h.coordinator.wakeAfterBootstrapCommit(input)).resolves.toBe(0);
+    expect(h.recover).not.toHaveBeenCalled();
+    expect(h.relay).not.toHaveBeenCalled();
+    expect(h.runtimeProbe).not.toHaveBeenCalled();
+  });
+
+  it('cancels an already scheduled bootstrap wake through the existing Stop cleanup', async () => {
+    vi.useFakeTimers();
+    const h = createHarness();
+    await h.coordinator.wakeAfterBootstrapCommit(input);
+    h.run.cancelRequested = true;
+    h.scheduler.cancelTeam(input.teamName);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(h.recover).not.toHaveBeenCalled();
+    expect(h.relay).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeLaunchWiring.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeLaunchWiring.test.ts
@@ -325,7 +325,11 @@ describe('TeamProvisioningOpenCodeLaunchWiring', () => {
       }),
     } as unknown as TeamLaunchRuntimeAdapter;
     const host = createHost(calls, adapter);
-    const wiring = createTeamProvisioningOpenCodeLaunchWiring(host);
+    const wiring = createTeamProvisioningOpenCodeLaunchWiring(host, ({ teamName, runId }) => {
+      expect(host.aliveRuns.get(teamName)).toBe(runId);
+      expect(host.runtimeAdapterRunByTeam.get(teamName)?.runId).toBe(runId);
+      calls.push('registeredInboxWake');
+    });
     const onProgress = vi.fn();
 
     const result = await wiring.runOpenCodeTeamRuntimeAdapterLaunch({
@@ -355,6 +359,7 @@ describe('TeamProvisioningOpenCodeLaunchWiring', () => {
       'syncApprovals',
       'progress:ready',
       'setAliveRun',
+      'registeredInboxWake',
       'invalidateCaches',
       'emit:process:ready',
     ]);
@@ -364,7 +369,10 @@ describe('TeamProvisioningOpenCodeLaunchWiring', () => {
     const calls: string[] = [];
     const adapter = {} as TeamLaunchRuntimeAdapter;
     const host = createHost(calls, adapter);
-    const wiring = createTeamProvisioningOpenCodeLaunchWiring(host);
+    const wiring = createTeamProvisioningOpenCodeLaunchWiring(host, ({ teamName, runId }) => {
+      expect(host.aliveRuns.get(teamName)).toBe(runId);
+      calls.push('registeredInboxWake');
+    });
     const alice = member('alice');
     const bob = member('bob');
 
@@ -398,6 +406,7 @@ describe('TeamProvisioningOpenCodeLaunchWiring', () => {
       'deliverLaunchPrompt:team-lead:launch',
       'progress:ready',
       'setAliveRun',
+      'registeredInboxWake',
       'invalidateCaches',
       'emit:process:ready',
     ]);
@@ -419,7 +428,8 @@ describe('TeamProvisioningOpenCodeLaunchWiring', () => {
       providerId: 'opencode',
     });
     host.aliveRuns.set('team-a', 'newer-run');
-    const wiring = createTeamProvisioningOpenCodeLaunchWiring(host);
+    const onRuntimeRegistered = vi.fn();
+    const wiring = createTeamProvisioningOpenCodeLaunchWiring(host, onRuntimeRegistered);
     const artifactModule = await import('../../TeamLaunchFailureArtifactPack');
     const storageModule =
       await import('../../opencode/store/OpenCodeRuntimeManifestEvidenceReader');
@@ -443,5 +453,6 @@ describe('TeamProvisioningOpenCodeLaunchWiring', () => {
     );
     expect(host.runtimeAdapterRunByTeam.get('team-a')?.runId).toBe('newer-run');
     expect(host.aliveRuns.get('team-a')).toBe('newer-run');
+    expect(onRuntimeRegistered).not.toHaveBeenCalled();
   });
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningRosterPrompt.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningRosterPrompt.test.ts
@@ -134,6 +134,75 @@ describe('buildCreateBootstrapUserPrompt', () => {
 });
 
 describe('lead launch prompts include the teammate roster rules', () => {
+  it.each([false, true])(
+    'executes an explicit launch request in the deferred operating turn (resume=%s)',
+    (isResume) => {
+      const instruction = 'Create two NEW tasks for HAIKU_RELAUNCH_OK and OPENCODE_RELAUNCH_OK.';
+      const prompt = buildDeterministicLaunchHydrationPrompt(
+        { teamName: 'sandbox-relaunch', cwd: '/sandbox', prompt: instruction },
+        teammates,
+        [],
+        isResume
+      );
+      expect(prompt.split(instruction)).toHaveLength(2);
+      expect(prompt).toContain(
+        'Apply the original user instructions now; do not wait for another user message.'
+      );
+      expect(prompt).toContain(
+        'Create or assign tasks only when the request calls for teammate work, using the exact roster below.'
+      );
+      expect(prompt).toContain('leave its assignment pending and wait for that owner');
+      expect(prompt).not.toContain('Do NOT create or assign any new task in this turn');
+      expect(prompt).not.toContain('Do not start work, create tasks, or delegate in this turn.');
+    }
+  );
+
+  it('allows an explicit solo relaunch request without inventing teammates', () => {
+    const prompt = buildDeterministicLaunchHydrationPrompt(
+      { teamName: 'sandbox-solo', cwd: '/sandbox', prompt: 'Write SOLO_RELAUNCH_OK.txt' },
+      [],
+      [],
+      false
+    );
+    expect(prompt).toContain(
+      'answer read-only questions or carry out requested work and update the task board as appropriate.'
+    );
+    expect(prompt).not.toContain('Do NOT start implementation in this turn.');
+    expect(prompt).not.toContain('Create and assign the requested work');
+  });
+
+  it('preserves read-only instructions instead of requiring tasks for every nonempty prompt', () => {
+    const prompt = buildDeterministicLaunchHydrationPrompt(
+      {
+        teamName: 'sandbox-question',
+        cwd: '/sandbox',
+        prompt: 'Only explain the current board. Do not create tasks.',
+      },
+      teammates,
+      [],
+      false
+    );
+    expect(prompt).toContain(
+      "Follow the user's requested action mode, including read-only answers."
+    );
+    expect(prompt).toContain(
+      'Create or assign tasks only when the request calls for teammate work'
+    );
+    expect(prompt).toContain('Only explain the current board. Do not create tasks.');
+  });
+
+  it('keeps blank-prompt launches limited to readiness hydration', () => {
+    const prompt = buildDeterministicLaunchHydrationPrompt(
+      { teamName: 'sandbox-hydration', cwd: '/sandbox', prompt: '   ' },
+      teammates,
+      [],
+      false
+    );
+    expect(prompt).toContain('Do NOT create, assign, or delegate any new task in this turn.');
+    expect(prompt).toContain('Do not start work, create tasks, or delegate in this turn.');
+    expect(prompt).not.toContain('first normal operating turn');
+  });
+
   it('puts exact teammate names and the integrity rules into the launch hydration prompt', () => {
     const request = {
       teamName: 'matrix-team',

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningStreamEventPortsFactory.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningStreamEventPortsFactory.test.ts
@@ -102,6 +102,7 @@ function createCallbacks(
     injectGeminiPostLaunchHydration: vi.fn(async () => undefined),
     completeProvisioningFromSuccessfulResult: vi.fn(),
     handleControlRequest: vi.fn(),
+    launchMixedSecondaryLaneIfNeeded: vi.fn(async () => undefined),
     handleProvisioningTurnComplete: vi.fn(async () => undefined),
     cleanupRun: vi.fn(),
     emitApiErrorWarning: vi.fn(),
@@ -139,6 +140,7 @@ function createServiceAdapter(
     injectGeminiPostLaunchHydration: callbacks.injectGeminiPostLaunchHydration,
     completeProvisioningFromSuccessfulResult: callbacks.completeProvisioningFromSuccessfulResult,
     handleControlRequest: callbacks.handleControlRequest,
+    launchMixedSecondaryLaneIfNeeded: callbacks.launchMixedSecondaryLaneIfNeeded,
     handleProvisioningTurnComplete: callbacks.handleProvisioningTurnComplete,
     cleanupRun: callbacks.cleanupRun,
     setMemberSpawnStatus: callbacks.setMemberSpawnStatus,
@@ -202,6 +204,7 @@ describe('TeamProvisioningStreamEventPortsFactory', () => {
         stopPersistentTeamMembers: callbacks.stopPersistentTeamMembers,
       },
       outputRecovery: createOutputRecoveryAdapter(callbacks),
+      prepareMixedSecondaryLaunch: vi.fn(async () => true),
       updateProgress: callbacks.updateProgress,
       emitTeamChange,
     });
@@ -252,6 +255,7 @@ describe('TeamProvisioningStreamEventPortsFactory', () => {
         stopPersistentTeamMembers: callbacks.stopPersistentTeamMembers,
       },
       outputRecovery: createOutputRecoveryAdapter(callbacks),
+      prepareMixedSecondaryLaunch: vi.fn(async () => true),
       updateProgress: callbacks.updateProgress,
     });
     const run = createRun();
@@ -282,4 +286,52 @@ describe('TeamProvisioningStreamEventPortsFactory', () => {
     expect(callbacks.captureTeamSpawnEvents).toHaveBeenCalledWith(run, msg.content);
     expect(callbacks.captureSendMessages).toHaveBeenCalledWith(run, msg.content);
   });
+
+  it('waits for authoritative roster publication before starting the early side lane', async () => {
+    const callbacks = createCallbacks();
+    let completePreparation!: (ready: boolean) => void;
+    const prepareMixedSecondaryLaunch = vi.fn(
+      () => new Promise<boolean>((resolve) => (completePreparation = resolve))
+    );
+    const ports = createTeamProvisioningStreamEventPortsBoundary({
+      service: createServiceAdapter(callbacks),
+      persistentRuntimeCleanup: { stopPersistentTeamMembers: callbacks.stopPersistentTeamMembers },
+      outputRecovery: createOutputRecoveryAdapter(callbacks),
+      updateProgress: callbacks.updateProgress,
+      prepareMixedSecondaryLaunch,
+    });
+    const run = createRun();
+    const pending = ports.launchMixedSecondaryLaneIfNeeded(run);
+    expect(prepareMixedSecondaryLaunch).toHaveBeenCalledWith(run);
+    expect(callbacks.launchMixedSecondaryLaneIfNeeded).not.toHaveBeenCalled();
+    completePreparation(true);
+    await pending;
+    expect(callbacks.launchMixedSecondaryLaneIfNeeded).toHaveBeenCalledWith(run);
+  });
+
+  it.each(['cancelled', 'killed', 'stale', 'write-failed'])(
+    'does not start an early side lane when roster preparation is %s',
+    async (outcome) => {
+      const callbacks = createCallbacks();
+      const run = createRun();
+      const ports = createTeamProvisioningStreamEventPortsBoundary({
+        service: createServiceAdapter(callbacks),
+        persistentRuntimeCleanup: {
+          stopPersistentTeamMembers: callbacks.stopPersistentTeamMembers,
+        },
+        outputRecovery: createOutputRecoveryAdapter(callbacks),
+        updateProgress: callbacks.updateProgress,
+        prepareMixedSecondaryLaunch: async () => {
+          if (outcome === 'cancelled') run.cancelRequested = true;
+          if (outcome === 'killed') run.processKilled = true;
+          if (outcome === 'write-failed') throw new Error('config write failed');
+          return outcome !== 'stale';
+        },
+      });
+      const pending = ports.launchMixedSecondaryLaneIfNeeded(run);
+      if (outcome === 'write-failed') await expect(pending).rejects.toThrow('config write failed');
+      else await pending;
+      expect(callbacks.launchMixedSecondaryLaneIfNeeded).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningStreamEventPortsFactory.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningStreamEventPortsFactory.test.ts
@@ -164,6 +164,61 @@ function createOutputRecoveryAdapter(
 }
 
 describe('TeamProvisioningStreamEventPortsFactory', () => {
+  it.each([
+    { content: [{ type: 'text', text: 'I am delegating the task.' }] },
+    {
+      content: [
+        { type: 'tool_use', id: 'tool-1', name: 'TaskCreate', input: { subject: 'Test task' } },
+      ],
+    },
+  ])(
+    'publishes substantive assistant activity without completing the first turn: %j',
+    ({ content }) => {
+      const callbacks = createCallbacks();
+      const ports = createTeamProvisioningStreamEventPorts(callbacks);
+      const run = createRun({ requiresFirstRealTurnSuccess: true });
+
+      handleTeamProvisioningStreamJsonMessage(run, { type: 'assistant', content }, ports);
+
+      expect(callbacks.setLeadActivity).toHaveBeenCalledWith(run, 'active');
+      expect(callbacks.completeProvisioningFromSuccessfulResult).not.toHaveBeenCalled();
+      expect(callbacks.handleProvisioningTurnComplete).not.toHaveBeenCalled();
+      expect(run.provisioningComplete).toBe(false);
+    }
+  );
+
+  it.each(['cancelled', 'killed', 'failed', 'empty', 'api-error', 'system-init'])(
+    'does not publish observed assistant activity for %s',
+    (reason) => {
+      const callbacks = createCallbacks();
+      const ports = createTeamProvisioningStreamEventPorts(callbacks);
+      const run = createRun({
+        cancelRequested: reason === 'cancelled',
+        processKilled: reason === 'killed',
+        progress: createProgress({ state: reason === 'failed' ? 'failed' : 'finalizing' }),
+      });
+      const text =
+        reason === 'empty'
+          ? '  '
+          : reason === 'api-error'
+            ? 'API Error: 429 Rate limit reached'
+            : 'Working';
+
+      handleTeamProvisioningStreamJsonMessage(
+        run,
+        {
+          type: reason === 'system-init' ? 'system' : 'assistant',
+          subtype: reason === 'system-init' ? 'init' : undefined,
+          content: [{ type: 'text', text }],
+        },
+        ports
+      );
+
+      expect(callbacks.setLeadActivity).not.toHaveBeenCalledWith(run, 'active');
+      expect(callbacks.completeProvisioningFromSuccessfulResult).not.toHaveBeenCalled();
+    }
+  );
+
   it('wires service callbacks and shared provisioning helpers into stream event ports', () => {
     const callbacks = createCallbacks();
     const ports = createTeamProvisioningStreamEventPorts(callbacks);

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningStreamEventPortsFactory.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningStreamEventPortsFactory.test.ts
@@ -288,7 +288,12 @@ describe('TeamProvisioningStreamEventPortsFactory', () => {
   });
 
   it('waits for authoritative roster publication before starting the early side lane', async () => {
-    const callbacks = createCallbacks();
+    let finishRuntimeLaunch!: () => void;
+    const callbacks = createCallbacks({
+      launchMixedSecondaryLaneIfNeeded: vi.fn(
+        () => new Promise<void>((resolve) => (finishRuntimeLaunch = resolve))
+      ),
+    });
     let completePreparation!: (ready: boolean) => void;
     const prepareMixedSecondaryLaunch = vi.fn(
       () => new Promise<boolean>((resolve) => (completePreparation = resolve))
@@ -303,10 +308,15 @@ describe('TeamProvisioningStreamEventPortsFactory', () => {
     const run = createRun();
     const pending = ports.launchMixedSecondaryLaneIfNeeded(run);
     expect(prepareMixedSecondaryLaunch).toHaveBeenCalledWith(run);
+    expect(run.mixedSecondaryRosterPreparation).toBe(
+      prepareMixedSecondaryLaunch.mock.results[0].value
+    );
     expect(callbacks.launchMixedSecondaryLaneIfNeeded).not.toHaveBeenCalled();
     completePreparation(true);
-    await pending;
+    await expect(run.mixedSecondaryRosterPreparation).resolves.toBe(true);
     expect(callbacks.launchMixedSecondaryLaneIfNeeded).toHaveBeenCalledWith(run);
+    finishRuntimeLaunch();
+    await pending;
   });
 
   it.each(['cancelled', 'killed', 'stale', 'write-failed'])(

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningTurnCompletePortsFactory.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningTurnCompletePortsFactory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { handleTeamProvisioningTurnComplete } from '../TeamProvisioningTurnComplete';
 import {
   createTeamProvisioningTurnCompletePorts,
   type TeamProvisioningTurnCompleteOutputRecoveryAdapter,
@@ -8,6 +9,10 @@ import {
 } from '../TeamProvisioningTurnCompletePortsFactory';
 
 import type { MemberSpawnStatusEntry, TeamProvisioningProgress } from '@shared/types';
+
+vi.mock('../TeamProvisioningRegularFileRead', () => ({
+  tryReadRegularFileUtf8: vi.fn(async () => null),
+}));
 
 type TestRun = TeamProvisioningTurnCompletePortsFactoryRun;
 interface TestSecondaryLaunchResult {
@@ -111,7 +116,104 @@ function createOutputRecoveryAdapter(): TeamProvisioningTurnCompleteOutputRecove
   };
 }
 
+function createCompletionContext() {
+  const service = createServiceAdapter();
+  const setAliveRunId = vi.fn();
+  const config = {
+    updateConfigPostLaunch: vi.fn(async () => undefined),
+    cleanupPrelaunchBackup: vi.fn(async () => undefined),
+    persistMembersMeta: vi.fn(async () => undefined),
+  };
+  const ports = createTeamProvisioningTurnCompletePorts({
+    service,
+    outputRecovery: createOutputRecoveryAdapter(),
+    config,
+    updateProgress: vi.fn((_run, state, message) => createProgress({ state, message })),
+    provisioningRunByTeam: new Map<string, TestRun>(),
+    setAliveRunId,
+    emitTeamChange: vi.fn(),
+    killTeamProcess: vi.fn(),
+  });
+  return { service, config, ports, setAliveRunId };
+}
+
 describe('TeamProvisioningTurnCompletePortsFactory', () => {
+  it.each([false, true])(
+    'waits for roster persistence before metadata, without waiting for runtime startup (isLaunch=%s)',
+    async (isLaunch) => {
+      let finishRoster!: (ready: boolean) => void;
+      let finishRuntime!: (result: TestSecondaryLaunchResult) => void;
+      const runtimeLaunch = new Promise<TestSecondaryLaunchResult>((resolve) => {
+        finishRuntime = resolve;
+      });
+      const run = createRun({
+        isLaunch,
+        mixedSecondaryRosterPreparation: new Promise((resolve) => (finishRoster = resolve)),
+      });
+      run.request.members = [{ name: 'alice' }];
+      const { service, config, ports, setAliveRunId } = createCompletionContext();
+      vi.mocked(service.launchMixedSecondaryLaneIfNeeded).mockReturnValue(runtimeLaunch);
+
+      const completion = handleTeamProvisioningTurnComplete(run, ports);
+      const duplicateCompletion = handleTeamProvisioningTurnComplete(run, ports);
+      await Promise.resolve();
+      expect(config.updateConfigPostLaunch).not.toHaveBeenCalled();
+      expect(run.provisioningComplete).toBe(false);
+
+      finishRoster(true);
+      await vi.waitFor(() => expect(service.launchMixedSecondaryLaneIfNeeded).toHaveBeenCalled());
+      expect(config.updateConfigPostLaunch).toHaveBeenCalledTimes(1);
+      expect(config.updateConfigPostLaunch).toHaveBeenCalledWith(
+        run.teamName,
+        run.request.cwd,
+        run.detectedSessionId,
+        run.request.color,
+        expect.objectContaining({ members: run.allEffectiveMembers })
+      );
+      expect(setAliveRunId).not.toHaveBeenCalled();
+
+      finishRuntime({ launched: true });
+      await Promise.all([completion, duplicateCompletion]);
+      expect(setAliveRunId).toHaveBeenCalledExactlyOnceWith(run.teamName, run.runId);
+    }
+  );
+
+  it.each(['cancelled', 'killed', 'failed', 'superseded'])(
+    'rechecks run eligibility after roster preparation becomes %s',
+    async (outcome) => {
+      let finishRoster!: (ready: boolean) => void;
+      const run = createRun({
+        mixedSecondaryRosterPreparation: new Promise((resolve) => (finishRoster = resolve)),
+      });
+      const { service, config, ports } = createCompletionContext();
+      const completion = handleTeamProvisioningTurnComplete(run, ports);
+      if (outcome === 'cancelled') run.cancelRequested = true;
+      if (outcome === 'killed') run.processKilled = true;
+      if (outcome === 'failed') run.progress.state = 'failed';
+      if (outcome === 'superseded') {
+        vi.mocked(service.isProvisioningRunStillPromotable).mockReturnValue(false);
+      }
+
+      finishRoster(false);
+      await completion;
+      expect(config.updateConfigPostLaunch).not.toHaveBeenCalled();
+      expect(run.provisioningComplete).toBe(false);
+    }
+  );
+
+  it('allows normal completion to recover after the early roster write fails', async () => {
+    const run = createRun({
+      isLaunch: false,
+      mixedSecondaryRosterPreparation: Promise.reject(new Error('roster write failed')),
+    });
+    const { config, ports, setAliveRunId } = createCompletionContext();
+
+    await handleTeamProvisioningTurnComplete(run, ports);
+
+    expect(config.updateConfigPostLaunch).toHaveBeenCalledTimes(1);
+    expect(setAliveRunId).toHaveBeenCalledExactlyOnceWith(run.teamName, run.runId);
+  });
+
   it('wires service callbacks and shared provisioning helpers into turn-complete ports', async () => {
     const service = createServiceAdapter();
     const config = {

--- a/src/renderer/components/common/ProviderActivityStatusStrip.tsx
+++ b/src/renderer/components/common/ProviderActivityStatusStrip.tsx
@@ -32,6 +32,7 @@ interface ProviderActivityStatusStripProps {
   readonly multimodelEnabled: boolean;
   readonly codexSnapshotPending?: boolean;
   readonly openCodePreparationEvidence?: OpenCodeScopedPreparationEvidence;
+  readonly forceLoadingProviderIds?: readonly CliProviderId[];
   readonly providerIds?: readonly CliProviderId[];
   readonly className?: string;
   readonly label?: string | null;
@@ -86,6 +87,7 @@ function useProviderActivityDisplay({
   multimodelEnabled,
   codexSnapshotPending = false,
   openCodePreparationEvidence,
+  forceLoadingProviderIds,
   providerIds,
   showReadyProviders,
 }: Pick<
@@ -98,6 +100,7 @@ function useProviderActivityDisplay({
   | 'multimodelEnabled'
   | 'codexSnapshotPending'
   | 'openCodePreparationEvidence'
+  | 'forceLoadingProviderIds'
   | 'providerIds'
   | 'showReadyProviders'
 >): {
@@ -118,6 +121,10 @@ function useProviderActivityDisplay({
     () => (providerIds ? new Set<CliProviderId>(providerIds) : null),
     [providerIds]
   );
+  const forcedLoadingProviderIdSet = useMemo(
+    () => new Set<CliProviderId>(forceLoadingProviderIds ?? []),
+    [forceLoadingProviderIds]
+  );
   const sourceProviderMap = useMemo(
     () =>
       new Map((sourceStatus?.providers ?? []).map((provider) => [provider.providerId, provider])),
@@ -134,6 +141,7 @@ function useProviderActivityDisplay({
       const provider = overridden ? providerStatusOverride : globalProvider;
       const sourceProvider = sourceProviderMap.get(provider.providerId) ?? null;
       const loading =
+        forcedLoadingProviderIdSet.has(provider.providerId) ||
         isTeamProviderRuntimeStatusLoading(
           provider.providerId,
           provider,
@@ -157,6 +165,7 @@ function useProviderActivityDisplay({
   }, [
     cliProviderStatusLoading,
     codexSnapshotPending,
+    forcedLoadingProviderIdSet,
     openCodePreparationEvidence,
     providerIdSet,
     renderCliStatus?.providers,
@@ -255,6 +264,7 @@ export const ProviderActivityStatusStrip = ({
   multimodelEnabled,
   codexSnapshotPending = false,
   openCodePreparationEvidence,
+  forceLoadingProviderIds,
   providerIds,
   className = '',
   label,
@@ -275,6 +285,7 @@ export const ProviderActivityStatusStrip = ({
     multimodelEnabled,
     codexSnapshotPending,
     openCodePreparationEvidence,
+    forceLoadingProviderIds,
     providerIds,
     showReadyProviders,
   });

--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -1637,13 +1637,12 @@ export const CliStatusBanner = ({
     enabled:
       isElectron &&
       multimodelEnabled &&
-      // The connected-provider directory fans out into several OpenCode model
-      // reads. Do not race that work against the authoritative passive status
-      // command or both can contend on the same profile until its timeout.
-      !cliStatusLoading &&
-      cliProviderStatusLoading.opencode !== true &&
       loadingCliStatus?.flavor === 'agent_teams_orchestrator' &&
+      openCodeRuntimeStatus?.installed !== false &&
       canLoadOpenCodeDashboardCatalog(passiveOpenCodeProvider, openCodeRuntimeStatus),
+    // Pause new reads during status checks without restarting an in-flight
+    // catalog every time passive provider status temporarily becomes pending.
+    statusChecking: cliStatusLoading || cliProviderStatusLoading.opencode === true,
     refreshRevision: providerQuickConnectRefreshKey,
     projectPath: selectedProjectPath,
     passiveProviderStatus: passiveOpenCodeProvider,

--- a/src/renderer/components/team/TeamDetailView.tsx
+++ b/src/renderer/components/team/TeamDetailView.tsx
@@ -109,6 +109,7 @@ import { type MemberActivityFilter, type MemberDetailTab } from './members/membe
 import { deriveMetrics } from './context-metric-alias';
 import { showTeamDeleteError } from './teamDeleteErrorDialog';
 import { resolvePinnedTeamActionTop } from './teamDetailLayout';
+import { TeamStatusBadge } from './TeamStatusBadge';
 import { useTeamStopControl } from './useTeamStopControl';
 
 import type { AddMemberEntry } from './dialogs/AddMemberDialog';
@@ -2881,16 +2882,12 @@ export const TeamDetailView = memo(function TeamDetailView({
                     <h2 className="min-w-0 truncate text-base font-semibold text-[var(--color-text)]">
                       {data.config.name}
                     </h2>
-                    {data.isAlive && (
-                      <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium text-emerald-400">
-                        <span className="size-1.5 rounded-full bg-emerald-400" />
-                        {t('detail.status.running')}
-                      </span>
-                    )}
-                    {!data.isAlive && isTeamProvisioning && (
-                      <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-yellow-500/15 px-1.5 py-0.5 text-[10px] font-medium text-yellow-400">
-                        <span className="size-1.5 animate-pulse rounded-full bg-yellow-400" />
-                        {t('detail.status.launching')}
+                    {(data.isAlive || isTeamProvisioning) && (
+                      <span className="shrink-0">
+                        <TeamStatusBadge
+                          teamName={teamName}
+                          status={isTeamProvisioning ? 'provisioning' : 'idle'}
+                        />
                       </span>
                     )}
                   </div>

--- a/src/renderer/components/team/TeamListView.tsx
+++ b/src/renderer/components/team/TeamListView.tsx
@@ -77,6 +77,7 @@ import {
   resolveTeamsProjectNavigationPath,
   teamMatchesProjectSelection,
 } from './teamProjectSelection';
+import { TeamStatusBadge } from './TeamStatusBadge';
 import { TeamTaskStatusSummary } from './TeamTaskStatusSummary';
 import { useTeamStopControl } from './useTeamStopControl';
 
@@ -257,60 +258,6 @@ function renderTeamRecentPaths(
 
 type TeamT = ReturnType<typeof useAppTranslation>['t'];
 
-const StatusBadge = ({ status, t }: { status: TeamStatus; t: TeamT }): React.JSX.Element => {
-  switch (status) {
-    case 'active':
-      return (
-        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
-          <span className="size-1.5 animate-pulse rounded-full bg-emerald-400" />
-          {t('list.status.active')}
-        </span>
-      );
-    case 'idle':
-      return (
-        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
-          <span className="size-1.5 rounded-full bg-emerald-400" />
-          {t('list.status.running')}
-        </span>
-      );
-    case 'provisioning':
-      return (
-        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-400">
-          <span className="size-1.5 animate-pulse rounded-full bg-amber-400" />
-          {t('list.status.launching')}
-        </span>
-      );
-    case 'offline':
-      return (
-        <span className="inline-flex items-center gap-1 rounded-full bg-zinc-500/15 px-2 py-0.5 text-[10px] font-medium text-zinc-500">
-          <span className="size-1.5 rounded-full bg-zinc-500" />
-          {t('list.status.offline')}
-        </span>
-      );
-    case 'partial_failure':
-      return (
-        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-400">
-          <span className="size-1.5 rounded-full bg-amber-400" />
-          {t('list.status.partialFailure')}
-        </span>
-      );
-    case 'partial_skipped':
-      return (
-        <span className="inline-flex items-center gap-1 rounded-full bg-sky-500/15 px-2 py-0.5 text-[10px] font-medium text-sky-300">
-          <span className="size-1.5 rounded-full bg-sky-300" />
-          {t('list.status.partialSkipped')}
-        </span>
-      );
-    case 'partial_pending':
-      return (
-        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-300">
-          <span className="size-1.5 rounded-full bg-amber-300" />
-          {t('list.status.partialPending')}
-        </span>
-      );
-  }
-};
-
 interface ActiveTeamCardProps {
   team: TeamSummary;
   status: TeamStatus;
@@ -395,7 +342,7 @@ const ActiveTeamCard = ({
               {team.displayName}
             </h3>
             <div className="pointer-events-none shrink-0">
-              <StatusBadge status={status} t={t} />
+              <TeamStatusBadge status={status} teamName={team.teamName} />
             </div>
           </div>
           <div className="flex min-h-6 items-center justify-between gap-2">

--- a/src/renderer/components/team/TeamStatusBadge.tsx
+++ b/src/renderer/components/team/TeamStatusBadge.tsx
@@ -1,0 +1,67 @@
+import { useAppTranslation } from '@features/localization/renderer';
+
+import { useTeamStartupCopy } from './useTeamStartupCopy';
+
+import type { TeamStatus } from '@renderer/utils/teamListStatus';
+
+export const TeamStatusBadge = ({
+  status,
+  teamName,
+}: {
+  status: TeamStatus;
+  teamName: string;
+}): React.JSX.Element => {
+  const { t } = useAppTranslation('team');
+  const startupCopy = useTeamStartupCopy(teamName);
+  switch (status) {
+    case 'active':
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
+          <span className="size-1.5 animate-pulse rounded-full bg-emerald-400" />
+          {t('list.status.active')}
+        </span>
+      );
+    case 'idle':
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
+          <span className="size-1.5 rounded-full bg-emerald-400" />
+          {t('list.status.running')}
+        </span>
+      );
+    case 'provisioning':
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-400">
+          <span className="size-1.5 animate-pulse rounded-full bg-amber-400" />
+          {startupCopy.statusLabel}
+        </span>
+      );
+    case 'offline':
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-zinc-500/15 px-2 py-0.5 text-[10px] font-medium text-zinc-500">
+          <span className="size-1.5 rounded-full bg-zinc-500" />
+          {t('list.status.offline')}
+        </span>
+      );
+    case 'partial_failure':
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-400">
+          <span className="size-1.5 rounded-full bg-amber-400" />
+          {t('list.status.partialFailure')}
+        </span>
+      );
+    case 'partial_skipped':
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-sky-500/15 px-2 py-0.5 text-[10px] font-medium text-sky-300">
+          <span className="size-1.5 rounded-full bg-sky-300" />
+          {t('list.status.partialSkipped')}
+        </span>
+      );
+    case 'partial_pending':
+      return (
+        <span className="inline-flex items-center gap-1 rounded-full bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-300">
+          <span className="size-1.5 rounded-full bg-amber-300" />
+          {t('list.status.partialPending')}
+        </span>
+      );
+  }
+};

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -120,6 +120,7 @@ import * as optionalPreflight from './optionalProviderPreflight';
 import { OptionalSettingsSection } from './OptionalSettingsSection';
 import {
   isDeletedProjectPathSelection,
+  isLaunchPreflightProjectSelectionReady,
   isSelectableProjectPathProject,
 } from './projectPathOptions';
 import { loadProjectPathProjects, type ProjectPathProject } from './projectPathProjects';
@@ -170,6 +171,7 @@ import { getNextSuggestedTeamName } from './teamNameSets';
 import { useMemberWorkspaceInfo } from './useMemberWorkspaceInfo';
 import { useOpenCodeLocalModelScope } from './useOpenCodeLocalModelScope';
 import { useOpenCodeProviderScopedDialogModelState } from './useOpenCodeProviderScopedModelAuthority';
+import { useProvisioningPreparePresentationState } from './useProvisioningPreparePresentationState';
 import {
   getWorktreeGitBlockingMessage,
   getWorktreeGitControlDisabledReason,
@@ -633,6 +635,16 @@ export const CreateTeamDialog = ({
       ? ''
       : selectedProjectPath.trim();
   const effectiveCwd = cwdMode === 'project' ? selectedProjectCwd : customCwd.trim();
+  const launchPreflightSelectionReady = isLaunchPreflightProjectSelectionReady({
+    draftLoaded,
+    effectiveCwd,
+    cwdMode,
+    projectsLoading,
+    projects,
+    selectedProjectPath,
+    defaultProjectPath,
+    appliedDefaultProjectPath: appliedDefaultProjectPathRef.current,
+  });
   const { cliStatus: projectScopedCliStatus, providerStatus: projectScopedOpenCodeStatus } =
     useEffectiveCliProviderStatus('opencode', {
       projectPath: effectiveCwd || null,
@@ -895,6 +907,10 @@ export const CreateTeamDialog = ({
 
   useEffect(() => {
     if (!open) {
+      cancelScheduledIdleSet(prepareIdleHandlesRef.current);
+      prepareRequestSeqRef.current += 1;
+      prepareChecksRef.current = [];
+      prepareMessageRef.current = null;
       lastPrepareProviderSignatureByIdRef.current.clear();
       pendingPrepareProviderSignatureByIdRef.current.clear();
       prepareProviderRequestSeqByIdRef.current.clear();
@@ -1113,6 +1129,29 @@ export const CreateTeamDialog = ({
     },
     [codexAccount]
   );
+
+  useEffect(() => {
+    if (
+      submissionFence.busy ||
+      !open ||
+      !canCreate ||
+      !launchTeam ||
+      prepareState !== 'idle' ||
+      !launchPreflightSelectionReady
+    ) {
+      return;
+    }
+    setPrepareState('loading');
+    setPrepareMessage(t('create.prepare.checkingProviders'));
+  }, [
+    canCreate,
+    launchPreflightSelectionReady,
+    launchTeam,
+    open,
+    prepareState,
+    submissionFence,
+    t,
+  ]);
 
   useEffect(() => {
     if (submissionFence.busy) return;
@@ -1576,7 +1615,6 @@ export const CreateTeamDialog = ({
       setCwdMode('project');
     }
   }, [cwdMode, defaultProjectPath, draftLoaded, forceDefaultProjectSelection, open, setCwdMode]);
-
   // Pre-select defaultProjectPath when the draft and projects are loaded.
   useEffect(() => {
     if (!open) {
@@ -2112,6 +2150,10 @@ export const CreateTeamDialog = ({
       }),
     [prepareChecks, prepareMessage, prepareState, prepareWarnings, t]
   );
+  const presentedPrepareState = useProvisioningPreparePresentationState(
+    effectivePrepare.state,
+    open
+  );
   const showCodexReconnectPrompt = shouldShowCodexReconnectPrompt({
     effectiveCliStatus,
     selectedProviderIds: selectedMemberProviders,
@@ -2203,14 +2245,11 @@ export const CreateTeamDialog = ({
       setLocalError(modelValidationError);
       return;
     }
-    if (
-      launchTeam &&
-      prepareState === 'idle' &&
-      launchPreflightCanResolveBlockers &&
-      !canSkipPreflight()
-    ) {
-      setPrepareState('loading');
-      setPrepareMessage(t('create.prepare.checkingProviders'));
+    if (launchTeam && prepareState === 'idle') {
+      if (launchPreflightSelectionReady) {
+        setPrepareState('loading');
+        setPrepareMessage(t('create.prepare.checkingProviders'));
+      }
       return;
     }
     if (
@@ -2397,7 +2436,7 @@ export const CreateTeamDialog = ({
   );
   const createActionLabel = isSubmitting
     ? t('create.actions.creating')
-    : launchTeam && (prepareState === 'loading' || canSkipPreflight())
+    : launchTeam && (presentedPrepareState === 'loading' || canSkipPreflight())
       ? canSkipPreflight()
         ? t('create.actions.skipPreflightAndCreate')
         : t('create.prepare.checkingProviders')
@@ -2919,14 +2958,16 @@ export const CreateTeamDialog = ({
                 className="mb-2"
                 label={t('create.prepare.selectedProvidersLabel')}
                 layout="stacked"
-                showReadyProviders={
-                  effectivePrepare.state === 'idle' || effectivePrepare.state === 'loading'
-                }
                 readyStatusText={t('create.prepare.readyStatus')}
-                showDetailMessages={effectivePrepare.state === 'idle'}
+                forceLoadingProviderIds={
+                  presentedPrepareState === 'idle' || presentedPrepareState === 'loading'
+                    ? selectedMemberProviders
+                    : undefined
+                }
+                showReadyProviders
               />
             ) : null}
-            {canCreate && launchTeam && prepareState === 'loading' ? (
+            {canCreate && launchTeam && presentedPrepareState === 'loading' ? (
               <>
                 <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
                   <span className="inline-block size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
@@ -2950,7 +2991,7 @@ export const CreateTeamDialog = ({
             ) : null}
             {canCreate &&
             launchTeam &&
-            effectivePrepare.state === 'ready' &&
+            presentedPrepareState === 'ready' &&
             !launchAuthorityBlocked ? (
               <div>
                 <div className="flex items-center gap-1.5 text-xs font-medium text-emerald-400">
@@ -2985,8 +3026,8 @@ export const CreateTeamDialog = ({
             ) : null}
             {canCreate &&
             launchTeam &&
-            effectivePrepare.state !== 'loading' &&
-            (!launchPreflightCanResolveBlockers || prepareState !== 'idle') &&
+            presentedPrepareState !== 'idle' &&
+            presentedPrepareState !== 'loading' &&
             launchAuthorityBlocked ? (
               <ProviderLaunchAuthorityNotice
                 id={CREATE_LAUNCH_AUTHORITY_BLOCKER_ID}
@@ -2995,7 +3036,7 @@ export const CreateTeamDialog = ({
                 onOpenProviderSettings={setProviderSettingsProviderId}
               />
             ) : null}
-            {canCreate && launchTeam && effectivePrepare.state === 'failed' ? (
+            {canCreate && launchTeam && presentedPrepareState === 'failed' ? (
               <div className="text-xs">
                 <div className="flex items-start gap-2 text-red-300">
                   <AlertTriangle className="mt-0.5 size-4 shrink-0" />
@@ -3084,8 +3125,8 @@ export const CreateTeamDialog = ({
                 className="min-w-32 text-sm"
                 aria-describedby={
                   launchAuthorityBlocked &&
-                  (!launchPreflightCanResolveBlockers || prepareState !== 'idle') &&
-                  effectivePrepare.state !== 'loading'
+                  presentedPrepareState !== 'idle' &&
+                  presentedPrepareState !== 'loading'
                     ? CREATE_LAUNCH_AUTHORITY_BLOCKER_ID
                     : undefined
                 }

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -2020,13 +2020,22 @@ export const CreateTeamDialog = ({
     selectedProviderId,
     syncModelsWithLead,
   ]);
+  const canSkipPreflight = () =>
+    launchTeam &&
+    optionalPreflight.canSkipProviderPreflight(
+      prepareState,
+      selectedMemberProviders,
+      runtimeProviderStatusById,
+      runtimeProviderLoadingById,
+      prepareChecksRef.current
+    );
   const hasCreateFormErrors =
     !!teamNameInlineError ||
     isNameTakenByExistingTeam ||
     isNameProvisioning ||
     !requestValidation.valid ||
     !!modelValidationError ||
-    (launchAuthorityBlocked && !launchPreflightCanResolveBlockers) ||
+    (launchAuthorityBlocked && !launchPreflightCanResolveBlockers && !canSkipPreflight()) ||
     teammateRuntimeCompatibility.blocksSubmission ||
     worktreeGitBlocksSubmission;
 
@@ -2156,16 +2165,6 @@ export const CreateTeamDialog = ({
     activeError?.includes('Team already exists') === true && request.teamName.length > 0;
   const prepareBlocksCreate =
     launchTeam && effectivePrepare.state === 'failed' && !experimentalLocalModelOverrideEnabled;
-  const canSkipPreflight = () =>
-    launchTeam &&
-    optionalPreflight.canSkipProviderPreflight(
-      prepareState,
-      selectedMemberProviders,
-      runtimeProviderStatusById,
-      runtimeProviderLoadingById,
-      prepareChecksRef.current
-    );
-
   const organizationPlacementOrganizations = organizationStructure?.organizations ?? [];
   const activePlacementOrganization =
     organizationPlacementOrganizations.find(
@@ -2952,11 +2951,11 @@ export const CreateTeamDialog = ({
                 label={t('create.prepare.selectedProvidersLabel')}
                 layout="stacked"
                 readyStatusText={t('create.prepare.readyStatus')}
-                forceLoadingProviderIds={
-                  presentedPrepareState === 'idle' || presentedPrepareState === 'loading'
-                    ? selectedMemberProviders
-                    : undefined
-                }
+                forceLoadingProviderIds={optionalPreflight.getPendingProviderPreflightIds(
+                  prepareState,
+                  selectedMemberProviders,
+                  prepareChecks
+                )}
                 showReadyProviders
               />
             ) : null}

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -2027,7 +2027,9 @@ export const CreateTeamDialog = ({
       selectedMemberProviders,
       runtimeProviderStatusById,
       runtimeProviderLoadingById,
-      prepareChecksRef.current
+      prepareChecksRef.current,
+      Date.now(),
+      loadingCliStatus?.providers
     );
   const hasCreateFormErrors =
     !!teamNameInlineError ||

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -644,6 +644,8 @@ export const CreateTeamDialog = ({
     selectedProjectPath,
     defaultProjectPath,
     appliedDefaultProjectPath: appliedDefaultProjectPathRef.current,
+    forceDefaultProjectSelection,
+    appliedDefaultProjectModePath: forcedDefaultProjectModePathRef.current,
   });
   const { cliStatus: projectScopedCliStatus, providerStatus: projectScopedOpenCodeStatus } =
     useEffectiveCliProviderStatus('opencode', {
@@ -1155,7 +1157,13 @@ export const CreateTeamDialog = ({
 
   useEffect(() => {
     if (submissionFence.busy) return;
-    if (!open || !canCreate || !launchTeam || prepareState === 'idle') {
+    if (
+      !open ||
+      !canCreate ||
+      !launchTeam ||
+      prepareState === 'idle' ||
+      !launchPreflightSelectionReady
+    ) {
       cancelScheduledIdleSet(prepareIdleHandlesRef.current);
       prepareRequestSeqRef.current += 1;
       lastPrepareProviderSignatureByIdRef.current.clear();
@@ -1420,6 +1428,7 @@ export const CreateTeamDialog = ({
     canCreate,
     launchTeam,
     prepareState,
+    launchPreflightSelectionReady,
     isSubmitting,
     submissionFence,
     effectiveCwd,
@@ -1638,7 +1647,7 @@ export const CreateTeamDialog = ({
       const match = selectableProjects.find(
         (p) => normalizePath(p.path) === normalizedDefaultProjectPath
       );
-      if (match && !defaultAlreadyApplied) {
+      if (match && (!defaultAlreadyApplied || !selectedProjectPath)) {
         appliedDefaultProjectPathRef.current = normalizedDefaultProjectPath;
         if (normalizePath(selectedProjectPath) !== normalizedDefaultProjectPath) {
           setSelectedProjectPath(match.path);
@@ -1648,16 +1657,6 @@ export const CreateTeamDialog = ({
     }
     if (selectedProjectPath) {
       return;
-    }
-    if (defaultProjectPath && !isEphemeralProjectPath(defaultProjectPath)) {
-      const normalizedDefaultProjectPath = normalizePath(defaultProjectPath);
-      const match = selectableProjects.find(
-        (p) => normalizePath(p.path) === normalizedDefaultProjectPath
-      );
-      if (match) {
-        setSelectedProjectPath(match.path);
-        return;
-      }
     }
     setSelectedProjectPath(selectableProjects[0].path);
   }, [

--- a/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/CreateTeamDialog.tsx
@@ -1170,6 +1170,13 @@ export const CreateTeamDialog = ({
       pendingPrepareProviderSignatureByIdRef.current.clear();
       prepareProviderRequestSeqByIdRef.current.clear();
       prepareWarningsByProviderIdRef.current.clear();
+      if (!launchPreflightSelectionReady && prepareState !== 'idle') {
+        setPrepareState('idle');
+        setPrepareMessage(null);
+        setPrepareWarnings([]);
+        setPrepareChecks([]);
+        setAllowExperimentalLocalModels(false);
+      }
       return;
     }
 
@@ -1184,20 +1191,6 @@ export const CreateTeamDialog = ({
       setPrepareWarnings([]);
       setPrepareChecks([]);
       setPrepareMessage(t('create.prepare.unsupportedPreload'));
-      return;
-    }
-
-    if (!effectiveCwd) {
-      cancelScheduledIdleSet(prepareIdleHandlesRef.current);
-      prepareRequestSeqRef.current += 1;
-      lastPrepareProviderSignatureByIdRef.current.clear();
-      pendingPrepareProviderSignatureByIdRef.current.clear();
-      prepareProviderRequestSeqByIdRef.current.clear();
-      prepareWarningsByProviderIdRef.current.clear();
-      setPrepareState('idle');
-      setPrepareWarnings([]);
-      setPrepareChecks([]);
-      setPrepareMessage(t('create.prepare.selectWorkingDirectory'));
       return;
     }
 
@@ -2222,6 +2215,7 @@ export const CreateTeamDialog = ({
 
   const handleSubmit = (): void => {
     if (!canCreate || !draftLoaded) return;
+    if (launchTeam && !launchPreflightSelectionReady) return;
     if (submissionFence.busy || isSubmitting) return;
     if (prepareState === 'loading' && !canSkipPreflight()) return;
     if (allTakenTeamNames.includes(sanitizedTeamName)) {
@@ -3133,6 +3127,7 @@ export const CreateTeamDialog = ({
                   !canCreate ||
                   !draftLoaded ||
                   isSubmitting ||
+                  (launchTeam && !launchPreflightSelectionReady) ||
                   (prepareState === 'loading' && !canSkipPreflight()) ||
                   hasCreateFormErrors ||
                   prepareBlocksCreate

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -3150,11 +3150,11 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                 providerIds={selectedMemberProviders}
                 label="Selected providers"
                 layout="stacked"
-                forceLoadingProviderIds={
-                  presentedPrepareState === 'idle' || presentedPrepareState === 'loading'
-                    ? selectedMemberProviders
-                    : undefined
-                }
+                forceLoadingProviderIds={optionalPreflight.getPendingProviderPreflightIds(
+                  prepareState,
+                  selectedMemberProviders,
+                  prepareChecks
+                )}
                 showReadyProviders
                 readyStatusText="Ready"
                 className="mb-2"

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -1634,6 +1634,13 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       lastPrepareProviderSignatureByIdRef.current.clear();
       prepareProviderRequestSeqByIdRef.current.clear();
       prepareWarningsByProviderIdRef.current.clear();
+      if (prepareState !== 'idle') {
+        setPrepareState('idle');
+        setPrepareMessage(null);
+        setPrepareWarnings([]);
+        setPrepareChecks([]);
+        setAllowExperimentalLocalModels(false);
+      }
       return;
     }
     if (prepareState === 'idle') {
@@ -2305,7 +2312,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
         return;
       }
     }
-    if (isLaunchMode && prepareState === 'idle') return;
+    if (isLaunchMode && (prepareState === 'idle' || !launchPreflightSelectionReady)) return;
     if (launchGuard.reject(isLaunchMode && !canSkipPreflight(), rejectProviderLaunch)) return;
     if (!submissionFence.acquire(prepareRequestSeqRef)) return;
     setLocalError(null);
@@ -2456,7 +2463,8 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   };
 
   const isDisabled = isLaunchMode
-    ? isSubmitting ||
+    ? !launchPreflightSelectionReady ||
+      isSubmitting ||
       launchInFlight ||
       (prepareState === 'loading' && !canSkipPreflight()) ||
       validationErrors.length > 0 ||
@@ -3156,12 +3164,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                   <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
                     <span className="inline-block size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
                     <div>
-                      <span>
-                        {effectivePrepare.message ??
-                          (effectivePrepare.state === 'idle'
-                            ? t('launch.prepare.checkingProviders')
-                            : t('launch.prepare.preparingEnvironment'))}
-                      </span>
+                      {effectivePrepare.message ?? t('launch.prepare.preparingEnvironment')}
                       <p className="mt-0.5 flex items-center gap-1.5 text-[10px] text-[var(--color-text-muted)] opacity-70">
                         <span>
                           {t('launch.prepare.preflight', {

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -2240,7 +2240,9 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       selectedMemberProviders,
       runtimeProviderStatusById,
       runtimeProviderLoadingById,
-      prepareChecksRef.current
+      prepareChecksRef.current,
+      Date.now(),
+      loadingCliStatus?.providers
     );
   const rejectProviderLaunch = () => setLocalError(t('launch.prepare.failed'));
   const showCodexReconnectPrompt = shouldShowCodexReconnectPrompt({
@@ -2476,9 +2478,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       teammateRuntimeCompatibility.blocksSubmission
     : isSubmitting || validationErrors.length > 0 || !!modelValidationError;
   const dialogTitle = isLaunchMode
-    ? isRelaunch
-      ? t('launch.title.relaunch')
-      : t('launch.title.launch')
+    ? t(isRelaunch ? 'launch.title.relaunch' : 'launch.title.launch')
     : isEditing
       ? t('launch.title.editSchedule')
       : t('launch.title.createSchedule');

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -904,7 +904,10 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   useEffect(() => {
     if (!open || !isLaunchMode) return;
     // Hydrate at most once per open dialog, and never on top of user edits.
-    if (hydrationRef.current.dirty || hydrationRef.current.key === effectiveTeamName) return;
+    if (hydrationRef.current.dirty || hydrationRef.current.key === effectiveTeamName) {
+      setLaunchHydratedTeamName(effectiveTeamName);
+      return;
+    }
 
     const applyEditableRoster = (
       savedMembers?: TeamCreateRequest['members'],
@@ -2302,13 +2305,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
         return;
       }
     }
-    if (isLaunchMode && prepareState === 'idle') {
-      if (launchPreflightSelectionReady) {
-        setPrepareState('loading');
-        setPrepareMessage(t('launch.prepare.checkingProviders'));
-      }
-      return;
-    }
+    if (isLaunchMode && prepareState === 'idle') return;
     if (launchGuard.reject(isLaunchMode && !canSkipPreflight(), rejectProviderLaunch)) return;
     if (!submissionFence.acquire(prepareRequestSeqRef)) return;
     setLocalError(null);

--- a/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/LaunchTeamDialog.tsx
@@ -116,6 +116,7 @@ import * as optionalPreflight from './optionalProviderPreflight';
 import { OptionalSettingsSection } from './OptionalSettingsSection';
 import {
   isDeletedProjectPathSelection,
+  isLaunchPreflightProjectSelectionReady,
   isSelectableProjectPathProject,
 } from './projectPathOptions';
 import { loadProjectPathProjects, syntheticProjectFromPath } from './projectPathProjects';
@@ -167,6 +168,7 @@ import {
 import { useMemberWorkspaceInfo } from './useMemberWorkspaceInfo';
 import { useOpenCodeLocalModelScope } from './useOpenCodeLocalModelScope';
 import { useOpenCodeProviderScopedDialogModelState } from './useOpenCodeProviderScopedModelAuthority';
+import { useProvisioningPreparePresentationState } from './useProvisioningPreparePresentationState';
 import {
   getWorktreeGitBlockingMessage,
   getWorktreeGitControlDisabledReason,
@@ -338,6 +340,8 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
 
   // Effective team name: from props if provided, otherwise from local selection
   const effectiveTeamName = propsTeamName || selectedTeamName;
+  const defaultProjectPath = isLaunchMode ? props.defaultProjectPath : undefined;
+  const [launchHydratedTeamName, setLaunchHydratedTeamName] = useState<string | null>(null);
   const needsTeamSelector = isSchedule && !propsTeamName;
 
   // ---------------------------------------------------------------------------
@@ -419,6 +423,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     if (!open) {
       setProviderSettingsProviderId(null);
       hydrationRef.current = { key: null, dirty: false, rosterDirty: false };
+      setLaunchHydratedTeamName(null);
     }
   }, [open]);
   // Advanced CLI section state (with localStorage persistence)
@@ -459,6 +464,16 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       ? ''
       : selectedProjectPath.trim();
   const effectiveCwd = cwdMode === 'project' ? selectedProjectCwd : customCwd.trim();
+  const launchPreflightSelectionReady = isLaunchPreflightProjectSelectionReady({
+    draftLoaded: launchHydratedTeamName === effectiveTeamName,
+    effectiveCwd,
+    cwdMode,
+    projectsLoading,
+    projects,
+    selectedProjectPath,
+    defaultProjectPath,
+    appliedDefaultProjectPath: appliedDefaultProjectPathRef.current,
+  });
   const { cliStatus: projectScopedCliStatus, providerStatus: projectScopedOpenCodeStatus } =
     useEffectiveCliProviderStatus('opencode', {
       projectPath: effectiveCwd || null,
@@ -937,6 +952,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       // Edits made while the request was in flight win over it, but an unrelated control is
       // not a roster edit — and with no live members the saved request is its only source.
       if (cancelled) return;
+      setLaunchHydratedTeamName(effectiveTeamName);
       if (!hydrationRef.current.rosterDirty) {
         applyEditableRoster(savedRequest?.members, savedRequest?.syncModelsWithLead);
       }
@@ -1610,11 +1626,16 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
   // Warm up CLI for the currently selected working directory (launch mode only).
   useEffect(() => {
     if (submissionFence.busy) return;
-    if (!open || !isLaunchMode || prepareState === 'idle') {
+    if (!open || !isLaunchMode || !launchPreflightSelectionReady) {
       prepareRequestSeqRef.current += 1;
       lastPrepareProviderSignatureByIdRef.current.clear();
       prepareProviderRequestSeqByIdRef.current.clear();
       prepareWarningsByProviderIdRef.current.clear();
+      return;
+    }
+    if (prepareState === 'idle') {
+      setPrepareState('loading');
+      setPrepareMessage(t('launch.prepare.checkingProviders'));
       return;
     }
 
@@ -1627,18 +1648,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       setPrepareWarnings([]);
       setPrepareChecks([]);
       setPrepareMessage(t('launch.prepare.unsupportedPreload'));
-      return;
-    }
-
-    if (!effectiveCwd) {
-      prepareRequestSeqRef.current += 1;
-      lastPrepareProviderSignatureByIdRef.current.clear();
-      prepareProviderRequestSeqByIdRef.current.clear();
-      prepareWarningsByProviderIdRef.current.clear();
-      setPrepareState('idle');
-      setPrepareWarnings([]);
-      setPrepareChecks([]);
-      setPrepareMessage(t('launch.prepare.selectWorkingDirectory'));
       return;
     }
 
@@ -1842,6 +1851,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     open,
     isLaunchMode,
     prepareState,
+    launchPreflightSelectionReady,
     isSubmitting,
     submissionFence,
     effectiveCwd,
@@ -1855,12 +1865,8 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
     t,
   ]);
 
-  // ---------------------------------------------------------------------------
   // Shared effects: projects
-  // ---------------------------------------------------------------------------
-
   const repositoryGroups = useStore(useShallow((s) => s.repositoryGroups));
-  const defaultProjectPath = isLaunchMode ? props.defaultProjectPath : undefined;
   const shouldDeferProjectListLoad =
     isLaunchMode &&
     !projectsLoadRequested &&
@@ -1930,7 +1936,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       const match = selectableProjects.find(
         (p) => normalizePath(p.path) === normalizedDefaultProjectPath
       );
-      if (match && !defaultAlreadyApplied) {
+      if (match && (!defaultAlreadyApplied || !selectedProjectPath)) {
         appliedDefaultProjectPathRef.current = normalizedDefaultProjectPath;
         if (normalizePath(selectedProjectPath) !== normalizedDefaultProjectPath) {
           setSelectedProjectPath(match.path);
@@ -1939,16 +1945,6 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       }
     }
     if (selectedProjectPath) return;
-    if (defaultProjectPath && !isEphemeralProjectPath(defaultProjectPath)) {
-      const normalizedDefaultProjectPath = normalizePath(defaultProjectPath);
-      const match = selectableProjects.find(
-        (p) => normalizePath(p.path) === normalizedDefaultProjectPath
-      );
-      if (match) {
-        setSelectedProjectPath(match.path);
-        return;
-      }
-    }
     setSelectedProjectPath(selectableProjects[0].path);
   }, [open, cwdMode, projects, selectedProjectPath, defaultProjectPath, setSelectedProjectPath]);
 
@@ -2213,6 +2209,10 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
       }),
     [prepareChecks, prepareMessage, prepareState, prepareWarnings, t]
   );
+  const presentedPrepareState = useProvisioningPreparePresentationState(
+    effectivePrepare.state,
+    open
+  );
   const {
     available: experimentalLocalModelOverrideAvailable,
     enabled: experimentalLocalModelOverrideEnabled,
@@ -2302,9 +2302,11 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
         return;
       }
     }
-    if (isLaunchMode && prepareState === 'idle' && !canSkipPreflight()) {
-      setPrepareState('loading');
-      setPrepareMessage(t('launch.prepare.checkingProviders'));
+    if (isLaunchMode && prepareState === 'idle') {
+      if (launchPreflightSelectionReady) {
+        setPrepareState('loading');
+        setPrepareMessage(t('launch.prepare.checkingProviders'));
+      }
       return;
     }
     if (launchGuard.reject(isLaunchMode && !canSkipPreflight(), rejectProviderLaunch)) return;
@@ -3143,13 +3145,16 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                 providerIds={selectedMemberProviders}
                 label="Selected providers"
                 layout="stacked"
-                showReadyProviders={
-                  effectivePrepare.state === 'idle' || effectivePrepare.state === 'loading'
+                forceLoadingProviderIds={
+                  presentedPrepareState === 'idle' || presentedPrepareState === 'loading'
+                    ? selectedMemberProviders
+                    : undefined
                 }
+                showReadyProviders
                 readyStatusText="Ready"
                 className="mb-2"
               />
-              {prepareState === 'loading' ? (
+              {presentedPrepareState === 'loading' ? (
                 <>
                   <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
                     <span className="inline-block size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
@@ -3174,14 +3179,12 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                   <ProvisioningProviderStatusList
                     checks={prepareChecks}
                     className="mt-2"
-                    onOpenProviderSettings={(providerId) =>
-                      setProviderSettingsProviderId(providerId)
-                    }
+                    onOpenProviderSettings={setProviderSettingsProviderId}
                   />
                 </>
               ) : null}
 
-              {effectivePrepare.state === 'ready' && !launchAuthorityBlocked ? (
+              {presentedPrepareState === 'ready' && !launchAuthorityBlocked ? (
                 <ProviderPrepareReadyNotice
                   checks={prepareChecks}
                   message={effectivePrepare.message}
@@ -3190,7 +3193,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                 />
               ) : null}
 
-              {effectivePrepare.state === 'ready' && launchAuthorityBlocked ? (
+              {presentedPrepareState === 'ready' && launchAuthorityBlocked ? (
                 <ProviderLaunchAuthorityNotice
                   id={LAUNCH_AUTHORITY_BLOCKER_ID}
                   action={
@@ -3203,7 +3206,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                 />
               ) : null}
 
-              {effectivePrepare.state === 'failed' ? (
+              {presentedPrepareState === 'failed' ? (
                 <div className="text-xs">
                   <div className="flex items-start gap-2 text-red-300">
                     <AlertTriangle className="mt-0.5 size-4 shrink-0" />
@@ -3235,9 +3238,7 @@ export const LaunchTeamDialog = (props: LaunchTeamDialogProps): React.JSX.Elemen
                       checks={prepareChecks}
                       className="mt-2"
                       suppressDetailsMatching={effectivePrepare.message}
-                      onOpenProviderSettings={(providerId) =>
-                        setProviderSettingsProviderId(providerId)
-                      }
+                      onOpenProviderSettings={setProviderSettingsProviderId}
                     />
                   ) : null}
                   {prepareWarnings.length > 0 && prepareChecks.length === 0 ? (

--- a/src/renderer/components/team/dialogs/MembersJsonEditor.test.tsx
+++ b/src/renderer/components/team/dialogs/MembersJsonEditor.test.tsx
@@ -34,7 +34,7 @@ describe('MembersJsonEditor', () => {
         )
       );
     render('[{"name":"worker","model":"old"}]');
-    const view = EditorView.findFromDOM(container.querySelector('.cm-editor') as HTMLElement)!;
+    const view = EditorView.findFromDOM(container.querySelector<HTMLElement>('.cm-editor')!)!;
     expect(view).toBeTruthy();
 
     render('[{"name":"worker","model":"new"}]');

--- a/src/renderer/components/team/dialogs/MembersJsonEditor.test.tsx
+++ b/src/renderer/components/team/dialogs/MembersJsonEditor.test.tsx
@@ -1,6 +1,7 @@
 import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { undo } from '@codemirror/commands';
 import { EditorView } from '@codemirror/view';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -43,5 +44,15 @@ describe('MembersJsonEditor', () => {
 
     act(() => view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: '[]' } }));
     expect(onChange).toHaveBeenCalledExactlyOnceWith('[]');
+    act(() => {
+      expect(undo(view)).toBe(true);
+    });
+    expect(view.state.doc.toString()).toBe('[{"name":"worker","model":"new"}]');
+    expect(onChange).toHaveBeenLastCalledWith('[{"name":"worker","model":"new"}]');
+    act(() => {
+      expect(undo(view)).toBe(false);
+    });
+    expect(view.state.doc.toString()).toBe('[{"name":"worker","model":"new"}]');
+    expect(onChange).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/renderer/components/team/dialogs/MembersJsonEditor.test.tsx
+++ b/src/renderer/components/team/dialogs/MembersJsonEditor.test.tsx
@@ -1,0 +1,47 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { EditorView } from '@codemirror/view';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MembersJsonEditor } from './MembersJsonEditor';
+
+describe('MembersJsonEditor', () => {
+  const container = document.createElement('div');
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true));
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not echo form updates as JSON edits, while preserving manual editing', () => {
+    document.body.append(container);
+    root = createRoot(container);
+    const onChange = vi.fn();
+    const render = (value: string) =>
+      act(() =>
+        root.render(
+          <MembersJsonEditor
+            value={value}
+            onChange={onChange}
+            error={null}
+            onClose={() => undefined}
+          />
+        )
+      );
+    render('[{"name":"worker","model":"old"}]');
+    const view = EditorView.findFromDOM(container.querySelector('.cm-editor') as HTMLElement)!;
+    expect(view).toBeTruthy();
+
+    render('[{"name":"worker","model":"new"}]');
+    expect(view.state.doc.toString()).toContain('"model":"new"');
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: '[]' } }));
+    expect(onChange).toHaveBeenCalledExactlyOnceWith('[]');
+  });
+});

--- a/src/renderer/components/team/dialogs/MembersJsonEditor.tsx
+++ b/src/renderer/components/team/dialogs/MembersJsonEditor.tsx
@@ -10,7 +10,7 @@ import {
   syntaxHighlighting,
 } from '@codemirror/language';
 import { lintGutter } from '@codemirror/lint';
-import { EditorState } from '@codemirror/state';
+import { Annotation, EditorState, Transaction } from '@codemirror/state';
 import { oneDarkHighlightStyle } from '@codemirror/theme-one-dark';
 import {
   EditorView,
@@ -40,6 +40,8 @@ const membersEditorTheme = EditorView.theme({
     overflow: 'auto',
   },
 });
+
+const externalValueSync = Annotation.define<boolean>();
 
 export const MembersJsonEditor = ({
   value,
@@ -75,7 +77,10 @@ export const MembersJsonEditor = ({
         baseEditorTheme,
         membersEditorTheme,
         EditorView.updateListener.of((update) => {
-          if (update.docChanged) {
+          if (
+            update.docChanged &&
+            !update.transactions.some((tr) => tr.annotation(externalValueSync))
+          ) {
             onChangeRef.current(update.state.doc.toString());
           }
         }),
@@ -104,6 +109,7 @@ export const MembersJsonEditor = ({
     if (currentDoc !== value) {
       view.dispatch({
         changes: { from: 0, to: currentDoc.length, insert: value },
+        annotations: [externalValueSync.of(true), Transaction.addToHistory.of(false)],
       });
     }
   }, [value]);

--- a/src/renderer/components/team/dialogs/ProviderLaunchAuthorityNotice.tsx
+++ b/src/renderer/components/team/dialogs/ProviderLaunchAuthorityNotice.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useAppTranslation } from '@features/localization/renderer';
+import { isTeamProviderRuntimeStatusLoading } from '@renderer/utils/teamProviderRuntimeStatusLoading';
 import { AlertTriangle } from 'lucide-react';
 
 import {
@@ -24,13 +25,22 @@ export const ProviderLaunchAuthorityNotice = ({
 }): React.JSX.Element | null => {
   const { t } = useAppTranslation('team');
   if (blockers.length === 0) return null;
-
   const checks = blockers.map((blocker) => ({
     providerId: blocker.providerId,
-    status: 'failed' as const,
+    status:
+      blocker.providerId === 'anthropic' &&
+      isTeamProviderRuntimeStatusLoading(blocker.providerId, blocker.providerStatus)
+        ? ('checking' as const)
+        : ('failed' as const),
     backendSummary: getProvisioningProviderBackendSummary(blocker.providerStatus),
     details: [blocker.detail],
   }));
+  if (checks.every((check) => check.status === 'checking'))
+    return (
+      <p id={id} role="status" className="text-xs text-[var(--color-text-muted)]">
+        {t('launch.prepare.checkingProviders')}
+      </p>
+    );
 
   return (
     <div id={id} role="alert" aria-live="polite" className="text-xs">

--- a/src/renderer/components/team/dialogs/ProviderPrepareReadyNotice.tsx
+++ b/src/renderer/components/team/dialogs/ProviderPrepareReadyNotice.tsx
@@ -21,14 +21,15 @@ export const ProviderPrepareReadyNotice = ({
 }): React.JSX.Element => {
   const { t } = useAppTranslation('team');
   const hasNotes = checks.some((check) => check.status === 'notes') || warnings.length > 0;
+  const heading = hasNotes ? t('launch.prepare.readyWithNotes') : t('launch.prepare.ready');
 
   return (
     <div>
       <div className="flex items-center gap-1.5 text-xs font-medium text-emerald-400">
         <CheckCircle2 className="size-3.5 shrink-0" />
-        <span>{hasNotes ? t('launch.prepare.readyWithNotes') : t('launch.prepare.ready')}</span>
+        <span>{heading}</span>
       </div>
-      {message ? (
+      {message?.trim() && message.trim() !== heading.trim() ? (
         <p className="mt-0.5 pl-5 text-[11px] text-[var(--color-text-muted)]">{message}</p>
       ) : null}
       <ProvisioningProviderStatusList

--- a/src/renderer/components/team/dialogs/ProvisioningProviderStatusList.tsx
+++ b/src/renderer/components/team/dialogs/ProvisioningProviderStatusList.tsx
@@ -801,24 +801,17 @@ export function deriveEffectiveProvisioningPrepareState(params: {
   checks: ProvisioningProviderCheck[];
   t?: TeamTranslator;
 }): { state: ProvisioningPrepareState; message: string | null } {
-  if (params.state !== 'loading') {
+  if (params.state !== 'loading' || params.checks.length === 0) {
     return {
       state: params.state,
       message: params.message,
     };
   }
 
-  if (params.checks.length === 0) {
-    return {
-      state: params.state,
-      message: params.message,
-    };
-  }
-
-  const hasPendingChecks = params.checks.some(
+  const pendingChecks = params.checks.filter(
     (check) => check.status === 'pending' || check.status === 'checking'
   );
-  if (hasPendingChecks) {
+  if (pendingChecks.length > 0) {
     if (hasCompatibilityPendingDetails(params.checks)) {
       return {
         state: params.state,
@@ -829,7 +822,11 @@ export function deriveEffectiveProvisioningPrepareState(params: {
     }
     return {
       state: params.state,
-      message: params.message,
+      message: getProvisioningProviderProgressMessage(
+        pendingChecks.map((check) => check.providerId),
+        params.checks.length,
+        params.t
+      ),
     };
   }
 

--- a/src/renderer/components/team/dialogs/TeamModelSelector.tsx
+++ b/src/renderer/components/team/dialogs/TeamModelSelector.tsx
@@ -100,6 +100,7 @@ import {
 import { OpenCodeLocalModelStatus } from './OpenCodeLocalModelStatus';
 import {
   canUseCachedOpenCodeModelsDuringTransientCheck,
+  getOpenCodeDisabledPanelPresentation,
   getOpenCodeReadinessBadgeLabel,
   getOpenCodeReadinessMessage,
   getOpenCodeReadinessSummary,
@@ -2653,19 +2654,13 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
         }
       : activeProviderDisabledReason && effectiveProviderId === 'opencode'
         ? {
-            tone: 'warning' as const,
-            title: t('modelSelector.openCodeStatus.notReadyTitle'),
-            summary: getOpenCodeReadinessSummary(
-              openCodeProviderStatus,
+            ...getOpenCodeDisabledPanelPresentation(
+              openCodeRuntimeStatusUiState,
+              activeProviderDisabledReason,
+              getProviderOverrideDisabledReason('opencode'),
               t,
-              openCodeRuntimeStatusUiState
+              openCodeProviderStatus
             ),
-            message: getOpenCodeReadinessMessage(
-              openCodeProviderStatus,
-              t,
-              openCodeRuntimeStatusUiState
-            ),
-            reason: activeProviderDisabledReason,
             actionLabel: null,
           }
         : showOpenCodeOverviewStatus &&
@@ -2703,7 +2698,9 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
                 reason: null,
                 actionLabel: null,
               }
-            : showOpenCodeOverviewStatus && canActivateInspectedOpenCode
+            : showOpenCodeOverviewStatus &&
+                canActivateInspectedOpenCode &&
+                openCodeRuntimeStatusUiState === 'ready'
               ? {
                   tone: 'ready' as const,
                   title: t('modelSelector.openCodeStatus.readyTitle'),

--- a/src/renderer/components/team/dialogs/memberModelScope.test.ts
+++ b/src/renderer/components/team/dialogs/memberModelScope.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 import {
   clearInheritedMemberModelsUnavailableForProvider,
   getDialogTeamModelValidationError,
+  resolveProviderScopedMemberModel,
 } from './memberModelScope';
 import { canResolveOpenCodeLaunchBlockers, createLaunchGuard } from './providerLaunchAuthority';
 
@@ -82,6 +83,30 @@ const providerStatusById = new Map<TeamProviderId, CliProviderStatus>([
 const providerLoadingById = new Map<TeamProviderId, boolean>();
 
 describe('getDialogTeamModelValidationError', () => {
+  it.each(['cursor-acp/auto', 'kiro/auto'])(
+    'blocks unsupported extension-bound model %s without scheduling it for preflight',
+    (modelId) => {
+      expect(
+        getDialogTeamModelValidationError({
+          selectedProviderId: 'opencode',
+          selectedModel: modelId,
+          members: [],
+          validateMembers: true,
+          runtimeProviderStatusById: new Map(),
+          runtimeProviderLoadingById: providerLoadingById,
+        })
+      ).toContain('not supported by the current Agent Teams launch runtime');
+      expect(
+        resolveProviderScopedMemberModel({
+          selectedProviderId: 'codex',
+          memberProviderId: 'opencode',
+          memberModel: modelId,
+          runtimeProviderStatusById: new Map(),
+        })
+      ).toEqual({ providerId: 'opencode', model: '' });
+    }
+  );
+
   it('allows a built-in Ollama lead route outside the general OpenCode catalog', () => {
     expect(
       getDialogTeamModelValidationError({

--- a/src/renderer/components/team/dialogs/memberModelScope.ts
+++ b/src/renderer/components/team/dialogs/memberModelScope.ts
@@ -1,7 +1,7 @@
 import {
   getAvailableTeamProviderModels,
-  getTeamModelUiDisabledReason,
   getTeamModelSelectionError,
+  getTeamModelUiDisabledReason,
   hasTerminalAuthoritativeModelVerification,
   isTeamModelAvailableForUi,
   isTeamProviderModelCatalogFresh,

--- a/src/renderer/components/team/dialogs/memberModelScope.ts
+++ b/src/renderer/components/team/dialogs/memberModelScope.ts
@@ -1,5 +1,6 @@
 import {
   getAvailableTeamProviderModels,
+  getTeamModelUiDisabledReason,
   getTeamModelSelectionError,
   hasTerminalAuthoritativeModelVerification,
   isTeamModelAvailableForUi,
@@ -186,6 +187,12 @@ export function resolveProviderScopedMemberModel(
 
   const normalizedModel = normalizeExplicitTeamModelForUi(providerId, rawModel);
   if (!normalizedModel) {
+    return { providerId, model: '' };
+  }
+  // Keep unsupported extension-backed routes visible in the selector, but do
+  // not send a stale saved selection into provider preflight. The form-level
+  // validation still explains why the user must choose another model.
+  if (getTeamModelUiDisabledReason(providerId, normalizedModel)) {
     return { providerId, model: '' };
   }
   // App-managed local providers are discovered through the local-provider overlay,

--- a/src/renderer/components/team/dialogs/openCodeRuntimeStatusUi.ts
+++ b/src/renderer/components/team/dialogs/openCodeRuntimeStatusUi.ts
@@ -8,6 +8,33 @@ import type { TFunction } from 'i18next';
 export type OpenCodeRuntimeStatusUiState = 'checking' | 'missing' | 'retry' | 'ready';
 type TeamTranslator = TFunction<TranslationNamespace, undefined>;
 
+export function getOpenCodeDisabledPanelPresentation(
+  runtimeStatusUiState: OpenCodeRuntimeStatusUiState,
+  reason: string,
+  overrideReason: string | null,
+  t: TeamTranslator,
+  providerStatus?: CliProviderStatus | null
+): {
+  tone: 'info' | 'warning';
+  title: string;
+  reason: string | null;
+  summary: string;
+  message: string;
+} {
+  const pending = runtimeStatusUiState === 'checking' && !overrideReason;
+  return {
+    tone: pending ? 'info' : 'warning',
+    title: t(
+      pending
+        ? 'modelSelector.openCodeStatus.loadingRuntime'
+        : 'modelSelector.openCodeStatus.notReadyTitle'
+    ),
+    reason: pending ? null : reason,
+    summary: getOpenCodeReadinessSummary(providerStatus, t, runtimeStatusUiState),
+    message: getOpenCodeReadinessMessage(providerStatus, t, runtimeStatusUiState),
+  };
+}
+
 export function getOpenCodeRuntimeStatusUiState({
   providerStatus,
   runtimeStatus,
@@ -45,6 +72,17 @@ export function getOpenCodeRuntimeStatusUiState({
     (runtimeStatus === null && !providerStatus) ||
     providerStatus?.statusCheckOutcome === 'pending' ||
     providerStatus?.statusCheckOutcome === 'model_only' ||
+    // The renderer gates launch while catalog authority settles. That is not
+    // a runtime failure, even when connection evidence is authoritative.
+    (providerStatus?.supported === true &&
+      providerStatus.authenticated === true &&
+      providerStatus.verificationState === 'verified' &&
+      providerStatus.statusCheckOutcome === 'authoritative' &&
+      providerStatus.modelVerificationState === 'idle' &&
+      providerStatus.modelCatalogRefreshState !== 'error' &&
+      providerStatus.modelCatalog?.status !== 'degraded' &&
+      providerStatus.modelCatalog?.status !== 'unavailable' &&
+      !providerStatus.capabilities.teamLaunch) ||
     isTeamProviderModelVerificationPending('opencode', providerStatus)
   ) {
     return 'checking';

--- a/src/renderer/components/team/dialogs/optionalProviderPreflight.ts
+++ b/src/renderer/components/team/dialogs/optionalProviderPreflight.ts
@@ -123,8 +123,53 @@ export function canSkipProviderPreflight(
   statuses: ReadonlyMap<TeamProviderId, CliProviderStatus | null | undefined>,
   loading: ReadonlyMap<TeamProviderId, boolean>,
   checks: readonly ProvisioningProviderCheck[],
-  now: number = Date.now()
+  now: number = Date.now(),
+  sourceProviders: readonly CliProviderStatus[] = []
 ): boolean {
+  const source = sourceProviders.find((provider) => provider.providerId === 'anthropic');
+  const effective = statuses.get('anthropic');
+  // The renderer gates teamLaunch on catalog freshness. Only the original
+  // runtime capability can distinguish that gate from an unsupported runtime.
+  const refreshingAnthropic =
+    state !== 'failed' &&
+    providerIds.includes('anthropic') &&
+    source?.capabilities.teamLaunch === true &&
+    [source, effective].every(
+      (provider) =>
+        provider?.supported === true &&
+        provider.authenticated === true &&
+        provider.verificationState === 'verified' &&
+        provider.statusCheckOutcome === 'authoritative' &&
+        provider.statusCheckErrorCode == null &&
+        provider.modelCatalogRefreshState === 'loading' &&
+        provider.modelCatalog?.providerId === 'anthropic' &&
+        ['ready', 'stale'].includes(provider.modelCatalog.status)
+    );
+  if (refreshingAnthropic) {
+    if (checks.some((check) => providerIds.includes(check.providerId) && check.status === 'failed'))
+      return false;
+    if (
+      providerIds.some(
+        (id) => id !== 'anthropic' && !hasEffectiveProviderLaunchAuthority(statuses.get(id), now)
+      )
+    )
+      return false;
+    const refreshStatuses = new Map(statuses).set('anthropic', source);
+    const refreshLoading = new Map(loading).set('anthropic', true);
+    if (state === 'idle')
+      return canSkipPendingProviderDiscovery(providerIds, refreshStatuses, refreshLoading, now);
+    // A passive refresh does not invalidate or repeat the completed deep check.
+    // Treat it as pending only for this optional-skip decision.
+    return canSkipOptionalProviderPreflight(
+      providerIds,
+      refreshStatuses,
+      refreshLoading,
+      checks.map((check) =>
+        check.providerId === 'anthropic' ? { ...check, status: 'checking' } : check
+      ),
+      now
+    );
+  }
   if (state === 'idle') {
     return canSkipPendingProviderDiscovery(providerIds, statuses, loading, now);
   }

--- a/src/renderer/components/team/dialogs/optionalProviderPreflight.ts
+++ b/src/renderer/components/team/dialogs/optionalProviderPreflight.ts
@@ -9,6 +9,30 @@ import type { CliProviderStatus, TeamProviderId } from '@shared/types';
 
 type OptionalProviderPreflightState = 'idle' | 'loading' | 'ready' | 'failed';
 
+/** Aggregate progress must not restart badges for providers whose own work settled. */
+export function getPendingProviderPreflightIds(
+  state: OptionalProviderPreflightState,
+  providerIds: readonly TeamProviderId[],
+  checks: readonly ProvisioningProviderCheck[]
+): TeamProviderId[] {
+  if (state !== 'idle' && state !== 'loading') return [];
+  return providerIds.filter((providerId) => {
+    const check = checks.find((entry) => entry.providerId === providerId);
+    return !check || check.status === 'pending' || check.status === 'checking';
+  });
+}
+
+function hasKnownProviderFailure(status: CliProviderStatus | null | undefined): boolean {
+  return Boolean(
+    status &&
+    (status.statusCheckErrorCode === 'runtime_missing' ||
+      status.statusCheckErrorCode === 'unavailable' ||
+      status.verificationState === 'error' ||
+      (status.statusCheckOutcome === 'authoritative' &&
+        (!status.supported || !status.authenticated || !status.capabilities.teamLaunch)))
+  );
+}
+
 function isProviderAuthorityStillResolving(
   providerId: TeamProviderId,
   status: CliProviderStatus | null | undefined,
@@ -16,17 +40,20 @@ function isProviderAuthorityStillResolving(
 ): boolean {
   return (
     loading.get(providerId) === true ||
+    status?.statusCheckOutcome === 'pending' ||
     status?.statusCheckOutcome === 'model_only' ||
     status?.modelCatalogRefreshState === 'loading' ||
-    isProviderAuthorityRetryableTimeout(status)
+    isProviderAuthorityRetryableDiscovery(status)
   );
 }
 
-function isProviderAuthorityRetryableTimeout(
+function isProviderAuthorityRetryableDiscovery(
   status: CliProviderStatus | null | undefined
 ): boolean {
   return (
-    status?.statusCheckOutcome === 'transient_error' && status.statusCheckErrorCode === 'timeout'
+    status?.statusCheckOutcome === 'transient_error' &&
+    (status.statusCheckErrorCode === 'timeout' ||
+      status.statusCheckErrorCode === 'partial_response')
   );
 }
 
@@ -42,7 +69,12 @@ export function canSkipPendingProviderDiscovery(
   let discoveryPending = false;
   for (const providerId of providerIds) {
     const status = statuses.get(providerId);
-    if (loading.get(providerId) === true || isProviderAuthorityRetryableTimeout(status)) {
+    if (hasKnownProviderFailure(status)) return false;
+    if (
+      loading.get(providerId) === true ||
+      status?.statusCheckOutcome === 'pending' ||
+      isProviderAuthorityRetryableDiscovery(status)
+    ) {
       discoveryPending = true;
       continue;
     }
@@ -67,6 +99,7 @@ export function canSkipOptionalProviderPreflight(
   for (const providerId of providerIds) {
     const check = checks.find((entry) => entry.providerId === providerId);
     if (!check || check.status === 'failed') return false;
+    if (hasKnownProviderFailure(statuses.get(providerId))) return false;
     if (check.status === 'ready') continue;
     if (check.status === 'pending' || check.status === 'checking') {
       optionalPending = true;

--- a/src/renderer/components/team/dialogs/optionalProviderPreflight.ts
+++ b/src/renderer/components/team/dialogs/optionalProviderPreflight.ts
@@ -1,4 +1,8 @@
 import { hasEffectiveProviderLaunchAuthority } from '@renderer/utils/providerReadiness';
+import {
+  hasAnthropicCatalogRefreshLaunchSupport,
+  isAuthenticatedAnthropicCatalogRefresh,
+} from '@shared/utils/providerStatusAuthority';
 
 import { runProviderPrepareDiagnostics } from './providerPrepareDiagnostics';
 
@@ -128,33 +132,35 @@ export function canSkipProviderPreflight(
 ): boolean {
   const source = sourceProviders.find((provider) => provider.providerId === 'anthropic');
   const effective = statuses.get('anthropic');
-  // The renderer gates teamLaunch on catalog freshness. Only the original
-  // runtime capability can distinguish that gate from an unsupported runtime.
+  // Main/store may already have gated teamLaunch. The app-derived restriction
+  // preserves affirmative support from this snapshot, never a previous one.
   const refreshingAnthropic =
     state !== 'failed' &&
     providerIds.includes('anthropic') &&
-    source?.capabilities.teamLaunch === true &&
-    [source, effective].every(
-      (provider) =>
-        provider?.supported === true &&
-        provider.authenticated === true &&
-        provider.verificationState === 'verified' &&
-        provider.statusCheckOutcome === 'authoritative' &&
-        provider.statusCheckErrorCode == null &&
-        provider.modelCatalogRefreshState === 'loading' &&
-        provider.modelCatalog?.providerId === 'anthropic' &&
-        ['ready', 'stale'].includes(provider.modelCatalog.status)
-    );
+    Boolean(source?.modelCatalog && effective?.modelCatalog) &&
+    hasAnthropicCatalogRefreshLaunchSupport(source) &&
+    isAuthenticatedAnthropicCatalogRefresh(effective);
   if (refreshingAnthropic) {
     if (checks.some((check) => providerIds.includes(check.providerId) && check.status === 'failed'))
       return false;
     if (
-      providerIds.some(
-        (id) => id !== 'anthropic' && !hasEffectiveProviderLaunchAuthority(statuses.get(id), now)
-      )
+      providerIds.some((id) => {
+        if (id === 'anthropic') return false;
+        const status = statuses.get(id);
+        // Completed checks cannot hide stale authority, but active discovery is
+        // still optional. Keep catalog errors terminal even during a retry.
+        return (
+          status?.modelCatalogRefreshState === 'error' ||
+          (!hasEffectiveProviderLaunchAuthority(status, now) &&
+            !canSkipPendingProviderDiscovery([id], statuses, loading, now))
+        );
+      })
     )
       return false;
-    const refreshStatuses = new Map(statuses).set('anthropic', source);
+    const refreshStatuses = new Map(statuses).set('anthropic', {
+      ...source,
+      capabilities: { ...source.capabilities, teamLaunch: true },
+    });
     const refreshLoading = new Map(loading).set('anthropic', true);
     if (state === 'idle')
       return canSkipPendingProviderDiscovery(providerIds, refreshStatuses, refreshLoading, now);

--- a/src/renderer/components/team/dialogs/projectPathOptions.ts
+++ b/src/renderer/components/team/dialogs/projectPathOptions.ts
@@ -1,4 +1,4 @@
-import { normalizePathForMatching } from '@renderer/utils/pathNormalize';
+import { normalizePath, normalizePathForMatching } from '@renderer/utils/pathNormalize';
 import { isEphemeralProjectPath } from '@shared/utils/ephemeralProjectPath';
 
 import type {
@@ -47,6 +47,49 @@ export function isSelectableProjectPathProject(
   project: Pick<ProjectPathProject, 'path' | 'filesystemState'>
 ): boolean {
   return !isEphemeralProjectPath(project.path) && project.filesystemState !== 'deleted';
+}
+
+export function isLaunchPreflightProjectSelectionReady({
+  draftLoaded,
+  effectiveCwd,
+  cwdMode,
+  projectsLoading,
+  projects,
+  selectedProjectPath,
+  defaultProjectPath,
+  appliedDefaultProjectPath,
+}: {
+  draftLoaded: boolean;
+  effectiveCwd: string;
+  cwdMode: 'project' | 'custom';
+  projectsLoading: boolean;
+  projects: readonly ProjectPathProject[];
+  selectedProjectPath: string;
+  defaultProjectPath?: string | null;
+  appliedDefaultProjectPath: string | null;
+}): boolean {
+  const normalizedDefaultPath = defaultProjectPath ? normalizePath(defaultProjectPath) : null;
+  const pendingDefaultSelection =
+    normalizedDefaultPath !== null &&
+    appliedDefaultProjectPath !== normalizedDefaultPath &&
+    projects.some(
+      (project) =>
+        isSelectableProjectPathProject(project) &&
+        normalizePath(project.path) === normalizedDefaultPath
+    );
+
+  return (
+    draftLoaded &&
+    Boolean(effectiveCwd) &&
+    (cwdMode === 'custom' ||
+      (!projectsLoading &&
+        projects.some(
+          (project) =>
+            isSelectableProjectPathProject(project) &&
+            normalizePath(project.path) === normalizePath(selectedProjectPath)
+        ) &&
+        (!pendingDefaultSelection || normalizePath(selectedProjectPath) === normalizedDefaultPath)))
+  );
 }
 
 export function findProjectPathProjectByPath(

--- a/src/renderer/components/team/dialogs/projectPathOptions.ts
+++ b/src/renderer/components/team/dialogs/projectPathOptions.ts
@@ -94,7 +94,7 @@ export function isLaunchPreflightProjectSelectionReady({
         projects.some(
           (project) =>
             isSelectableProjectPathProject(project) &&
-            normalizePath(project.path) === normalizePath(selectedProjectPath)
+            normalizePathForMatching(project.path) === normalizePathForMatching(selectedProjectPath)
         ) &&
         (!pendingDefaultSelection || normalizePath(selectedProjectPath) === normalizedDefaultPath)))
   );

--- a/src/renderer/components/team/dialogs/projectPathOptions.ts
+++ b/src/renderer/components/team/dialogs/projectPathOptions.ts
@@ -58,6 +58,8 @@ export function isLaunchPreflightProjectSelectionReady({
   selectedProjectPath,
   defaultProjectPath,
   appliedDefaultProjectPath,
+  forceDefaultProjectSelection = false,
+  appliedDefaultProjectModePath,
 }: {
   draftLoaded: boolean;
   effectiveCwd: string;
@@ -67,6 +69,8 @@ export function isLaunchPreflightProjectSelectionReady({
   selectedProjectPath: string;
   defaultProjectPath?: string | null;
   appliedDefaultProjectPath: string | null;
+  forceDefaultProjectSelection?: boolean;
+  appliedDefaultProjectModePath?: string | null;
 }): boolean {
   const normalizedDefaultPath = defaultProjectPath ? normalizePath(defaultProjectPath) : null;
   const pendingDefaultSelection =
@@ -80,6 +84,10 @@ export function isLaunchPreflightProjectSelectionReady({
 
   return (
     draftLoaded &&
+    (!forceDefaultProjectSelection ||
+      !defaultProjectPath ||
+      isEphemeralProjectPath(defaultProjectPath) ||
+      appliedDefaultProjectModePath === normalizedDefaultPath) &&
     Boolean(effectiveCwd) &&
     (cwdMode === 'custom' ||
       (!projectsLoading &&

--- a/src/renderer/components/team/dialogs/providerLaunchAuthority.ts
+++ b/src/renderer/components/team/dialogs/providerLaunchAuthority.ts
@@ -12,6 +12,7 @@ import {
   hasSettledOpenCodeScopedPreparation,
   type OpenCodeScopedPreparationEvidence,
 } from '@renderer/utils/teamProviderRuntimeStatusLoading';
+import { parseOpenCodeQualifiedModelRef } from '@shared/utils/opencodeModelRef';
 
 import type { CliInstallationStatus, CliProviderStatus, TeamProviderId } from '@shared/types';
 
@@ -46,11 +47,77 @@ function getProviderStatusDetail(provider: CliProviderStatus): string | null {
     return null;
   }
   return (
+    provider.modelCatalog?.diagnostics.message?.trim() ||
     provider.detailMessage?.trim() ||
     provider.statusMessage?.trim() ||
-    provider.modelCatalog?.diagnostics.message?.trim() ||
     null
   );
+}
+
+/** A failed duplicate source refresh cannot revoke fresher exact-project authority.
+ * Only catalogue transport timeouts qualify, never authentication or model failures.
+ */
+function hasAuthoritativeOpenCodeCatalogFallback(
+  provider: CliProviderStatus | null,
+  evidence: OpenCodeScopedPreparationEvidence | undefined,
+  now: number
+): boolean {
+  if (
+    !provider ||
+    !hasEffectiveProviderLaunchAuthority(provider, now) ||
+    !evidence?.selectedModels.length
+  )
+    return false;
+  const catalog = provider.modelCatalog!;
+  return evidence.selectedModels.every((model) => {
+    const sourceId = parseOpenCodeQualifiedModelRef(model)?.sourceId;
+    const item = catalog.models.find((entry) => entry.launchModel === model);
+    if (!sourceId || !item || item.metadata?.opencode?.proofState === 'failed') return false;
+    if (
+      provider.modelAvailability?.some(
+        (entry) =>
+          (entry.modelId === model || entry.modelId === item.id) && entry.status !== 'available'
+      )
+    )
+      return false;
+    const source = evidence.scopedStatusBySourceId.get(sourceId);
+    if (
+      source &&
+      (source.providerId !== 'opencode' ||
+        !source.supported ||
+        !source.authenticated ||
+        source.verificationState === 'error' ||
+        source.statusCheckErrorCode != null ||
+        source.modelCatalog?.models.some(
+          (entry) =>
+            entry.launchModel === model && entry.metadata?.opencode?.proofState === 'failed'
+        ) ||
+        source.modelAvailability?.some(
+          (entry) =>
+            (entry.modelId === model || entry.modelId === item.id) && entry.status !== 'available'
+        ))
+    )
+      return false;
+    if (source?.modelCatalogRefreshState !== 'error') return true;
+    const sourceCatalog = source.modelCatalog;
+    const fetchedAt = Date.parse(sourceCatalog?.fetchedAt ?? '');
+    const diagnostics = sourceCatalog?.diagnostics;
+    return (
+      source.verificationState === 'verified' &&
+      source.statusCheckOutcome === 'authoritative' &&
+      source.modelVerificationState !== 'verifying' &&
+      sourceCatalog?.status === 'stale' &&
+      sourceCatalog.providerId === 'opencode' &&
+      Number.isFinite(fetchedAt) &&
+      new Date(fetchedAt).toISOString() === sourceCatalog.fetchedAt &&
+      Date.parse(catalog.fetchedAt) >= fetchedAt &&
+      (diagnostics?.code
+        ? ['timeout', 'deadline_exceeded'].includes(diagnostics.code)
+        : /\bcatalog\b[^.\n]*(?:timed?\s*out|timeout|deadline exceeded)/i.test(
+            diagnostics?.message ?? ''
+          ))
+    );
+  });
 }
 
 export function createLaunchGuard(
@@ -76,6 +143,7 @@ export function createLaunchGuard(
       const scopedFailure =
         providerId === 'opencode' ? getOpenCodeScopedPreparationFailure(openCodeEvidence) : null;
       if (scopedFailure) {
+        if (hasAuthoritativeOpenCodeCatalogFallback(provider, openCodeEvidence, now)) return [];
         return [
           {
             providerId,

--- a/src/renderer/components/team/dialogs/useProvisioningPreparePresentationState.test.tsx
+++ b/src/renderer/components/team/dialogs/useProvisioningPreparePresentationState.test.tsx
@@ -1,0 +1,72 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useProvisioningPreparePresentationState } from './useProvisioningPreparePresentationState';
+
+import type { ProvisioningPrepareState } from './provisioningProviderChecks';
+
+const StateProbe = ({
+  state,
+  open = true,
+}: {
+  state: ProvisioningPrepareState;
+  open?: boolean;
+}): React.JSX.Element => {
+  return <span>{useProvisioningPreparePresentationState(state, open)}</span>;
+};
+
+describe('useProvisioningPreparePresentationState', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    document.body.innerHTML = '';
+  });
+
+  it('does not expose a transient failure that settles successfully', async () => {
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    act(() => root.render(<StateProbe state="failed" />));
+    expect(host.textContent).toBe('loading');
+
+    await act(async () => vi.advanceTimersByTimeAsync(199));
+    expect(host.textContent).toBe('loading');
+    act(() => root.render(<StateProbe state="ready" />));
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(host.textContent).toBe('ready');
+
+    act(() => root.unmount());
+  });
+
+  it('shows a failure once it remains stable', async () => {
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    act(() => root.render(<StateProbe state="failed" />));
+
+    await act(async () => vi.advanceTimersByTimeAsync(200));
+    expect(host.textContent).toBe('failed');
+    act(() => root.unmount());
+  });
+
+  it('starts a fresh grace period after the dialog is reopened', async () => {
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    act(() => root.render(<StateProbe state="failed" />));
+    await act(async () => vi.advanceTimersByTimeAsync(200));
+    expect(host.textContent).toBe('failed');
+
+    act(() => root.render(<StateProbe state="failed" open={false} />));
+    act(() => root.render(<StateProbe state="failed" />));
+    expect(host.textContent).toBe('loading');
+    await act(async () => vi.advanceTimersByTimeAsync(200));
+    expect(host.textContent).toBe('failed');
+
+    act(() => root.unmount());
+  });
+});

--- a/src/renderer/components/team/dialogs/useProvisioningPreparePresentationState.ts
+++ b/src/renderer/components/team/dialogs/useProvisioningPreparePresentationState.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+import type { ProvisioningPrepareState } from './provisioningProviderChecks';
+
+const FAILURE_PRESENTATION_DELAY_MS = 200;
+
+export function useProvisioningPreparePresentationState(
+  state: ProvisioningPrepareState,
+  open: boolean
+): ProvisioningPrepareState {
+  const [failureVisible, setFailureVisible] = useState(false);
+
+  useEffect(() => {
+    if (!open || state !== 'failed') {
+      setFailureVisible(false);
+      return undefined;
+    }
+
+    const timeout = globalThis.setTimeout(
+      () => setFailureVisible(true),
+      FAILURE_PRESENTATION_DELAY_MS
+    );
+    return () => globalThis.clearTimeout(timeout);
+  }, [open, state]);
+
+  return state === 'failed' && !failureVisible ? 'loading' : state;
+}

--- a/src/renderer/components/team/members/LeadModelRow.test.tsx
+++ b/src/renderer/components/team/members/LeadModelRow.test.tsx
@@ -67,7 +67,27 @@ vi.mock('@renderer/components/team/dialogs/TeamModelSelector', () => ({
   getProviderScopedTeamModelLabel: (_providerId: string, model: string) => model || 'Default',
   getTeamEffortLabel: (effort: string) => effort || 'Default',
   getTeamProviderLabel: (providerId: string) => providerId,
-  TeamModelSelector: () => React.createElement('div', null, 'team-model-selector'),
+  TeamModelSelector: ({
+    onProviderChange,
+    onValueChange,
+  }: {
+    onProviderChange: (providerId: string) => void;
+    onValueChange: (model: string) => void;
+  }) =>
+    React.createElement(
+      'div',
+      { 'data-testid': 'team-model-selector' },
+      React.createElement(
+        'button',
+        { type: 'button', onClick: () => onProviderChange('codex') },
+        'choose-codex'
+      ),
+      React.createElement(
+        'button',
+        { type: 'button', onClick: () => onValueChange('gpt-5.6-sol') },
+        'choose-model'
+      )
+    ),
 }));
 
 vi.mock('@renderer/components/ui/checkbox', () => ({
@@ -168,6 +188,51 @@ describe('LeadModelRow', () => {
 
   afterEach(() => {
     document.body.innerHTML = '';
+  });
+
+  it('keeps the model selector open while provider and model choices update', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const Harness = (): React.JSX.Element => {
+      const [providerId, setProviderId] = React.useState<'anthropic' | 'codex'>('anthropic');
+      const [model, setModel] = React.useState('opus');
+      return (
+        <LeadModelRow
+          providerId={providerId}
+          model={model}
+          effort="medium"
+          limitContext={false}
+          onProviderChange={(provider) => setProviderId(provider as 'anthropic' | 'codex')}
+          onModelChange={setModel}
+          onEffortChange={() => undefined}
+          onLimitContextChange={() => undefined}
+          syncModelsWithTeammates
+          onSyncModelsWithTeammatesChange={() => undefined}
+        />
+      );
+    };
+
+    act(() => root.render(<Harness />));
+    act(() =>
+      host.querySelector<HTMLButtonElement>('[aria-label="anthropic provider, opus"]')?.click()
+    );
+    expect(host.querySelector('[data-testid="team-model-selector"]')).not.toBeNull();
+
+    act(() =>
+      Array.from(host.querySelectorAll('button'))
+        .find((button) => button.textContent === 'choose-codex')
+        ?.click()
+    );
+    expect(host.querySelector('[data-testid="team-model-selector"]')).not.toBeNull();
+    act(() =>
+      Array.from(host.querySelectorAll('button'))
+        .find((button) => button.textContent === 'choose-model')
+        ?.click()
+    );
+    expect(host.querySelector('[data-testid="team-model-selector"]')).not.toBeNull();
+
+    act(() => root.unmount());
   });
 
   it('uses the canonical team-lead color for the preview stripe', () => {

--- a/src/renderer/components/team/members/LeadModelRow.test.tsx
+++ b/src/renderer/components/team/members/LeadModelRow.test.tsx
@@ -214,22 +214,24 @@ describe('LeadModelRow', () => {
     };
 
     act(() => root.render(<Harness />));
-    act(() =>
-      host.querySelector<HTMLButtonElement>('[aria-label="anthropic provider, opus"]')?.click()
-    );
+    const opener = host.querySelector<HTMLButtonElement>('[aria-label="anthropic provider, opus"]');
+    expect(opener).not.toBeNull();
+    act(() => opener!.click());
     expect(host.querySelector('[data-testid="team-model-selector"]')).not.toBeNull();
 
-    act(() =>
-      Array.from(host.querySelectorAll('button'))
-        .find((button) => button.textContent === 'choose-codex')
-        ?.click()
+    const providerControl = Array.from(host.querySelectorAll('button')).find(
+      (button) => button.textContent === 'choose-codex'
     );
+    expect(providerControl).toBeDefined();
+    act(() => providerControl!.click());
+    expect(host.querySelector('[aria-label="codex provider, opus"]')).not.toBeNull();
     expect(host.querySelector('[data-testid="team-model-selector"]')).not.toBeNull();
-    act(() =>
-      Array.from(host.querySelectorAll('button'))
-        .find((button) => button.textContent === 'choose-model')
-        ?.click()
+    const modelControl = Array.from(host.querySelectorAll('button')).find(
+      (button) => button.textContent === 'choose-model'
     );
+    expect(modelControl).toBeDefined();
+    act(() => modelControl!.click());
+    expect(host.querySelector('[aria-label="codex provider, gpt-5.6-sol"]')).not.toBeNull();
     expect(host.querySelector('[data-testid="team-model-selector"]')).not.toBeNull();
 
     act(() => root.unmount());

--- a/src/renderer/components/team/messages/MessageComposer.pendingSend.test.tsx
+++ b/src/renderer/components/team/messages/MessageComposer.pendingSend.test.tsx
@@ -4,7 +4,11 @@ import { createRoot } from 'react-dom/client';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ResolvedTeamMember } from '@shared/types';
+import type {
+  LeadActivityState,
+  ResolvedTeamMember,
+  TeamProvisioningProgress,
+} from '@shared/types';
 
 const draftHarness = vi.hoisted(() => {
   const initialState = {
@@ -62,10 +66,16 @@ const draftHarness = vi.hoisted(() => {
 const provisioningHarness = vi.hoisted(() => {
   const state = {
     active: false,
+    progress: null as TeamProvisioningProgress | null,
+    leadActivity: undefined as LeadActivityState | undefined,
+    currentRunId: undefined as string | undefined,
   };
   return {
     reset: () => {
       state.active = false;
+      state.progress = null;
+      state.leadActivity = undefined;
+      state.currentRunId = undefined;
     },
     state,
   };
@@ -152,6 +162,7 @@ vi.mock('@renderer/components/ui/MentionableTextarea', () => {
     HTMLTextAreaElement,
     {
       value: string;
+      placeholder?: string;
       disabled?: boolean;
       className?: string;
       surfaceClassName?: string;
@@ -166,6 +177,7 @@ vi.mock('@renderer/components/ui/MentionableTextarea', () => {
     (
       {
         value,
+        placeholder,
         disabled,
         className,
         surfaceClassName,
@@ -193,6 +205,7 @@ vi.mock('@renderer/components/ui/MentionableTextarea', () => {
             readOnly: true,
             ref,
             value,
+            placeholder,
           }),
           React.createElement('div', null, cornerActionLeft),
           React.createElement('div', null, cornerAction)
@@ -275,11 +288,14 @@ vi.mock('@renderer/store', () => ({
       selectedTeamName: null,
       skillsProjectCatalogByProjectPath: {},
       skillsUserCatalog: [],
+      leadActivityByTeam: { 'team-alpha': provisioningHarness.state.leadActivity },
+      currentRuntimeRunIdByTeam: { 'team-alpha': provisioningHarness.state.currentRunId },
     }),
 }));
 
 vi.mock('@renderer/store/slices/teamSlice', () => ({
   isTeamProvisioningActive: () => provisioningHarness.state.active,
+  getCurrentProvisioningProgressForTeam: () => provisioningHarness.state.progress,
 }));
 
 import { MessageComposer } from './MessageComposer';
@@ -722,6 +738,37 @@ describe('MessageComposer pending send lifecycle', () => {
       root.unmount();
     });
   });
+
+  it.each([false, true])(
+    'shows working startup copy without changing the alive=%s send gate',
+    (isTeamAlive) => {
+      provisioningHarness.state.active = true;
+      provisioningHarness.state.progress = {
+        runId: 'run-current',
+        teamName: 'team-alpha',
+        state: 'finalizing',
+        startedAt: '2026-09-06T12:00:00Z',
+        updatedAt: '2026-09-06T12:00:05Z',
+        message: 'Auditing bootstrap truth',
+      };
+      provisioningHarness.state.leadActivity = 'active';
+      provisioningHarness.state.currentRunId = 'run-current';
+      const { host, onSend, root } = renderComposer({ isTeamAlive });
+      expect(getSendButton(host).disabled).toBe(!isTeamAlive);
+      if (!isTeamAlive) {
+        expect(getTextarea(host).placeholder).toContain(
+          'Lead is working. Startup checks are finishing'
+        );
+        expect(getTextarea(host).placeholder).toContain('sending is not yet available');
+        expect(getTextarea(host).placeholder).not.toContain('will be queued');
+        act(() => getSendButton(host).click());
+        expect(onSend).not.toHaveBeenCalled();
+      } else {
+        expect(getTextarea(host).placeholder).not.toContain('Startup checks');
+      }
+      act(() => root.unmount());
+    }
+  );
 
   it('returns focus to the textarea after sending', () => {
     const { host, root } = renderComposer();

--- a/src/renderer/components/team/messages/MessageComposer.tsx
+++ b/src/renderer/components/team/messages/MessageComposer.tsx
@@ -11,6 +11,7 @@ import {
 import { MemberBadge } from '@renderer/components/team/MemberBadge';
 import { ActionModeSelector } from '@renderer/components/team/messages/ActionModeSelector';
 import { OpenCodeDeliveryWarning } from '@renderer/components/team/messages/OpenCodeDeliveryWarning';
+import { useTeamStartupCopy } from '@renderer/components/team/useTeamStartupCopy';
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/components/ui/popover';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/components/ui/tooltip';
 import { getTeamColorSet } from '@renderer/constants/teamColors';
@@ -19,7 +20,6 @@ import { useTaskSuggestions } from '@renderer/hooks/useTaskSuggestions';
 import { useTeamSuggestions } from '@renderer/hooks/useTeamSuggestions';
 import { cn } from '@renderer/lib/utils';
 import { useStore } from '@renderer/store';
-import { isTeamProvisioningActive } from '@renderer/store/slices/teamSlice';
 import { serializeChipsWithText } from '@renderer/types/inlineChip';
 import {
   canMemberShowAttachmentControl,
@@ -282,7 +282,7 @@ export const MessageComposer = ({
     const displayName = s.selectedTeamData?.config.name ?? teamName;
     return nameColorSet(displayName).border;
   });
-  const isProvisioning = useStore((s) => isTeamProvisioningActive(s, teamName));
+  const startupCopy = useTeamStartupCopy(teamName);
   const draft = useComposerDraft(teamName);
   const appliedRevisionRequestIdRef = useRef<string | null>(null);
   const textHasTeamMentionTrigger = draft.text.includes('@');
@@ -333,7 +333,7 @@ export const MessageComposer = ({
     useShallow((s) => (slashCommandDataEnabled ? s.skillsUserCatalog : EMPTY_SKILL_CATALOG))
   );
   const fetchSkillsCatalog = useStore((s) => s.fetchSkillsCatalog);
-  const isLaunchBlocking = isProvisioning && !isTeamAlive;
+  const isLaunchBlocking = startupCopy.isProvisioning && !isTeamAlive;
 
   // Fetch the catalog only when slash suggestions are actually needed.
   useEffect(() => {
@@ -1250,7 +1250,7 @@ export const MessageComposer = ({
           id={`compose-${teamName}`}
           placeholder={
             isLaunchBlocking
-              ? t('messageComposer.input.teamLaunchingPlaceholder')
+              ? startupCopy.placeholder
               : isCrossTeam
                 ? t('messageComposer.input.crossTeamPlaceholder', {
                     team: targetDisplayName ?? t('messageComposer.input.teamFallback'),
@@ -1327,9 +1327,7 @@ export const MessageComposer = ({
                     {slashCommandRestrictionReason ? (
                       <TooltipContent side="top">{slashCommandRestrictionReason}</TooltipContent>
                     ) : isLaunchBlocking && !sending ? (
-                      <TooltipContent side="top">
-                        {t('messageComposer.actions.sendingUnavailableLaunching')}
-                      </TooltipContent>
+                      <TooltipContent side="top">{startupCopy.sendingUnavailable}</TooltipContent>
                     ) : null}
                   </Tooltip>
                 ) : null}

--- a/src/renderer/components/team/useTeamProvisioningPresentation.ts
+++ b/src/renderer/components/team/useTeamProvisioningPresentation.ts
@@ -7,6 +7,7 @@ import {
   selectTeamMemberSnapshotsForName,
 } from '@renderer/store/slices/teamSlice';
 import { buildTeamMemberLaunchDiagnosticsPayloads } from '@renderer/utils/memberLaunchDiagnostics';
+import { applyLeadActivityToProvisioningPresentation } from '@renderer/utils/teamProvisioningLeadActivityPresentation';
 import { buildTeamProvisioningPresentation } from '@renderer/utils/teamProvisioningPresentation';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -32,6 +33,8 @@ export function useTeamProvisioningPresentation(teamName: string): {
     memberSpawnStatuses,
     memberSpawnSnapshot,
     runtimeSnapshot,
+    leadActivity,
+    currentRuntimeRunId,
   } = useStore(
     useShallow((s) => ({
       progress: getCurrentProvisioningProgressForTeam(s, teamName),
@@ -41,20 +44,43 @@ export function useTeamProvisioningPresentation(teamName: string): {
       memberSpawnStatuses: s.memberSpawnStatusesByTeam[teamName],
       memberSpawnSnapshot: s.memberSpawnSnapshotsByTeam[teamName],
       runtimeSnapshot: s.teamAgentRuntimeByTeam?.[teamName],
+      leadActivity: s.leadActivityByTeam?.[teamName],
+      currentRuntimeRunId: s.currentRuntimeRunIdByTeam?.[teamName],
     }))
   );
 
   const presentation = useMemo(
     () =>
-      buildTeamProvisioningPresentation({
-        progress,
-        members: teamMembers,
-        memberSpawnStatuses,
-        memberSpawnSnapshot,
-        memberRuntimeEntries: runtimeSnapshot?.members,
-        t,
-      }),
-    [memberSpawnSnapshot, memberSpawnStatuses, progress, runtimeSnapshot?.members, teamMembers, t]
+      applyLeadActivityToProvisioningPresentation(
+        buildTeamProvisioningPresentation({
+          progress,
+          members: teamMembers,
+          memberSpawnStatuses,
+          memberSpawnSnapshot,
+          memberRuntimeEntries: runtimeSnapshot?.members,
+          t,
+        }),
+        {
+          leadActivity,
+          currentRuntimeRunId,
+          title: t('provisioning.presentation.panel.completingStartupChecks', {
+            defaultValue: 'Completing startup checks',
+          }),
+          detail: t('provisioning.presentation.active.leadWorking', {
+            defaultValue: 'Lead is working while startup checks finish.',
+          }),
+        }
+      ),
+    [
+      memberSpawnSnapshot,
+      memberSpawnStatuses,
+      progress,
+      runtimeSnapshot?.members,
+      teamMembers,
+      leadActivity,
+      currentRuntimeRunId,
+      t,
+    ]
   );
   const memberDiagnostics = useMemo(
     () =>

--- a/src/renderer/components/team/useTeamStartupCopy.ts
+++ b/src/renderer/components/team/useTeamStartupCopy.ts
@@ -1,0 +1,45 @@
+import { useAppTranslation } from '@features/localization/renderer';
+import { useStore } from '@renderer/store';
+import {
+  getCurrentProvisioningProgressForTeam,
+  isTeamProvisioningActive,
+} from '@renderer/store/slices/teamSlice';
+import { hasObservedLeadWorkDuringProvisioning } from '@renderer/utils/teamProvisioningLeadActivityPresentation';
+import { useShallow } from 'zustand/react/shallow';
+
+/** Display-only copy; observed work must not release launch or delivery gates. */
+export function useTeamStartupCopy(teamName: string): {
+  isProvisioning: boolean;
+  statusLabel: string;
+  placeholder: string;
+  sendingUnavailable: string;
+} {
+  const { t } = useAppTranslation('team');
+  const { isProvisioning, leadWorking } = useStore(
+    useShallow((state) => ({
+      isProvisioning: isTeamProvisioningActive(state, teamName),
+      leadWorking: hasObservedLeadWorkDuringProvisioning({
+        progress: getCurrentProvisioningProgressForTeam(state, teamName),
+        leadActivity: state.leadActivityByTeam?.[teamName],
+        currentRuntimeRunId: state.currentRuntimeRunIdByTeam?.[teamName],
+      }),
+    }))
+  );
+  return {
+    isProvisioning,
+    statusLabel: leadWorking
+      ? t('provisioning.presentation.panel.finishingStartup', { defaultValue: 'Finishing startup' })
+      : t('detail.status.launching'),
+    placeholder: leadWorking
+      ? t('messageComposer.input.finishingStartupPlaceholder', {
+          defaultValue:
+            'Lead is working. Startup checks are finishing; sending is not yet available.',
+        })
+      : t('messageComposer.input.teamLaunchingPlaceholder'),
+    sendingUnavailable: leadWorking
+      ? t('messageComposer.actions.sendingUnavailableStartupChecks', {
+          defaultValue: 'Sending unavailable while startup checks finish',
+        })
+      : t('messageComposer.actions.sendingUnavailableLaunching'),
+  };
+}

--- a/src/renderer/hooks/useEffectiveCliProviderStatus.ts
+++ b/src/renderer/hooks/useEffectiveCliProviderStatus.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useReducer } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer } from 'react';
 
 import {
   isCodexAccountSnapshotPending,
@@ -32,7 +32,7 @@ interface ConservativeClockSnapshot {
   now: number;
 }
 
-/** Starts fail-closed, then publishes clock reads only from timer callbacks. */
+/** Revalidates each source before paint without reading the clock during render. */
 function useConservativeNow(source: unknown): readonly [number, (now: number) => void] {
   const [snapshot, publishSnapshot] = useReducer(
     (_current: ConservativeClockSnapshot, next: ConservativeClockSnapshot) => next,
@@ -40,9 +40,8 @@ function useConservativeNow(source: unknown): readonly [number, (now: number) =>
   );
   const publishNow = useCallback((now: number) => publishSnapshot({ source, now }), [source]);
 
-  useEffect(() => {
-    const timeoutId = window.setTimeout(() => publishNow(Date.now()), 0);
-    return () => window.clearTimeout(timeoutId);
+  useLayoutEffect(() => {
+    publishNow(Date.now());
   }, [publishNow]);
 
   return [Object.is(snapshot.source, source) ? snapshot.now : Number.POSITIVE_INFINITY, publishNow];

--- a/src/renderer/hooks/useOpenCodePassiveStatusPrefetch.ts
+++ b/src/renderer/hooks/useOpenCodePassiveStatusPrefetch.ts
@@ -2,6 +2,9 @@ import { useEffect, useReducer, useRef } from 'react';
 
 import { useStore } from '@renderer/store';
 import { getCliProviderStatusScopeKey } from '@renderer/store/slices/cliInstallerSlice';
+import { isTeamProviderModelCatalogFresh } from '@renderer/utils/teamModelAvailability';
+
+const MAX_BROWSER_TIMEOUT_MS = 2_147_483_647;
 
 export function useOpenCodePassiveStatusPrefetch({
   enabled,
@@ -22,16 +25,39 @@ export function useOpenCodePassiveStatusPrefetch({
       : null
   );
   const requestedRevisionByScopeRef = useRef(new Map<string, number>());
+  const refreshedExpiryByScopeRef = useRef(new Map<string, string>());
   const scopesWithObservedStatusRef = useRef(new Set<string>());
   const activeScopeRef = useRef('');
-  const [, publishCompletion] = useReducer((sequence: number) => sequence + 1, 0);
+  const [refreshSequence, publishCompletion] = useReducer((sequence: number) => sequence + 1, 0);
 
   activeScopeRef.current = normalizedProjectPath;
 
   useEffect(() => {
+    if (!enabled || !isTeamProviderModelCatalogFresh('opencode', scopedProviderStatus)) return;
+    const staleAt = Date.parse(scopedProviderStatus!.modelCatalog!.staleAt);
+    const timeout = window.setTimeout(
+      publishCompletion,
+      Math.min(Math.max(0, staleAt - Date.now()), MAX_BROWSER_TIMEOUT_MS)
+    );
+    return () => window.clearTimeout(timeout);
+  }, [enabled, normalizedProjectPath, scopedProviderStatus, scopeRevision, refreshSequence]);
+
+  useEffect(() => {
+    const catalog = scopedProviderStatus?.modelCatalog;
+    const staleAt = Date.parse(catalog?.staleAt ?? '');
+    const expiryKey =
+      catalog &&
+      !isTeamProviderModelCatalogFresh('opencode', scopedProviderStatus) &&
+      Number.isFinite(staleAt) &&
+      staleAt <= Date.now()
+        ? JSON.stringify([scopeRevision, catalog.fetchedAt, catalog.staleAt])
+        : null;
+    const expiryRefreshDue =
+      expiryKey !== null &&
+      refreshedExpiryByScopeRef.current.get(normalizedProjectPath) !== expiryKey;
     if (scopedProviderStatus) {
       scopesWithObservedStatusRef.current.add(normalizedProjectPath);
-      if (!requestedRevisionByScopeRef.current.has(normalizedProjectPath)) {
+      if (!requestedRevisionByScopeRef.current.has(normalizedProjectPath) && !expiryRefreshDue) {
         requestedRevisionByScopeRef.current.set(normalizedProjectPath, scopeRevision);
         return;
       }
@@ -40,30 +66,33 @@ export function useOpenCodePassiveStatusPrefetch({
       // this hook still remembers its requested revision. Make that scope eligible
       // for another request without disturbing requests that are still in flight.
       requestedRevisionByScopeRef.current.delete(normalizedProjectPath);
+      refreshedExpiryByScopeRef.current.delete(normalizedProjectPath);
     }
     if (
       !enabled ||
       !normalizedProjectPath ||
       cliStatus?.flavor !== 'agent_teams_orchestrator' ||
       typeof fetchCliProviderStatus !== 'function' ||
-      requestedRevisionByScopeRef.current.get(normalizedProjectPath) === scopeRevision
+      (requestedRevisionByScopeRef.current.get(normalizedProjectPath) === scopeRevision &&
+        !expiryRefreshDue)
     ) {
       return;
     }
 
     requestedRevisionByScopeRef.current.set(normalizedProjectPath, scopeRevision);
+    if (expiryKey !== null) refreshedExpiryByScopeRef.current.set(normalizedProjectPath, expiryKey);
     let cancelled = false;
+    // A settled failure (including the same expired payload) gets one attempt.
+    // Explicit scope invalidation or a newer catalog can authorize another read.
     void fetchCliProviderStatus('opencode', {
       silent: true,
       checkReason: 'launch_preflight',
       projectPath: normalizedProjectPath,
     }).then(
-      (loaded) => {
-        if (!loaded) requestedRevisionByScopeRef.current.delete(normalizedProjectPath);
+      () => {
         if (!cancelled && activeScopeRef.current === normalizedProjectPath) publishCompletion();
       },
       () => {
-        requestedRevisionByScopeRef.current.delete(normalizedProjectPath);
         if (!cancelled && activeScopeRef.current === normalizedProjectPath) publishCompletion();
       }
     );
@@ -78,5 +107,6 @@ export function useOpenCodePassiveStatusPrefetch({
     normalizedProjectPath,
     scopedProviderStatus,
     scopeRevision,
+    refreshSequence,
   ]);
 }

--- a/src/renderer/hooks/useOpenCodePassiveStatusPrefetch.ts
+++ b/src/renderer/hooks/useOpenCodePassiveStatusPrefetch.ts
@@ -47,6 +47,8 @@ export function useOpenCodePassiveStatusPrefetch({
     const staleAt = Date.parse(catalog?.staleAt ?? '');
     const expiryKey =
       catalog &&
+      catalog.status === 'ready' &&
+      scopedProviderStatus.modelCatalogRefreshState === 'ready' &&
       !isTeamProviderModelCatalogFresh('opencode', scopedProviderStatus) &&
       Number.isFinite(staleAt) &&
       staleAt <= Date.now()

--- a/src/renderer/store/slices/__tests__/cliInstallerSlice.test.ts
+++ b/src/renderer/store/slices/__tests__/cliInstallerSlice.test.ts
@@ -535,43 +535,64 @@ describe('provider catalog invalidation races', () => {
 });
 
 describe('codex catalog watchdog races', () => {
-  it('keeps retrying a loading catalog beyond the old three-attempt window', async () => {
-    vi.useFakeTimers();
-    const provider = {
-      ...createLoadingMultimodelCliStatus().providers.find((item) => item.providerId === 'codex')!,
-      modelCatalog: null,
-      modelCatalogRefreshState: 'loading' as const,
-      runtimeCapabilities: { modelCatalog: { dynamic: true } },
-    };
-    const previousApi = window.electronAPI;
-    const getProviderStatus = vi.fn().mockResolvedValue(provider);
-    Object.defineProperty(window, 'electronAPI', {
-      configurable: true,
-      writable: true,
-      value: {
-        cliInstaller: { getProviderStatus, invalidateStatus: vi.fn(async () => undefined) },
-      },
-    });
-    const store = createCliInstallerStore();
-    store.setState({ cliStatus: { ...createLoadingMultimodelCliStatus(), installed: true } });
-    try {
-      await store.getState().fetchCliProviderStatus('codex');
-      for (let attempt = 0; attempt < 6; attempt += 1) {
-        await vi.advanceTimersByTimeAsync(5_000);
-      }
-      expect(getProviderStatus).toHaveBeenCalledTimes(7);
-      await vi.advanceTimersByTimeAsync(5_000);
-      expect(getProviderStatus).toHaveBeenCalledTimes(7);
-    } finally {
-      await store.getState().invalidateCliStatus();
+  it.each([false, true])(
+    'retries a loading catalog with retained cache=%s',
+    async (retainedCache) => {
+      vi.useFakeTimers();
+      const provider = {
+        ...createLoadingMultimodelCliStatus().providers.find(
+          (item) => item.providerId === 'codex'
+        )!,
+        modelCatalog: retainedCache
+          ? {
+              schemaVersion: 1 as const,
+              providerId: 'codex',
+              source: 'app-server' as const,
+              status: 'stale' as const,
+              fetchedAt: '2026-09-01T00:00:00.000Z',
+              staleAt: '2026-09-01T00:05:00.000Z',
+              defaultModelId: null,
+              defaultLaunchModel: null,
+              models: [],
+              diagnostics: {
+                configReadState: 'skipped' as const,
+                appServerState: 'healthy' as const,
+              },
+            }
+          : null,
+        modelCatalogRefreshState: 'loading' as const,
+        runtimeCapabilities: { modelCatalog: { dynamic: true } },
+      };
+      const previousApi = window.electronAPI;
+      const getProviderStatus = vi.fn().mockResolvedValue(provider);
       Object.defineProperty(window, 'electronAPI', {
         configurable: true,
         writable: true,
-        value: previousApi,
+        value: {
+          cliInstaller: { getProviderStatus, invalidateStatus: vi.fn(async () => undefined) },
+        },
       });
-      vi.useRealTimers();
+      const store = createCliInstallerStore();
+      store.setState({ cliStatus: { ...createLoadingMultimodelCliStatus(), installed: true } });
+      try {
+        await store.getState().fetchCliProviderStatus('codex');
+        for (let attempt = 0; attempt < 6; attempt += 1) {
+          await vi.advanceTimersByTimeAsync(5_000);
+        }
+        expect(getProviderStatus).toHaveBeenCalledTimes(7);
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(getProviderStatus).toHaveBeenCalledTimes(7);
+      } finally {
+        await store.getState().invalidateCliStatus();
+        Object.defineProperty(window, 'electronAPI', {
+          configurable: true,
+          writable: true,
+          value: previousApi,
+        });
+        vi.useRealTimers();
+      }
     }
-  });
+  );
 
   it('keeps the newer retry timer when an older request rejects', async () => {
     vi.useFakeTimers();

--- a/src/renderer/store/slices/cliInstallerSlice.ts
+++ b/src/renderer/store/slices/cliInstallerSlice.ts
@@ -1290,7 +1290,6 @@ export const createCliInstallerSlice: StateCreator<AppState, [], [], CliInstalle
           responseProviderStatus?.statusCheckErrorCode === 'partial_response' &&
           responseProviderStatus.statusCheckOutcome !== 'model_only';
         const shouldRetryTransientTimeout =
-          providerId !== 'opencode' &&
           !verifyModels &&
           responseProviderStatus?.statusCheckOutcome === 'transient_error' &&
           responseProviderStatus.statusCheckErrorCode === 'timeout';

--- a/src/renderer/store/slices/cliInstallerSlice.ts
+++ b/src/renderer/store/slices/cliInstallerSlice.ts
@@ -205,7 +205,7 @@ function getProviderStatus(
 function isCodexCatalogLoadingSnapshot(provider: CliProviderStatus | undefined): boolean {
   return (
     provider?.providerId === 'codex' &&
-    provider.modelCatalog == null &&
+    provider.modelCatalog?.status !== 'ready' &&
     provider.modelCatalogRefreshState === 'loading' &&
     provider.runtimeCapabilities?.modelCatalog?.dynamic === true
   );

--- a/src/renderer/store/slices/cliInstallerSlice.ts
+++ b/src/renderer/store/slices/cliInstallerSlice.ts
@@ -380,6 +380,7 @@ function areProviderStatusContentEqual(a: CliProviderStatus, b: CliProviderStatu
     a.verificationState === b.verificationState &&
     (a.statusCheckOutcome ?? null) === (b.statusCheckOutcome ?? null) &&
     (a.statusCheckErrorCode ?? null) === (b.statusCheckErrorCode ?? null) &&
+    a.teamLaunchAuthorityRestriction === b.teamLaunchAuthorityRestriction &&
     (a.modelVerificationState ?? null) === (b.modelVerificationState ?? null) &&
     (a.modelCatalogRefreshState ?? null) === (b.modelCatalogRefreshState ?? null) &&
     (a.statusMessage ?? null) === (b.statusMessage ?? null) &&

--- a/src/renderer/store/slices/cliInstallerStatusReconciliation.ts
+++ b/src/renderer/store/slices/cliInstallerStatusReconciliation.ts
@@ -1,4 +1,5 @@
 import {
+  hasAnthropicCatalogRefreshLaunchSupport,
   hasAuthoritativeProviderLaunchEvidence,
   hasAuthoritativeProviderStatusEvidence,
   isProviderModelCatalogExactReady,
@@ -54,6 +55,9 @@ function mergeProviderCatalogCache(
     incomingProvider.statusCheckErrorCode === 'partial_response';
   return {
     ...incomingProvider,
+    teamLaunchAuthorityRestriction: hasAnthropicCatalogRefreshLaunchSupport(incomingProvider)
+      ? incomingProvider.teamLaunchAuthorityRestriction
+      : undefined,
     supported: incomingProvider.supported,
     authenticated: hasAuthoritativeStatusEvidence ? incomingProvider.authenticated : false,
     authMethod: hasAuthoritativeStatusEvidence ? incomingProvider.authMethod : null,
@@ -98,6 +102,9 @@ export function revokeProviderLaunchAuthority(provider: CliProviderStatus): CliP
   const hasAuthoritativeStatusEvidence = hasAuthoritativeProviderStatusEvidence(provider);
   return {
     ...provider,
+    teamLaunchAuthorityRestriction: hasAnthropicCatalogRefreshLaunchSupport(provider)
+      ? provider.teamLaunchAuthorityRestriction
+      : undefined,
     authenticated: hasAuthoritativeStatusEvidence ? provider.authenticated : false,
     authMethod: hasAuthoritativeStatusEvidence ? provider.authMethod : null,
     capabilities: { ...provider.capabilities, teamLaunch: false },
@@ -116,7 +123,10 @@ export function reconcileCliProviderSnapshot(
   incomingProvider: CliProviderStatus
 ): CliProviderStatus {
   if (currentProvider && currentProvider.providerId !== incomingProvider.providerId) {
-    return revokeProviderLaunchAuthority(currentProvider);
+    return revokeProviderLaunchAuthority({
+      ...currentProvider,
+      teamLaunchAuthorityRestriction: undefined,
+    });
   }
   const mergedProvider = currentProvider
     ? mergeProviderCatalogCache(incomingProvider, currentProvider)

--- a/src/renderer/utils/teamModelAvailability.ts
+++ b/src/renderer/utils/teamModelAvailability.ts
@@ -16,6 +16,8 @@ import {
   type TeamProviderModelOption,
 } from './teamModelCatalog';
 import { extractProviderScopedBaseModel } from './teamModelContext';
+import { getUnsupportedTeamModelRouteReason } from './teamModelLaunchSupport';
+export { OPENCODE_EXTENSION_BOUND_TEAM_LAUNCH_UNAVAILABLE_REASON } from './teamModelLaunchSupport';
 
 import type {
   CliProviderId,
@@ -131,7 +133,10 @@ export function getTeamModelUiDisabledReason(
   model: string | undefined,
   providerStatus?: TeamModelRuntimeProviderStatus | null
 ): string | null {
-  return getRuntimeAwareTeamModelUiDisabledReason(providerId, model, providerStatus);
+  return (
+    getUnsupportedTeamModelRouteReason(providerId, model) ??
+    getRuntimeAwareTeamModelUiDisabledReason(providerId, model, providerStatus)
+  );
 }
 
 export function isTeamModelUiDisabled(
@@ -197,11 +202,11 @@ export function hasTerminalAuthoritativeModelVerification(
 ): boolean {
   return Boolean(
     providerStatus?.statusCheckOutcome === 'authoritative' &&
-      providerStatus.statusCheckErrorCode == null &&
-      providerStatus.verificationState === 'verified' &&
-      providerStatus.modelCatalogRefreshState === 'ready' &&
-      providerStatus.modelCatalog?.status === 'ready' &&
-      providerStatus.modelVerificationState !== 'verifying'
+    providerStatus.statusCheckErrorCode == null &&
+    providerStatus.verificationState === 'verified' &&
+    providerStatus.modelCatalogRefreshState === 'ready' &&
+    providerStatus.modelCatalog?.status === 'ready' &&
+    providerStatus.modelVerificationState !== 'verifying'
   );
 }
 

--- a/src/renderer/utils/teamModelLaunchSupport.ts
+++ b/src/renderer/utils/teamModelLaunchSupport.ts
@@ -1,0 +1,14 @@
+import type { CliProviderId, TeamProviderId } from '@shared/types';
+
+export const OPENCODE_EXTENSION_BOUND_TEAM_LAUNCH_UNAVAILABLE_REASON =
+  'This extension-backed OpenCode route is not supported by the current Agent Teams launch runtime. Choose another OpenCode model.';
+
+export function getUnsupportedTeamModelRouteReason(
+  providerId: CliProviderId | TeamProviderId | undefined,
+  model: string | undefined
+): string | null {
+  const sourceId = model?.trim().toLowerCase().split('/', 1)[0];
+  return providerId === 'opencode' && (sourceId === 'cursor-acp' || sourceId === 'kiro')
+    ? OPENCODE_EXTENSION_BOUND_TEAM_LAUNCH_UNAVAILABLE_REASON
+    : null;
+}

--- a/src/renderer/utils/teamProviderRuntimeStatusLoading.ts
+++ b/src/renderer/utils/teamProviderRuntimeStatusLoading.ts
@@ -80,6 +80,17 @@ export function isTeamProviderRuntimeStatusLoading(
     return false;
   }
 
+  if (
+    providerId === 'anthropic' &&
+    providerStatus?.supported &&
+    providerStatus.authenticated &&
+    providerStatus.verificationState === 'verified' &&
+    providerStatus.statusCheckOutcome === 'authoritative' &&
+    providerStatus.statusCheckErrorCode == null &&
+    providerStatus.modelCatalogRefreshState === 'loading'
+  )
+    return true;
+
   if (isTeamProviderModelVerificationPending(providerId, providerStatus)) {
     if (providerId === 'opencode' && getOpenCodeScopedPreparationFailure(openCodeEvidence)) {
       return false;

--- a/src/renderer/utils/teamProvisioningLeadActivityPresentation.ts
+++ b/src/renderer/utils/teamProvisioningLeadActivityPresentation.ts
@@ -1,0 +1,34 @@
+import type { TeamProvisioningPresentation } from './teamProvisioningPresentation';
+import type { LeadActivityState } from '@shared/types';
+
+/** Keep observed work separate from the launch-success and teammate-readiness gates. */
+export function applyLeadActivityToProvisioningPresentation(
+  presentation: TeamProvisioningPresentation | null,
+  input: {
+    leadActivity?: LeadActivityState;
+    currentRuntimeRunId?: string | null;
+    title: string;
+    detail: string;
+  }
+): TeamProvisioningPresentation | null {
+  if (
+    !presentation?.isActive ||
+    presentation.isReady ||
+    presentation.isFailed ||
+    input.leadActivity !== 'active' ||
+    input.currentRuntimeRunId !== presentation.progress.runId
+  )
+    return presentation;
+
+  const canReplaceGenericDetail =
+    presentation.failedSpawnCount === 0 &&
+    presentation.skippedSpawnCount === 0 &&
+    presentation.panelMessage === presentation.progress.message &&
+    !presentation.progress.messageSeverity;
+  return {
+    ...presentation,
+    panelTitle: input.title,
+    compactTitle: input.title,
+    ...(canReplaceGenericDetail ? { panelMessage: input.detail } : {}),
+  };
+}

--- a/src/renderer/utils/teamProvisioningLeadActivityPresentation.ts
+++ b/src/renderer/utils/teamProvisioningLeadActivityPresentation.ts
@@ -1,5 +1,20 @@
+import { isProvisioningProgressActive } from './teamProvisioningPresentation';
+
 import type { TeamProvisioningPresentation } from './teamProvisioningPresentation';
-import type { LeadActivityState } from '@shared/types';
+import type { LeadActivityState, TeamProvisioningProgress } from '@shared/types';
+
+export function hasObservedLeadWorkDuringProvisioning(input: {
+  progress: TeamProvisioningProgress | null | undefined;
+  leadActivity?: LeadActivityState;
+  currentRuntimeRunId?: string | null;
+}): boolean {
+  return (
+    isProvisioningProgressActive(input.progress) &&
+    input.leadActivity === 'active' &&
+    input.currentRuntimeRunId != null &&
+    input.currentRuntimeRunId === input.progress?.runId
+  );
+}
 
 /** Keep observed work separate from the launch-success and teammate-readiness gates. */
 export function applyLeadActivityToProvisioningPresentation(
@@ -15,8 +30,7 @@ export function applyLeadActivityToProvisioningPresentation(
     !presentation?.isActive ||
     presentation.isReady ||
     presentation.isFailed ||
-    input.leadActivity !== 'active' ||
-    input.currentRuntimeRunId !== presentation.progress.runId
+    !hasObservedLeadWorkDuringProvisioning({ ...input, progress: presentation.progress })
   )
     return presentation;
 

--- a/src/shared/types/cliInstaller.ts
+++ b/src/shared/types/cliInstaller.ts
@@ -277,6 +277,8 @@ export interface CliProviderStatus {
   /** Optional for compatibility with runtimes that predate typed status-check outcomes. */
   statusCheckOutcome?: CliProviderStatusCheckOutcome;
   statusCheckErrorCode?: CliProviderStatusCheckErrorCode;
+  /** App-derived from affirmative runtime support; never launch authorization. */
+  teamLaunchAuthorityRestriction?: 'catalog-refresh';
   modelVerificationState?: 'idle' | 'verifying' | 'verified';
   statusMessage?: string | null;
   detailMessage?: string | null;

--- a/src/shared/utils/providerStatusAuthority.ts
+++ b/src/shared/utils/providerStatusAuthority.ts
@@ -79,6 +79,35 @@ export function hasAuthoritativeProviderStatusEvidence(provider: CliProviderStat
   );
 }
 
+/** Accept only the current authenticated refresh snapshot, never cached support.
+ * Runtime DTO mapping deliberately does not import the app-derived restriction.
+ */
+export function isAuthenticatedAnthropicCatalogRefresh(
+  provider: CliProviderStatus | null | undefined
+): provider is CliProviderStatus {
+  return Boolean(
+    provider?.providerId === 'anthropic' &&
+    provider.supported &&
+    provider.authenticated &&
+    hasAuthoritativeProviderStatusEvidence(provider) &&
+    provider.modelCatalogRefreshState === 'loading' &&
+    (provider.modelCatalog
+      ? provider.modelCatalog.providerId === 'anthropic' &&
+        ['ready', 'stale'].includes(provider.modelCatalog.status)
+      : provider.runtimeCapabilities?.modelCatalog?.dynamic === true)
+  );
+}
+
+export function hasAnthropicCatalogRefreshLaunchSupport(
+  provider: CliProviderStatus | null | undefined
+): provider is CliProviderStatus {
+  return (
+    isAuthenticatedAnthropicCatalogRefresh(provider) &&
+    (provider.capabilities.teamLaunch === true ||
+      provider.teamLaunchAuthorityRestriction === 'catalog-refresh')
+  );
+}
+
 export function hasExactReadyDynamicProviderCatalog(provider: CliProviderStatus): boolean {
   return (
     provider.runtimeCapabilities?.modelCatalog?.dynamic !== true ||

--- a/test/main/features/codex-runtime-installer/CodexRuntimeInstallerService.test.ts
+++ b/test/main/features/codex-runtime-installer/CodexRuntimeInstallerService.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { gzipSync } from 'zlib';
 
 const execCliMock = vi.hoisted(() => vi.fn());
+const managedProbeWarningMock = vi.hoisted(() => vi.fn());
 const buildMergedCliPathMock = vi.hoisted(() => vi.fn(() => process.env.PATH ?? ''));
 const getCachedShellEnvMock = vi.hoisted(() => vi.fn<() => NodeJS.ProcessEnv | null>(() => null));
 const resolveInteractiveShellEnvBestEffortMock = vi.hoisted(() =>
@@ -14,6 +15,14 @@ const resolveInteractiveShellEnvBestEffortMock = vi.hoisted(() =>
 
 vi.mock('@main/utils/childProcess', () => ({
   execCli: execCliMock,
+}));
+vi.mock('@shared/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: managedProbeWarningMock,
+    error: vi.fn(),
+  }),
 }));
 vi.mock('@main/utils/cliPathMerge', () => ({
   buildMergedCliPath: buildMergedCliPathMock,
@@ -78,6 +87,7 @@ describe('CodexRuntimeInstallerService resolver', () => {
     tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-runtime-resolver-'));
     setAppDataBasePath(tempRoot);
     execCliMock.mockReset();
+    managedProbeWarningMock.mockReset();
     execCliMock.mockResolvedValue({ stdout: 'codex-cli 1.0.0\n', stderr: '' });
     buildMergedCliPathMock.mockReset();
     buildMergedCliPathMock.mockImplementation(() => process.env.PATH ?? '');
@@ -189,6 +199,130 @@ describe('CodexRuntimeInstallerService resolver', () => {
     execCliMock.mockRejectedValueOnce(new Error('broken binary'));
 
     await expect(resolveVerifiedAppManagedCodexRuntimeBinaryPath()).resolves.toBeNull();
+  });
+
+  describe.each(['status', 'resolver'] as const)('managed probe recovery via %s', (consumer) => {
+    let binaryPath: string;
+    let pathBinary: string;
+
+    beforeEach(async () => {
+      const runtimeRoot = path.join(tempRoot!, 'data', 'runtimes', 'codex');
+      const pathBinDir = path.join(tempRoot!, 'path-bin');
+      const executableName = process.platform === 'win32' ? 'codex.exe' : 'codex';
+      binaryPath = path.join(runtimeRoot, executableName);
+      pathBinary = path.join(pathBinDir, executableName);
+      await mkdir(runtimeRoot, { recursive: true });
+      await mkdir(pathBinDir, { recursive: true });
+      await writeFile(binaryPath, 'managed fixture', { mode: 0o755 });
+      await writeFile(pathBinary, 'PATH fixture', { mode: 0o755 });
+      await writeFile(
+        path.join(runtimeRoot, 'current.json'),
+        JSON.stringify({
+          schemaVersion: 1,
+          rootVersion: '1.0.0',
+          platformVersion: '1.0.0-darwin-arm64',
+          platformTarget: 'aarch64-apple-darwin',
+          binaryPath,
+          integrity: 'sha512-test',
+          installedAt: '2026-05-13T00:00:00.000Z',
+        })
+      );
+      process.env.PATH = pathBinDir;
+      buildMergedCliPathMock.mockReturnValue(pathBinDir);
+    });
+
+    const runProbe = () =>
+      consumer === 'status'
+        ? createCodexRuntimeInstallerFeature({
+            resolveLatestVersion: async () => '1.0.0',
+          }).getStatus()
+        : resolveVerifiedAppManagedCodexRuntimeBinaryPath();
+
+    const expectFinalFailureFallback = async () => {
+      const result = await runProbe();
+      if (consumer === 'status') {
+        expect(result).toMatchObject({ installed: true, source: 'path', binaryPath: pathBinary });
+      } else {
+        expect(result).toBeNull();
+      }
+    };
+
+    const timeoutError = () =>
+      Object.assign(new Error(`Command timed out after 10000ms: ${binaryPath} --version`), {
+        killed: true,
+        signal: 'SIGTERM',
+        stdout: 'secret stdout',
+        stderr: 'secret stderr',
+      });
+
+    it.each(['execCli', 'ETIMEDOUT'])(
+      'retries one %s timeout and retains managed Codex',
+      async (kind) => {
+        const error =
+          kind === 'execCli'
+            ? timeoutError()
+            : Object.assign(new Error('secret error output'), { code: 'ETIMEDOUT' });
+        execCliMock.mockRejectedValueOnce(error);
+
+        const result = await runProbe();
+
+        if (consumer === 'status') {
+          expect(result).toMatchObject({
+            installed: true,
+            source: 'app-managed',
+            binaryPath,
+            state: 'ready',
+          });
+        } else {
+          expect(result).toBe(binaryPath);
+        }
+        expect(execCliMock).toHaveBeenCalledTimes(2);
+        expect(execCliMock).toHaveBeenNthCalledWith(2, binaryPath, ['--version'], {
+          timeout: 10_000,
+          windowsHide: true,
+        });
+        expect(managedProbeWarningMock).toHaveBeenCalledWith(
+          'Managed Codex version probe failed',
+          expect.objectContaining({ binaryPath, attempt: 1, timedOut: true, retrying: true })
+        );
+        expect(JSON.stringify(managedProbeWarningMock.mock.calls)).not.toContain('secret');
+      }
+    );
+
+    it('stops after two timeouts and preserves the existing final-failure fallback', async () => {
+      execCliMock.mockRejectedValueOnce(timeoutError()).mockRejectedValueOnce(timeoutError());
+
+      await expectFinalFailureFallback();
+
+      expect(execCliMock.mock.calls.filter(([candidate]) => candidate === binaryPath)).toHaveLength(
+        2
+      );
+      expect(managedProbeWarningMock).toHaveBeenCalledTimes(2);
+      expect(managedProbeWarningMock).toHaveBeenLastCalledWith(
+        'Managed Codex version probe failed',
+        expect.objectContaining({ attempt: 2, timedOut: true, retrying: false })
+      );
+    });
+
+    it.each(['ENOENT', 'ENOEXEC', 1, 'ABORT_ERR'])(
+      'does not retry a hard failure with code %s',
+      async (code) => {
+        execCliMock.mockRejectedValueOnce(
+          Object.assign(new Error('secret error output'), { code, killed: true, signal: 'SIGTERM' })
+        );
+
+        await expectFinalFailureFallback();
+
+        expect(
+          execCliMock.mock.calls.filter(([candidate]) => candidate === binaryPath)
+        ).toHaveLength(1);
+        expect(managedProbeWarningMock).toHaveBeenCalledWith(
+          'Managed Codex version probe failed',
+          expect.objectContaining({ code, attempt: 1, timedOut: false, retrying: false })
+        );
+        expect(JSON.stringify(managedProbeWarningMock.mock.calls)).not.toContain('secret');
+      }
+    );
   });
 
   it('detects a PATH Codex binary from best-effort shell env when process PATH is cold', async () => {

--- a/test/main/services/infrastructure/TeamTaskWatchRegistry.test.ts
+++ b/test/main/services/infrastructure/TeamTaskWatchRegistry.test.ts
@@ -3,6 +3,14 @@ import * as os from 'os';
 import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  computeLiveTeamWatchScope,
+  computeTeamWatchScope,
+  markTeamEngaged,
+  resetTeamWatchScopeForTests,
+  setAliveTeamsProvider,
+} from '../../../../src/main/services/infrastructure/teamWatchScope';
+
 type MockChokidarWatcher = {
   targets: string[];
   options: unknown;
@@ -112,6 +120,7 @@ describe('TeamTaskWatchRegistry scoping', () => {
   });
 
   afterEach(() => {
+    resetTeamWatchScopeForTests();
     setPlatform(originalPlatform);
     statGate.hold = null;
     statGate.parked = false;
@@ -247,6 +256,36 @@ describe('TeamTaskWatchRegistry scoping', () => {
       // The registry always emits forward-slash relative paths (see toRelativePath).
       relativePath: 'beta/inboxes/team-lead.json',
     });
+  });
+
+  it('recovers provisioning inboxes before ready without replaying historical teams', async () => {
+    let nowMs = 0;
+    setAliveTeamsProvider(() => []);
+    const events: string[] = [];
+    const registry = new TeamTaskWatchRegistry({
+      kind: 'teams',
+      rootPath: root,
+      onChange: (_eventType, relativePath) => events.push(relativePath),
+      onError: () => {},
+      getScopedTeamNames: () => computeTeamWatchScope(nowMs),
+      getScopedInboxTeamNames: () => computeLiveTeamWatchScope(nowMs),
+    });
+    try {
+      await registry.start();
+      markTeamEngaged('beta', nowMs);
+      await registry.requestReconcile();
+      expect(events).toContain('beta/inboxes/team-lead.json');
+      expect(events.some((event) => /^(alpha|gamma)\//.test(event))).toBe(false);
+      const deliveredCount = events.length;
+      await registry.requestReconcile();
+      expect(events).toHaveLength(deliveredCount);
+
+      nowMs = 5 * 60_000 + 1;
+      await registry.requestReconcile();
+      expect(latestTargets()).not.toContain(path.join(root, 'beta', 'inboxes'));
+    } finally {
+      await registry.close();
+    }
   });
 
   it('backfills only explicitly scoped live inboxes on initial startup', async () => {

--- a/test/main/services/infrastructure/teamWatchScope.test.ts
+++ b/test/main/services/infrastructure/teamWatchScope.test.ts
@@ -22,13 +22,14 @@ describe('teamWatchScope', () => {
     expect([...(computeTeamWatchScope(1000) ?? [])]).toContain('t-alive');
   });
 
-  it('keeps inbox live scope limited to alive teams', () => {
+  it('includes recently engaged launch teams in inbox scope before ready', () => {
     setAliveTeamsProvider(() => ['t-alive']);
     markTeamEngaged('t-engaged', 0);
 
     expect(computeTeamWatchScope(1000)?.has('t-engaged')).toBe(true);
-    expect(computeLiveTeamWatchScope()?.has('t-alive')).toBe(true);
-    expect(computeLiveTeamWatchScope()?.has('t-engaged')).toBe(false);
+    expect(computeLiveTeamWatchScope(1000)?.has('t-alive')).toBe(true);
+    expect(computeLiveTeamWatchScope(1000)?.has('t-engaged')).toBe(true);
+    expect(computeLiveTeamWatchScope(FIVE_MIN + 1)?.has('t-engaged')).toBe(false);
   });
 
   it('includes engaged teams within TTL and prunes after expiry', () => {

--- a/test/main/services/runtime/ProviderConnectionService.test.ts
+++ b/test/main/services/runtime/ProviderConnectionService.test.ts
@@ -1486,6 +1486,37 @@ describe('ProviderConnectionService', () => {
     expect(execCliMock).not.toHaveBeenCalled();
   });
 
+  it.each(['/managed/codex/bin/codex', '/explicit/codex'])(
+    'preserves passive binary %s over stale cached context while keeping account auth and home',
+    async (binaryPath) => {
+      const { ProviderConnectionService } =
+        await import('@main/services/runtime/ProviderConnectionService');
+      const getSnapshot = vi.fn().mockRejectedValue(new Error('passive status must not refresh'));
+      const getCachedSnapshot = vi.fn().mockReturnValue(createCodexSnapshot());
+      const lookupPreferred = vi.fn();
+      const service = new ProviderConnectionService(
+        { lookupPreferred } as never,
+        { getConfig: () => createConfig('auto') } as never
+      );
+      service.setCodexAccountFeature({ getSnapshot, getCachedSnapshot });
+
+      const env = await service.applyPassiveProviderStatusConnectionEnv(
+        { CODEX_CLI_PATH: binaryPath, OPENAI_API_KEY: 'must-not-leak-to-chatgpt-status' },
+        'codex'
+      );
+
+      expect(env).toMatchObject({
+        CODEX_CLI_PATH: binaryPath,
+        CODEX_HOME: '/Users/tester/.codex-custom',
+        CLAUDE_CODE_CODEX_FORCED_LOGIN_METHOD: 'chatgpt',
+      });
+      expect(env.OPENAI_API_KEY).toBeUndefined();
+      expect(getSnapshot).not.toHaveBeenCalled();
+      expect(lookupPreferred).not.toHaveBeenCalled();
+      expect(execCliMock).not.toHaveBeenCalled();
+    }
+  );
+
   it('keeps passive non-Codex status probes free of account resolution', async () => {
     const { ProviderConnectionService } =
       await import('@main/services/runtime/ProviderConnectionService');

--- a/test/main/services/runtime/providerAwareCliEnv.test.ts
+++ b/test/main/services/runtime/providerAwareCliEnv.test.ts
@@ -17,6 +17,7 @@ const resolveAppManagedOpenCodeRuntimeBinaryPathMock = vi.fn();
 const resolveCachedVerifiedOpenCodeRuntimeBinaryPathMock = vi.fn();
 const resolveVerifiedOpenCodeRuntimeBinaryPathMock = vi.fn();
 const isSupportedOpenCodeRuntimeBinaryPathMock = vi.fn();
+const resolveAppManagedCodexRuntimeBinaryPathMock = vi.fn();
 const resolveVerifiedAppManagedCodexRuntimeBinaryPathMock = vi.fn();
 const resolveAgentTeamsMcpLaunchSpecMock = vi.fn();
 const resolvePackagedAgentTeamsMcpEntryMock = vi.fn();
@@ -83,6 +84,7 @@ vi.mock('../../../../src/main/services/infrastructure/OpenCodeRuntimeInstallerSe
 }));
 
 vi.mock('@features/codex-runtime-installer/main', () => ({
+  resolveAppManagedCodexRuntimeBinaryPath: () => resolveAppManagedCodexRuntimeBinaryPathMock(),
   resolveVerifiedAppManagedCodexRuntimeBinaryPath: () =>
     resolveVerifiedAppManagedCodexRuntimeBinaryPathMock(),
 }));
@@ -121,6 +123,7 @@ describe('buildProviderAwareCliEnv', () => {
     resolveCachedVerifiedOpenCodeRuntimeBinaryPathMock.mockReturnValue(null);
     resolveVerifiedOpenCodeRuntimeBinaryPathMock.mockResolvedValue(null);
     isSupportedOpenCodeRuntimeBinaryPathMock.mockResolvedValue(true);
+    resolveAppManagedCodexRuntimeBinaryPathMock.mockReturnValue(null);
     resolveVerifiedAppManagedCodexRuntimeBinaryPathMock.mockResolvedValue(null);
     resolveAgentTeamsMcpLaunchSpecMock.mockResolvedValue({
       command: 'node',
@@ -166,6 +169,7 @@ describe('buildProviderAwareCliEnv', () => {
       expect(result.providerArgs).toEqual([]);
       expect(result.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
       expect(result.env.CLAUDE_CODE_ENTRY_PROVIDER).toBe('codex');
+      expect(result.env.CODEX_CLI_PATH).toBeUndefined();
       expect(resolveAppManagedOpenCodeRuntimeBinaryPathMock).not.toHaveBeenCalled();
       expect(resolveVerifiedAppManagedCodexRuntimeBinaryPathMock).not.toHaveBeenCalled();
       expect(resolveVerifiedOpenCodeRuntimeBinaryPathMock).not.toHaveBeenCalled();
@@ -209,6 +213,56 @@ describe('buildProviderAwareCliEnv', () => {
     expect(resolveAgentTeamsMcpLaunchSpecMock).not.toHaveBeenCalled();
     expect(applyConfiguredConnectionEnvMock).not.toHaveBeenCalled();
   });
+
+  it.each([undefined, 'codex'] as const)(
+    'projects managed Codex metadata into passive status for provider %s without probes',
+    async (providerId) => {
+      const managedBinary = '/managed/codex/bin/codex';
+      resolveAppManagedCodexRuntimeBinaryPathMock.mockReturnValue(managedBinary);
+      const { buildPassiveProviderStatusCliEnv } =
+        await import('../../../../src/main/services/runtime/providerAwareCliEnv');
+
+      const { env } = buildPassiveProviderStatusCliEnv({ providerId });
+
+      expect(env.CODEX_CLI_PATH).toBe(managedBinary);
+      expect(resolveVerifiedAppManagedCodexRuntimeBinaryPathMock).not.toHaveBeenCalled();
+      expect(applyConfiguredConnectionEnvMock).not.toHaveBeenCalled();
+      expect(resolveAgentTeamsMcpLaunchSpecMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['call', 'shell', 'inherited'])(
+    'preserves a %s Codex binary override over passive managed metadata',
+    async (source) => {
+      const override = { CODEX_CLI_PATH: '/custom/codex' };
+      resolveAppManagedCodexRuntimeBinaryPathMock.mockReturnValue('/managed/codex');
+      if (source === 'shell') getCachedShellEnvMock.mockReturnValue(override);
+      if (source === 'inherited') buildEnrichedEnvMock.mockReturnValue(override);
+      const { buildPassiveProviderStatusCliEnv } =
+        await import('../../../../src/main/services/runtime/providerAwareCliEnv');
+
+      const { env } = buildPassiveProviderStatusCliEnv({
+        providerId: 'codex',
+        env: source === 'call' ? override : undefined,
+      });
+
+      expect(env.CODEX_CLI_PATH).toBe('/custom/codex');
+    }
+  );
+
+  it.each(['anthropic', 'gemini', 'opencode'] as const)(
+    'does not project managed Codex into passive %s status',
+    async (providerId) => {
+      resolveAppManagedCodexRuntimeBinaryPathMock.mockReturnValue('/managed/codex');
+      const { buildPassiveProviderStatusCliEnv } =
+        await import('../../../../src/main/services/runtime/providerAwareCliEnv');
+
+      const { env } = buildPassiveProviderStatusCliEnv({ providerId });
+
+      expect(env.CODEX_CLI_PATH).toBeUndefined();
+      expect(resolveAppManagedCodexRuntimeBinaryPathMock).not.toHaveBeenCalled();
+    }
+  );
 
   it('projects a previously verified PATH runtime into passive status without probing again', async () => {
     const cachedBinaryPath = path.join('/opt', 'homebrew', 'bin', 'opencode');

--- a/test/main/services/runtime/providerStatusCheckContract.test.ts
+++ b/test/main/services/runtime/providerStatusCheckContract.test.ts
@@ -80,6 +80,49 @@ function providerStatus(overrides: Partial<CliProviderStatus> = {}): CliProvider
   };
 }
 
+describe('Anthropic catalog refresh restriction provenance', () => {
+  const refresh = () =>
+    providerStatus({
+      providerId: 'anthropic',
+      modelCatalogRefreshState: 'loading',
+      modelCatalog: { ...providerStatus().modelCatalog!, providerId: 'anthropic' },
+    });
+  it('records affirmative support before catalog gating and preserves repeat sanitization', () => {
+    const first = sanitizeProviderStatusAuthority(refresh());
+    expect(first.capabilities.teamLaunch).toBe(false);
+    expect(first.teamLaunchAuthorityRestriction).toBe('catalog-refresh');
+    expect(sanitizeProviderStatusAuthority(first).teamLaunchAuthorityRestriction).toBe(
+      'catalog-refresh'
+    );
+  });
+  it('does not inherit an old restriction for a new unsupported runtime snapshot', () => {
+    const previous = sanitizeProviderStatusAuthority(refresh());
+    const incoming = refresh();
+    incoming.capabilities.teamLaunch = false;
+    expect(
+      mergeProviderStatusDisplayEvidence(incoming, previous).teamLaunchAuthorityRestriction
+    ).toBeUndefined();
+    expect(
+      createDegradedProviderStatus(previous, new Error('unavailable'))
+        .teamLaunchAuthorityRestriction
+    ).toBeUndefined();
+  });
+  it.each([
+    { authenticated: false },
+    { supported: false },
+    { verificationState: 'error' as const },
+    { statusCheckOutcome: 'pending' as const, statusCheckErrorCode: 'partial_response' as const },
+    { statusCheckErrorCode: 'unavailable' as const },
+    { modelCatalogRefreshState: 'error' as const },
+    { modelCatalogRefreshState: 'ready' as const },
+  ])('clears same-snapshot restriction after %j', (change) => {
+    const previous = sanitizeProviderStatusAuthority(refresh());
+    expect(
+      sanitizeProviderStatusAuthority({ ...previous, ...change }).teamLaunchAuthorityRestriction
+    ).toBeUndefined();
+  });
+});
+
 function completeRuntimeStatus(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     providerId: 'opencode',

--- a/test/main/services/team/TeamProvisioningService.test.ts
+++ b/test/main/services/team/TeamProvisioningService.test.ts
@@ -308,6 +308,7 @@ import {
   stubProvisioningConfigProjectPath,
   verificationProbePortsHarness,
 } from './provisioningHarness';
+import { registerActiveProvisioningRun } from './provisioningHarness/servicePrivateHarness';
 
 import type { TeamProvisioningConfigFacade } from '@main/services/team/provisioning/TeamProvisioningConfigFacade';
 import type { OpenCodeTeamRuntimeMessageResult } from '@main/services/team/runtime';
@@ -8218,6 +8219,7 @@ describe('TeamProvisioningService', () => {
         },
       ];
 
+      registerActiveProvisioningRun(svc, run);
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await run.mixedSecondaryLaneLaunchQueue;
 
@@ -14381,6 +14383,7 @@ describe('TeamProvisioningService', () => {
         'utf8'
       );
 
+      registerActiveProvisioningRun(svc, run);
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await vi.waitFor(
         async () => {
@@ -14499,6 +14502,7 @@ describe('TeamProvisioningService', () => {
         },
       ];
 
+      registerActiveProvisioningRun(svc, run);
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await vi.waitFor(
         async () => {
@@ -14612,6 +14616,7 @@ describe('TeamProvisioningService', () => {
         },
       ];
 
+      registerActiveProvisioningRun(svc, run);
       await (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await vi.waitFor(
         async () => {
@@ -14755,6 +14760,7 @@ describe('TeamProvisioningService', () => {
         },
       ];
 
+      registerActiveProvisioningRun(svc, run);
       const resultPromise = (svc as any).launchMixedSecondaryLaneIfNeeded(run);
       await Promise.resolve();
       await Promise.resolve();

--- a/test/main/services/team/TeamProvisioningServiceLiveMessages.test.ts
+++ b/test/main/services/team/TeamProvisioningServiceLiveMessages.test.ts
@@ -369,7 +369,12 @@ describe('TeamProvisioningService pre-ready live messages', () => {
       content: [{ type: 'text', text: 'Launching teammates now.' }],
     });
 
-    expect(emitter).toHaveBeenCalledTimes(1);
+    const events = emitter.mock.calls.map(([event]) => event);
+    expect(events.filter((event) => event.type === 'lead-message')).toHaveLength(1);
+    expect(events.filter((event) => event.type === 'lead-activity')).toEqual([
+      { type: 'lead-activity', teamName: 'my-team', runId: run.runId, detail: 'active' },
+    ]);
+    expect(events.some((event) => event.type === 'inbox')).toBe(false);
     expect(emitter).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'lead-message', teamName: 'my-team' })
     );
@@ -387,14 +392,17 @@ describe('TeamProvisioningService pre-ready live messages', () => {
       type: 'assistant',
       content: [{ type: 'text', text: 'Message 1' }],
     });
-    expect(emitter).toHaveBeenCalledTimes(1);
+    expect(emitter.mock.calls.filter(([event]) => event.type === 'lead-message')).toHaveLength(1);
 
     // Second message immediately after: should be coalesced (not emitted again)
     callHandleStreamJsonMessage(service, run, {
       type: 'assistant',
       content: [{ type: 'text', text: 'Message 2' }],
     });
-    expect(emitter).toHaveBeenCalledTimes(1); // Still 1
+    expect(emitter.mock.calls.filter(([event]) => event.type === 'lead-message')).toHaveLength(1);
+    expect(
+      emitter.mock.calls.filter(([event]) => event.type === 'lead-activity').map(([event]) => event)
+    ).toEqual([{ type: 'lead-activity', teamName: 'my-team', runId: run.runId, detail: 'active' }]);
 
     // Messages are still cached though
     const live = service.getLiveLeadProcessMessages('my-team');
@@ -604,21 +612,24 @@ describe('TeamProvisioningService pre-ready live messages', () => {
     );
   });
 
-  it('suppresses bare transcript speaker placeholders from lead thought output', () => {
-    const service = new TeamProvisioningService();
-    seedConfig('my-team');
-    const emitter = vi.fn<(event: TeamChangeEvent) => void>();
-    service.setTeamChangeEmitter(emitter);
-    const run = attachRun(service, 'my-team', { provisioningComplete: true });
+  it.each([false, true])(
+    'suppresses bare transcript speaker placeholders with provisioningComplete=%s',
+    (provisioningComplete) => {
+      const service = new TeamProvisioningService();
+      seedConfig('my-team');
+      const emitter = vi.fn<(event: TeamChangeEvent) => void>();
+      service.setTeamChangeEmitter(emitter);
+      const run = attachRun(service, 'my-team', { provisioningComplete });
 
-    callHandleStreamJsonMessage(service, run, {
-      type: 'assistant',
-      content: [{ type: 'text', text: 'Human: ' }],
-    });
+      callHandleStreamJsonMessage(service, run, {
+        type: 'assistant',
+        content: [{ type: 'text', text: 'Human: ' }],
+      });
 
-    expect(service.getLiveLeadProcessMessages('my-team')).toHaveLength(0);
-    expect(emitter).not.toHaveBeenCalled();
-  });
+      expect(service.getLiveLeadProcessMessages('my-team')).toHaveLength(0);
+      expect(emitter).not.toHaveBeenCalled();
+    }
+  );
 
   it('SendMessage(to:teammate) creates inbox row and emits inbox detail for recipient', () => {
     const service = new TeamProvisioningService();

--- a/test/main/services/team/TeamProvisioningServicePrompts.test.ts
+++ b/test/main/services/team/TeamProvisioningServicePrompts.test.ts
@@ -1366,7 +1366,7 @@ describe('TeamProvisioningService prompt content (solo mode discipline)', () => 
     await svc.cancelProvisioning(runId);
   });
 
-  it('coalesces codex cross-provider launch overrides into launchTeam Anthropic runtime settings', async () => {
+  it('keeps mixed runtime settings and the full roster in one actionable relaunch prompt', async () => {
     const teamName = 'anthropic-codex-launch-team';
     const teamDir = path.join(tempTeamsBase, teamName);
     fs.mkdirSync(teamDir, { recursive: true });
@@ -1396,7 +1396,7 @@ describe('TeamProvisioningService prompt content (solo mode discipline)', () => 
     );
 
     vi.mocked(ClaudeBinaryResolver.resolve).mockResolvedValue('/fake/claude');
-    const { child } = createFakeChild();
+    const { child, writeSpy } = createFakeChild();
     vi.mocked(spawnCli).mockReturnValue(child as any);
 
     const svc = new TeamProvisioningService();
@@ -1446,6 +1446,7 @@ describe('TeamProvisioningService prompt content (solo mode discipline)', () => 
         cwd: process.cwd(),
         providerId: 'anthropic',
         clearContext: true,
+        prompt: 'Create one new task per teammate for RELAUNCH_OK.txt.',
       } as any,
       () => {}
     );
@@ -1456,6 +1457,15 @@ describe('TeamProvisioningService prompt content (solo mode discipline)', () => 
     expect(extractBootstrapSpec().members).toEqual([
       expect.objectContaining({ name: 'alice', provider: 'codex' }),
     ]);
+    const prompt = extractPromptFromBootstrapFile();
+    expect(prompt).toContain('Your teammates are EXACTLY: alice, bob. No other teammate exists.');
+    expect(prompt).toContain(
+      'Apply the original user instructions now; do not wait for another user message.'
+    );
+    expect(prompt.split('Create one new task per teammate for RELAUNCH_OK.txt.')).toHaveLength(2);
+    expect(prompt).not.toContain('Do not start work, create tasks, or delegate in this turn.');
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(spawnCli).toHaveBeenCalledTimes(1);
     const settingsPath = readRuntimeSettingsPathFromLaunchArgs();
     const launchEnv = vi.mocked(spawnCli).mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv;
     expect(launchEnv.CLAUDE_TEAM_RUNTIME_SETTINGS_PATH).toBe(settingsPath);

--- a/test/main/services/team/TeamProvisioningServiceRelay.test.ts
+++ b/test/main/services/team/TeamProvisioningServiceRelay.test.ts
@@ -230,6 +230,14 @@ function attachAliveRun(
   (service as unknown as { runs: Map<string, unknown> }).runs.set(runId, {
     runId,
     teamName,
+    progress: {
+      runId,
+      teamName,
+      state: (opts?.provisioningComplete ?? true) ? 'ready' : 'spawning',
+      message: 'Relay fixture runtime',
+      startedAt: '2026-02-23T09:59:00.000Z',
+      updatedAt: '2026-02-23T09:59:00.000Z',
+    },
     request: {
       teamName,
       members: [{ name: 'team-lead', role: 'team-lead' }],
@@ -254,6 +262,7 @@ function attachAliveRun(
     },
     processKilled: false,
     cancelRequested: false,
+    leadActivityState: 'idle',
     provisioningComplete: opts?.provisioningComplete ?? true,
     leadRelayCapture: null,
   });
@@ -506,9 +515,7 @@ describe('TeamProvisioningService relayLeadInboxMessages', () => {
         causedByRecoveryMessageId: 'runtime-recovery-2',
       })
     );
-    expect(vi.mocked(console.warn).mock.calls[0]?.join(' ')).toContain(
-      'stream-json result: error'
-    );
+    expect(vi.mocked(console.warn).mock.calls[0]?.join(' ')).toContain('stream-json result: error');
     vi.mocked(console.warn).mockClear();
   });
 
@@ -1318,6 +1325,14 @@ Messages:
     (service as unknown as { runs: Map<string, unknown> }).runs.set('run-1', {
       runId: 'run-1',
       teamName,
+      progress: {
+        runId: 'run-1',
+        teamName,
+        state: 'ready',
+        message: 'Relay fixture runtime',
+        startedAt: '2026-02-23T09:59:00.000Z',
+        updatedAt: '2026-02-23T09:59:00.000Z',
+      },
       request: {
         teamName,
         members: [{ name: 'team-lead', role: 'team-lead' }],
@@ -1334,6 +1349,7 @@ Messages:
       child: { stdin: { writable: true, write: writeSpy } },
       processKilled: false,
       cancelRequested: false,
+      leadActivityState: 'idle',
       provisioningComplete: true,
       leadRelayCapture: null,
     });

--- a/test/main/services/team/TeamProvisioningStreamEvents.test.ts
+++ b/test/main/services/team/TeamProvisioningStreamEvents.test.ts
@@ -380,6 +380,57 @@ describe('TeamProvisioningStreamEvents', () => {
     expect(launchMixedSecondaryLaneIfNeeded).toHaveBeenCalledTimes(1);
   });
 
+  it.each([false, true])(
+    'starts secondary preparation before immediate completion (isLaunch=%s)',
+    (isLaunch) => {
+      const { run } = createDeterministicBootstrapRun({
+        isLaunch,
+        requiresFirstRealTurnSuccess: false,
+        mixedSecondaryLanes: [{}],
+      });
+      const { ports, launchMixedSecondaryLaneIfNeeded } = createStreamEventPorts();
+
+      expect(
+        handleDeterministicBootstrapEvent(
+          run,
+          {
+            type: 'system',
+            subtype: 'team_bootstrap',
+            event: 'completed',
+            failed_members: [],
+            run_id: run.runId,
+            team_name: run.teamName,
+            seq: 1,
+          },
+          ports
+        )
+      ).toBe(true);
+
+      expect(ports.handleProvisioningTurnComplete).toHaveBeenCalledExactlyOnceWith(run);
+      expect(launchMixedSecondaryLaneIfNeeded).toHaveBeenCalledExactlyOnceWith(run);
+      expect(launchMixedSecondaryLaneIfNeeded.mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(ports.handleProvisioningTurnComplete).mock.invocationCallOrder[0]
+      );
+    }
+  );
+
+  it('does not start eager roster preparation after completion has claimed the run', () => {
+    const { run } = createDeterministicBootstrapRun({
+      provisioningComplete: true,
+      mixedSecondaryLanes: [{}],
+    });
+    const { ports, launchMixedSecondaryLaneIfNeeded } = createStreamEventPorts();
+
+    handleDeterministicBootstrapEvent(
+      run,
+      { type: 'system', subtype: 'team_bootstrap', event: 'completed' },
+      ports
+    );
+
+    expect(launchMixedSecondaryLaneIfNeeded).not.toHaveBeenCalled();
+    expect(ports.handleProvisioningTurnComplete).not.toHaveBeenCalled();
+  });
+
   it('reports workspace trust deterministic bootstrap failures through stream events', () => {
     const reason =
       'Teammate "Gayani" cannot start in headless process runtime because workspace trust is not accepted for "C:\\Users\\vilok\\OneDrive\\Desktop\\Safar 0.1". Open that workspace once interactively and accept trust, then launch the team again.';
@@ -459,7 +510,11 @@ describe('handleTeamProvisioningStreamJsonMessage result handling', () => {
       const { run } = createDeterministicBootstrapRun({ provisioningComplete: false });
       const ports = makeResultPorts();
 
-      handleTeamProvisioningStreamJsonMessage(run, { type: 'result', subtype, error: 'boom' }, ports);
+      handleTeamProvisioningStreamJsonMessage(
+        run,
+        { type: 'result', subtype, error: 'boom' },
+        ports
+      );
 
       expect(run.progress.state).toBe('failed');
       expect(ports.killTeamProcess).toHaveBeenCalledWith(run.child);

--- a/test/main/services/team/TeamProvisioningStreamEvents.test.ts
+++ b/test/main/services/team/TeamProvisioningStreamEvents.test.ts
@@ -114,6 +114,7 @@ function createStreamEventPorts(): {
   killTeamProcess: ReturnType<typeof vi.fn>;
   markUnconfirmedBootstrapMembersFailed: ReturnType<typeof vi.fn>;
   persistLaunchStateSnapshot: ReturnType<typeof vi.fn>;
+  launchMixedSecondaryLaneIfNeeded: ReturnType<typeof vi.fn>;
   cleanupRun: ReturnType<typeof vi.fn>;
   reevaluateMemberLaunchStatus: ReturnType<typeof vi.fn>;
 } {
@@ -121,6 +122,7 @@ function createStreamEventPorts(): {
   const killTeamProcess = vi.fn();
   const markUnconfirmedBootstrapMembersFailed = vi.fn();
   const persistLaunchStateSnapshot = vi.fn(async () => null);
+  const launchMixedSecondaryLaneIfNeeded = vi.fn(async () => null);
   const cleanupRun = vi.fn();
   const reevaluateMemberLaunchStatus = vi.fn(async () => undefined);
 
@@ -175,6 +177,7 @@ function createStreamEventPorts(): {
     stopPersistentTeamMembers: vi.fn(),
     killTeamProcess,
     persistLaunchStateSnapshot,
+    launchMixedSecondaryLaneIfNeeded,
     cleanupRun,
     handleProvisioningTurnComplete: vi.fn(async () => undefined),
   } as Partial<
@@ -187,6 +190,7 @@ function createStreamEventPorts(): {
     killTeamProcess,
     markUnconfirmedBootstrapMembersFailed,
     persistLaunchStateSnapshot,
+    launchMixedSecondaryLaneIfNeeded,
     cleanupRun,
     reevaluateMemberLaunchStatus,
   };
@@ -350,6 +354,30 @@ describe('TeamProvisioningStreamEvents', () => {
       hardFailure: true,
       hardFailureReason: 'spawn failed hard',
     });
+  });
+
+  it('starts mixed secondary lanes when primary bootstrap completes before the first real turn', () => {
+    const { run } = createDeterministicBootstrapRun({
+      requiresFirstRealTurnSuccess: true,
+      mixedSecondaryLanes: [{}],
+    });
+    const { ports, launchMixedSecondaryLaneIfNeeded } = createStreamEventPorts();
+
+    const event = {
+      type: 'system',
+      subtype: 'team_bootstrap',
+      event: 'completed',
+      failed_members: [],
+      run_id: run.runId,
+      team_name: run.teamName,
+      seq: 1,
+    };
+    expect(handleDeterministicBootstrapEvent(run, event, ports)).toBe(true);
+    expect(launchMixedSecondaryLaneIfNeeded).toHaveBeenCalledWith(run);
+    expect(ports.handleProvisioningTurnComplete).not.toHaveBeenCalled();
+
+    expect(handleDeterministicBootstrapEvent(run, event, ports)).toBe(true);
+    expect(launchMixedSecondaryLaneIfNeeded).toHaveBeenCalledTimes(1);
   });
 
   it('reports workspace trust deterministic bootstrap failures through stream events', () => {

--- a/test/renderer/components/cli/CliStatusVisibility.test.ts
+++ b/test/renderer/components/cli/CliStatusVisibility.test.ts
@@ -88,6 +88,7 @@ const refreshOpenCodeCatalog = vi.fn();
 let openCodeCatalogHookInputs: {
   refreshRevision?: number;
   enabled?: boolean;
+  statusChecking?: boolean;
 }[] = [];
 const codexAccountHookState = {
   snapshot: null as CodexAccountSnapshotDto | null,
@@ -1790,7 +1791,10 @@ describe('CLI status visibility during completed install state', () => {
       root.render(React.createElement(CliStatusBanner));
       await Promise.resolve();
     });
-    expect(openCodeCatalogHookInputs.at(-1)?.enabled).toBe(false);
+    expect(openCodeCatalogHookInputs.at(-1)).toMatchObject({
+      enabled: true,
+      statusChecking: true,
+    });
 
     storeState.cliStatusLoading = false;
     storeState.cliProviderStatusLoading = { opencode: true };
@@ -1798,14 +1802,20 @@ describe('CLI status visibility during completed install state', () => {
       root.render(React.createElement(CliStatusBanner));
       await Promise.resolve();
     });
-    expect(openCodeCatalogHookInputs.at(-1)?.enabled).toBe(false);
+    expect(openCodeCatalogHookInputs.at(-1)).toMatchObject({
+      enabled: true,
+      statusChecking: true,
+    });
 
     storeState.cliProviderStatusLoading = {};
     await act(async () => {
       root.render(React.createElement(CliStatusBanner));
       await Promise.resolve();
     });
-    expect(openCodeCatalogHookInputs.at(-1)?.enabled).toBe(true);
+    expect(openCodeCatalogHookInputs.at(-1)).toMatchObject({
+      enabled: true,
+      statusChecking: false,
+    });
 
     await act(async () => {
       root.unmount();

--- a/test/renderer/components/common/ProviderActivityStatusStrip.test.ts
+++ b/test/renderer/components/common/ProviderActivityStatusStrip.test.ts
@@ -218,6 +218,31 @@ describe('ProviderActivityStatusStrip', () => {
     await act(async () => root.unmount());
   });
 
+  it('keeps a selected provider neutral while a detailed preflight is still running', async () => {
+    const provider = createProvider({
+      providerId: 'opencode',
+      displayName: 'OpenCode',
+      verificationState: 'error',
+      statusMessage: 'Provider launch status could not be verified.',
+    });
+    const host = document.createElement('div');
+    let root!: ReturnType<typeof createRoot>;
+
+    await act(async () => {
+      root = renderStrip(host, {
+        cliStatus: createMultimodelStatus([provider]),
+        providerStatusOverride: provider,
+        forceLoadingProviderIds: ['opencode'],
+        showReadyProviders: true,
+      });
+    });
+
+    expect(host.textContent).toContain('OpenCode');
+    expect(host.textContent).toContain('Checking...');
+    expect(host.textContent).not.toContain('Needs attention');
+    await act(async () => root.unmount());
+  });
+
   it('shows concise provider details only when requested', async () => {
     const provider = createProvider({
       providerId: 'codex',

--- a/test/renderer/components/common/ProviderActivityStatusStrip.test.ts
+++ b/test/renderer/components/common/ProviderActivityStatusStrip.test.ts
@@ -2,6 +2,7 @@ import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { ProviderActivityStatusStrip } from '@renderer/components/common/ProviderActivityStatusStrip';
+import { getPendingProviderPreflightIds } from '@renderer/components/team/dialogs/optionalProviderPreflight';
 import { createDefaultCliExtensionCapabilities } from '@shared/utils/providerExtensionCapabilities';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -92,6 +93,7 @@ describe('ProviderActivityStatusStrip', () => {
     ['codex', true],
     ['codex', false],
     ['opencode', true],
+    ['anthropic', true],
   ] as const)(
     'shows Ready only with complete launch authority (%s teamLaunch=%s)',
     async (providerId, teamLaunch) => {
@@ -138,15 +140,44 @@ describe('ProviderActivityStatusStrip', () => {
             providerId === 'opencode'
               ? { ...provider, modelCatalogRefreshState: 'loading' }
               : provider,
+            ...(providerId !== 'codex'
+              ? [
+                  createProvider({
+                    providerId: 'codex',
+                    displayName: 'Codex',
+                    statusCheckOutcome: 'pending',
+                    statusCheckErrorCode: 'partial_response',
+                    verificationState: 'unknown',
+                  }),
+                ]
+              : []),
           ]),
           providerStatusOverride: providerId === 'opencode' ? provider : null,
           cliProviderStatusLoading: providerId === 'opencode' ? { opencode: true } : {},
           showReadyProviders: true,
           readyStatusText: 'Ready',
+          forceLoadingProviderIds: getPendingProviderPreflightIds(
+            'loading',
+            providerId === 'codex' ? [providerId] : [providerId, 'codex'],
+            [
+              { providerId, status: 'ready', details: [] },
+              ...(providerId !== 'codex'
+                ? [{ providerId: 'codex' as const, status: 'pending' as const, details: [] }]
+                : []),
+            ]
+          ),
         });
       });
       expect(host.textContent?.includes('Ready')).toBe(teamLaunch);
       if (!teamLaunch) expect(host.textContent).toContain('Needs attention');
+      if (providerId !== 'codex') {
+        expect(
+          host.querySelector(`[data-testid="provider-activity-status-${providerId}"]`)?.textContent
+        ).toContain('Ready');
+        expect(
+          host.querySelector('[data-testid="provider-activity-status-codex"]')?.textContent
+        ).toContain('Checking...');
+      }
       await act(async () => root.unmount());
     }
   );

--- a/test/renderer/components/common/ProviderActivityStatusStrip.test.ts
+++ b/test/renderer/components/common/ProviderActivityStatusStrip.test.ts
@@ -3,6 +3,8 @@ import { createRoot } from 'react-dom/client';
 
 import { ProviderActivityStatusStrip } from '@renderer/components/common/ProviderActivityStatusStrip';
 import { getPendingProviderPreflightIds } from '@renderer/components/team/dialogs/optionalProviderPreflight';
+import { createLaunchGuard } from '@renderer/components/team/dialogs/providerLaunchAuthority';
+import { ProviderLaunchAuthorityNotice } from '@renderer/components/team/dialogs/ProviderLaunchAuthorityNotice';
 import { createDefaultCliExtensionCapabilities } from '@shared/utils/providerExtensionCapabilities';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -89,6 +91,87 @@ function renderStrip(
 }
 
 describe('ProviderActivityStatusStrip', () => {
+  it.each([
+    'refresh',
+    'auth',
+    'unsupported',
+    'error',
+    'catalog-error',
+    'unavailable',
+    'mixed',
+  ] as const)(
+    'presents authenticated Anthropic catalog refresh neutrally without hiding %s failures',
+    async (scenario) => {
+      const provider = createProvider({
+        providerId: 'anthropic',
+        displayName: 'Anthropic',
+        authenticated: scenario !== 'auth',
+        supported: scenario !== 'unsupported',
+        verificationState: scenario === 'error' ? 'error' : 'verified',
+        statusCheckOutcome: 'authoritative',
+        statusCheckErrorCode: scenario === 'unavailable' ? 'unavailable' : undefined,
+        modelCatalogRefreshState: scenario === 'catalog-error' ? 'error' : 'loading',
+        models: ['claude-haiku-4-5'],
+      });
+      provider.capabilities.teamLaunch = false;
+      const providers =
+        scenario === 'mixed'
+          ? [
+              provider,
+              createProvider({
+                providerId: 'opencode',
+                displayName: 'OpenCode',
+                verificationState: 'error',
+              }),
+            ]
+          : [provider];
+      const guard = createLaunchGuard(
+        scenario === 'mixed' ? ['anthropic', 'opencode'] : ['anthropic'],
+        new Map(providers.map((entry) => [entry.providerId, entry]))
+      );
+      expect(guard.blocked(true)).toBe(true);
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = createRoot(host);
+      await act(async () => {
+        root.render(
+          React.createElement(
+            React.Fragment,
+            null,
+            React.createElement(ProviderActivityStatusStrip, {
+              cliStatus: createMultimodelStatus(providers),
+              cliStatusLoading: false,
+              cliProviderStatusLoading: {},
+              multimodelEnabled: true,
+              showReadyProviders: true,
+            }),
+            React.createElement(ProviderLaunchAuthorityNotice, {
+              action: 'launch',
+              blockers: guard.blockers(true),
+              id: 'provider-refresh-notice',
+              onOpenProviderSettings: vi.fn(),
+            })
+          )
+        );
+      });
+      if (scenario === 'refresh') {
+        expect(host.textContent).toContain('Checking...');
+        expect(host.querySelector('#provider-refresh-notice')?.getAttribute('role')).toBe('status');
+        expect(host.textContent).not.toContain('Needs attention');
+        expect(host.querySelector('[role="alert"]')).toBeNull();
+      } else {
+        expect(host.textContent).toContain('Needs attention');
+        expect(host.querySelector('#provider-refresh-notice')?.getAttribute('role')).toBe('alert');
+        if (scenario === 'mixed') {
+          expect(host.querySelector('#provider-refresh-notice')?.textContent).toMatch(
+            /Anthropic.*checking/i
+          );
+        }
+      }
+      await act(async () => root.unmount());
+    }
+  );
+
   it.each([
     ['codex', true],
     ['codex', false],

--- a/test/renderer/components/team/TeamModelSelectorDisabledState.test.ts
+++ b/test/renderer/components/team/TeamModelSelectorDisabledState.test.ts
@@ -3035,7 +3035,12 @@ describe('TeamModelSelector disabled Codex models', () => {
         expect(activeOpenCodeButton?.getAttribute('data-state')).toBe('active');
       });
     });
-    expect(host.textContent).toContain('OpenCode is not ready for team launch');
+    expect(host.textContent).not.toContain('OpenCode is not ready for team launch');
+    expect(
+      host
+        .querySelector('[data-testid="team-model-selector-provider-status"]')
+        ?.getAttribute('data-tone')
+    ).toBe('info');
     expect(host.textContent).toContain('OpenCode status: checking runtime');
     expect(host.textContent).toContain(
       'The app is still checking the OpenCode runtime. Wait for provider status to finish, then try again.'
@@ -3847,7 +3852,8 @@ describe('TeamModelSelector disabled Codex models', () => {
     });
 
     expect(openCodeButton?.getAttribute('aria-disabled')).toBeNull();
-    expect(host.textContent).toContain('OpenCode is not ready for team launch');
+    expect(host.textContent).not.toContain('OpenCode is not ready for team launch');
+    expect(host.textContent).toContain('OpenCode runtime status is still loading.');
     expect(onValueChange).not.toHaveBeenCalled();
 
     await act(async () => {

--- a/test/renderer/components/team/TeamModelSelectorDisabledState.test.ts
+++ b/test/renderer/components/team/TeamModelSelectorDisabledState.test.ts
@@ -1415,7 +1415,7 @@ describe('TeamModelSelector disabled Codex models', () => {
     });
   });
 
-  it('keeps stale local OpenCode models visible without remote catalog loading', async () => {
+  it('refreshes stale passive OpenCode status while keeping local models visible without remote catalog loading', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     const loadModels = vi.fn(async () => providerModelsResponse('ollama'));
     installLoadModelsApi(loadModels);
@@ -1479,7 +1479,11 @@ describe('TeamModelSelector disabled Codex models', () => {
     });
 
     expect(loadModels).not.toHaveBeenCalled();
-    expect(storeState.fetchCliProviderStatus).not.toHaveBeenCalled();
+    expect(storeState.fetchCliProviderStatus).toHaveBeenCalledExactlyOnceWith('opencode', {
+      silent: true,
+      checkReason: 'launch_preflight',
+      projectPath: '/tmp/stale-project',
+    });
     expect(
       host.querySelector('[data-testid="team-model-selector-opencode-loading-skeleton"]')
     ).toBeNull();

--- a/test/renderer/components/team/TeamStatusBadge.test.tsx
+++ b/test/renderer/components/team/TeamStatusBadge.test.tsx
@@ -1,0 +1,99 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TeamStatus } from '@renderer/utils/teamListStatus';
+import type { LeadActivityState, TeamProvisioningProgress } from '@shared/types';
+
+const storeState = {
+  progress: null as TeamProvisioningProgress | null,
+  leadActivityByTeam: {} as Record<string, LeadActivityState>,
+  currentRuntimeRunIdByTeam: {} as Record<string, string>,
+};
+
+vi.mock('@renderer/store', () => ({
+  useStore: (selector: (state: typeof storeState) => unknown) => selector(storeState),
+}));
+vi.mock('@renderer/store/slices/teamSlice', () => ({
+  getCurrentProvisioningProgressForTeam: () => storeState.progress,
+  isTeamProvisioningActive: () => storeState.progress?.state === 'finalizing',
+}));
+
+import { TeamStatusBadge } from '@renderer/components/team/TeamStatusBadge';
+
+function renderBadge(status: TeamStatus = 'provisioning') {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  const render = () => {
+    act(() => root.render(<TeamStatusBadge teamName="sandbox-team" status={status} />));
+  };
+  render();
+  return { host, render, root };
+}
+
+describe('shared header and team-card status badge', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    storeState.progress = {
+      runId: 'current-run',
+      teamName: 'sandbox-team',
+      state: 'finalizing',
+      startedAt: '2026-09-06T12:00:00Z',
+      updatedAt: '2026-09-06T12:00:05Z',
+      message: 'Auditing bootstrap truth',
+    };
+    storeState.leadActivityByTeam = { 'sandbox-team': 'active' };
+    storeState.currentRuntimeRunIdByTeam = { 'sandbox-team': 'current-run' };
+  });
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps observed work as finishing startup across progress updates, never ready/running', () => {
+    const { host, render, root } = renderBadge();
+    expect(host.textContent).toBe('Finishing startup');
+    storeState.progress = { ...storeState.progress!, message: 'Checking teammate readiness' };
+    render();
+    expect(host.textContent).toBe('Finishing startup');
+    expect(host.textContent).not.toMatch(/Running|Ready/);
+    act(() => root.unmount());
+  });
+
+  it.each([
+    'missing-activity',
+    'idle',
+    'offline',
+    'missing-run',
+    'stale-run',
+    'ready',
+    'failed',
+    'cancelled',
+  ])('does not use %s as observed current startup work', (reason) => {
+    if (reason === 'missing-activity') storeState.leadActivityByTeam = {};
+    if (reason === 'idle' || reason === 'offline')
+      storeState.leadActivityByTeam['sandbox-team'] = reason;
+    if (reason === 'missing-run') storeState.currentRuntimeRunIdByTeam = {};
+    if (reason === 'stale-run') storeState.currentRuntimeRunIdByTeam['sandbox-team'] = 'older-run';
+    if (reason === 'ready' || reason === 'failed' || reason === 'cancelled')
+      storeState.progress!.state = reason;
+    const { host, root } = renderBadge();
+    expect(host.textContent).toBe('Launching...');
+    act(() => root.unmount());
+  });
+
+  it.each([
+    ['partial_failure', 'Launch failed partway'],
+    ['partial_skipped', 'Launch skipped member'],
+    ['partial_pending', 'Bootstrap pending'],
+    ['offline', 'Offline'],
+    ['idle', 'Running'],
+    ['active', 'Active'],
+  ] as const)('does not replace %s with finishing startup', (status, label) => {
+    const { host, root } = renderBadge(status);
+    expect(host.textContent).toBe(label);
+    act(() => root.unmount());
+  });
+});

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -703,9 +703,14 @@ function createAuthoritativeProviderStatus(
 }
 
 describe('LaunchTeamDialog', () => {
-  it.each(['create', 'launch'] as const)(
-    'enables %s skip while Codex authority is pending with a partial response',
-    async (mode) => {
+  it.each([
+    ['create', 'pending-codex'],
+    ['launch', 'pending-codex'],
+    ['create', 'refreshing-anthropic'],
+    ['launch', 'refreshing-anthropic'],
+  ] as const)(
+    'enables %s skip during %s without repeating completed deep checks',
+    async (mode, scenario) => {
       vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
       const modelAvailability = await vi.importActual<
         typeof import('@renderer/utils/teamModelAvailability')
@@ -719,34 +724,37 @@ describe('LaunchTeamDialog', () => {
       vi.mocked(isTeamProviderRuntimeStatusLoading).mockImplementation(
         runtimeLoading.isTeamProviderRuntimeStatusLoading
       );
-      localStorage.setItem('team:lastSelectedProvider', 'codex');
+      const refreshing = scenario === 'refreshing-anthropic';
+      localStorage.setItem('team:lastSelectedProvider', refreshing ? 'anthropic' : 'codex');
       localStorage.setItem('team:lastSelectedModel:codex', 'gpt-5.4');
+      localStorage.setItem('team:lastSelectedModel:anthropic', 'opus');
       createTeamDraftMock.state.soloTeam = true;
       const codex = storeState.cliStatus.providers.find(
         (provider) => provider.providerId === 'codex'
       )!;
-      Object.assign(codex, {
-        authenticated: false,
-        verificationState: 'unknown',
-        statusCheckOutcome: 'pending',
-        statusCheckErrorCode: 'partial_response',
-        modelCatalog: {
-          ...codex.modelCatalog,
-          source: 'static-fallback',
-          status: 'stale',
-          diagnostics: {
-            appServerState: 'degraded',
-            message: 'JSON-RPC request timed out: initialize',
+      if (!refreshing)
+        Object.assign(codex, {
+          authenticated: false,
+          verificationState: 'unknown',
+          statusCheckOutcome: 'pending',
+          statusCheckErrorCode: 'partial_response',
+          modelCatalog: {
+            ...codex.modelCatalog,
+            source: 'static-fallback',
+            status: 'stale',
+            diagnostics: {
+              appServerState: 'degraded',
+              message: 'JSON-RPC request timed out: initialize',
+            },
           },
-        },
-        modelVerificationState: 'idle',
-        modelCatalogRefreshState: 'loading',
-      });
+          modelVerificationState: 'idle',
+          modelCatalogRefreshState: 'loading',
+        });
       const submit = vi.fn(async () => {});
       const host = document.createElement('div');
       document.body.appendChild(host);
       const root = createRoot(host);
-      await act(async () => {
+      const renderDialog = () => {
         root.render(
           mode === 'create'
             ? React.createElement(CreateTeamDialog, {
@@ -775,13 +783,44 @@ describe('LaunchTeamDialog', () => {
                 onLaunch: submit,
               })
         );
+      };
+      await act(async () => {
+        renderDialog();
         await flush();
       });
-      for (let i = 0; i < 5; i++)
+      const settle = async () => {
+        for (let i = 0; i < 5; i++)
+          await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            await flush();
+          });
+      };
+      await settle();
+      const completedChecks = vi.mocked(runProviderPrepareDiagnostics).mock.calls.length;
+      if (refreshing) {
+        expect(completedChecks).toBeGreaterThan(0);
+        storeState.cliStatus = {
+          ...storeState.cliStatus,
+          providers: storeState.cliStatus.providers.map((provider) =>
+            provider.providerId === 'anthropic'
+              ? {
+                  ...provider,
+                  modelCatalogRefreshState: 'loading',
+                  modelCatalog: {
+                    ...provider.modelCatalog!,
+                    staleAt: new Date(Date.now() - 1).toISOString(),
+                  },
+                }
+              : provider
+          ),
+        };
         await act(async () => {
-          await new Promise((resolve) => setTimeout(resolve, 0));
+          renderDialog();
           await flush();
         });
+        await settle();
+        expect(vi.mocked(runProviderPrepareDiagnostics)).toHaveBeenCalledTimes(completedChecks);
+      }
       const button = Array.from(host.querySelectorAll('button')).find(
         (candidate) => candidate.textContent === `Skip preflight and ${mode}`
       );

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -620,7 +620,11 @@ import { CreateTeamDialog } from '@renderer/components/team/dialogs/CreateTeamDi
 import { LaunchTeamDialog } from '@renderer/components/team/dialogs/LaunchTeamDialog';
 import { runProviderPrepareDiagnostics } from '@renderer/components/team/dialogs/providerPrepareDiagnostics';
 import { getCliProviderStatusScopeKey } from '@renderer/store/slices/cliInstallerSlice';
-import { isTeamModelAvailableForUi } from '@renderer/utils/teamModelAvailability';
+import {
+  isTeamModelAvailableForUi,
+  isTeamProviderModelVerificationPending,
+} from '@renderer/utils/teamModelAvailability';
+import { isTeamProviderRuntimeStatusLoading } from '@renderer/utils/teamProviderRuntimeStatusLoading';
 import { createDefaultCliExtensionCapabilities } from '@shared/utils/providerExtensionCapabilities';
 
 import type { CliInstallationStatus, CliProviderId, CliProviderStatus } from '@shared/types';
@@ -699,6 +703,99 @@ function createAuthoritativeProviderStatus(
 }
 
 describe('LaunchTeamDialog', () => {
+  it.each(['create', 'launch'] as const)(
+    'enables %s skip while Codex authority is pending with a partial response',
+    async (mode) => {
+      vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+      const modelAvailability = await vi.importActual<
+        typeof import('@renderer/utils/teamModelAvailability')
+      >('@renderer/utils/teamModelAvailability');
+      const runtimeLoading = await vi.importActual<
+        typeof import('@renderer/utils/teamProviderRuntimeStatusLoading')
+      >('@renderer/utils/teamProviderRuntimeStatusLoading');
+      vi.mocked(isTeamProviderModelVerificationPending).mockImplementation(
+        modelAvailability.isTeamProviderModelVerificationPending
+      );
+      vi.mocked(isTeamProviderRuntimeStatusLoading).mockImplementation(
+        runtimeLoading.isTeamProviderRuntimeStatusLoading
+      );
+      localStorage.setItem('team:lastSelectedProvider', 'codex');
+      localStorage.setItem('team:lastSelectedModel:codex', 'gpt-5.4');
+      createTeamDraftMock.state.soloTeam = true;
+      const codex = storeState.cliStatus.providers.find(
+        (provider) => provider.providerId === 'codex'
+      )!;
+      Object.assign(codex, {
+        authenticated: false,
+        verificationState: 'unknown',
+        statusCheckOutcome: 'pending',
+        statusCheckErrorCode: 'partial_response',
+        modelCatalog: {
+          ...codex.modelCatalog,
+          source: 'static-fallback',
+          status: 'stale',
+          diagnostics: {
+            appServerState: 'degraded',
+            message: 'JSON-RPC request timed out: initialize',
+          },
+        },
+        modelVerificationState: 'idle',
+        modelCatalogRefreshState: 'loading',
+      });
+      const submit = vi.fn(async () => {});
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = createRoot(host);
+      await act(async () => {
+        root.render(
+          mode === 'create'
+            ? React.createElement(CreateTeamDialog, {
+                open: true,
+                canCreate: true,
+                provisioningErrorsByTeam: {},
+                clearProvisioningError: vi.fn(),
+                existingTeamNames: [],
+                provisioningTeamNames: [],
+                activeTeams: [],
+                defaultProjectPath: '/tmp/project',
+                onClose: vi.fn(),
+                onCreate: submit,
+                onOpenTeam: vi.fn(),
+              })
+            : React.createElement(LaunchTeamDialog, {
+                mode: 'launch',
+                open: true,
+                teamName: 'team-alpha',
+                members: [],
+                defaultProjectPath: '/tmp/project',
+                provisioningError: null,
+                clearProvisioningError: vi.fn(),
+                activeTeams: [],
+                onClose: vi.fn(),
+                onLaunch: submit,
+              })
+        );
+        await flush();
+      });
+      for (let i = 0; i < 5; i++)
+        await act(async () => {
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          await flush();
+        });
+      const button = Array.from(host.querySelectorAll('button')).find(
+        (candidate) => candidate.textContent === `Skip preflight and ${mode}`
+      );
+      expect(button, host.textContent ?? '').toBeDefined();
+      expect(button?.disabled).toBe(false);
+      await act(async () => {
+        button!.click();
+        await flush();
+      });
+      expect(submit).toHaveBeenCalledOnce();
+      await act(async () => root.unmount());
+    }
+  );
+
   it.each([
     ['create', 'anthropic', 'codex', false, ['anthropic', 'codex']],
     ['launch', 'anthropic', 'codex', false, ['anthropic', 'codex']],
@@ -1030,6 +1127,8 @@ describe('LaunchTeamDialog', () => {
   );
 
   beforeEach(() => {
+    vi.mocked(isTeamProviderModelVerificationPending).mockImplementation(() => false);
+    vi.mocked(isTeamProviderRuntimeStatusLoading).mockImplementation(() => false);
     vi.mocked(api.workspaceTrust!.getLaunchStatus!)
       .mockReset()
       .mockResolvedValue({ providers: [] });

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -113,6 +113,7 @@ vi.mock('@renderer/api', () => ({
       ),
     },
     teams: {
+      createConfig: vi.fn(async () => {}),
       getSavedRequest: vi.fn(async () => null),
       replaceMembers: vi.fn(async () => {}),
       prepareProvisioning: vi.fn(async () => ({})),
@@ -4418,6 +4419,83 @@ describe('LaunchTeamDialog', () => {
       root.unmount();
       await flush();
     });
+  });
+
+  it('clears completed create preflight while selection is unresolved but permits create without launch', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.useFakeTimers();
+    const onCreate = vi.fn(async () => {});
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const render = () =>
+      root.render(
+        React.createElement(CreateTeamDialog, {
+          open: true,
+          canCreate: true,
+          provisioningErrorsByTeam: {},
+          clearProvisioningError: vi.fn(),
+          existingTeamNames: [],
+          provisioningTeamNames: [],
+          activeTeams: [],
+          defaultProjectPath: '/tmp/project',
+          onClose: vi.fn(),
+          onCreate,
+          onOpenTeam: vi.fn(),
+        })
+      );
+    const settle = async () => {
+      for (let attempt = 0; attempt < 4; attempt++)
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+          await flush();
+        });
+    };
+    const submit = () => host.querySelector<HTMLButtonElement>('button.min-w-32')!;
+    await act(async () => {
+      render();
+      await flush();
+    });
+    await settle();
+    expect(submit()).not.toBeNull();
+    expect(submit().disabled).toBe(false);
+    expect(host.textContent).toContain('All selected providers are ready.');
+    createTeamDraftMock.state.selectedProjectPath = '/tmp/unresolved-project';
+    await act(async () => {
+      render();
+      await flush();
+    });
+    expect(submit().disabled).toBe(true);
+    expect(host.textContent).not.toContain('All selected providers are ready.');
+    await act(async () => {
+      submit().click();
+      await flush();
+    });
+    expect(onCreate).not.toHaveBeenCalled();
+    createTeamDraftMock.state.selectedProjectPath = '/tmp/project';
+    await act(async () => {
+      render();
+      await flush();
+    });
+    await settle();
+    expect(submit().disabled).toBe(false);
+    expect(host.textContent).toContain('All selected providers are ready.');
+    createTeamDraftMock.state.selectedProjectPath = '';
+    createTeamDraftMock.state.launchTeam = false;
+    await act(async () => {
+      render();
+      await flush();
+    });
+    expect(submit().disabled).toBe(false);
+    await act(async () => {
+      submit().click();
+      await flush();
+    });
+    expect(api.teams.createConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: undefined })
+    );
+    expect(onCreate).not.toHaveBeenCalled();
+    await act(async () => root.unmount());
   });
 
   it.each(['project', 'custom'] as const)(

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -1103,6 +1103,7 @@ describe('LaunchTeamDialog', () => {
     localStorage.clear();
     vi.useRealTimers();
     vi.clearAllMocks();
+    createTeamDraftMock.state.setCwdMode.mockReset();
     storeState.cliStatus = { providers: [] };
     storeState.cliProviderStatusByScope = {};
     storeState.cliProviderStatusLoading = {};
@@ -1547,6 +1548,54 @@ describe('LaunchTeamDialog', () => {
       root.unmount();
       await flush();
     });
+  });
+
+  it('starts preflight with user choices when a roster refresh cancels pending hydration', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.useFakeTimers();
+    vi.mocked(api.teams.getSavedRequest).mockReturnValueOnce(new Promise(() => {}));
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const render = () =>
+      root.render(
+        React.createElement(LaunchTeamDialog, {
+          mode: 'launch',
+          open: true,
+          teamName: 'team-alpha',
+          members: [],
+          defaultProjectPath: '/tmp/project',
+          provisioningError: null,
+          clearProvisioningError: vi.fn(),
+          activeTeams: [],
+          onClose: vi.fn(),
+          onLaunch: vi.fn(async () => {}),
+        })
+      );
+    await act(async () => {
+      render();
+      await flush();
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(runProviderPrepareDiagnostics).not.toHaveBeenCalled();
+    await act(async () => {
+      teamRosterEditorSectionMock.lastProps.onSyncModelsWithTeammatesChange(true);
+      await flush();
+    });
+    await act(async () => {
+      render();
+      await flush();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    expect(teamRosterEditorSectionMock.lastProps.syncModelsWithTeammates).toBe(true);
+    expect(runProviderPrepareDiagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: '/tmp/project' })
+    );
+    expect(api.teams.getSavedRequest).toHaveBeenCalledTimes(1);
+    await act(async () => root.unmount());
   });
 
   it('keeps a programmatic effort reset from cancelling saved-request hydration', async () => {
@@ -4307,143 +4356,152 @@ describe('LaunchTeamDialog', () => {
     });
   });
 
-  it('starts detailed create-team preflight only after the current project selection settles', async () => {
-    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
-    vi.useFakeTimers();
-    storeState.cliStatus = {
-      flavor: 'agent_teams_orchestrator',
-      providers: [
-        {
-          ...createAuthoritativeProviderStatus('anthropic', ['haiku']),
-          modelVerificationState: 'verified',
-        },
-        {
-          ...createAuthoritativeProviderStatus('codex', ['gpt-5.5']),
-          authMethod: 'chatgpt',
-          modelVerificationState: 'verified',
-          selectedBackendId: 'codex-native',
-          resolvedBackendId: 'codex-native',
-        },
-        {
-          ...createAuthoritativeProviderStatus('opencode', ['opencode/big-pickle']),
-          authMethod: 'opencode_managed',
-          modelVerificationState: 'verified',
-          statusMessage: 'warming up',
-          detailMessage: 'first render',
-          capabilities: {
-            teamLaunch: true,
-            oneShot: false,
-            extensions: createDefaultCliExtensionCapabilities(),
+  it.each(['project', 'custom'] as const)(
+    'starts detailed create-team preflight only after the current project selection settles from %s mode',
+    async (initialCwdMode) => {
+      vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+      vi.useFakeTimers();
+      storeState.cliStatus = {
+        flavor: 'agent_teams_orchestrator',
+        providers: [
+          {
+            ...createAuthoritativeProviderStatus('anthropic', ['haiku']),
+            modelVerificationState: 'verified',
           },
-        },
-      ],
-    } as any;
-    await fetchCliProviderStatus('opencode', {
-      silent: true,
-      checkReason: 'launch_preflight',
-      projectPath: '/tmp/project',
-    });
-    fetchCliProviderStatus.mockClear();
-    let resolvePrepare!: (value: {
-      status: 'ready';
-      warnings: [];
-      details: [];
-      modelResultsById: {};
-    }) => void;
-    const preparePromise = new Promise<{
-      status: 'ready';
-      warnings: [];
-      details: [];
-      modelResultsById: {};
-    }>((resolve) => {
-      resolvePrepare = resolve;
-    });
-    vi.mocked(runProviderPrepareDiagnostics).mockReturnValue(preparePromise as any);
-
-    const host = document.createElement('div');
-    document.body.appendChild(host);
-    const root = createRoot(host);
-
-    createTeamDraftMock.state.selectedProjectPath = '/tmp/stale-real-project';
-    const renderDialog = async (): Promise<void> => {
-      root.render(
-        React.createElement(CreateTeamDialog, {
-          open: true,
-          canCreate: true,
-          provisioningErrorsByTeam: {},
-          clearProvisioningError: vi.fn(),
-          existingTeamNames: [],
-          provisioningTeamNames: [],
-          activeTeams: [],
-          defaultProjectPath: '/tmp/project',
-          onClose: vi.fn(),
-          onCreate: vi.fn(async () => {}),
-          onOpenTeam: vi.fn(),
-        })
-      );
-      await flush();
-    };
-
-    await act(async () => {
-      await renderDialog();
-      await flush();
-    });
-    await act(async () => {
-      vi.runOnlyPendingTimers();
-      await flush();
-    });
-    await act(async () => {
-      vi.runOnlyPendingTimers();
-      await flush();
-    });
-
-    expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
-    expect(fetchCliProviderStatus).not.toHaveBeenCalled();
-
-    createTeamDraftMock.state.selectedProjectPath = '/tmp/project';
-    await act(async () => {
-      await renderDialog();
-      await flush();
-    });
-
-    await act(async () => {
-      vi.runOnlyPendingTimers();
-      await flush();
-    });
-
-    expect(
-      new Set(
-        vi.mocked(runProviderPrepareDiagnostics).mock.calls.map(([input]) => input.providerId)
-      )
-    ).toEqual(new Set(['anthropic', 'codex', 'opencode']));
-    expect(
-      vi
-        .mocked(runProviderPrepareDiagnostics)
-        .mock.calls.every(([input]) => input.cwd === '/tmp/project')
-    ).toBe(true);
-    expect(
-      vi
-        .mocked(runProviderPrepareDiagnostics)
-        .mock.calls.flatMap(([input]) => input.selectedModelIds)
-    ).toEqual(expect.arrayContaining(['gpt-5.5', 'opencode/big-pickle']));
-
-    await act(async () => {
-      resolvePrepare({
-        status: 'ready',
-        warnings: [],
-        details: [],
-        modelResultsById: {},
+          {
+            ...createAuthoritativeProviderStatus('codex', ['gpt-5.5']),
+            authMethod: 'chatgpt',
+            modelVerificationState: 'verified',
+            selectedBackendId: 'codex-native',
+            resolvedBackendId: 'codex-native',
+          },
+          {
+            ...createAuthoritativeProviderStatus('opencode', ['opencode/big-pickle']),
+            authMethod: 'opencode_managed',
+            modelVerificationState: 'verified',
+            statusMessage: 'warming up',
+            detailMessage: 'first render',
+            capabilities: {
+              teamLaunch: true,
+              oneShot: false,
+              extensions: createDefaultCliExtensionCapabilities(),
+            },
+          },
+        ],
+      } as any;
+      await fetchCliProviderStatus('opencode', {
+        silent: true,
+        checkReason: 'launch_preflight',
+        projectPath: '/tmp/project',
       });
-      await flush();
-      await flush();
-    });
-    expect(vi.mocked(runProviderPrepareDiagnostics)).toHaveBeenCalledTimes(3);
+      fetchCliProviderStatus.mockClear();
+      let resolvePrepare!: (value: {
+        status: 'ready';
+        warnings: [];
+        details: [];
+        modelResultsById: {};
+      }) => void;
+      const preparePromise = new Promise<{
+        status: 'ready';
+        warnings: [];
+        details: [];
+        modelResultsById: {};
+      }>((resolve) => {
+        resolvePrepare = resolve;
+      });
+      vi.mocked(runProviderPrepareDiagnostics).mockReturnValue(preparePromise as any);
 
-    await act(async () => {
-      root.unmount();
-      await flush();
-    });
-  });
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = createRoot(host);
+
+      createTeamDraftMock.state.selectedProjectPath = '/tmp/stale-real-project';
+      createTeamDraftMock.state.cwdMode = initialCwdMode;
+      createTeamDraftMock.state.customCwd = '/tmp/stale-custom-project';
+      createTeamDraftMock.state.setCwdMode.mockImplementation((mode) => {
+        createTeamDraftMock.state.cwdMode = mode;
+      });
+      const renderDialog = async (): Promise<void> => {
+        root.render(
+          React.createElement(CreateTeamDialog, {
+            open: true,
+            canCreate: true,
+            provisioningErrorsByTeam: {},
+            clearProvisioningError: vi.fn(),
+            existingTeamNames: [],
+            provisioningTeamNames: [],
+            activeTeams: [],
+            defaultProjectPath: '/tmp/project',
+            forceDefaultProjectSelection: true,
+            onClose: vi.fn(),
+            onCreate: vi.fn(async () => {}),
+            onOpenTeam: vi.fn(),
+          })
+        );
+        await flush();
+      };
+
+      await act(async () => {
+        await renderDialog();
+        await flush();
+      });
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+        await flush();
+      });
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+        await flush();
+      });
+
+      expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
+      expect(fetchCliProviderStatus).not.toHaveBeenCalled();
+
+      createTeamDraftMock.state.selectedProjectPath = '/tmp/project';
+      await act(async () => {
+        await renderDialog();
+        await flush();
+      });
+
+      await act(async () => {
+        vi.runOnlyPendingTimers();
+        await flush();
+      });
+
+      expect(
+        new Set(
+          vi.mocked(runProviderPrepareDiagnostics).mock.calls.map(([input]) => input.providerId)
+        )
+      ).toEqual(new Set(['anthropic', 'codex', 'opencode']));
+      expect(
+        vi
+          .mocked(runProviderPrepareDiagnostics)
+          .mock.calls.every(([input]) => input.cwd === '/tmp/project')
+      ).toBe(true);
+      expect(
+        vi
+          .mocked(runProviderPrepareDiagnostics)
+          .mock.calls.flatMap(([input]) => input.selectedModelIds)
+      ).toEqual(expect.arrayContaining(['gpt-5.5', 'opencode/big-pickle']));
+
+      await act(async () => {
+        resolvePrepare({
+          status: 'ready',
+          warnings: [],
+          details: [],
+          modelResultsById: {},
+        });
+        await flush();
+        await flush();
+      });
+      expect(vi.mocked(runProviderPrepareDiagnostics)).toHaveBeenCalledTimes(3);
+
+      await act(async () => {
+        root.unmount();
+        await flush();
+      });
+    }
+  );
 
   it('does not report the submitted team name as a duplicate while creation is in flight', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -615,11 +615,13 @@ vi.mock('@renderer/components/team/dialogs/CodexFastModeSelector', () => ({
     ),
 }));
 
+import { sanitizeProviderStatusAuthority } from '@main/services/runtime/providerStatusCheckContract';
 import { api } from '@renderer/api';
 import { CreateTeamDialog } from '@renderer/components/team/dialogs/CreateTeamDialog';
 import { LaunchTeamDialog } from '@renderer/components/team/dialogs/LaunchTeamDialog';
 import { runProviderPrepareDiagnostics } from '@renderer/components/team/dialogs/providerPrepareDiagnostics';
 import { getCliProviderStatusScopeKey } from '@renderer/store/slices/cliInstallerSlice';
+import { reconcileCliProviderSnapshot } from '@renderer/store/slices/cliInstallerStatusReconciliation';
 import {
   isTeamModelAvailableForUi,
   isTeamProviderModelVerificationPending,
@@ -803,17 +805,24 @@ describe('LaunchTeamDialog', () => {
           ...storeState.cliStatus,
           providers: storeState.cliStatus.providers.map((provider) =>
             provider.providerId === 'anthropic'
-              ? {
-                  ...provider,
-                  modelCatalogRefreshState: 'loading',
-                  modelCatalog: {
-                    ...provider.modelCatalog!,
-                    staleAt: new Date(Date.now() - 1).toISOString(),
-                  },
-                }
+              ? reconcileCliProviderSnapshot(
+                  provider,
+                  sanitizeProviderStatusAuthority({
+                    ...provider,
+                    modelCatalogRefreshState: 'loading',
+                    modelCatalog: null,
+                    runtimeCapabilities: { modelCatalog: { dynamic: true } },
+                  })
+                )
               : provider
           ),
         };
+        expect(
+          storeState.cliStatus.providers.find((provider) => provider.providerId === 'anthropic')
+        ).toMatchObject({
+          capabilities: { teamLaunch: false },
+          teamLaunchAuthorityRestriction: 'catalog-refresh',
+        });
         await act(async () => {
           renderDialog();
           await flush();

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -631,10 +631,6 @@ async function confirmLaunchPreflight(
   if (!button) {
     throw new Error(`Expected "${label}" button.`);
   }
-  await act(async () => {
-    button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    await flush();
-  });
   for (let attempt = 0; attempt < 4; attempt += 1) {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -816,7 +812,11 @@ describe('LaunchTeamDialog', () => {
       expect(host.textContent).not.toContain('First launch');
       expect(host.textContent).not.toContain('Project status unknown');
       expect(submit()?.disabled).toBe(false);
-      expect(runProviderPrepareDiagnostics).not.toHaveBeenCalled();
+      expect(
+        new Set(
+          vi.mocked(runProviderPrepareDiagnostics).mock.calls.map(([input]) => input.providerId)
+        )
+      ).toEqual(new Set(expectedProviders));
       await act(async () => root.unmount());
     }
   );
@@ -950,12 +950,6 @@ describe('LaunchTeamDialog', () => {
         Array.from(host.querySelectorAll('button')).find(
           (button) => button.textContent?.trim() === label
         )!;
-      const first = findButton(mode === 'create' ? 'Create' : 'Launch team');
-      await act(async () => {
-        first.click();
-        await flush();
-      });
-      await settle();
       const skipLabel =
         mode === 'create' ? 'Skip preflight and create' : 'Skip preflight and launch';
       const skip = findButton(skipLabel);
@@ -1440,7 +1434,12 @@ describe('LaunchTeamDialog', () => {
 
   it('hydrates existing teammate models before a slow saved-request lookup completes', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
-    vi.mocked(api.teams.getSavedRequest).mockReturnValueOnce(new Promise(() => {}));
+    let resolveSavedRequest!: (value: any) => void;
+    vi.mocked(api.teams.getSavedRequest).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSavedRequest = resolve;
+      })
+    );
     const localModel = 'ollama/qwen2.5-coder:0.5b';
     vi.mocked(isTeamModelAvailableForUi).mockImplementation(
       (_providerId, model, providerStatus) => providerStatus?.models?.includes(model ?? '') ?? false
@@ -1525,6 +1524,12 @@ describe('LaunchTeamDialog', () => {
         model: localModel,
       }),
     ]);
+    expect(runProviderPrepareDiagnostics).not.toHaveBeenCalled();
+    await act(async () => {
+      resolveSavedRequest(null);
+      await flush();
+    });
+    await confirmLaunchPreflight(host);
     expect(
       vi
         .mocked(runProviderPrepareDiagnostics)
@@ -1546,6 +1551,7 @@ describe('LaunchTeamDialog', () => {
 
   it('keeps a programmatic effort reset from cancelling saved-request hydration', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.useFakeTimers();
     localStorage.setItem('team:lastSelectedEffort', 'xhigh');
     let resolveSavedRequest: (value: unknown) => void = () => {};
     vi.mocked(api.teams.getSavedRequest).mockReturnValueOnce(
@@ -1582,6 +1588,11 @@ describe('LaunchTeamDialog', () => {
       teamRosterEditorSectionMock.lastProps?.onEffortAutoReset();
       await flush();
     });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    expect(runProviderPrepareDiagnostics).not.toHaveBeenCalled();
 
     await act(async () => {
       resolveSavedRequest({
@@ -1600,6 +1611,17 @@ describe('LaunchTeamDialog', () => {
     ]);
     // The auto reset kept the form pristine, so the saved request fields still hydrate.
     expect(teamRosterEditorSectionMock.lastProps?.providerId).toBe('codex');
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    expect(runProviderPrepareDiagnostics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: '/tmp/project',
+        providerId: 'codex',
+        selectedModelIds: expect.arrayContaining(['gpt-5.5']),
+      })
+    );
 
     await act(async () => {
       root.unmount();
@@ -2290,14 +2312,6 @@ describe('LaunchTeamDialog', () => {
       );
       await flush();
     });
-    const createButton = Array.from(host.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Create'
-    );
-    expect(createButton?.disabled).toBe(false);
-    await act(async () => {
-      createButton?.click();
-      await flush();
-    });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
       await flush();
@@ -2415,14 +2429,6 @@ describe('LaunchTeamDialog', () => {
           onOpenTeam: vi.fn(),
         })
       );
-      await flush();
-    });
-    const createButton = Array.from(host.querySelectorAll('button')).find(
-      (button) => button.textContent === 'Create'
-    );
-    expect(createButton?.disabled).toBe(false);
-    await act(async () => {
-      createButton?.click();
       await flush();
     });
     await act(async () => {
@@ -3864,13 +3870,12 @@ describe('LaunchTeamDialog', () => {
       await renderDialog();
     });
 
-    expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
+    expect(vi.mocked(runProviderPrepareDiagnostics)).toHaveBeenCalledTimes(1);
     expect(fetchCliProviderStatus).not.toHaveBeenCalled();
     const initialLaunchButton = Array.from(host.querySelectorAll('button')).find(
       (button) => button.textContent === 'Launch team'
     );
     await act(async () => {
-      initialLaunchButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
       await new Promise((resolve) => setTimeout(resolve, 0));
       await flush();
     });
@@ -4232,7 +4237,7 @@ describe('LaunchTeamDialog', () => {
       attempt += 1
     ) {
       await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        await new Promise((resolve) => setTimeout(resolve, 25));
         await flush();
       });
     }
@@ -4302,7 +4307,7 @@ describe('LaunchTeamDialog', () => {
     });
   });
 
-  it('does not start create-team preflight across same-signature rerenders before confirmation', async () => {
+  it('starts detailed create-team preflight only after the current project selection settles', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     vi.useFakeTimers();
     storeState.cliStatus = {
@@ -4359,6 +4364,7 @@ describe('LaunchTeamDialog', () => {
     document.body.appendChild(host);
     const root = createRoot(host);
 
+    createTeamDraftMock.state.selectedProjectPath = '/tmp/stale-real-project';
     const renderDialog = async (): Promise<void> => {
       root.render(
         React.createElement(CreateTeamDialog, {
@@ -4394,12 +4400,32 @@ describe('LaunchTeamDialog', () => {
     expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
     expect(fetchCliProviderStatus).not.toHaveBeenCalled();
 
+    createTeamDraftMock.state.selectedProjectPath = '/tmp/project';
     await act(async () => {
       await renderDialog();
       await flush();
     });
 
-    expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
+    await act(async () => {
+      vi.runOnlyPendingTimers();
+      await flush();
+    });
+
+    expect(
+      new Set(
+        vi.mocked(runProviderPrepareDiagnostics).mock.calls.map(([input]) => input.providerId)
+      )
+    ).toEqual(new Set(['anthropic', 'codex', 'opencode']));
+    expect(
+      vi
+        .mocked(runProviderPrepareDiagnostics)
+        .mock.calls.every(([input]) => input.cwd === '/tmp/project')
+    ).toBe(true);
+    expect(
+      vi
+        .mocked(runProviderPrepareDiagnostics)
+        .mock.calls.flatMap(([input]) => input.selectedModelIds)
+    ).toEqual(expect.arrayContaining(['gpt-5.5', 'opencode/big-pickle']));
 
     await act(async () => {
       resolvePrepare({
@@ -4411,7 +4437,7 @@ describe('LaunchTeamDialog', () => {
       await flush();
       await flush();
     });
-    expect(vi.mocked(runProviderPrepareDiagnostics)).not.toHaveBeenCalled();
+    expect(vi.mocked(runProviderPrepareDiagnostics)).toHaveBeenCalledTimes(3);
 
     await act(async () => {
       root.unmount();

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -16,6 +16,7 @@ const fetchCliProviderStatus = vi.fn<
 const createSchedule = vi.fn();
 const updateSchedule = vi.fn();
 const teamRosterEditorSectionMock = vi.hoisted(() => ({ lastProps: null as any }));
+const projectPathSelectorMock = vi.hoisted(() => ({ onSelect: (_path: string) => {} }));
 type TestCliStatus = Pick<CliInstallationStatus, 'providers'> &
   Partial<Pick<CliInstallationStatus, 'flavor'>>;
 const createTeamDraftMock = vi.hoisted(() => ({
@@ -302,8 +303,16 @@ vi.mock('@renderer/components/team/dialogs/OptionalSettingsSection', () => ({
 }));
 
 vi.mock('@renderer/components/team/dialogs/ProjectPathSelector', () => ({
-  ProjectPathSelector: ({ selectedProjectPath }: { selectedProjectPath: string }) =>
-    React.createElement('div', { 'data-testid': 'project-path' }, selectedProjectPath),
+  ProjectPathSelector: ({
+    selectedProjectPath,
+    onSelectedProjectPathChange,
+  }: {
+    selectedProjectPath: string;
+    onSelectedProjectPathChange: (path: string) => void;
+  }) => {
+    projectPathSelectorMock.onSelect = onSelectedProjectPathChange;
+    return React.createElement('div', { 'data-testid': 'project-path' }, selectedProjectPath);
+  },
 }));
 
 vi.mock('@renderer/components/ui/button', () => ({
@@ -1548,6 +1557,61 @@ describe('LaunchTeamDialog', () => {
       root.unmount();
       await flush();
     });
+  });
+
+  it('invalidates ready checks and blocks launch while project selection is unresolved', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.useFakeTimers();
+    const onLaunch = vi.fn(async () => {});
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    await act(async () => {
+      root.render(
+        React.createElement(LaunchTeamDialog, {
+          mode: 'launch',
+          open: true,
+          teamName: 'team-alpha',
+          members: [],
+          defaultProjectPath: '/tmp/project',
+          provisioningError: null,
+          clearProvisioningError: vi.fn(),
+          activeTeams: [],
+          onClose: vi.fn(),
+          onLaunch,
+        })
+      );
+      await flush();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    const submit = () =>
+      Array.from(host.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Launch team'
+      )!;
+    expect(submit().disabled).toBe(false);
+    expect(host.textContent).toContain('All selected providers are ready.');
+    await act(async () => {
+      projectPathSelectorMock.onSelect('/tmp/unresolved-project');
+      await flush();
+    });
+    expect(submit().disabled).toBe(true);
+    expect(host.textContent).not.toContain('All selected providers are ready.');
+    await act(async () => {
+      submit().click();
+      await flush();
+    });
+    expect(onLaunch).not.toHaveBeenCalled();
+    expect(api.teams.replaceMembers).not.toHaveBeenCalled();
+    await act(async () => {
+      projectPathSelectorMock.onSelect('/tmp/project');
+      await flush();
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(submit().disabled).toBe(false);
+    await act(async () => root.unmount());
   });
 
   it('starts preflight with user choices when a roster refresh cancels pending hydration', async () => {

--- a/test/renderer/components/team/dialogs/ProviderPrepareReadyNotice.test.tsx
+++ b/test/renderer/components/team/dialogs/ProviderPrepareReadyNotice.test.tsx
@@ -1,0 +1,48 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { ProviderPrepareReadyNotice } from '@renderer/components/team/dialogs/ProviderPrepareReadyNotice';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@features/localization/renderer', () => ({
+  useAppTranslation: () => ({
+    t: (key: string) =>
+      key.endsWith('readyWithNotes') ? 'Ready with notes.' : 'All selected providers are ready.',
+  }),
+}));
+vi.mock('@renderer/components/team/dialogs/ProvisioningProviderStatusList', () => ({
+  ProvisioningProviderStatusList: () => null,
+}));
+
+describe('ProviderPrepareReadyNotice', () => {
+  beforeEach(() => vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true));
+  afterEach(() => vi.unstubAllGlobals());
+  it.each([
+    ['All selected providers are ready.', [], 0],
+    ['  All selected providers are ready.  ', [], 0],
+    ['Ready with notes.', ['Optional note'], 0],
+    ['Selected model was verified.', [], 1],
+  ] as const)(
+    'does not repeat the heading but retains distinct detail: %s',
+    async (message, warnings, count) => {
+      const host = document.createElement('div');
+      const root = createRoot(host);
+      try {
+        await act(async () => {
+          root.render(
+            <ProviderPrepareReadyNotice
+              checks={[]}
+              message={message}
+              warnings={[...warnings]}
+              onOpenProviderSettings={() => {}}
+            />
+          );
+        });
+        expect(host.querySelectorAll('p.mt-0\\.5')).toHaveLength(count);
+        if (count) expect(host.textContent).toContain(message);
+      } finally {
+        await act(async () => root.unmount());
+      }
+    }
+  );
+});

--- a/test/renderer/components/team/dialogs/ProvisioningProviderStatusList.test.ts
+++ b/test/renderer/components/team/dialogs/ProvisioningProviderStatusList.test.ts
@@ -828,6 +828,21 @@ describe('ProvisioningProviderStatusList', () => {
     });
   });
 
+  it('updates the progress message when one of the previously pending providers settles', () => {
+    expect(
+      deriveEffectiveProvisioningPrepareState({
+        state: 'loading',
+        message: 'Checking Codex, OpenCode providers...',
+        warnings: [],
+        checks: [
+          { providerId: 'anthropic', status: 'ready', details: [] },
+          { providerId: 'codex', status: 'pending', details: [] },
+          { providerId: 'opencode', status: 'ready', details: [] },
+        ],
+      })
+    ).toEqual({ state: 'loading', message: 'Checking Codex provider...' });
+  });
+
   it('exposes only terminal successful providers as ready for model selectors', () => {
     expect(
       getProvisioningProviderReadyById([

--- a/test/renderer/components/team/dialogs/openCodeRuntimeStatusUi.test.ts
+++ b/test/renderer/components/team/dialogs/openCodeRuntimeStatusUi.test.ts
@@ -77,6 +77,16 @@ describe('OpenCode pending launch presentation', () => {
       reason,
     });
   });
+  it('does not call a ready catalog launch-blocked while renderer authority is still gated', () => {
+    const providerStatus = { ...connected, modelCatalog: { status: 'ready' } } as CliProviderStatus;
+    expect(
+      getOpenCodeRuntimeStatusUiState({
+        providerStatus,
+        runtimeStatus,
+        runtimeStatusLoading: false,
+      })
+    ).toBe('checking');
+  });
   it.each([
     { verificationState: 'error' },
     { modelCatalogRefreshState: 'error' },

--- a/test/renderer/components/team/dialogs/openCodeRuntimeStatusUi.test.ts
+++ b/test/renderer/components/team/dialogs/openCodeRuntimeStatusUi.test.ts
@@ -1,4 +1,8 @@
-import { isOpenCodePassiveStatusReadyForCatalog } from '@renderer/components/team/dialogs/openCodeRuntimeStatusUi';
+import {
+  getOpenCodeDisabledPanelPresentation,
+  getOpenCodeRuntimeStatusUiState,
+  isOpenCodePassiveStatusReadyForCatalog,
+} from '@renderer/components/team/dialogs/openCodeRuntimeStatusUi';
 import { describe, expect, it } from 'vitest';
 
 import type { CliProviderStatus, OpenCodeRuntimeStatus } from '@shared/types';
@@ -32,5 +36,60 @@ describe('isOpenCodePassiveStatusReadyForCatalog', () => {
     expect(
       isOpenCodePassiveStatusReadyForCatalog(status('authoritative', false), runtimeStatus)
     ).toBe(false);
+  });
+});
+
+describe('OpenCode pending launch presentation', () => {
+  const connected = {
+    ...status('authoritative', true),
+    authenticated: true,
+    verificationState: 'verified',
+    modelVerificationState: 'idle',
+    modelCatalogRefreshState: 'ready',
+    capabilities: { teamLaunch: false },
+    detailMessage: 'version 1.17.18 - auth /test/auth.json',
+  } as CliProviderStatus;
+  const translate = ((key: string) => key) as Parameters<
+    typeof getOpenCodeDisabledPanelPresentation
+  >[3];
+  it('presents catalog-gated connected runtime as pending without raw diagnostics or Ready', () => {
+    const uiState = getOpenCodeRuntimeStatusUiState({
+      providerStatus: connected,
+      runtimeStatus,
+      runtimeStatusLoading: false,
+    });
+    expect(uiState).toBe('checking');
+    expect(
+      getOpenCodeDisabledPanelPresentation(uiState, connected.detailMessage!, null, translate)
+    ).toMatchObject({
+      tone: 'info',
+      title: 'modelSelector.openCodeStatus.loadingRuntime',
+      reason: null,
+    });
+  });
+  it('preserves explicit selected-model failure overrides during a passive check', () => {
+    const reason = 'Selected model failed the Agent Teams protocol check';
+    expect(
+      getOpenCodeDisabledPanelPresentation('checking', reason, reason, translate)
+    ).toMatchObject({
+      tone: 'warning',
+      title: 'modelSelector.openCodeStatus.notReadyTitle',
+      reason,
+    });
+  });
+  it.each([
+    { verificationState: 'error' },
+    { modelCatalogRefreshState: 'error' },
+    { modelVerificationState: 'verified' },
+    { modelCatalog: { status: 'degraded' } },
+    { modelCatalog: { status: 'unavailable' } },
+  ])('does not turn terminal failure into pending: %j', (overrides) => {
+    expect(
+      getOpenCodeRuntimeStatusUiState({
+        providerStatus: { ...connected, ...overrides } as CliProviderStatus,
+        runtimeStatus,
+        runtimeStatusLoading: false,
+      })
+    ).toBe('ready');
   });
 });

--- a/test/renderer/components/team/dialogs/optionalProviderPreflight.test.ts
+++ b/test/renderer/components/team/dialogs/optionalProviderPreflight.test.ts
@@ -1,7 +1,9 @@
 import {
   canSkipOptionalProviderPreflight,
   canSkipPendingProviderDiscovery,
+  canSkipProviderPreflight,
   createProviderSubmissionFence,
+  getPendingProviderPreflightIds,
   resumeInterruptedProviderPreflight,
 } from '@renderer/components/team/dialogs/optionalProviderPreflight';
 import { createDefaultCliExtensionCapabilities } from '@shared/utils/providerExtensionCapabilities';
@@ -70,6 +72,80 @@ const check = (
 
 describe('optional provider preflight skip', () => {
   afterEach(() => vi.useRealTimers());
+  it('keeps only the unfinished provider badge checking in a mixed preflight', () => {
+    expect(
+      getPendingProviderPreflightIds(
+        'loading',
+        ['anthropic', 'codex', 'opencode'],
+        [check('anthropic', 'ready'), check('codex', 'pending'), check('opencode', 'ready')]
+      )
+    ).toEqual(['codex']);
+  });
+  it('keeps shallow compatibility checking until its remaining deep work finishes', () => {
+    expect(
+      getPendingProviderPreflightIds(
+        'loading',
+        ['anthropic', 'codex', 'opencode'],
+        [
+          {
+            ...check('anthropic', 'checking'),
+            details: ['Selected model is available for launch.'],
+          },
+          check('opencode', 'failed'),
+        ]
+      )
+    ).toEqual(['anthropic', 'codex']);
+  });
+  it.each(['idle', 'loading'] as const)(
+    'allows skipping %s optional checks with a pending partial Codex discovery response',
+    (state) => {
+      const statuses = new Map<TeamProviderId, CliProviderStatus>([
+        ['anthropic', provider('anthropic')],
+        [
+          'codex',
+          {
+            ...provider('codex'),
+            authenticated: false,
+            verificationState: 'unknown',
+            statusCheckOutcome: 'pending',
+            statusCheckErrorCode: 'partial_response',
+            modelCatalog: null,
+          },
+        ],
+        ['opencode', provider('opencode')],
+      ]);
+      expect(
+        canSkipProviderPreflight(
+          state,
+          [...statuses.keys()],
+          statuses,
+          new Map(),
+          [check('anthropic', 'ready'), check('codex', 'pending'), check('opencode', 'ready')],
+          NOW
+        )
+      ).toBe(true);
+    }
+  );
+  it.each([
+    { authenticated: false },
+    { supported: false },
+    { verificationState: 'error' as const },
+    { statusCheckErrorCode: 'runtime_missing' as const },
+    { statusCheckErrorCode: 'unavailable' as const },
+  ])('never skips a known failure during background loading: %j', (override) => {
+    const statuses = new Map([['codex' as const, { ...provider('codex'), ...override }]]);
+    const loading = new Map([['codex' as const, true]]);
+    expect(canSkipPendingProviderDiscovery(['codex'], statuses, loading, NOW)).toBe(false);
+    expect(
+      canSkipOptionalProviderPreflight(
+        ['codex'],
+        statuses,
+        loading,
+        [check('codex', 'checking')],
+        NOW
+      )
+    ).toBe(false);
+  });
   it('allows initial skip when one selected provider is still loading', () => {
     expect(
       canSkipPendingProviderDiscovery(

--- a/test/renderer/components/team/dialogs/optionalProviderPreflight.test.ts
+++ b/test/renderer/components/team/dialogs/optionalProviderPreflight.test.ts
@@ -72,6 +72,77 @@ const check = (
 
 describe('optional provider preflight skip', () => {
   afterEach(() => vi.useRealTimers());
+  function refreshingAnthropicSelection(override: Partial<CliProviderStatus> = {}) {
+    const source = {
+      ...provider('anthropic'),
+      modelCatalogRefreshState: 'loading' as const,
+      modelCatalog: {
+        ...provider('anthropic').modelCatalog!,
+        staleAt: new Date(NOW - 1).toISOString(),
+      },
+      ...override,
+    };
+    return {
+      source,
+      statuses: new Map<TeamProviderId, CliProviderStatus>([
+        ['anthropic', { ...source, capabilities: { ...source.capabilities, teamLaunch: false } }],
+        ['codex', provider('codex')],
+        ['opencode', provider('opencode')],
+      ]),
+      checks: [check('anthropic', 'ready'), check('codex', 'ready'), check('opencode', 'ready')],
+    };
+  }
+  it.each(['idle', 'loading', 'ready'] as const)(
+    'allows %s skip during a verified Anthropic catalog refresh without replacing completed checks',
+    (state) => {
+      const { source, statuses, checks } = refreshingAnthropicSelection();
+      expect(
+        canSkipProviderPreflight(state, [...statuses.keys()], statuses, new Map(), checks, NOW, [
+          source,
+        ])
+      ).toBe(true);
+      expect(checks.every((entry) => entry.status === 'ready')).toBe(true);
+    }
+  );
+  it.each([
+    { authenticated: false },
+    { supported: false },
+    { verificationState: 'error' as const },
+    { capabilities: { ...provider('anthropic').capabilities, teamLaunch: false } },
+    { statusCheckErrorCode: 'unavailable' as const },
+    { statusCheckErrorCode: 'runtime_missing' as const },
+    { modelCatalogRefreshState: 'error' as const },
+    { modelCatalogRefreshState: 'ready' as const },
+    { modelCatalog: { ...provider('anthropic').modelCatalog!, status: 'unavailable' as const } },
+  ])('does not bypass Anthropic failure or expiry without refresh: %j', (override) => {
+    const { source, statuses, checks } = refreshingAnthropicSelection(override);
+    for (const state of ['loading', 'ready'] as const)
+      expect(
+        canSkipProviderPreflight(state, [...statuses.keys()], statuses, new Map(), checks, NOW, [
+          source,
+        ])
+      ).toBe(false);
+  });
+  it.each(['failed-model', 'other-expired', 'missing-source', 'failed-state'] as const)(
+    'does not bypass %s during Anthropic refresh',
+    (failure) => {
+      const { source, statuses, checks } = refreshingAnthropicSelection();
+      if (failure === 'failed-model') checks[0].status = 'failed';
+      if (failure === 'other-expired')
+        statuses.get('codex')!.modelCatalog!.staleAt = new Date(NOW - 1).toISOString();
+      expect(
+        canSkipProviderPreflight(
+          failure === 'failed-state' ? 'failed' : 'ready',
+          [...statuses.keys()],
+          statuses,
+          new Map(),
+          checks,
+          NOW,
+          failure === 'missing-source' ? [] : [source]
+        )
+      ).toBe(false);
+    }
+  );
   it('keeps only the unfinished provider badge checking in a mixed preflight', () => {
     expect(
       getPendingProviderPreflightIds(

--- a/test/renderer/components/team/dialogs/optionalProviderPreflight.test.ts
+++ b/test/renderer/components/team/dialogs/optionalProviderPreflight.test.ts
@@ -123,6 +123,92 @@ describe('optional provider preflight skip', () => {
         ])
       ).toBe(false);
   });
+  it.each(['pending', 'transient_error'] as const)(
+    'allows mixed Anthropic refresh plus %s/partial_response discovery, including a previously ready check',
+    (statusCheckOutcome) => {
+      for (const state of ['idle', 'loading', 'ready'] as const) {
+        const { source, statuses, checks } = refreshingAnthropicSelection();
+        statuses.set('codex', {
+          ...provider('codex'),
+          authenticated: false,
+          verificationState: 'unknown',
+          statusCheckOutcome,
+          statusCheckErrorCode: 'partial_response',
+          modelCatalog: null,
+          capabilities: { ...provider('codex').capabilities, teamLaunch: false },
+        });
+        for (const status of ['pending', 'ready'] as const) {
+          checks[1].status = status;
+          expect(
+            canSkipProviderPreflight(
+              state,
+              [...statuses.keys()],
+              statuses,
+              new Map(),
+              checks,
+              NOW,
+              [source]
+            )
+          ).toBe(true);
+        }
+      }
+    }
+  );
+  it.each([
+    { authenticated: false },
+    { verificationState: 'error' as const },
+    { statusCheckErrorCode: 'runtime_missing' as const },
+    { statusCheckErrorCode: 'unavailable' as const },
+    { modelCatalogRefreshState: 'error' as const },
+    {
+      statusCheckOutcome: 'pending' as const,
+      statusCheckErrorCode: 'partial_response' as const,
+      modelCatalogRefreshState: 'error' as const,
+    },
+  ])('blocks mixed secondary provider failure even with discovery loading: %j', (override) => {
+    const { source, statuses, checks } = refreshingAnthropicSelection();
+    statuses.set('codex', { ...provider('codex'), ...override });
+    expect(
+      canSkipProviderPreflight(
+        'loading',
+        [...statuses.keys()],
+        statuses,
+        new Map([['codex', true]]),
+        checks,
+        NOW,
+        [source]
+      )
+    ).toBe(false);
+  });
+  it.each(['pending', 'ready'] as const)(
+    'blocks settled stale secondary authority despite a %s check during Anthropic refresh',
+    (checkStatus) => {
+      const { source, statuses, checks } = refreshingAnthropicSelection();
+      statuses.get('codex')!.modelCatalog!.staleAt = new Date(NOW - 1).toISOString();
+      checks[1].status = checkStatus;
+      expect(
+        canSkipProviderPreflight(
+          'loading',
+          [...statuses.keys()],
+          statuses,
+          new Map(),
+          checks,
+          NOW,
+          [source]
+        )
+      ).toBe(false);
+    }
+  );
+  it('blocks a failed secondary model check even when its provider discovery is pending', () => {
+    const { source, statuses, checks } = refreshingAnthropicSelection();
+    statuses.get('codex')!.statusCheckOutcome = 'pending';
+    checks[1].status = 'failed';
+    expect(
+      canSkipProviderPreflight('loading', [...statuses.keys()], statuses, new Map(), checks, NOW, [
+        source,
+      ])
+    ).toBe(false);
+  });
   it.each(['failed-model', 'other-expired', 'missing-source', 'failed-state'] as const)(
     'does not bypass %s during Anthropic refresh',
     (failure) => {

--- a/test/renderer/components/team/dialogs/projectPathOptions.test.ts
+++ b/test/renderer/components/team/dialogs/projectPathOptions.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from 'vitest';
-
 import {
   buildProjectPathOptions,
   isDeletedProjectPathSelection,
+  isLaunchPreflightProjectSelectionReady,
   isSelectableProjectPathProject,
 } from '@renderer/components/team/dialogs/projectPathOptions';
+import { describe, expect, it } from 'vitest';
 
 import type { Project } from '@shared/types';
 
@@ -145,5 +145,105 @@ describe('buildProjectPathOptions', () => {
         '/Users/belief/dev/projects/claude/claude_team'
       )
     ).toBe(false);
+  });
+});
+
+describe('isLaunchPreflightProjectSelectionReady', () => {
+  const selectedProjectPath = '/Users/test/saved-project';
+  const defaultProjectPath = '/Users/test/navigation-project';
+  const readySelection = {
+    draftLoaded: true,
+    effectiveCwd: selectedProjectPath,
+    cwdMode: 'project' as const,
+    projectsLoading: false,
+    projects: [
+      createProject({ path: selectedProjectPath }),
+      createProject({ path: defaultProjectPath }),
+    ],
+    selectedProjectPath,
+    defaultProjectPath,
+    appliedDefaultProjectPath: null,
+  };
+
+  it('waits for the navigation default before checking an old saved selection', () => {
+    expect(isLaunchPreflightProjectSelectionReady(readySelection)).toBe(false);
+    expect(
+      isLaunchPreflightProjectSelectionReady({
+        ...readySelection,
+        selectedProjectPath: `${defaultProjectPath}/`,
+        effectiveCwd: defaultProjectPath,
+      })
+    ).toBe(true);
+  });
+
+  it('allows explicit project changes once the navigation default was applied', () => {
+    expect(
+      isLaunchPreflightProjectSelectionReady({
+        ...readySelection,
+        appliedDefaultProjectPath: defaultProjectPath,
+      })
+    ).toBe(true);
+  });
+
+  it('waits for a new navigation default even when a previous one was applied', () => {
+    expect(
+      isLaunchPreflightProjectSelectionReady({
+        ...readySelection,
+        appliedDefaultProjectPath: '/Users/test/previous-default',
+      })
+    ).toBe(false);
+  });
+
+  it.each(['missing', 'deleted', 'ephemeral'] as const)(
+    'allows an available fallback when the navigation default is %s',
+    (state) => {
+      const defaultPath =
+        state === 'ephemeral'
+          ? '/private/var/folders/7b/cache/T/codex-agent-teams-appstyle-zudek6i9'
+          : defaultProjectPath;
+      expect(
+        isLaunchPreflightProjectSelectionReady({
+          ...readySelection,
+          defaultProjectPath: defaultPath,
+          projects: [
+            createProject({ path: selectedProjectPath }),
+            ...(state === 'missing'
+              ? []
+              : [
+                  createProject({
+                    path: defaultPath,
+                    filesystemState: state === 'deleted' ? 'deleted' : 'available',
+                  }),
+                ]),
+          ],
+        })
+      ).toBe(true);
+    }
+  );
+
+  it.each([
+    { draftLoaded: false },
+    { projectsLoading: true },
+    { effectiveCwd: '' },
+    { projects: [] },
+    { projects: [createProject({ path: selectedProjectPath, filesystemState: 'deleted' })] },
+  ])('still blocks unresolved or unavailable project selections: %j', (overrides) => {
+    expect(
+      isLaunchPreflightProjectSelectionReady({
+        ...readySelection,
+        appliedDefaultProjectPath: defaultProjectPath,
+        ...overrides,
+      })
+    ).toBe(false);
+  });
+
+  it('allows custom cwd independently of navigation project selection', () => {
+    expect(
+      isLaunchPreflightProjectSelectionReady({
+        ...readySelection,
+        cwdMode: 'custom',
+        projectsLoading: true,
+      })
+    ).toBe(true);
   });
 });

--- a/test/renderer/components/team/dialogs/projectPathOptions.test.ts
+++ b/test/renderer/components/team/dialogs/projectPathOptions.test.ts
@@ -185,6 +185,37 @@ describe('isLaunchPreflightProjectSelectionReady', () => {
     ).toBe(true);
   });
 
+  it('accepts a saved selection with different casing, consistently with the project picker', () => {
+    expect(
+      isLaunchPreflightProjectSelectionReady({
+        ...readySelection,
+        selectedProjectPath: '/users/TEST/Saved-Project/',
+        effectiveCwd: '/users/TEST/Saved-Project/',
+        appliedDefaultProjectPath: defaultProjectPath,
+      })
+    ).toBe(true);
+  });
+
+  it('still waits for a navigation default when the saved path differs only in casing', () => {
+    expect(
+      isLaunchPreflightProjectSelectionReady({
+        ...readySelection,
+        selectedProjectPath: selectedProjectPath.toUpperCase(),
+      })
+    ).toBe(false);
+  });
+
+  it('does not accept a deleted selection through case-insensitive matching', () => {
+    expect(
+      isLaunchPreflightProjectSelectionReady({
+        ...readySelection,
+        defaultProjectPath: null,
+        selectedProjectPath: selectedProjectPath.toUpperCase(),
+        projects: [createProject({ path: selectedProjectPath, filesystemState: 'deleted' })],
+      })
+    ).toBe(false);
+  });
+
   it('waits for a new navigation default even when a previous one was applied', () => {
     expect(
       isLaunchPreflightProjectSelectionReady({

--- a/test/renderer/components/team/dialogs/providerLaunchAuthority.test.ts
+++ b/test/renderer/components/team/dialogs/providerLaunchAuthority.test.ts
@@ -10,6 +10,38 @@ import type { CliProviderStatus } from '@shared/types';
 
 const NOW = Date.parse('2026-09-01T20:00:00.000Z');
 
+function createOpenCodeCatalog(model = 'opencode/big-pickle'): CliProviderStatus {
+  const base = createReadyProvider('anthropic');
+  return {
+    ...base,
+    providerId: 'opencode',
+    models: [model],
+    modelCatalog: {
+      ...base.modelCatalog!,
+      providerId: 'opencode',
+      models: [{ ...base.modelCatalog!.models[0]!, id: model, launchModel: model }],
+    },
+  };
+}
+
+function createTimedOutSource(): CliProviderStatus {
+  const source = createOpenCodeCatalog();
+  return {
+    ...source,
+    detailMessage: 'version 1.17.18 - auth /profile/auth.json',
+    modelCatalogRefreshState: 'error',
+    modelCatalog: {
+      ...source.modelCatalog!,
+      status: 'stale',
+      diagnostics: {
+        configReadState: 'ready',
+        appServerState: 'healthy',
+        message: 'OpenCode catalog overall deadline exceeded after 60000ms',
+      },
+    },
+  };
+}
+
 function createReadyProvider(providerId: 'anthropic' | 'codex'): CliProviderStatus {
   const modelId = providerId === 'codex' ? 'gpt-5.6-sol' : 'opus';
   return {
@@ -61,6 +93,98 @@ function createReadyProvider(providerId: 'anthropic' | 'codex'): CliProviderStat
 }
 
 describe('createLaunchGuard', () => {
+  it('uses fresh exact-project authority when a duplicate source catalog timed out', () => {
+    const provider = createOpenCodeCatalog();
+    const guard = createLaunchGuard(['opencode'], new Map([['opencode', provider]]), {
+      selectedModels: ['opencode/big-pickle'],
+      scopedStatusBySourceId: new Map([['opencode', createTimedOutSource()]]),
+    });
+    expect(guard.blockers(true, NOW)).toEqual([]);
+    expect(guard.blocked(true, NOW)).toBe(false);
+    expect(guard.blocked(true, Date.parse(provider.modelCatalog!.staleAt))).toBe(true);
+  });
+
+  it.each([
+    'auth',
+    'auth-timeout',
+    'permanent',
+    'newer',
+    'invalid-date',
+    'future',
+    'missing-model',
+    'unavailable-model',
+    'unknown-model',
+    'unscoped',
+    'unknown-authority',
+    'expired',
+  ])('does not replace a source failure with unsafe %s evidence', (scenario) => {
+    const provider = createOpenCodeCatalog();
+    const source = createTimedOutSource();
+    if (scenario === 'auth') source.authenticated = false;
+    if (scenario === 'auth-timeout')
+      source.modelCatalog!.diagnostics.message = 'Authentication timed out';
+    if (scenario === 'permanent') source.modelCatalog!.diagnostics.code = 'authentication_required';
+    if (scenario === 'newer') source.modelCatalog!.fetchedAt = '2026-09-01T19:56:00.000Z';
+    if (scenario === 'invalid-date') source.modelCatalog!.fetchedAt = 'invalid';
+    if (scenario === 'future') source.modelCatalog!.fetchedAt = '2026-09-01T20:01:00.000Z';
+    if (scenario === 'unavailable-model' || scenario === 'unknown-model')
+      source.modelAvailability = [
+        {
+          modelId: 'opencode/big-pickle',
+          status: scenario === 'unknown-model' ? 'unknown' : 'unavailable',
+        },
+      ];
+    if (scenario === 'unknown-authority') provider.statusCheckOutcome = 'model_only';
+    if (scenario === 'expired') provider.modelCatalog!.staleAt = new Date(NOW).toISOString();
+    const guard = createLaunchGuard(
+      ['opencode'],
+      new Map([['opencode', scenario === 'unscoped' ? null : provider]]),
+      {
+        selectedModels: [
+          scenario === 'missing-model' ? 'opencode/other-model' : 'opencode/big-pickle',
+        ],
+        scopedStatusBySourceId: new Map([['opencode', source]]),
+      }
+    );
+    expect(guard.blocked(true, NOW)).toBe(true);
+  });
+
+  it.each(['auth', 'model'])(
+    'does not hide a second source %s failure behind the first timeout',
+    (failure) => {
+      const provider = createOpenCodeCatalog();
+      const otherModel = 'openrouter/auto';
+      provider.modelCatalog!.models.push({
+        ...provider.modelCatalog!.models[0]!,
+        id: otherModel,
+        launchModel: otherModel,
+      });
+      const otherSource = createTimedOutSource();
+      if (failure === 'auth') otherSource.authenticated = false;
+      else {
+        otherSource.modelCatalogRefreshState = 'ready';
+        otherSource.modelAvailability = [{ modelId: otherModel, status: 'unavailable' }];
+      }
+      const guard = createLaunchGuard(['opencode'], new Map([['opencode', provider]]), {
+        selectedModels: ['opencode/big-pickle', otherModel],
+        scopedStatusBySourceId: new Map([
+          ['opencode', createTimedOutSource()],
+          ['openrouter', otherSource],
+        ]),
+      });
+      expect(guard.blocked(true, NOW)).toBe(true);
+    }
+  );
+
+  it('shows the actual source catalog error before runtime inventory', () => {
+    const source = createTimedOutSource();
+    const guard = createLaunchGuard(['opencode'], new Map(), {
+      selectedModels: ['opencode/big-pickle'],
+      scopedStatusBySourceId: new Map([['opencode', source]]),
+    });
+    expect(guard.blockers(true, NOW)[0]?.detail).toBe(source.modelCatalog!.diagnostics.message);
+    expect(guard.blockers(true, NOW)[0]?.detail).not.toContain('auth.json');
+  });
   it.each(['codex', 'anthropic'] as const)('shares fail-closed readiness for %s', (providerId) => {
     const provider = createReadyProvider(providerId);
     expect(hasEffectiveProviderLaunchAuthority(provider, NOW)).toBe(true);

--- a/test/renderer/hooks/useEffectiveCliProviderStatus.test.ts
+++ b/test/renderer/hooks/useEffectiveCliProviderStatus.test.ts
@@ -329,6 +329,13 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     };
   }
 
+  async function flushReactUpdate(update: () => void): Promise<void> {
+    await act(async () => {
+      update();
+      await Promise.resolve();
+    });
+  }
+
   afterEach(() => {
     document.body.innerHTML = '';
     storeState.cliStatus = null;
@@ -345,13 +352,13 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     setProjectCatalog('/project', baseTime + 100);
     const root = createRoot(document.createElement('div'));
 
-    await act(() => root.render(createElement(Harness, { projectPath: '/project' })));
+    await flushReactUpdate(() => root.render(createElement(Harness, { projectPath: '/project' })));
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(99));
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(1));
     expect(renderedLaunchReady).toBe(false);
-    await act(() => root.unmount());
+    await flushReactUpdate(() => root.unmount());
   });
 
   it('chunks delays above the browser timer maximum and still revokes at the exact boundary', async () => {
@@ -361,7 +368,7 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     setProjectCatalog('/project', baseTime + MAX_BROWSER_TIMEOUT_MS + 100);
     const root = createRoot(document.createElement('div'));
 
-    await act(() => root.render(createElement(Harness, { projectPath: '/project' })));
+    await flushReactUpdate(() => root.render(createElement(Harness, { projectPath: '/project' })));
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(MAX_BROWSER_TIMEOUT_MS));
     expect(renderedLaunchReady).toBe(true);
@@ -370,7 +377,7 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(1));
     expect(renderedLaunchReady).toBe(false);
-    await act(() => root.unmount());
+    await flushReactUpdate(() => root.unmount());
   });
 
   it('reschedules when the project catalog changes', async () => {
@@ -379,17 +386,17 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     vi.setSystemTime(baseTime);
     setProjectCatalog('/first', baseTime + 100);
     const root = createRoot(document.createElement('div'));
-    await act(() => root.render(createElement(Harness, { projectPath: '/first' })));
+    await flushReactUpdate(() => root.render(createElement(Harness, { projectPath: '/first' })));
     expect(renderedLaunchReady).toBe(true);
 
     setProjectCatalog('/second', baseTime + 200);
-    await act(() => root.render(createElement(Harness, { projectPath: '/second' })));
+    await flushReactUpdate(() => root.render(createElement(Harness, { projectPath: '/second' })));
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(100));
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(100));
     expect(renderedLaunchReady).toBe(false);
-    await act(() => root.unmount());
+    await flushReactUpdate(() => root.unmount());
   });
 
   it.each(['fresh', 'expired', 'unauthenticated'] as const)(
@@ -400,7 +407,7 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
       vi.setSystemTime(baseTime);
       setProjectCatalog('/project', baseTime + 100);
       const root = createRoot(document.createElement('div'));
-      await act(() => root.render(createElement(Harness, { projectPath: '/project' })));
+      await flushReactUpdate(() => root.render(createElement(Harness, { projectPath: '/project' })));
       expect(renderedLaunchReady).toBe(true);
 
       // Move wall time without firing timers: retaining the old clock would accept
@@ -415,9 +422,9 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
       } else if (replacement === 'unauthenticated') {
         scoped.authenticated = false;
       }
-      await act(() => root.render(createElement(Harness, { projectPath: '/project' })));
+      await flushReactUpdate(() => root.render(createElement(Harness, { projectPath: '/project' })));
       expect(renderedLaunchReady).toBe(replacement === 'fresh');
-      await act(() => root.unmount());
+      await flushReactUpdate(() => root.unmount());
     }
   );
 
@@ -442,7 +449,7 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     document.body.appendChild(host);
     const root = createRoot(host);
     storeState.cliStatus = { flavor: 'agent_teams_orchestrator', providers };
-    await act(() => root.render(createElement(GlobalHarness)));
+    await flushReactUpdate(() => root.render(createElement(GlobalHarness)));
     expect(host.textContent).toBe('true,true,true');
     storeState.cliStatus = {
       flavor: 'agent_teams_orchestrator',
@@ -452,19 +459,19 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
           : provider
       ),
     };
-    await act(() => root.render(createElement(GlobalHarness)));
+    await flushReactUpdate(() => root.render(createElement(GlobalHarness)));
     expect(host.textContent).toBe('false,true,true');
 
     const observed: (string | null)[] = [];
     const observer = new MutationObserver(() => observed.push(host.textContent));
     observer.observe(host, { childList: true, characterData: true, subtree: true });
     storeState.cliStatus = { flavor: 'agent_teams_orchestrator', providers };
-    await act(() => root.render(createElement(GlobalHarness)));
+    await flushReactUpdate(() => root.render(createElement(GlobalHarness)));
     expect(host.textContent).toBe('true,true,true');
     expect(observed.length).toBeGreaterThan(0);
     expect(observed.every((value) => value === 'true,true,true')).toBe(true);
     observer.disconnect();
-    await act(() => root.unmount());
+    await flushReactUpdate(() => root.unmount());
   });
 
   it('cleans up the expiry timer on unmount', async () => {
@@ -473,10 +480,10 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     vi.setSystemTime(baseTime);
     setProjectCatalog('/project', baseTime + 100);
     const root = createRoot(document.createElement('div'));
-    await act(() => root.render(createElement(Harness, { projectPath: '/project' })));
+    await flushReactUpdate(() => root.render(createElement(Harness, { projectPath: '/project' })));
     expect(vi.getTimerCount()).toBe(1);
 
-    await act(() => root.unmount());
+    await flushReactUpdate(() => root.unmount());
     expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/test/renderer/hooks/useEffectiveCliProviderStatus.test.ts
+++ b/test/renderer/hooks/useEffectiveCliProviderStatus.test.ts
@@ -142,7 +142,7 @@ describe('resolveProjectScopedProviderStatus', () => {
 
   it.each([undefined, 'not-a-date'])('fails closed for a %s staleAt', (staleAt) => {
     const scoped = status({
-      modelCatalog: { ...status().modelCatalog!, staleAt: staleAt as string },
+      modelCatalog: { ...status().modelCatalog!, staleAt: staleAt! },
     });
 
     expect(
@@ -345,13 +345,13 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     setProjectCatalog('/project', baseTime + 100);
     const root = createRoot(document.createElement('div'));
 
-    await act(async () => root.render(createElement(Harness, { projectPath: '/project' })));
+    await act(() => root.render(createElement(Harness, { projectPath: '/project' })));
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(99));
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(1));
     expect(renderedLaunchReady).toBe(false);
-    await act(async () => root.unmount());
+    await act(() => root.unmount());
   });
 
   it('chunks delays above the browser timer maximum and still revokes at the exact boundary', async () => {
@@ -361,7 +361,7 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     setProjectCatalog('/project', baseTime + MAX_BROWSER_TIMEOUT_MS + 100);
     const root = createRoot(document.createElement('div'));
 
-    await act(async () => root.render(createElement(Harness, { projectPath: '/project' })));
+    await act(() => root.render(createElement(Harness, { projectPath: '/project' })));
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(MAX_BROWSER_TIMEOUT_MS));
     expect(renderedLaunchReady).toBe(true);
@@ -370,7 +370,7 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(1));
     expect(renderedLaunchReady).toBe(false);
-    await act(async () => root.unmount());
+    await act(() => root.unmount());
   });
 
   it('reschedules when the project catalog changes', async () => {
@@ -379,17 +379,17 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     vi.setSystemTime(baseTime);
     setProjectCatalog('/first', baseTime + 100);
     const root = createRoot(document.createElement('div'));
-    await act(async () => root.render(createElement(Harness, { projectPath: '/first' })));
+    await act(() => root.render(createElement(Harness, { projectPath: '/first' })));
     expect(renderedLaunchReady).toBe(true);
 
     setProjectCatalog('/second', baseTime + 200);
-    await act(async () => root.render(createElement(Harness, { projectPath: '/second' })));
+    await act(() => root.render(createElement(Harness, { projectPath: '/second' })));
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(100));
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(100));
     expect(renderedLaunchReady).toBe(false);
-    await act(async () => root.unmount());
+    await act(() => root.unmount());
   });
 
   it.each(['fresh', 'expired', 'unauthenticated'] as const)(
@@ -400,7 +400,7 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
       vi.setSystemTime(baseTime);
       setProjectCatalog('/project', baseTime + 100);
       const root = createRoot(document.createElement('div'));
-      await act(async () => root.render(createElement(Harness, { projectPath: '/project' })));
+      await act(() => root.render(createElement(Harness, { projectPath: '/project' })));
       expect(renderedLaunchReady).toBe(true);
 
       // Move wall time without firing timers: retaining the old clock would accept
@@ -415,9 +415,9 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
       } else if (replacement === 'unauthenticated') {
         scoped.authenticated = false;
       }
-      await act(async () => root.render(createElement(Harness, { projectPath: '/project' })));
+      await act(() => root.render(createElement(Harness, { projectPath: '/project' })));
       expect(renderedLaunchReady).toBe(replacement === 'fresh');
-      await act(async () => root.unmount());
+      await act(() => root.unmount());
     }
   );
 
@@ -442,7 +442,7 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     document.body.appendChild(host);
     const root = createRoot(host);
     storeState.cliStatus = { flavor: 'agent_teams_orchestrator', providers };
-    await act(async () => root.render(createElement(GlobalHarness)));
+    await act(() => root.render(createElement(GlobalHarness)));
     expect(host.textContent).toBe('true,true,true');
     storeState.cliStatus = {
       flavor: 'agent_teams_orchestrator',
@@ -452,19 +452,19 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
           : provider
       ),
     };
-    await act(async () => root.render(createElement(GlobalHarness)));
+    await act(() => root.render(createElement(GlobalHarness)));
     expect(host.textContent).toBe('false,true,true');
 
     const observed: (string | null)[] = [];
     const observer = new MutationObserver(() => observed.push(host.textContent));
     observer.observe(host, { childList: true, characterData: true, subtree: true });
     storeState.cliStatus = { flavor: 'agent_teams_orchestrator', providers };
-    await act(async () => root.render(createElement(GlobalHarness)));
+    await act(() => root.render(createElement(GlobalHarness)));
     expect(host.textContent).toBe('true,true,true');
     expect(observed.length).toBeGreaterThan(0);
     expect(observed.every((value) => value === 'true,true,true')).toBe(true);
     observer.disconnect();
-    await act(async () => root.unmount());
+    await act(() => root.unmount());
   });
 
   it('cleans up the expiry timer on unmount', async () => {
@@ -473,10 +473,10 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     vi.setSystemTime(baseTime);
     setProjectCatalog('/project', baseTime + 100);
     const root = createRoot(document.createElement('div'));
-    await act(async () => root.render(createElement(Harness, { projectPath: '/project' })));
+    await act(() => root.render(createElement(Harness, { projectPath: '/project' })));
     expect(vi.getTimerCount()).toBe(1);
 
-    await act(async () => root.unmount());
+    await act(() => root.unmount());
     expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/test/renderer/hooks/useEffectiveCliProviderStatus.test.ts
+++ b/test/renderer/hooks/useEffectiveCliProviderStatus.test.ts
@@ -5,12 +5,13 @@ import {
   MAX_BROWSER_TIMEOUT_MS,
   resolveProjectScopedProviderStatus,
   useEffectiveCliProviderStatus,
+  useLaunchAuthorityGatedCliStatus,
 } from '@renderer/hooks/useEffectiveCliProviderStatus';
 import { getCliProviderStatusScopeKey } from '@renderer/store/slices/cliInstallerSlice';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { CodexAccountSnapshotDto } from '@features/codex-account/contracts';
-import type { CliProviderStatus } from '@shared/types';
+import type { CliInstallationStatus, CliProviderStatus } from '@shared/types';
 
 const storeState = {
   appConfig: { general: { multimodelEnabled: true } },
@@ -328,11 +329,6 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     };
   }
 
-  async function hydrateAuthorityClock() {
-    await act(async () => vi.advanceTimersByTimeAsync(0));
-    await act(async () => vi.advanceTimersByTimeAsync(0));
-  }
-
   afterEach(() => {
     document.body.innerHTML = '';
     storeState.cliStatus = null;
@@ -350,8 +346,6 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     const root = createRoot(document.createElement('div'));
 
     await act(async () => root.render(createElement(Harness, { projectPath: '/project' })));
-    expect(renderedLaunchReady).toBe(false);
-    await hydrateAuthorityClock();
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(99));
     expect(renderedLaunchReady).toBe(true);
@@ -368,8 +362,6 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     const root = createRoot(document.createElement('div'));
 
     await act(async () => root.render(createElement(Harness, { projectPath: '/project' })));
-    expect(renderedLaunchReady).toBe(false);
-    await hydrateAuthorityClock();
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(MAX_BROWSER_TIMEOUT_MS));
     expect(renderedLaunchReady).toBe(true);
@@ -388,18 +380,90 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     setProjectCatalog('/first', baseTime + 100);
     const root = createRoot(document.createElement('div'));
     await act(async () => root.render(createElement(Harness, { projectPath: '/first' })));
-    await hydrateAuthorityClock();
     expect(renderedLaunchReady).toBe(true);
 
     setProjectCatalog('/second', baseTime + 200);
     await act(async () => root.render(createElement(Harness, { projectPath: '/second' })));
-    expect(renderedLaunchReady).toBe(false);
-    await hydrateAuthorityClock();
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(100));
     expect(renderedLaunchReady).toBe(true);
     await act(async () => vi.advanceTimersByTimeAsync(100));
     expect(renderedLaunchReady).toBe(false);
+    await act(async () => root.unmount());
+  });
+
+  it.each(['fresh', 'expired', 'unauthenticated'] as const)(
+    'checks the current clock and auth before timers run for a %s replacement snapshot',
+    async (replacement) => {
+      vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+      vi.useFakeTimers();
+      vi.setSystemTime(baseTime);
+      setProjectCatalog('/project', baseTime + 100);
+      const root = createRoot(document.createElement('div'));
+      await act(async () => root.render(createElement(Harness, { projectPath: '/project' })));
+      expect(renderedLaunchReady).toBe(true);
+
+      // Move wall time without firing timers: retaining the old clock would accept
+      // the expired catalog or reject the newly fetched fresh replacement.
+      vi.setSystemTime(baseTime + 200);
+      setProjectCatalog('/project', baseTime + (replacement === 'expired' ? 200 : 300));
+      const scoped = storeState.cliProviderStatusByScope[
+        getCliProviderStatusScopeKey('opencode', '/project')
+      ];
+      if (replacement === 'fresh') {
+        scoped.modelCatalog!.fetchedAt = new Date(baseTime + 200).toISOString();
+      } else if (replacement === 'unauthenticated') {
+        scoped.authenticated = false;
+      }
+      await act(async () => root.render(createElement(Harness, { projectPath: '/project' })));
+      expect(renderedLaunchReady).toBe(replacement === 'fresh');
+      await act(async () => root.unmount());
+    }
+  );
+
+  it('does not expose false aggregate failures between Anthropic refresh snapshots', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.useFakeTimers();
+    vi.setSystemTime(baseTime);
+    const providers = (['anthropic', 'codex', 'opencode'] as const).map((providerId) =>
+      status({ providerId, modelCatalog: { ...status().modelCatalog!, providerId } })
+    );
+    function GlobalHarness() {
+      const gated = useLaunchAuthorityGatedCliStatus(
+        storeState.cliStatus as CliInstallationStatus
+      );
+      return createElement(
+        'span',
+        null,
+        gated?.providers.map((provider) => String(provider.capabilities.teamLaunch)).join(',')
+      );
+    }
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    storeState.cliStatus = { flavor: 'agent_teams_orchestrator', providers };
+    await act(async () => root.render(createElement(GlobalHarness)));
+    expect(host.textContent).toBe('true,true,true');
+    storeState.cliStatus = {
+      flavor: 'agent_teams_orchestrator',
+      providers: providers.map((provider) =>
+        provider.providerId === 'anthropic'
+          ? { ...provider, modelCatalogRefreshState: 'loading' }
+          : provider
+      ),
+    };
+    await act(async () => root.render(createElement(GlobalHarness)));
+    expect(host.textContent).toBe('false,true,true');
+
+    const observed: (string | null)[] = [];
+    const observer = new MutationObserver(() => observed.push(host.textContent));
+    observer.observe(host, { childList: true, characterData: true, subtree: true });
+    storeState.cliStatus = { flavor: 'agent_teams_orchestrator', providers };
+    await act(async () => root.render(createElement(GlobalHarness)));
+    expect(host.textContent).toBe('true,true,true');
+    expect(observed.length).toBeGreaterThan(0);
+    expect(observed.every((value) => value === 'true,true,true')).toBe(true);
+    observer.disconnect();
     await act(async () => root.unmount());
   });
 
@@ -410,7 +474,6 @@ describe('useEffectiveCliProviderStatus catalog expiry', () => {
     setProjectCatalog('/project', baseTime + 100);
     const root = createRoot(document.createElement('div'));
     await act(async () => root.render(createElement(Harness, { projectPath: '/project' })));
-    await hydrateAuthorityClock();
     expect(vi.getTimerCount()).toBe(1);
 
     await act(async () => root.unmount());

--- a/test/renderer/hooks/useOpenCodePassiveStatusPrefetch.test.tsx
+++ b/test/renderer/hooks/useOpenCodePassiveStatusPrefetch.test.tsx
@@ -27,8 +27,26 @@ function Harness({
   return null;
 }
 
+const NOW = Date.parse('2026-09-06T15:00:00.000Z');
+const PROJECT = '/tmp/passive-status-project';
+
+function cachedCatalog(staleAt: number) {
+  return {
+    providerId: 'opencode',
+    statusCheckOutcome: 'authoritative',
+    modelCatalogRefreshState: 'ready',
+    modelCatalog: {
+      providerId: 'opencode',
+      status: 'ready',
+      fetchedAt: new Date(staleAt - 600_000).toISOString(),
+      staleAt: new Date(staleAt).toISOString(),
+    },
+  };
+}
+
 describe('useOpenCodePassiveStatusPrefetch', () => {
   afterEach(() => {
+    vi.useRealTimers();
     document.body.innerHTML = '';
     storeState.cliProviderStatusScopeRevision = 0;
     storeState.cliProviderStatusByScope = {};
@@ -36,29 +54,143 @@ describe('useOpenCodePassiveStatusPrefetch', () => {
     storeState.fetchCliProviderStatus.mockResolvedValue(true);
   });
 
-  it('loads one passive project status without catalog retries', async () => {
+  it.each(['success', 'false', 'rejected'] as const)(
+    'refreshes an expired cached catalog once without spinning after %s with unchanged evidence',
+    async (result) => {
+      vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+      storeState.cliProviderStatusByScope = {
+        [getCliProviderStatusScopeKey('opencode', PROJECT)]: cachedCatalog(NOW - 1),
+      };
+      if (result === 'rejected')
+        storeState.fetchCliProviderStatus.mockRejectedValue(new Error('offline'));
+      else storeState.fetchCliProviderStatus.mockResolvedValue(result === 'success');
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = createRoot(host);
+      await act(async () => root.render(<Harness />));
+      expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+        root.render(<Harness />);
+      });
+      expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(1);
+      storeState.cliProviderStatusScopeRevision += 1;
+      await act(async () => root.render(<Harness />));
+      expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(2);
+      await act(async () => root.unmount());
+    }
+  );
+
+  it('refreshes at each fresh catalog expiry while enabled without reusing the old deadline', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const key = getCliProviderStatusScopeKey('opencode', PROJECT);
+    storeState.cliProviderStatusByScope = { [key]: cachedCatalog(NOW + 1000) };
+    storeState.fetchCliProviderStatus.mockImplementation(async () => {
+      storeState.cliProviderStatusByScope = { [key]: cachedCatalog(Date.now() + 2000) };
+      return true;
+    });
     const host = document.createElement('div');
     document.body.appendChild(host);
     const root = createRoot(host);
-
-    await act(async () => {
-      root.render(<Harness />);
-      await Promise.resolve();
-    });
-    await act(async () => {
-      root.render(<Harness />);
-      await Promise.resolve();
-    });
-
+    await act(async () => root.render(<Harness />));
+    expect(storeState.fetchCliProviderStatus).not.toHaveBeenCalled();
+    await act(async () => vi.advanceTimersByTimeAsync(999));
+    expect(storeState.fetchCliProviderStatus).not.toHaveBeenCalled();
+    await act(async () => vi.advanceTimersByTimeAsync(1));
     expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(1);
-    expect(storeState.fetchCliProviderStatus).toHaveBeenCalledWith('opencode', {
-      silent: true,
-      checkReason: 'launch_preflight',
-      projectPath: '/tmp/passive-status-project',
-    });
+    await act(async () => vi.advanceTimersByTimeAsync(1999));
+    expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(1);
+    await act(async () => vi.advanceTimersByTimeAsync(1));
+    expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(2);
     await act(async () => root.unmount());
   });
+
+  it('cancels expiry while disabled and refreshes the expired scope when enabled again', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    storeState.cliProviderStatusByScope = {
+      [getCliProviderStatusScopeKey('opencode', PROJECT)]: cachedCatalog(NOW + 1000),
+    };
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    await act(async () => root.render(<Harness />));
+    await act(async () => root.render(<Harness enabled={false} />));
+    await act(async () => vi.advanceTimersByTimeAsync(1000));
+    expect(storeState.fetchCliProviderStatus).not.toHaveBeenCalled();
+    await act(async () => root.render(<Harness />));
+    expect(storeState.fetchCliProviderStatus).toHaveBeenCalledOnce();
+    await act(async () => root.unmount());
+  });
+
+  it('cancels the previous scope timer and ignores its late rejected completion', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const otherProject = '/tmp/other-passive-status-project';
+    storeState.cliProviderStatusByScope = {
+      [getCliProviderStatusScopeKey('opencode', PROJECT)]: cachedCatalog(NOW + 1000),
+      [getCliProviderStatusScopeKey('opencode', otherProject)]: cachedCatalog(NOW + 2000),
+    };
+    let rejectOldRequest!: (error: Error) => void;
+    storeState.fetchCliProviderStatus.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((_resolve, reject) => {
+          rejectOldRequest = reject;
+        })
+    );
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    await act(async () => root.render(<Harness />));
+    await act(async () => root.render(<Harness projectPath={otherProject} />));
+    await act(async () => vi.advanceTimersByTimeAsync(1000));
+    expect(storeState.fetchCliProviderStatus).not.toHaveBeenCalled();
+    await act(async () => root.render(<Harness />));
+    expect(storeState.fetchCliProviderStatus).toHaveBeenCalledOnce();
+    storeState.cliProviderStatusScopeRevision += 1;
+    await act(async () => root.render(<Harness projectPath={otherProject} />));
+    expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(2);
+    await act(async () => rejectOldRequest(new Error('old scope cancelled')));
+    await act(async () => root.render(<Harness projectPath={otherProject} />));
+    expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(2);
+    await act(async () => root.unmount());
+  });
+
+  it.each(['success', 'false', 'rejected'] as const)(
+    'loads one absent passive project status without retries after %s',
+    async (result) => {
+      vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+      if (result === 'rejected')
+        storeState.fetchCliProviderStatus.mockRejectedValue(new Error('offline'));
+      else storeState.fetchCliProviderStatus.mockResolvedValue(result === 'success');
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = createRoot(host);
+
+      await act(async () => {
+        root.render(<Harness />);
+        await Promise.resolve();
+      });
+      await act(async () => {
+        root.render(<Harness />);
+        await Promise.resolve();
+      });
+
+      expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(1);
+      expect(storeState.fetchCliProviderStatus).toHaveBeenCalledWith('opencode', {
+        silent: true,
+        checkReason: 'launch_preflight',
+        projectPath: '/tmp/passive-status-project',
+      });
+      await act(async () => root.unmount());
+    }
+  );
 
   it('loads again only after scope invalidation', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);

--- a/test/renderer/hooks/useOpenCodePassiveStatusPrefetch.test.tsx
+++ b/test/renderer/hooks/useOpenCodePassiveStatusPrefetch.test.tsx
@@ -109,6 +109,44 @@ describe('useOpenCodePassiveStatusPrefetch', () => {
     await act(async () => root.unmount());
   });
 
+  it.each(['error', 'loading'] as const)(
+    'does not refresh retained expired evidence during %s until invalidation or recovery',
+    async (refreshState) => {
+      vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW);
+      const scopeKey = getCliProviderStatusScopeKey('opencode', PROJECT);
+      const expired = cachedCatalog(NOW - 1);
+      const retained = { ...expired, modelCatalogRefreshState: refreshState };
+      storeState.cliProviderStatusByScope = { [scopeKey]: retained };
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = createRoot(host);
+      await act(async () => root.render(<Harness />));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+        root.render(<Harness />);
+      });
+      expect(storeState.fetchCliProviderStatus).not.toHaveBeenCalled();
+
+      // Store reconciliation also marks retained catalogs stale after a failed check.
+      storeState.cliProviderStatusByScope = {
+        [scopeKey]: { ...retained, modelCatalog: { ...expired.modelCatalog, status: 'stale' } },
+      };
+      await act(async () => root.render(<Harness />));
+      expect(storeState.fetchCliProviderStatus).not.toHaveBeenCalled();
+      storeState.cliProviderStatusScopeRevision += 1;
+      await act(async () => root.render(<Harness />));
+      expect(storeState.fetchCliProviderStatus).toHaveBeenCalledOnce();
+
+      storeState.cliProviderStatusByScope = { [scopeKey]: cachedCatalog(Date.now() + 1000) };
+      await act(async () => root.render(<Harness />));
+      await act(async () => vi.advanceTimersByTimeAsync(1000));
+      expect(storeState.fetchCliProviderStatus).toHaveBeenCalledTimes(2);
+      await act(async () => root.unmount());
+    }
+  );
+
   it('cancels expiry while disabled and refreshes the expired scope when enabled again', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     vi.useFakeTimers();

--- a/test/renderer/store/cliInstallerSlice.test.ts
+++ b/test/renderer/store/cliInstallerSlice.test.ts
@@ -252,7 +252,9 @@ describe('cliInstallerSlice', () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Clear module-owned watchdog handles before replacing their timer clock.
+    await useStore.getState().invalidateCliStatus();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -2803,8 +2805,9 @@ describe('cliInstallerSlice', () => {
           ?.modelCatalogRefreshState
       ).toBe('loading');
 
-      await vi.runOnlyPendingTimersAsync();
-
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
       expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(2);
       expect(
         useStore.getState().cliStatus?.providers.find((provider) => provider.providerId === 'codex')

--- a/test/renderer/store/cliInstallerSlice.test.ts
+++ b/test/renderer/store/cliInstallerSlice.test.ts
@@ -283,6 +283,30 @@ describe('cliInstallerSlice', () => {
   });
 
   describe('reconcileCliStatus', () => {
+    it('does not suppress updates whose only change is current refresh provenance', () => {
+      const base = createReadyOpenCodeCatalogProvider('haiku');
+      const provider = {
+        ...base,
+        providerId: 'anthropic' as const,
+        modelCatalog: {
+          ...base.modelCatalog!,
+          providerId: 'anthropic' as const,
+          status: 'stale' as const,
+        },
+        modelCatalogRefreshState: 'loading' as const,
+        capabilities: { ...base.capabilities, teamLaunch: false },
+      };
+      const current = reconcileCliStatus(null, createMultimodelStatus([provider]));
+      const incoming = createMultimodelStatus([
+        { ...current.providers[0], teamLaunchAuthorityRestriction: 'catalog-refresh' },
+      ]);
+      const next = reconcileCliStatus(current, incoming);
+      expect(next).not.toBe(current);
+      expect(next.providers[0].teamLaunchAuthorityRestriction).toBe('catalog-refresh');
+      expect(
+        reconcileCliStatus(next, current).providers[0].teamLaunchAuthorityRestriction
+      ).toBeUndefined();
+    });
     it('keeps last-known readiness for a model-only OpenCode inventory', () => {
       const current = createMultimodelStatus([
         createMultimodelProvider({

--- a/test/renderer/store/cliInstallerSlice.test.ts
+++ b/test/renderer/store/cliInstallerSlice.test.ts
@@ -1976,47 +1976,90 @@ describe('cliInstallerSlice', () => {
       expect(useStore.getState().cliStatusError).toBeNull();
     });
 
-    it('settles an OpenCode timeout without repeating the full catalog request', async () => {
-      const connectedProvider = createReadyOpenCodeCatalogProvider('openrouter/auto');
-      const timedOutProvider = createMultimodelProvider({
-        providerId: 'opencode',
-        displayName: 'OpenCode',
-        supported: false,
-        authenticated: false,
-        authMethod: null,
-        verificationState: 'error',
-        statusCheckOutcome: 'transient_error',
-        statusCheckErrorCode: 'timeout',
-        statusMessage: CLI_PROVIDER_STATUS_UNAVAILABLE_MESSAGE,
-        modelCatalogRefreshState: 'error',
-        capabilities: {
-          teamLaunch: false,
-          oneShot: false,
-          extensions: createDefaultCliExtensionCapabilities(),
-        },
-      });
-      useStore.setState({ cliStatus: createMultimodelStatus([connectedProvider]) });
-      vi.mocked(api.cliInstaller.getProviderStatus).mockResolvedValueOnce(timedOutProvider);
+    it.each(['ready', 'timeout'] as const)(
+      'retries a scoped OpenCode timeout once and settles the %s result',
+      async (result) => {
+        const connectedProvider = createReadyOpenCodeCatalogProvider('openrouter/auto');
+        const timedOutProvider = createMultimodelProvider({
+          providerId: 'opencode',
+          displayName: 'OpenCode',
+          supported: false,
+          authenticated: false,
+          authMethod: null,
+          verificationState: 'error',
+          statusCheckOutcome: 'transient_error',
+          statusCheckErrorCode: 'timeout',
+          statusMessage: CLI_PROVIDER_STATUS_UNAVAILABLE_MESSAGE,
+          modelCatalogRefreshState: 'error',
+          capabilities: {
+            teamLaunch: false,
+            oneShot: false,
+            extensions: createDefaultCliExtensionCapabilities(),
+          },
+        });
+        useStore.setState({ cliStatus: createMultimodelStatus([connectedProvider]) });
+        vi.mocked(api.cliInstaller.getProviderStatus)
+          .mockResolvedValueOnce(timedOutProvider)
+          .mockResolvedValueOnce(result === 'ready' ? connectedProvider : timedOutProvider);
 
-      await expect(
-        useStore.getState().fetchCliProviderStatus('opencode', {
-          projectPath: '/tmp/opencode-timeout',
-          checkReason: 'launch_preflight',
-        })
-      ).resolves.toBe(false);
+        await expect(
+          useStore.getState().fetchCliProviderStatus('opencode', {
+            projectPath: '/tmp/opencode-timeout',
+            checkReason: 'launch_preflight',
+          })
+        ).resolves.toBe(result === 'ready');
 
-      expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(1);
-      expect(useStore.getState().cliProviderStatusLoading.opencode).toBe(false);
-      expect(
-        useStore.getState().cliProviderStatusByScope[
-          getCliProviderStatusScopeKey('opencode', '/tmp/opencode-timeout')
-        ]
-      ).toMatchObject({
-        statusCheckOutcome: 'transient_error',
-        modelCatalogRefreshState: 'error',
-        capabilities: { teamLaunch: false },
-      });
-    });
+        expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(2);
+        expect(vi.mocked(api.cliInstaller.getProviderStatus).mock.calls).toEqual([
+          ['opencode', { projectPath: '/tmp/opencode-timeout' }],
+          ['opencode', { projectPath: '/tmp/opencode-timeout' }],
+        ]);
+        expect(useStore.getState().cliProviderStatusLoading.opencode).toBe(false);
+        expect(
+          useStore.getState().cliProviderStatusByScope[
+            getCliProviderStatusScopeKey('opencode', '/tmp/opencode-timeout')
+          ]
+        ).toMatchObject(
+          result === 'ready'
+            ? {
+                statusCheckOutcome: 'authoritative',
+                modelCatalogRefreshState: 'ready',
+                authenticated: true,
+                models: ['openrouter/auto'],
+              }
+            : {
+                statusCheckOutcome: 'transient_error',
+                modelCatalogRefreshState: 'error',
+                capabilities: { teamLaunch: false },
+              }
+        );
+      }
+    );
+
+    it.each([
+      { statusCheckOutcome: 'model_only', statusCheckErrorCode: 'timeout' },
+      { statusCheckOutcome: 'model_only', statusCheckErrorCode: 'partial_response' },
+      { statusCheckOutcome: 'authoritative', statusCheckErrorCode: undefined },
+    ] as const)(
+      'does not retry scoped OpenCode model-only or permanent/auth failures: %j',
+      async (outcome) => {
+        const provider = createMultimodelProvider({
+          providerId: 'opencode',
+          displayName: 'OpenCode',
+          supported: true,
+          authenticated: false,
+          verificationState: 'error',
+          ...outcome,
+        });
+        useStore.setState({ cliStatus: createMultimodelStatus([provider]) });
+        vi.mocked(api.cliInstaller.getProviderStatus).mockResolvedValue(provider);
+        await useStore
+          .getState()
+          .fetchCliProviderStatus('opencode', { projectPath: '/tmp/opencode-nontransient' });
+        expect(api.cliInstaller.getProviderStatus).toHaveBeenCalledTimes(1);
+        expect(useStore.getState().cliProviderStatusLoading.opencode).toBe(false);
+      }
+    );
 
     it('reports a scoped OpenCode catalog loaded only after an authoritative ready response', async () => {
       const fetchedAt = new Date();

--- a/test/renderer/store/cliInstallerStatusReconciliation.test.ts
+++ b/test/renderer/store/cliInstallerStatusReconciliation.test.ts
@@ -61,6 +61,36 @@ function provider(overrides: Partial<CliProviderStatus> = {}): CliProviderStatus
 }
 
 describe('cli provider status reconciliation', () => {
+  it('clears previous refresh provenance when the response provider does not match', () => {
+    const current = provider({
+      modelCatalogRefreshState: 'loading',
+      teamLaunchAuthorityRestriction: 'catalog-refresh',
+    });
+    const result = reconcileCliProviderSnapshot(current, provider({ providerId: 'codex' }));
+    expect(result.providerId).toBe('anthropic');
+    expect(result.capabilities.teamLaunch).toBe(false);
+    expect(result.teamLaunchAuthorityRestriction).toBeUndefined();
+  });
+  it('preserves only incoming refresh provenance and clears it for failures or new unsupported snapshots', () => {
+    const incoming = provider({
+      modelCatalogRefreshState: 'loading',
+      teamLaunchAuthorityRestriction: 'catalog-refresh',
+    });
+    incoming.capabilities.teamLaunch = false;
+    const first = reconcileCliProviderSnapshot(provider(), incoming);
+    expect(first.teamLaunchAuthorityRestriction).toBe('catalog-refresh');
+    expect(reconcileCliProviderSnapshot(first, first).teamLaunchAuthorityRestriction).toBe(
+      'catalog-refresh'
+    );
+    for (const next of [
+      { ...incoming, teamLaunchAuthorityRestriction: undefined },
+      { ...incoming, authenticated: false },
+      { ...incoming, modelCatalogRefreshState: 'error' as const },
+    ])
+      expect(
+        reconcileCliProviderSnapshot(first, next).teamLaunchAuthorityRestriction
+      ).toBeUndefined();
+  });
   it('keeps a retained catalog loading during an authoritative partial refresh', () => {
     const current = provider();
     const incoming = provider({

--- a/test/renderer/utils/teamModelAvailability.test.ts
+++ b/test/renderer/utils/teamModelAvailability.test.ts
@@ -6,6 +6,7 @@ import {
   GPT_5_1_CODEX_MINI_UI_DISABLED_REASON,
   GPT_5_2_CODEX_UI_DISABLED_REASON,
   GPT_5_3_CODEX_SPARK_UI_DISABLED_REASON,
+  isTeamModelAvailableForUi,
   isTeamProviderModelCatalogFresh,
   isTeamProviderModelCatalogSettled,
   isTeamProviderModelVerificationPending,
@@ -89,6 +90,21 @@ function createAnthropicCompatibleProviderStatus(
 }
 
 describe('teamModelAvailability', () => {
+  it.each(['cursor-acp/auto', 'kiro/auto'])(
+    'keeps extension-bound model %s visible but unavailable for team launch',
+    (modelId) => {
+      const providerStatus = createOpenCodeProviderStatus([modelId]);
+
+      expect(getAvailableTeamProviderModelOptions('opencode', providerStatus)).toEqual(
+        expect.arrayContaining([expect.objectContaining({ value: modelId })])
+      );
+      expect(isTeamModelAvailableForUi('opencode', modelId, providerStatus)).toBe(false);
+      expect(getTeamModelSelectionError('opencode', modelId, providerStatus)).toContain(
+        'not supported by the current Agent Teams launch runtime'
+      );
+    }
+  );
+
   it('keeps Codex pending while its runtime checks a settled cached catalog', () => {
     const providerStatus = createCodexProviderStatus(['gpt-5.4'], {
       modelCatalogRefreshState: 'ready',

--- a/test/renderer/utils/teamProvisioningLeadActivityPresentation.test.ts
+++ b/test/renderer/utils/teamProvisioningLeadActivityPresentation.test.ts
@@ -1,0 +1,94 @@
+import { applyLeadActivityToProvisioningPresentation } from '@renderer/utils/teamProvisioningLeadActivityPresentation';
+import { buildTeamProvisioningPresentation } from '@renderer/utils/teamProvisioningPresentation';
+import { describe, expect, it } from 'vitest';
+
+const activeInput = {
+  leadActivity: 'active' as const,
+  currentRuntimeRunId: 'run-1',
+  title: 'Completing startup checks',
+  detail: 'Lead is working while startup checks finish.',
+};
+
+function createPresentation() {
+  return buildTeamProvisioningPresentation({
+    progress: {
+      runId: 'run-1',
+      teamName: 'sandbox-team',
+      state: 'finalizing',
+      startedAt: '2026-09-06T12:00:00.000Z',
+      updatedAt: '2026-09-06T12:00:05.000Z',
+      message: 'Auditing registered teammates and bootstrap truth',
+      pid: 1234,
+    },
+    members: [{ name: 'team-lead', agentType: 'team-lead' }, { name: 'alice' }],
+  })!;
+}
+
+describe('observed lead activity during provisioning', () => {
+  it('shows working activity while preserving incomplete startup and teammate gates', () => {
+    const original = createPresentation();
+    const presentation = applyLeadActivityToProvisioningPresentation(original, activeInput);
+
+    expect(presentation).toMatchObject({
+      panelTitle: activeInput.title,
+      compactTitle: activeInput.title,
+      panelMessage: activeInput.detail,
+      isReady: false,
+      isActive: true,
+      canCancel: true,
+      currentStepIndex: original.currentStepIndex,
+      pendingSpawnCount: original.pendingSpawnCount,
+      allTeammatesConfirmedAlive: false,
+    });
+    expect(presentation?.progress).toBe(original.progress);
+  });
+
+  it.each(['missing', 'stale', 'idle', 'offline'])(
+    'ignores %s activity and does not infer work from a PID',
+    (reason) => {
+      const original = createPresentation();
+      const presentation = applyLeadActivityToProvisioningPresentation(original, {
+        ...activeInput,
+        currentRuntimeRunId: reason === 'stale' ? 'old-run' : 'run-1',
+        leadActivity:
+          reason === 'missing'
+            ? undefined
+            : reason === 'idle' || reason === 'offline'
+              ? reason
+              : 'active',
+      });
+
+      expect(presentation).toBe(original);
+    }
+  );
+
+  it.each(['failure', 'permission', 'warning'])(
+    'preserves specific %s details while indicating active startup',
+    (reason) => {
+      const original = createPresentation();
+      const detail =
+        reason === 'permission' ? 'Awaiting permission for alice' : 'alice failed to start';
+      original.panelMessage = detail;
+      if (reason === 'failure') original.failedSpawnCount = 1;
+      if (reason === 'warning') original.progress.messageSeverity = 'warning';
+
+      expect(applyLeadActivityToProvisioningPresentation(original, activeInput)).toMatchObject({
+        panelTitle: activeInput.title,
+        panelMessage: detail,
+        isReady: false,
+      });
+    }
+  );
+
+  it.each(['ready', 'failed', 'cancelled'])(
+    'does not replace %s terminal presentation with working status',
+    (state) => {
+      const original = createPresentation();
+      original.isActive = false;
+      original.isReady = state === 'ready';
+      original.isFailed = state === 'failed';
+
+      expect(applyLeadActivityToProvisioningPresentation(original, activeInput)).toBe(original);
+    }
+  );
+});

--- a/test/scripts/runtimeCliVersion.test.ts
+++ b/test/scripts/runtimeCliVersion.test.ts
@@ -1,0 +1,72 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+interface RuntimeCliVersionModule {
+  getExpectedRuntimeCliVersion(lock: { version: string; cliVersion?: unknown }): string;
+  matchesRuntimeCliVersion(output: unknown, expectedVersion: string): boolean;
+}
+
+async function loadModule(): Promise<RuntimeCliVersionModule> {
+  const moduleUrl = pathToFileURL(
+    path.join(process.cwd(), 'scripts/lib/runtime-cli-version.mjs')
+  ).href;
+  return (await import(moduleUrl)) as RuntimeCliVersionModule;
+}
+
+describe('runtime CLI version contract', () => {
+  it('accepts a pinned compatibility version that differs from the release identity', async () => {
+    const { getExpectedRuntimeCliVersion, matchesRuntimeCliVersion } = await loadModule();
+    const lock = { version: '0.0.79', cliVersion: '2.1.251' };
+    const expected = getExpectedRuntimeCliVersion(lock);
+
+    expect(expected).toBe('2.1.251');
+    expect(matchesRuntimeCliVersion('2.1.251 (Claude Code)\n', expected)).toBe(true);
+    expect(matchesRuntimeCliVersion('0.0.79 (Claude Code)', expected)).toBe(false);
+    expect(lock.version).toBe('0.0.79');
+  });
+
+  it('preserves the release version contract for legacy locks', async () => {
+    const { getExpectedRuntimeCliVersion, matchesRuntimeCliVersion } = await loadModule();
+    const expected = getExpectedRuntimeCliVersion({ version: '0.0.78' });
+
+    expect(expected).toBe('0.0.78');
+    expect(matchesRuntimeCliVersion('0.0.78 (Claude Code)', expected)).toBe(true);
+    expect(matchesRuntimeCliVersion('2.1.251 (Claude Code)', expected)).toBe(false);
+  });
+
+  it.each([undefined, null, 251, '', '  ', 'compatible', '2.1', '2.1.251 (Claude Code)'])(
+    'rejects an explicitly invalid CLI version instead of silently falling back: %s',
+    async (cliVersion) => {
+      const { getExpectedRuntimeCliVersion } = await loadModule();
+      expect(() => getExpectedRuntimeCliVersion({ version: '0.0.79', cliVersion })).toThrow(
+        /cliVersion must be a version/
+      );
+    }
+  );
+
+  it.each([
+    '12.1.251 (Claude Code)',
+    '2.1.2510 (Claude Code)',
+    '2.1.251-dev (Claude Code)',
+    '2.1.251+other-build (Claude Code)',
+    'unexpected version 2.1.251',
+    '',
+    undefined,
+  ])('rejects mismatched or missing leading version tokens: %s', async (output) => {
+    const { matchesRuntimeCliVersion } = await loadModule();
+    expect(matchesRuntimeCliVersion(output, '2.1.251')).toBe(false);
+  });
+
+  it('accepts whitespace and a separately pinned prerelease version', async () => {
+    const { getExpectedRuntimeCliVersion, matchesRuntimeCliVersion } = await loadModule();
+    const expected = getExpectedRuntimeCliVersion({
+      version: '0.0.79',
+      cliVersion: ' 2.1.251-dev+abc123 ',
+    });
+    expect(matchesRuntimeCliVersion(' \r\n2.1.251-dev+abc123 (Claude Code)\r\n', expected)).toBe(
+      true
+    );
+  });
+});

--- a/test/scripts/runtimeCliVersion.test.ts
+++ b/test/scripts/runtimeCliVersion.test.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 interface RuntimeCliVersionModule {
+  formatRuntimeVersionForDisplay(output: string): string;
   getExpectedRuntimeCliVersion(lock: { version: string; cliVersion?: unknown }): string;
   matchesRuntimeCliVersion(output: unknown, expectedVersion: string): boolean;
 }
@@ -16,6 +17,14 @@ async function loadModule(): Promise<RuntimeCliVersionModule> {
 }
 
 describe('runtime CLI version contract', () => {
+  it('displays the compatibility version with the orchestrator label', async () => {
+    const { formatRuntimeVersionForDisplay } = await loadModule();
+    expect(formatRuntimeVersionForDisplay('2.1.251 (Claude Code)\n')).toBe(
+      '2.1.251 (teams orchestrator)'
+    );
+    expect(formatRuntimeVersionForDisplay('')).toBe('teams orchestrator');
+  });
+
   it('accepts a pinned compatibility version that differs from the release identity', async () => {
     const { getExpectedRuntimeCliVersion, matchesRuntimeCliVersion } = await loadModule();
     const lock = { version: '0.0.79', cliVersion: '2.1.251' };


### PR DESCRIPTION
## Summary
- Restore automatic selected-model preflight, detailed progress and provider logos in create/relaunch; keep the model picker expanded.
- Watch recently engaged inboxes before final ready and materialize the OpenCode roster before secondary startup.
- Execute explicit relaunch requests once, with current-run cancellation and identity guards.
- Preserve provider/model catalogues on transient inventory failures and prefer fresh exact-project authority over older redundant catalogue timeouts.
- Keep dashboard model loading from restarting on background provider checks while preserving sequential reads and scope cancellation.
- Pin published runtime 0.0.82 with verified checksums for all five platforms. Related runtime fixes: https://github.com/777genius/agent_teams_orchestrator/pull/61, https://github.com/777genius/agent_teams_orchestrator/pull/62, https://github.com/777genius/agent_teams_orchestrator/pull/63 and https://github.com/777genius/agent_teams_orchestrator/pull/64.
- Keep completed provider badges ready while remaining providers check, and keep optional Skip active for transient pending status without bypassing known launch failures.
- Serialize early roster persistence before post-launch metadata writes, without waiting for teammate runtime startup; align saved project selection matching with the picker.
- Publish actual lead activity before first-turn completion and keep startup labels consistent without weakening readiness or message-delivery gates.
- Use the selected managed Codex runtime for passive catalogues; retry one transient managed version-probe timeout without changing final-failure fallback policy.
- Wake unread OpenCode assignments after verified bootstrap commit and runtime registration, including primary and secondary lanes; preserve current-run/Stop guards and existing delivery deduplication.
- Refresh expired project-scoped OpenCode catalogs automatically, with bounded failure handling. Show authenticated Anthropic catalog refresh as Checking instead of a transient red failure.
- Revalidate provider freshness before paint instead of exposing a false red frame during clock hydration. Keep optional Skip active during authenticated Anthropic catalog refresh, using app-derived current-snapshot refresh provenance across main/store gates and preserving real failure blockers.

## Verification
- Focused watcher, provisioning, selector, preflight and catalogue regressions pass; typecheck, scoped lint and architecture/size guards checked locally.
- Dev MCP mixed create and Stop/relaunch: Codex Luna lead, Haiku and OpenCode big-pickle completed separate sandbox tasks without extra user prompts or manual inbox delivery.
- Additional startup-assignment test: both tasks completed after the original message arrived before OpenCode bootstrap; exactly two marker files matched expected bytes.
- CodeRabbit findings on previous heads addressed; independent reviews of the scoped authority, directory normalization and runtime changes found no critical/major defect.
- Runtime 0.0.82 release workflow passed for all five platforms; arm64 archive and release manifest verified; released CLI compatibility version is 2.1.251. Terminal-turn evidence fix passes 325 focused tests, production build and independent review; CodeRabbit was rate limited on runtime PR64.
- Latest focused checks: 85 badge/skip/preflight tests, 43 roster/completion race tests, 21 project-selection tests and 4 ready-summary DOM tests passed, with typecheck and architecture guards.
- A real dev Create via Skip completed both owner-scoped sandbox tasks. Subsequent UI Stop took 1.339 seconds and persisted OpenCode stop authority, removed lanes/leases, and exited owned lead/OpenCode processes. Full connected model list and +N more visible.
- Installed local package at 5ece68fb7/runtime81 completed both sandbox tasks and full-lane Stop. Fresh dev046eac170/runtime terminal-evidence patch also completed both tasks; OpenCode settled after task completion and visible reply, with one delivery attempt and no premature idle diagnostic. Observed lead showed processing during startup checks.
- Further focused checks: 100 lead-activity/presentation tests, 67 shared-label/composer tests, 24 Codex installer tests. Whole-suite CI fixture/event-count assumptions and placeholder activity classification were fixed; exact-head CI34039862416 at37814328 passed fully.
- Public runtime82 live retest at41e2a705d proved pre-ready bootstrap wake: assignment preceded bootstrap, ledger created528ms after committed evidence, one delivery attempt, both new tasks/files completed, frontend Ready and full-lane Stop. No manual relay or agent nudge. The shared tracking/scheduler/recovery integration regressions and independent review passed.
- New catalog-expiry hook:13 tests passed; a dev sandbox expiry fixture caused a real automatic provider refresh to504models without clicking Refresh. Anthropic refresh presentation:116 focused tests, typecheck and lint passed; launch guards remain closed during refresh.
- Follow-up expired-catalog failure handling:83focused tests passed, successful expired snapshots refresh once while terminal errors require explicit retry. Optional Skip:59focused tests including actualCreate/Launch submit, no repeated deep check. Shared provider clock:135focused tests; frame-level dev MutationObserver recorded repeatedChecking/Ready cycles with no false red alerts and activeSkip.
- Final installed normal-profile package at17b9d897f/publicruntime82 passed fresh Create plus Stop/relaunch. Relaunchc34ef7cb completed exactly2new owner tasks, exact markerfiles, all3ready/idle and full-lane Stop in2.322seconds. OpenCode assignment reached ledger543ms after committed bootstrap, accepted once and responded; no manual relay/nudge. Currentbe431d998 differs only in test syntax, not production.
- Final refresh-provenance fix:260main/store/preflight tests,86catalog hook/visibility tests and44delivery tests pass. Actual main sanitizer + store reconciliation dev fixture recorded2Checking/Ready cycles without any transient alerts, with active Skip while OpenCode was also pending. Fresh CodeRabbit3findings addressed with focused regressions and independent review; interrupted-render test corrected to React.use, full typed ESLint passes.
- Final current-head CI and refreshed CodeRabbit verdict remain pending before merge. No new frontend GitHub release created; local installed app remains open.

## Limitations
- External provider response times and overloaded filesystem delays can still occur. The changes fix false status transitions and startup delivery, not all provider latency.
- Some agent-generated acknowledgement replies remain; no claim of perfect semantic message dedupe or zero provider latency is made.
- Extension-bound Cursor/Kiro routes retain route-specific readiness requirements; no blanket launch bypass or host-starting passive fallback was added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved team launch readiness checks for project selection, provider verification, and unsupported models.
  * Added clearer startup, lead-activity, and team-status messaging.
  * Mixed-provider launches now preserve complete rosters and begin requested work sooner.
  * OpenCode catalog loading pauses safely during status checks and recovers from transient timeouts.
  * Improved delivery of messages generated during team startup.

* **Bug Fixes**
  * Prevented stale or superseded launches from starting secondary runtimes.
  * Improved Codex runtime detection and passive provider status handling.
  * Expanded team watch recovery for recently active teams.
  * Updated runtime validation for the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

