### PR TITLE
fix(provisioning): retry safe secondary roster publication conflicts

### DIFF
--- a/src/main/services/team/provisioning/TeamProvisioningLaunchRosterMaterialization.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchRosterMaterialization.ts
@@ -128,9 +128,13 @@ async function publishLaunchRoster(
           (candidate) => candidate?.name?.trim().toLowerCase() === name
         );
         const existing = matches[0];
+        const legacyProvider = (existing as { provider?: unknown } | undefined)?.provider;
         if (
           matches.length !== 1 ||
           normalizeOptionalTeamProviderId(existing.providerId) !== 'opencode' ||
+          (legacyProvider != null &&
+            normalizeOptionalTeamProviderId(legacyProvider) !== 'opencode') ||
+          (existing.providerBackendId != null && existing.providerBackendId !== 'opencode-cli') ||
           existing.model?.trim() !== member.model?.trim() ||
           existing.agentId !== `${member.name.trim()}@${input.teamName}`
         ) {

--- a/src/main/services/team/provisioning/TeamProvisioningLaunchRosterMaterialization.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningLaunchRosterMaterialization.ts
@@ -18,10 +18,71 @@ export interface TeamProvisioningLaunchRosterPorts {
   now(): number;
 }
 
+const ROSTER_CONFLICT_MESSAGE = 'Secondary launch roster changed before config commit';
+class RetryableRosterConflict extends Error {
+  constructor(readonly originalConfig: Record<string, unknown>) {
+    super(ROSTER_CONFLICT_MESSAGE);
+  }
+}
+
+// Startup may add members or update liveness while the atomic write is being prepared.
+// A retry must not cross a replaced team/lead, removed member, or changed runtime identity.
+function canRebaseRoster(
+  original: Record<string, unknown>,
+  current: Record<string, unknown>
+): boolean {
+  if (!Array.isArray(original.members) || !Array.isArray(current.members)) return false;
+  if (
+    ['name', 'leadSessionId', 'leadAgentId', 'projectPath'].some(
+      (key) => original[key] !== current[key]
+    )
+  ) {
+    return false;
+  }
+  const identityKeys = [
+    'agentId',
+    'providerId',
+    'provider',
+    'providerBackendId',
+    'model',
+    'removedAt',
+  ];
+  const currentMembers = current.members as TeamMember[];
+  return (original.members as TeamMember[]).every((member) => {
+    const matches = currentMembers.filter(
+      (candidate) => candidate?.name?.trim().toLowerCase() === member?.name?.trim().toLowerCase()
+    );
+    return (
+      matches.length === 1 &&
+      identityKeys.every(
+        (key) =>
+          (member as unknown as Record<string, unknown>)[key] ===
+          (matches[0] as unknown as Record<string, unknown>)[key]
+      )
+    );
+  });
+}
+
 /** Publish side-lane identities before runtime startup, independently of the lead's first turn. */
 export async function materializeTeamProvisioningLaunchRoster(
   input: TeamProvisioningLaunchRosterInput,
   ports: TeamProvisioningLaunchRosterPorts
+): Promise<boolean> {
+  let originalConfig: Record<string, unknown> | undefined;
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await publishLaunchRoster(input, ports, originalConfig);
+    } catch (error) {
+      if (!(error instanceof RetryableRosterConflict) || attempt >= 2) throw error;
+      originalConfig ??= error.originalConfig;
+    }
+  }
+}
+
+async function publishLaunchRoster(
+  input: TeamProvisioningLaunchRosterInput,
+  ports: TeamProvisioningLaunchRosterPorts,
+  retryBase?: Record<string, unknown>
 ): Promise<boolean> {
   if (!input.isCurrentRun()) return false;
   const members = input.members.filter(
@@ -35,6 +96,9 @@ export async function materializeTeamProvisioningLaunchRoster(
   const config = JSON.parse(raw) as Record<string, unknown>;
   if (!Array.isArray(config.members)) {
     throw new Error('Cannot prepare secondary launch: config members missing');
+  }
+  if (retryBase && !canRebaseRoster(retryBase, config)) {
+    throw new Error(ROSTER_CONFLICT_MESSAGE);
   }
   const configMembers = config.members as TeamMember[];
   const names = new Set(members.map((member) => member.name.trim().toLowerCase()));
@@ -54,10 +118,27 @@ export async function materializeTeamProvisioningLaunchRoster(
   const existingNames = new Set(
     configMembers.map((member) => member?.name?.trim().toLowerCase()).filter(Boolean)
   );
+  const originalConfig = { ...config, members: [...configMembers] };
   const previousMemberCount = configMembers.length;
   for (const member of members) {
     const name = member.name.trim().toLowerCase();
-    if (existingNames.has(name)) continue;
+    if (existingNames.has(name)) {
+      if (retryBase) {
+        const matches = configMembers.filter(
+          (candidate) => candidate?.name?.trim().toLowerCase() === name
+        );
+        const existing = matches[0];
+        if (
+          matches.length !== 1 ||
+          normalizeOptionalTeamProviderId(existing.providerId) !== 'opencode' ||
+          existing.model?.trim() !== member.model?.trim() ||
+          existing.agentId !== `${member.name.trim()}@${input.teamName}`
+        ) {
+          throw new Error(ROSTER_CONFLICT_MESSAGE);
+        }
+      }
+      continue;
+    }
     config.members.push(
       buildOpenCodeConfigMemberFromLaunchMember(input.teamName, member, { now: ports.now })
     );
@@ -71,8 +152,20 @@ export async function materializeTeamProvisioningLaunchRoster(
   await ports.writeConfig(nextRaw, async () => {
     const currentRaw = await ports.readConfig();
     const currentMeta = await ports.readMetaMembers();
-    if (!input.isCurrentRun() || currentRaw !== raw || hasRemovedMember(currentMeta)) {
-      throw new Error('Secondary launch roster changed before config commit');
+    if (!input.isCurrentRun() || hasRemovedMember(currentMeta)) {
+      throw new Error(ROSTER_CONFLICT_MESSAGE);
+    }
+    if (currentRaw !== raw) {
+      const currentConfig = currentRaw ? (JSON.parse(currentRaw) as Record<string, unknown>) : null;
+      if (
+        currentConfig &&
+        Array.isArray(currentConfig.members) &&
+        !hasRemovedMember(currentConfig.members as TeamMember[]) &&
+        canRebaseRoster(originalConfig, currentConfig)
+      ) {
+        throw new RetryableRosterConflict(originalConfig);
+      }
+      throw new Error(ROSTER_CONFLICT_MESSAGE);
     }
   });
   ports.invalidateTeam(input.teamName);

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchRosterMaterialization.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchRosterMaterialization.test.ts
@@ -104,6 +104,120 @@ describe('TeamProvisioningLaunchRosterMaterialization', () => {
     expect(ports.writeConfig).not.toHaveBeenCalled();
   });
 
+  it('rebases a concurrent native startup update without waiting for the first lead turn', async () => {
+    const { state, input, ports } = createHarness();
+    state.beforeWrite = () => {
+      state.beforeWrite = () => {};
+      const latest = JSON.parse(state.raw);
+      latest.members[1].lastHeartbeatAt = 456;
+      latest.members.push({ name: 'native-worker', providerId: 'codex', model: 'gpt-5.6-luna' });
+      latest.updatedAt = 456;
+      state.raw = JSON.stringify(latest);
+    };
+    await expect(materializeTeamProvisioningLaunchRoster(input, ports)).resolves.toBe(true);
+    expect(JSON.parse(state.raw)).toMatchObject({
+      updatedAt: 456,
+      members: [
+        { name: 'team-lead' },
+        { name: 'haiku', lastHeartbeatAt: 456 },
+        { name: 'native-worker', providerId: 'codex' },
+        { name: 'opencode-worker', providerId: 'opencode' },
+      ],
+    });
+    expect(ports.writeConfig).toHaveBeenCalledTimes(2);
+    expect(ports.invalidateTeam).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds repeated conflicts without publishing a stale snapshot', async () => {
+    const { state, input, ports } = createHarness();
+    let updates = 0;
+    state.beforeWrite = () => {
+      state.raw = JSON.stringify({ ...JSON.parse(state.raw), updatedAt: ++updates });
+    };
+    await expect(materializeTeamProvisioningLaunchRoster(input, ports)).rejects.toThrow(
+      'roster changed before config commit'
+    );
+    expect(ports.writeConfig).toHaveBeenCalledTimes(3);
+    expect(JSON.parse(state.raw).members).toHaveLength(2);
+    expect(ports.invalidateTeam).not.toHaveBeenCalled();
+  });
+
+  it.each(['lead-session', 'provider', 'model', 'removed-config', 'cancelled', 'removed-meta'])(
+    'does not retry publication across %s changes',
+    async (change) => {
+      const { state, input, ports } = createHarness();
+      state.beforeWrite = () => {
+        const latest = JSON.parse(state.raw);
+        if (change === 'lead-session') latest.leadSessionId = 'replacement-session';
+        if (change === 'provider') latest.members[1].providerId = 'codex';
+        if (change === 'model') latest.members[1].model = 'replacement-model';
+        if (change === 'removed-config')
+          latest.members.push({ name: 'opencode-worker', removedAt: 456 });
+        if (change === 'cancelled') state.current = false;
+        if (change === 'removed-meta') state.meta[0].removedAt = 456;
+        state.raw = JSON.stringify({ ...latest, updatedAt: 456 });
+      };
+      await expect(materializeTeamProvisioningLaunchRoster(input, ports)).rejects.toThrow(
+        'roster changed before config commit'
+      );
+      expect(ports.writeConfig).toHaveBeenCalledTimes(1);
+      expect(ports.invalidateTeam).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not retry an unrelated storage error', async () => {
+    const { input, ports } = createHarness();
+    vi.mocked(ports.writeConfig).mockRejectedValue(new Error('disk full'));
+    await expect(materializeTeamProvisioningLaunchRoster(input, ports)).rejects.toThrow(
+      'disk full'
+    );
+    expect(ports.writeConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a replacement lead appearing between a conflict and the next read', async () => {
+    const { state, input, ports } = createHarness();
+    state.beforeWrite = () => {
+      state.raw = JSON.stringify({ ...JSON.parse(state.raw), updatedAt: 456 });
+    };
+    const read = ports.readConfig;
+    let reads = 0;
+    ports.readConfig = async () => {
+      if (++reads === 3) {
+        state.raw = JSON.stringify({ ...JSON.parse(state.raw), leadSessionId: 'replacement' });
+      }
+      return read();
+    };
+    await expect(materializeTeamProvisioningLaunchRoster(input, ports)).rejects.toThrow(
+      'roster changed before config commit'
+    );
+    expect(ports.writeConfig).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(state.raw).leadSessionId).toBe('replacement');
+  });
+
+  it.each(['opencode', 'codex'])(
+    'handles a concurrent %s member with the same target name',
+    async (providerId) => {
+      const { state, input, ports } = createHarness();
+      state.beforeWrite = () => {
+        state.beforeWrite = () => {};
+        const latest = JSON.parse(state.raw);
+        latest.members.push({
+          name: 'opencode-worker',
+          agentId: 'opencode-worker@sandbox-mixed',
+          providerId,
+          model: 'openai/gpt-5',
+        });
+        state.raw = JSON.stringify(latest);
+      };
+      const result = materializeTeamProvisioningLaunchRoster(input, ports);
+      if (providerId === 'opencode') await expect(result).resolves.toBe(true);
+      else await expect(result).rejects.toThrow('roster changed before config commit');
+      expect(ports.writeConfig).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(state.raw).members).toHaveLength(3);
+      expect(JSON.parse(state.raw).members[2].providerId).toBe(providerId);
+    }
+  );
+
   it.each(['cancelled', 'config-changed', 'removed'])(
     'aborts atomic publication when the launch becomes %s during the write',
     async (change) => {

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchRosterMaterialization.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningLaunchRosterMaterialization.test.ts
@@ -194,9 +194,16 @@ describe('TeamProvisioningLaunchRosterMaterialization', () => {
     expect(JSON.parse(state.raw).leadSessionId).toBe('replacement');
   });
 
-  it.each(['opencode', 'codex'])(
+  it.each([
+    ['opencode', { providerId: 'opencode' }, true],
+    ['codex', { providerId: 'codex' }, false],
+    ['matching legacy provider', { providerId: 'opencode', provider: 'opencode' }, true],
+    ['conflicting legacy provider', { providerId: 'opencode', provider: 'codex' }, false],
+    ['matching backend', { providerId: 'opencode', providerBackendId: 'opencode-cli' }, true],
+    ['conflicting backend', { providerId: 'opencode', providerBackendId: 'codex-native' }, false],
+  ])(
     'handles a concurrent %s member with the same target name',
-    async (providerId) => {
+    async (_label, identity, compatible) => {
       const { state, input, ports } = createHarness();
       state.beforeWrite = () => {
         state.beforeWrite = () => {};
@@ -204,17 +211,17 @@ describe('TeamProvisioningLaunchRosterMaterialization', () => {
         latest.members.push({
           name: 'opencode-worker',
           agentId: 'opencode-worker@sandbox-mixed',
-          providerId,
+          ...identity,
           model: 'openai/gpt-5',
         });
         state.raw = JSON.stringify(latest);
       };
       const result = materializeTeamProvisioningLaunchRoster(input, ports);
-      if (providerId === 'opencode') await expect(result).resolves.toBe(true);
+      if (compatible) await expect(result).resolves.toBe(true);
       else await expect(result).rejects.toThrow('roster changed before config commit');
       expect(ports.writeConfig).toHaveBeenCalledTimes(1);
       expect(JSON.parse(state.raw).members).toHaveLength(3);
-      expect(JSON.parse(state.raw).members[2].providerId).toBe(providerId);
+      expect(JSON.parse(state.raw).members[2]).toMatchObject(identity);
     }
   );
 


### PR DESCRIPTION
## Summary

Downloaded v2.13.0 mixed-team canary exposed an early OpenCode startup conflict: `Secondary launch roster changed before config commit`. Haiku completed its assigned task, but OpenCode only joined through later recovery, about 4.5 minutes after Create.

The early roster publication compares the complete config snapshot, so a concurrent compatible startup update can reject its memoized preparation promise. This change retries only the config read/merge/publication, at most three attempts. It does not retry runtime launch or loosen the commit guard.

- Keep the original team/lead/member identity across retries.
- Preserve concurrent member additions and liveness updates.
- Abort on Stop/supersession, removals, replacement identities, incompatible same-name members and storage errors.
- Scope: one existing helper and focused regression tests. No runtime, UI or release changes.

Related: https://github.com/777genius/agent-teams-ai/pull/599

## Verification

- Red/green regression: compatible concurrent update failed before the fix.
- 69 focused tests passed, including 24 roster-publication cases.
- Typecheck, fast lint, source-size and provisioning-architecture guards passed.
- Type-aware ESLint: zero errors; warnings follow the existing test harness style.
- Independent read-only review: no critical/major findings.
- CodeRabbit's same-name backend/legacy-provider identity finding is fixed in fcfbd7a; current-head review is successful and the thread is resolved.
- Exact-head CI 34050982852 passed, including both test shards and Windows smoke.
- Fresh `dev:mcp` Create/Stop/relaunch/Stop passed with source runtime a16da080 in a disposable sandbox. Codex Luna led, Haiku and OpenCode big-pickle each completed one new task per launch with exact file bytes. Current relaunch run e4d7a995-f805-43d4-a433-a49798a7f150: two new completed owner tasks; current OpenCode delivery 44913a53-2f64-4979-95b1-6ce5e2b0f512 responded with attempts=1. Early OpenCode roster publication no longer delayed until lead turn completion. No new release packaging.
