### PR TITLE
fix(preflight): keep Codex catalog refresh pending and skippable

### DIFF
--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -62,11 +62,15 @@ function verifiedOpenCodeProvider(): CliProviderStatus {
 }
 
 describe('ClaudeMultimodelBridgeService runtime status mapping', () => {
-  test.each([true, false])(
-    'mints refresh provenance only from raw affirmative teamLaunch=%s, ignoring injected markers',
-    (teamLaunch) => {
-      const provider = mapRuntimeProviderStatus('anthropic', {
-        providerId: 'anthropic',
+  test.each(
+    (['anthropic', 'codex'] as const).flatMap((providerId) =>
+      [true, false].map((teamLaunch) => ({ providerId, teamLaunch }))
+    )
+  )(
+    '$providerId mints refresh provenance only from raw affirmative teamLaunch=$teamLaunch, ignoring injected markers',
+    ({ providerId, teamLaunch }) => {
+      const provider = mapRuntimeProviderStatus(providerId, {
+        providerId,
         supported: true,
         authenticated: true,
         authMethod: 'claude.ai',

--- a/src/main/services/runtime/providerStatusCheckContract.ts
+++ b/src/main/services/runtime/providerStatusCheckContract.ts
@@ -4,9 +4,9 @@ import {
   createLegacyRuntimeFallbackCliExtensionCapabilities,
 } from '@shared/utils/providerExtensionCapabilities';
 import {
-  hasAnthropicCatalogRefreshLaunchSupport,
   hasAuthoritativeProviderLaunchEvidence,
   hasAuthoritativeProviderStatusEvidence,
+  hasProviderCatalogRefreshLaunchSupport,
   isProviderModelCatalogExactReady,
   selectProviderModelDisplayPair,
 } from '@shared/utils/providerStatusAuthority';
@@ -269,7 +269,7 @@ export function mergeProviderStatusDisplayEvidence(
 
   return {
     ...incoming,
-    teamLaunchAuthorityRestriction: hasAnthropicCatalogRefreshLaunchSupport(incoming)
+    teamLaunchAuthorityRestriction: hasProviderCatalogRefreshLaunchSupport(incoming)
       ? 'catalog-refresh'
       : undefined,
     supported: incoming.supported,

--- a/src/renderer/components/team/dialogs/optionalProviderPreflight.ts
+++ b/src/renderer/components/team/dialogs/optionalProviderPreflight.ts
@@ -1,7 +1,7 @@
 import { hasEffectiveProviderLaunchAuthority } from '@renderer/utils/providerReadiness';
 import {
-  hasAnthropicCatalogRefreshLaunchSupport,
-  isAuthenticatedAnthropicCatalogRefresh,
+  hasProviderCatalogRefreshLaunchSupport,
+  isAuthenticatedProviderCatalogRefresh,
 } from '@shared/utils/providerStatusAuthority';
 
 import { runProviderPrepareDiagnostics } from './providerPrepareDiagnostics';
@@ -130,22 +130,26 @@ export function canSkipProviderPreflight(
   now: number = Date.now(),
   sourceProviders: readonly CliProviderStatus[] = []
 ): boolean {
-  const source = sourceProviders.find((provider) => provider.providerId === 'anthropic');
-  const effective = statuses.get('anthropic');
   // Main/store may already have gated teamLaunch. The app-derived restriction
   // preserves affirmative support from this snapshot, never a previous one.
-  const refreshingAnthropic =
-    state !== 'failed' &&
-    providerIds.includes('anthropic') &&
-    Boolean(source?.modelCatalog && effective?.modelCatalog) &&
-    hasAnthropicCatalogRefreshLaunchSupport(source) &&
-    isAuthenticatedAnthropicCatalogRefresh(effective);
-  if (refreshingAnthropic) {
+  const refreshingProviders = new Map<TeamProviderId, CliProviderStatus>();
+  if (state !== 'failed') {
+    for (const id of providerIds) {
+      const source = sourceProviders.find((provider) => provider.providerId === id);
+      if (
+        hasProviderCatalogRefreshLaunchSupport(source) &&
+        isAuthenticatedProviderCatalogRefresh(statuses.get(id))
+      ) {
+        refreshingProviders.set(id, source);
+      }
+    }
+  }
+  if (refreshingProviders.size > 0) {
     if (checks.some((check) => providerIds.includes(check.providerId) && check.status === 'failed'))
       return false;
     if (
       providerIds.some((id) => {
-        if (id === 'anthropic') return false;
+        if (refreshingProviders.has(id)) return false;
         const status = statuses.get(id);
         // Completed checks cannot hide stale authority, but active discovery is
         // still optional. Keep catalog errors terminal even during a retry.
@@ -157,11 +161,15 @@ export function canSkipProviderPreflight(
       })
     )
       return false;
-    const refreshStatuses = new Map(statuses).set('anthropic', {
-      ...source,
-      capabilities: { ...source.capabilities, teamLaunch: true },
-    });
-    const refreshLoading = new Map(loading).set('anthropic', true);
+    const refreshStatuses = new Map(statuses);
+    const refreshLoading = new Map(loading);
+    for (const [id, source] of refreshingProviders) {
+      refreshStatuses.set(id, {
+        ...source,
+        capabilities: { ...source.capabilities, teamLaunch: true },
+      });
+      refreshLoading.set(id, true);
+    }
     if (state === 'idle')
       return canSkipPendingProviderDiscovery(providerIds, refreshStatuses, refreshLoading, now);
     // A passive refresh does not invalidate or repeat the completed deep check.
@@ -171,7 +179,7 @@ export function canSkipProviderPreflight(
       refreshStatuses,
       refreshLoading,
       checks.map((check) =>
-        check.providerId === 'anthropic' ? { ...check, status: 'checking' } : check
+        refreshingProviders.has(check.providerId) ? { ...check, status: 'checking' } : check
       ),
       now
     );

--- a/src/renderer/store/slices/cliInstallerStatusReconciliation.ts
+++ b/src/renderer/store/slices/cliInstallerStatusReconciliation.ts
@@ -1,7 +1,7 @@
 import {
-  hasAnthropicCatalogRefreshLaunchSupport,
   hasAuthoritativeProviderLaunchEvidence,
   hasAuthoritativeProviderStatusEvidence,
+  hasProviderCatalogRefreshLaunchSupport,
   isProviderModelCatalogExactReady,
   selectProviderModelDisplayPair,
 } from '@shared/utils/providerStatusAuthority';
@@ -55,7 +55,7 @@ function mergeProviderCatalogCache(
     incomingProvider.statusCheckErrorCode === 'partial_response';
   return {
     ...incomingProvider,
-    teamLaunchAuthorityRestriction: hasAnthropicCatalogRefreshLaunchSupport(incomingProvider)
+    teamLaunchAuthorityRestriction: hasProviderCatalogRefreshLaunchSupport(incomingProvider)
       ? incomingProvider.teamLaunchAuthorityRestriction
       : undefined,
     supported: incomingProvider.supported,
@@ -102,7 +102,7 @@ export function revokeProviderLaunchAuthority(provider: CliProviderStatus): CliP
   const hasAuthoritativeStatusEvidence = hasAuthoritativeProviderStatusEvidence(provider);
   return {
     ...provider,
-    teamLaunchAuthorityRestriction: hasAnthropicCatalogRefreshLaunchSupport(provider)
+    teamLaunchAuthorityRestriction: hasProviderCatalogRefreshLaunchSupport(provider)
       ? provider.teamLaunchAuthorityRestriction
       : undefined,
     authenticated: hasAuthoritativeStatusEvidence ? provider.authenticated : false,

--- a/src/renderer/utils/teamProviderRuntimeStatusLoading.ts
+++ b/src/renderer/utils/teamProviderRuntimeStatusLoading.ts
@@ -81,7 +81,7 @@ export function isTeamProviderRuntimeStatusLoading(
   }
 
   if (
-    providerId === 'anthropic' &&
+    (providerId === 'anthropic' || providerId === 'codex') &&
     providerStatus?.supported &&
     providerStatus.authenticated &&
     providerStatus.verificationState === 'verified' &&

--- a/src/shared/utils/providerStatusAuthority.ts
+++ b/src/shared/utils/providerStatusAuthority.ts
@@ -82,27 +82,28 @@ export function hasAuthoritativeProviderStatusEvidence(provider: CliProviderStat
 /** Accept only the current authenticated refresh snapshot, never cached support.
  * Runtime DTO mapping deliberately does not import the app-derived restriction.
  */
-export function isAuthenticatedAnthropicCatalogRefresh(
+export function isAuthenticatedProviderCatalogRefresh(
   provider: CliProviderStatus | null | undefined
 ): provider is CliProviderStatus {
   return Boolean(
-    provider?.providerId === 'anthropic' &&
+    provider &&
+    (provider.providerId === 'anthropic' || provider.providerId === 'codex') &&
     provider.supported &&
     provider.authenticated &&
     hasAuthoritativeProviderStatusEvidence(provider) &&
     provider.modelCatalogRefreshState === 'loading' &&
     (provider.modelCatalog
-      ? provider.modelCatalog.providerId === 'anthropic' &&
+      ? provider.modelCatalog.providerId === provider.providerId &&
         ['ready', 'stale'].includes(provider.modelCatalog.status)
       : provider.runtimeCapabilities?.modelCatalog?.dynamic === true)
   );
 }
 
-export function hasAnthropicCatalogRefreshLaunchSupport(
+export function hasProviderCatalogRefreshLaunchSupport(
   provider: CliProviderStatus | null | undefined
 ): provider is CliProviderStatus {
   return (
-    isAuthenticatedAnthropicCatalogRefresh(provider) &&
+    isAuthenticatedProviderCatalogRefresh(provider) &&
     (provider.capabilities.teamLaunch === true ||
       provider.teamLaunchAuthorityRestriction === 'catalog-refresh')
   );

--- a/test/main/services/runtime/providerStatusCheckContract.test.ts
+++ b/test/main/services/runtime/providerStatusCheckContract.test.ts
@@ -80,12 +80,12 @@ function providerStatus(overrides: Partial<CliProviderStatus> = {}): CliProvider
   };
 }
 
-describe('Anthropic catalog refresh restriction provenance', () => {
+describe.each(['anthropic', 'codex'] as const)('%s refresh provenance', (providerId) => {
   const refresh = () =>
     providerStatus({
-      providerId: 'anthropic',
+      providerId,
       modelCatalogRefreshState: 'loading',
-      modelCatalog: { ...providerStatus().modelCatalog!, providerId: 'anthropic' },
+      modelCatalog: { ...providerStatus().modelCatalog!, providerId },
     });
   it('records affirmative support before catalog gating and preserves repeat sanitization', () => {
     const first = sanitizeProviderStatusAuthority(refresh());
@@ -107,6 +107,22 @@ describe('Anthropic catalog refresh restriction provenance', () => {
         .teamLaunchAuthorityRestriction
     ).toBeUndefined();
   });
+  it.each(['missing', 'stale'] as const)(
+    'preserves provenance with a %s catalog without granting launch authority',
+    (catalogState) => {
+      const source = refresh();
+      source.modelCatalog =
+        catalogState === 'missing' ? null : { ...source.modelCatalog!, status: 'stale' };
+      const sanitized = sanitizeProviderStatusAuthority(source);
+      expect(sanitized).toMatchObject({
+        authenticated: true,
+        capabilities: { teamLaunch: false },
+        teamLaunchAuthorityRestriction: 'catalog-refresh',
+        modelCatalogRefreshState: 'loading',
+      });
+      expect(isProviderModelCatalogExactReady(sanitized)).toBe(false);
+    }
+  );
   it.each([
     { authenticated: false },
     { supported: false },

--- a/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
+++ b/test/renderer/components/team/dialogs/LaunchTeamDialog.test.ts
@@ -710,6 +710,8 @@ describe('LaunchTeamDialog', () => {
     ['launch', 'pending-codex'],
     ['create', 'refreshing-anthropic'],
     ['launch', 'refreshing-anthropic'],
+    ['create', 'refreshing-codex'],
+    ['launch', 'refreshing-codex'],
   ] as const)(
     'enables %s skip during %s without repeating completed deep checks',
     async (mode, scenario) => {
@@ -726,8 +728,26 @@ describe('LaunchTeamDialog', () => {
       vi.mocked(isTeamProviderRuntimeStatusLoading).mockImplementation(
         runtimeLoading.isTeamProviderRuntimeStatusLoading
       );
-      const refreshing = scenario === 'refreshing-anthropic';
-      localStorage.setItem('team:lastSelectedProvider', refreshing ? 'anthropic' : 'codex');
+      const refreshing = scenario !== 'pending-codex';
+      const refreshProviderId = scenario === 'refreshing-anthropic' ? 'anthropic' : 'codex';
+      if (scenario === 'refreshing-codex') {
+        vi.mocked(api.getCodexAccountSnapshot).mockResolvedValueOnce({
+          preferredAuthMode: 'chatgpt',
+          effectiveAuthMode: 'chatgpt',
+          launchAllowed: true,
+          launchIssueMessage: null,
+          launchReadinessState: 'ready_chatgpt',
+          appServerState: 'healthy',
+          appServerStatusMessage: null,
+          managedAccount: { type: 'chatgpt', email: null, planType: 'pro' },
+          apiKey: { available: false, source: null, sourceLabel: null },
+          requiresOpenaiAuth: false,
+          login: { status: 'idle', error: null, startedAt: null },
+          rateLimits: null,
+          updatedAt: new Date().toISOString(),
+        });
+      }
+      localStorage.setItem('team:lastSelectedProvider', refreshProviderId);
       localStorage.setItem('team:lastSelectedModel:codex', 'gpt-5.4');
       localStorage.setItem('team:lastSelectedModel:anthropic', 'opus');
       createTeamDraftMock.state.soloTeam = true;
@@ -804,7 +824,7 @@ describe('LaunchTeamDialog', () => {
         storeState.cliStatus = {
           ...storeState.cliStatus,
           providers: storeState.cliStatus.providers.map((provider) =>
-            provider.providerId === 'anthropic'
+            provider.providerId === refreshProviderId
               ? reconcileCliProviderSnapshot(
                   provider,
                   sanitizeProviderStatusAuthority({
@@ -818,7 +838,7 @@ describe('LaunchTeamDialog', () => {
           ),
         };
         expect(
-          storeState.cliStatus.providers.find((provider) => provider.providerId === 'anthropic')
+          storeState.cliStatus.providers.find((provider) => provider.providerId === refreshProviderId)
         ).toMatchObject({
           capabilities: { teamLaunch: false },
           teamLaunchAuthorityRestriction: 'catalog-refresh',

--- a/test/renderer/components/team/dialogs/optionalProviderPreflight.test.ts
+++ b/test/renderer/components/team/dialogs/optionalProviderPreflight.test.ts
@@ -6,6 +6,7 @@ import {
   getPendingProviderPreflightIds,
   resumeInterruptedProviderPreflight,
 } from '@renderer/components/team/dialogs/optionalProviderPreflight';
+import { hasEffectiveProviderLaunchAuthority } from '@renderer/utils/providerReadiness';
 import { createDefaultCliExtensionCapabilities } from '@shared/utils/providerExtensionCapabilities';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -72,6 +73,105 @@ const check = (
 
 describe('optional provider preflight skip', () => {
   afterEach(() => vi.useRealTimers());
+  function refreshingCodex(catalog: 'missing' | 'stale' = 'stale'): CliProviderStatus {
+    return {
+      ...provider('codex'),
+      models: ['gpt-5.6-luna'],
+      runtimeCapabilities: { modelCatalog: { dynamic: true, source: 'runtime' } },
+      modelCatalogRefreshState: 'loading',
+      modelCatalog:
+        catalog === 'missing' ? null : { ...provider('codex').modelCatalog!, status: 'stale' },
+    };
+  }
+  it.each(['missing', 'stale'] as const)(
+    'allows optional Codex skip with %s catalog and ready selected-model check',
+    (catalog) => {
+      for (const provenance of ['runtime', 'restriction'] as const) {
+        const source = refreshingCodex(catalog);
+        if (provenance === 'restriction') {
+          source.capabilities.teamLaunch = false;
+          source.teamLaunchAuthorityRestriction = 'catalog-refresh';
+        }
+        const effective = {
+          ...source,
+          capabilities: { ...source.capabilities, teamLaunch: false },
+        };
+        for (const state of ['idle', 'loading', 'ready'] as const) {
+          expect(
+            canSkipProviderPreflight(
+              state,
+              ['codex'],
+              new Map([['codex', effective]]),
+              new Map([['codex', false]]),
+              [check('codex', 'ready')],
+              NOW,
+              [source]
+            )
+          ).toBe(true);
+        }
+        expect(hasEffectiveProviderLaunchAuthority(effective, NOW)).toBe(false);
+      }
+    }
+  );
+  it.each([
+    'missing-source',
+    'unsupported',
+    'failed-check',
+    'auth-error',
+    'runtime-error',
+    'catalog-error',
+    'settled-stale',
+  ] as const)('blocks Codex refresh bypass for %s', (failure) => {
+    const source = refreshingCodex();
+    if (failure === 'unsupported') source.capabilities.teamLaunch = false;
+    if (failure === 'auth-error') source.authenticated = false;
+    if (failure === 'runtime-error') source.statusCheckErrorCode = 'unavailable';
+    if (failure === 'catalog-error') source.modelCatalogRefreshState = 'error';
+    if (failure === 'settled-stale') source.modelCatalogRefreshState = 'ready';
+    const effective = { ...source, capabilities: { ...source.capabilities, teamLaunch: false } };
+    expect(
+      canSkipProviderPreflight(
+        'ready',
+        ['codex'],
+        new Map([['codex', effective]]),
+        new Map(),
+        [check('codex', failure === 'failed-check' ? 'failed' : 'ready')],
+        NOW,
+        failure === 'missing-source' ? [] : [source]
+      )
+    ).toBe(false);
+  });
+  it.each([
+    { authenticated: false },
+    { statusCheckErrorCode: 'unavailable' as const },
+  ])('rejects effective Codex failure despite valid source refresh provenance: %j', (override) => {
+    const source = refreshingCodex();
+    source.capabilities.teamLaunch = false;
+    source.teamLaunchAuthorityRestriction = 'catalog-refresh';
+    const effective = { ...source, ...override };
+    expect(
+      canSkipProviderPreflight(
+        'ready',
+        ['codex'],
+        new Map([['codex', effective]]),
+        new Map(),
+        [check('codex', 'ready')],
+        NOW,
+        [source]
+      )
+    ).toBe(false);
+  });
+  it('allows both authenticated native providers to refresh simultaneously', () => {
+    const { source: anthropic, statuses, checks } = refreshingAnthropicSelection();
+    const codex = refreshingCodex('missing');
+    statuses.set('codex', { ...codex, capabilities: { ...codex.capabilities, teamLaunch: false } });
+    expect(
+      canSkipProviderPreflight('ready', [...statuses.keys()], statuses, new Map(), checks, NOW, [
+        anthropic,
+        codex,
+      ])
+    ).toBe(true);
+  });
   function refreshingAnthropicSelection(override: Partial<CliProviderStatus> = {}) {
     const source = {
       ...provider('anthropic'),

--- a/test/renderer/utils/teamProviderRuntimeStatusLoading.test.ts
+++ b/test/renderer/utils/teamProviderRuntimeStatusLoading.test.ts
@@ -1,0 +1,41 @@
+import { isTeamProviderRuntimeStatusLoading } from '@renderer/utils/teamProviderRuntimeStatusLoading';
+import { describe, expect, it } from 'vitest';
+
+import type { TeamModelRuntimeProviderStatus } from '@renderer/utils/teamModelAvailability';
+
+describe('authenticated native catalog refresh indicator', () => {
+  const refreshing = (providerId: 'anthropic' | 'codex'): TeamModelRuntimeProviderStatus => ({
+    providerId,
+    supported: true,
+    authenticated: true,
+    authMethod: 'subscription',
+    verificationState: 'verified',
+    statusCheckOutcome: 'authoritative',
+    detailMessage: null,
+    models: ['gpt-5.6-luna'],
+    modelAvailability: [],
+    modelVerificationState: 'verified',
+    modelCatalog: null,
+    modelCatalogRefreshState: 'loading',
+    runtimeCapabilities: { modelCatalog: { dynamic: true, source: 'runtime' } },
+  });
+  it.each(['anthropic', 'codex'] as const)(
+    'keeps %s checking after provider discovery and selected-model verification settle',
+    (providerId) => {
+      expect(isTeamProviderRuntimeStatusLoading(providerId, refreshing(providerId), false)).toBe(
+        true
+      );
+    }
+  );
+  it.each([
+    { modelCatalogRefreshState: 'error' as const },
+    { modelCatalogRefreshState: 'ready' as const },
+    { authenticated: false },
+    { verificationState: 'error' as const },
+    { statusCheckErrorCode: 'unavailable' as const },
+  ])('does not hide a settled Codex failure with Checking: %j', (override) => {
+    expect(
+      isTeamProviderRuntimeStatusLoading('codex', { ...refreshing('codex'), ...override }, false)
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fix a reproduced cold-start preflight contradiction: the Codex account was healthy and Luna's selected-model check succeeded, but a background catalog refresh changed the provider badge to Needs attention and disabled Skip preflight.

- Reuse the existing authenticated catalog-refresh provenance for both Anthropic and Codex.
- Keep native-provider badges Checking while their catalog is refreshing, including retained display models.
- Keep optional Skip available during proven native catalog refreshes, including concurrent Anthropic and Codex refreshes.
- Preserve strict launch-time verification. Missing provenance, failed selected-model checks, auth revocation, unsupported runtimes and settled catalog errors remain blocking.

Related: https://github.com/777genius/agent-teams-ai/pull/599

## Verification

- Reproduced in dev:mcp with a disposable sandbox; captured account/provider/UI transitions before the fix.
- 136 focused contract/preflight/loading tests, 66 Create/Launch dialog tests, 14 runtime DTO mapper tests and 3 store reconciliation tests passed.
- Independent read-only review found no critical/major defects; effective-only auth-revocation regressions added.
- Typecheck and focused lint run locally; exact-head CI follows this PR.
- No runtime source changes, account configuration changes, new release packaging or publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Codex model catalog refreshes alongside Anthropic.
  - Team launch preflight checks can now accommodate authenticated Codex catalog refreshes, including simultaneous refreshes for supported providers.
  - Codex refresh activity now remains visibly in a loading state until catalog verification is complete.

- **Bug Fixes**
  - Preserved accurate launch restrictions and refresh status when provider catalogs are missing, stale, or still updating.
  - Improved consistency of provider status handling across Anthropic and Codex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->