### PR TITLE
test(opencode): isolate provisioning smoke and verify task completion

### DIFF
--- a/scripts/lib/opencode-live-preflight.mjs
+++ b/scripts/lib/opencode-live-preflight.mjs
@@ -18,6 +18,7 @@ export async function preflightOpenCodeLiveEnvironment(input) {
     : [];
   const opencodeBin =
     sourceEnv.CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH?.trim() ||
+    sourceEnv.OPENCODE_BIN_PATH?.trim() ||
     sourceEnv.OPENCODE_BIN?.trim() ||
     '/opt/homebrew/bin/opencode';
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-live-preflight-'));
@@ -27,7 +28,9 @@ export async function preflightOpenCodeLiveEnvironment(input) {
     Boolean(sourceEnv.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH?.trim());
   const env = {
     ...sourceEnv,
-    ...(useManagedAppCredentials ? {} : { XDG_DATA_HOME: xdgDataHome }),
+    ...(useManagedAppCredentials || shouldPreserveSandboxDataHome(input, sourceEnv)
+      ? {}
+      : { XDG_DATA_HOME: xdgDataHome }),
     OPENCODE_DISABLE_AUTOUPDATE: sourceEnv.OPENCODE_DISABLE_AUTOUPDATE ?? '1',
   };
 
@@ -36,7 +39,13 @@ export async function preflightOpenCodeLiveEnvironment(input) {
       return skip(`OpenCode binary not found at ${opencodeBin}`);
     }
 
-    const models = shouldUseManagedAppCredentials(env)
+    if (
+      input.useManagedRuntimeModels === true &&
+      !env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH?.trim()
+    ) {
+      return skip('Managed runtime model preflight requires an explicit runtime CLI');
+    }
+    const models = shouldUseManagedRuntimeModels(input, env)
       ? runManagedOpenCodeModels(requiredModels, projectPath, env)
       : runOpenCodeCommand(opencodeBin, ['models'], projectPath, env);
     if (!models.ok) {
@@ -70,6 +79,14 @@ export async function preflightOpenCodeLiveEnvironment(input) {
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }
+}
+
+function shouldPreserveSandboxDataHome(input, env) {
+  return input.preserveSandboxDataHome === true && Boolean(env.XDG_DATA_HOME);
+}
+
+function shouldUseManagedRuntimeModels(input, env) {
+  return input.useManagedRuntimeModels === true || shouldUseManagedAppCredentials(env);
 }
 
 function shouldUseManagedAppCredentials(env) {
@@ -380,6 +397,8 @@ function compactOutput(value) {
 }
 
 export const __opencodeLivePreflightTestHooks = {
+  shouldUseManagedRuntimeModels,
+  shouldPreserveSandboxDataHome,
   findMissingOpenCodeModels,
   isHealthyOpenCodeHostResponse,
   parseOpenCodeModels,

--- a/scripts/prove-opencode-team-provisioning.mjs
+++ b/scripts/prove-opencode-team-provisioning.mjs
@@ -1,62 +1,254 @@
 #!/usr/bin/env node
 
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 import { resolveLiveSmokeOrchestratorCliPath } from './lib/live-smoke-runtime.mjs';
-import {
-  exitForSkippedPreflight,
-  preflightOpenCodeLiveEnvironment,
-} from './lib/opencode-live-preflight.mjs';
-import { spawnSyncWithWindowsShell } from './lib/windows-shell-spawn.mjs';
+import { preflightOpenCodeLiveEnvironment } from './lib/opencode-live-preflight.mjs';
 
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(scriptDir, '..');
+// An explicit project must contain this exact opt-in; a name containing "test" is insufficient.
+export const TEST_PROJECT_MARKER = '.opencode-team-provisioning-test-only';
+export const TEST_PROJECT_MARKER_CONTENT = 'opencode-team-provisioning-test-only-v1';
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
-const env = {
-  ...process.env,
-  OPENCODE_E2E: '1',
-  OPENCODE_E2E_TEAM_PROVISIONING: '1',
-  OPENCODE_E2E_PROJECT_PATH: process.env.OPENCODE_E2E_PROJECT_PATH?.trim() || repoRoot,
-  OPENCODE_E2E_MODEL: process.env.OPENCODE_E2E_MODEL?.trim() || 'opencode/big-pickle',
-  OPENCODE_DISABLE_AUTOUPDATE: process.env.OPENCODE_DISABLE_AUTOUPDATE ?? '1',
-};
-
-if (!env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH?.trim()) {
-  env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH = resolveLiveSmokeOrchestratorCliPath({
-    env,
-    repoRoot,
-  });
-}
-
-console.log('Running OpenCode team provisioning live smoke');
-console.log(`Model: ${env.OPENCODE_E2E_MODEL}`);
-console.log(`Project: ${env.OPENCODE_E2E_PROJECT_PATH}`);
-console.log(`Orchestrator CLI: ${env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH}`);
-
-const preflight = await preflightOpenCodeLiveEnvironment({ repoRoot });
-exitForSkippedPreflight(preflight);
-
-const result = spawnSyncWithWindowsShell(
-  'pnpm',
-  [
-    'exec',
-    'vitest',
-    'run',
-    '--maxWorkers=1',
-    'test/main/services/team/OpenCodeTeamProvisioning.live.test.ts',
-  ],
-  {
-    cwd: repoRoot,
-    env,
-    stdio: 'inherit',
+export async function runProvisioningSmoke({
+  sourceEnv = process.env,
+  preflight = preflightOpenCodeLiveEnvironment,
+  spawn = spawnSync,
+  vitestEntryPath = path.join(repoRoot, 'node_modules/vitest/vitest.mjs'),
+  log = console.log,
+} = {}) {
+  if (
+    !path.isAbsolute(vitestEntryPath) ||
+    !fs.existsSync(vitestEntryPath) ||
+    !fs.statSync(vitestEntryPath).isFile()
+  ) {
+    throw new Error(
+      'Existing local Vitest entrypoint is required; smoke never installs dependencies'
+    );
   }
-);
-
-if (result.error) {
-  console.error(`Failed to run OpenCode team provisioning smoke: ${result.error.message}`);
-  process.exit(1);
+  const explicitProject = sourceEnv.OPENCODE_E2E_PROJECT_PATH;
+  let projectPath;
+  if (explicitProject !== undefined) {
+    if (!explicitProject.trim() || !path.isAbsolute(explicitProject.trim())) {
+      throw new Error('OPENCODE_E2E_PROJECT_PATH must be an absolute test-only directory');
+    }
+    projectPath = fs.realpathSync(explicitProject.trim());
+    if (projectPath === fs.realpathSync(repoRoot) || !fs.statSync(projectPath).isDirectory()) {
+      throw new Error('The repository root cannot be a smoke project');
+    }
+    const marker = path.join(projectPath, TEST_PROJECT_MARKER);
+    if (
+      !fs.lstatSync(marker).isFile() ||
+      fs.readFileSync(marker, 'utf8').trim() !== TEST_PROJECT_MARKER_CONTENT
+    ) {
+      throw new Error(
+        `Explicit smoke project requires ${TEST_PROJECT_MARKER} containing ${TEST_PROJECT_MARKER_CONTENT}`
+      );
+    }
+  }
+  const model = sourceEnv.OPENCODE_E2E_MODEL?.trim();
+  if (!model || !/^[^\s/]+\/[^\s]+$/.test(model)) {
+    throw new Error('Set OPENCODE_E2E_MODEL explicitly to the authorized test provider/model');
+  }
+  const binaryPath =
+    sourceEnv.CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH?.trim() ||
+    sourceEnv.OPENCODE_BIN_PATH?.trim() ||
+    sourceEnv.OPENCODE_BIN?.trim();
+  if (!binaryPath || !path.isAbsolute(binaryPath) || binaryPath.includes('\0')) {
+    throw new Error(
+      'Set an explicit absolute OpenCode binary path via CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH, OPENCODE_BIN_PATH, or OPENCODE_BIN'
+    );
+  }
+  let credentials = {};
+  if (sourceEnv.OPENCODE_E2E_TEST_CREDENTIALS_JSON !== undefined) {
+    try {
+      credentials = JSON.parse(sourceEnv.OPENCODE_E2E_TEST_CREDENTIALS_JSON);
+      if (
+        !credentials ||
+        Array.isArray(credentials) ||
+        typeof credentials !== 'object' ||
+        Object.entries(credentials).some(
+          ([key, value]) =>
+            !/^[A-Z][A-Z0-9_]*(?:API_KEY|AUTH_TOKEN|ACCESS_TOKEN)$/.test(key) ||
+            typeof value !== 'string' ||
+            !value.trim() ||
+            value.includes('\0')
+        )
+      )
+        throw new Error();
+    } catch {
+      throw new Error(
+        'OPENCODE_E2E_TEST_CREDENTIALS_JSON must be an object of test API_KEY/AUTH_TOKEN/ACCESS_TOKEN strings'
+      );
+    }
+  }
+  let selectedAuth;
+  if (sourceEnv.OPENCODE_E2E_TEST_AUTH_PATH !== undefined) {
+    try {
+      const sourcePath = sourceEnv.OPENCODE_E2E_TEST_AUTH_PATH.trim();
+      if (!path.isAbsolute(sourcePath) || !fs.statSync(sourcePath).isFile()) throw new Error();
+      const store = JSON.parse(fs.readFileSync(sourcePath, 'utf8'));
+      const provider = model.slice(0, model.indexOf('/'));
+      if (
+        !store ||
+        typeof store !== 'object' ||
+        Array.isArray(store) ||
+        !Object.hasOwn(store, provider)
+      )
+        throw new Error();
+      const entry = store[provider];
+      const nonempty = (value) => typeof value === 'string' && value.trim().length > 0;
+      if (
+        !entry ||
+        typeof entry !== 'object' ||
+        Array.isArray(entry) ||
+        !(
+          (entry.type === 'api' && nonempty(entry.key)) ||
+          (entry.type === 'oauth' && (nonempty(entry.access) || nonempty(entry.refresh)))
+        )
+      )
+        throw new Error();
+      selectedAuth = JSON.stringify({ [provider]: entry });
+    } catch {
+      // Never attach filesystem/JSON errors: they can contain the source path or token text.
+      throw new Error(
+        'OPENCODE_E2E_TEST_AUTH_PATH must select an absolute auth file with a valid selected-provider api/oauth record'
+      );
+    }
+  }
+  const ownedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-team-smoke-'));
+  let ownedProject;
+  let preserveFailedRun = false;
+  try {
+    // An explicit marked target is a test-only parent, never the mutable run project itself.
+    ownedProject = projectPath
+      ? fs.mkdtempSync(path.join(projectPath, 'opencode-team-smoke-'))
+      : path.join(ownedRoot, 'project');
+    projectPath = ownedProject;
+    fs.mkdirSync(projectPath, { recursive: true });
+    const env = {
+      ...Object.fromEntries(
+        Object.entries(sourceEnv).filter(([key]) =>
+          [
+            'PATH',
+            'Path',
+            'SystemRoot',
+            'WINDIR',
+            'COMSPEC',
+            'PATHEXT',
+            'LANG',
+            'LC_ALL',
+            'CLAUDE_DEV_RUNTIME_ROOT',
+            'CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH',
+          ].includes(key)
+        )
+      ),
+      ...credentials,
+      CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH: binaryPath,
+      OPENCODE_E2E_DEFAULT_MODEL_LAUNCH:
+        sourceEnv.OPENCODE_E2E_DEFAULT_MODEL_LAUNCH === '1' ? '1' : '0',
+      OPENCODE_E2E: '1',
+      OPENCODE_E2E_TEAM_PROVISIONING: '1',
+      OPENCODE_E2E_PROJECT_PATH: projectPath,
+      OPENCODE_E2E_OWNED_PROJECT_PATH: projectPath,
+      OPENCODE_E2E_MODEL: model,
+      OPENCODE_DISABLE_AUTOUPDATE: '1',
+    };
+    // Credentials enter only via the explicit test input above; never inherit auth profiles.
+    for (const key of [
+      'HOME',
+      'USERPROFILE',
+      'APPDATA',
+      'LOCALAPPDATA',
+      'XDG_CONFIG_HOME',
+      'XDG_DATA_HOME',
+      'XDG_STATE_HOME',
+      'XDG_CACHE_HOME',
+      'TMP',
+      'TEMP',
+      'TMPDIR',
+    ]) {
+      env[key] = path.join(ownedRoot, key.toLowerCase());
+      fs.mkdirSync(env[key], { recursive: true });
+    }
+    if (selectedAuth !== undefined) {
+      const authDirectory = path.join(env.XDG_DATA_HOME, 'opencode');
+      fs.mkdirSync(authDirectory, { recursive: true, mode: 0o700 });
+      fs.writeFileSync(path.join(authDirectory, 'auth.json'), selectedAuth, {
+        mode: 0o600,
+        flag: 'wx',
+      });
+    }
+    env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH = resolveLiveSmokeOrchestratorCliPath({
+      env,
+      repoRoot,
+    });
+    log(
+      `OpenCode provisioning smoke: ${model}, project ${projectPath}, CLI ${env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH}`
+    );
+    const projects = [projectPath];
+    if (env.OPENCODE_E2E_DEFAULT_MODEL_LAUNCH === '1') {
+      const defaultProject = path.join(ownedRoot, 'default-model-project');
+      fs.mkdirSync(defaultProject);
+      fs.writeFileSync(
+        path.join(defaultProject, 'opencode.json'),
+        JSON.stringify({ model, small_model: model })
+      );
+      env.OPENCODE_E2E_DEFAULT_MODEL_PROJECT_PATH = defaultProject;
+      projects.push(defaultProject);
+    }
+    for (const target of projects) {
+      const readiness = await preflight({
+        repoRoot,
+        projectPath: target,
+        env,
+        requiredModels: [model],
+        preserveSandboxDataHome: true,
+        useManagedRuntimeModels: true,
+      });
+      if (!readiness.ok) {
+        log(`SKIPPED: ${readiness.reason}`);
+        return 1; // Missing prerequisites are never successful proof.
+      }
+    }
+    const result = spawn(
+      process.execPath,
+      [
+        vitestEntryPath,
+        'run',
+        '--maxWorkers=1',
+        'test/main/services/team/OpenCodeTeamProvisioning.live.test.ts',
+      ],
+      { cwd: repoRoot, env, stdio: 'inherit' }
+    );
+    if (result.error) throw result.error;
+    preserveFailedRun = result.status !== 0;
+    return result.status ?? 1;
+  } finally {
+    // The caller's marked project is never owned by this wrapper.
+    if (preserveFailedRun) {
+      log(
+        `Smoke failed; preserving owned state for targeted cleanup: ${ownedRoot}, project ${ownedProject}`
+      );
+    } else {
+      if (ownedProject) fs.rmSync(ownedProject, { recursive: true, force: true });
+      fs.rmSync(ownedRoot, { recursive: true, force: true });
+    }
+  }
 }
 
-process.exit(result.status ?? 1);
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runProvisioningSmoke()
+    .then((status) => {
+      process.exitCode = status;
+    })
+    .catch((error) => {
+      console.error(`OpenCode provisioning smoke failed: ${error.message}`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/prove-opencode-team-provisioning.mjs
+++ b/scripts/prove-opencode-team-provisioning.mjs
@@ -123,7 +123,7 @@ export async function runProvisioningSmoke({
   }
   const ownedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-team-smoke-'));
   let ownedProject;
-  let preserveFailedRun = false;
+  let completedSuccessfully = false;
   try {
     // An explicit marked target is a test-only parent, never the mutable run project itself.
     ownedProject = projectPath
@@ -227,11 +227,12 @@ export async function runProvisioningSmoke({
       { cwd: repoRoot, env, stdio: 'inherit' }
     );
     if (result.error) throw result.error;
-    preserveFailedRun = result.status !== 0;
+    completedSuccessfully = result.status === 0;
     return result.status ?? 1;
   } finally {
     // The caller's marked project is never owned by this wrapper.
-    if (preserveFailedRun) {
+    // Preflight can already start managed hosts; retain their state until success is proven.
+    if (!completedSuccessfully) {
       log(
         `Smoke failed; preserving owned state for targeted cleanup: ${ownedRoot}, project ${ownedProject}`
       );

--- a/test/main/services/team/OpenCodeTeamProvisioning.live.test.ts
+++ b/test/main/services/team/OpenCodeTeamProvisioning.live.test.ts
@@ -3,6 +3,9 @@ import {
   OpenCodeRuntimeManifestEvidenceReader,
   readOpenCodeRuntimeLaneIndex,
 } from '@main/services/team/opencode/store/OpenCodeRuntimeManifestEvidenceReader';
+import { boundedDiagnosticString } from '@shared/utils/diagnosticsRedaction';
+import { redactSentryEvent } from '@shared/utils/sentryConfig';
+import { randomUUID } from 'crypto';
 import { constants as fsConstants, promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -23,11 +26,15 @@ import { OpenCodeStateChangingBridgeCommandService } from '../../../../src/main/
 import { OpenCodeTeamRuntimeAdapter } from '../../../../src/main/services/team/runtime/OpenCodeTeamRuntimeAdapter';
 import { TeamRuntimeAdapterRegistry } from '../../../../src/main/services/team/runtime/TeamRuntimeAdapter';
 import { resolveAgentTeamsMcpLaunchSpec } from '../../../../src/main/services/team/TeamMcpConfigBuilder';
+import { TeamDataService } from '../../../../src/main/services/team/TeamDataService';
+import { TeamTaskReader } from '../../../../src/main/services/team/TeamTaskReader';
 import { TeamProvisioningService } from '../../../../src/main/services/team/TeamProvisioningService';
 import {
   getTeamsBasePath,
   setClaudeBasePathOverride,
 } from '../../../../src/main/utils/pathDecoder';
+
+import { assertOpenCodeSmokeCleanup } from './assertOpenCodeSmokeCleanup';
 
 import type { OpenCodeBridgeCommandExecutor } from '../../../../src/main/services/team/opencode/bridge/OpenCodeStateChangingBridgeCommandService';
 import type { TeamProvisioningProgress } from '../../../../src/shared/types';
@@ -38,12 +45,12 @@ const liveDescribe =
     : describe.skip;
 
 const PROJECT_PATH = process.env.OPENCODE_E2E_PROJECT_PATH?.trim() || process.cwd();
-const DEFAULT_ORCHESTRATOR_CLI = '/Users/belief/dev/projects/claude/agent_teams_orchestrator/cli-source';
-const DEFAULT_MODEL = 'opencode/big-pickle';
+const DEFAULT_ORCHESTRATOR_CLI =
+  '/Users/belief/dev/projects/claude/agent_teams_orchestrator/cli-source';
+const DEFAULT_MODEL = process.env.OPENCODE_E2E_MODEL?.trim() || 'opencode/big-pickle';
 
 liveDescribe('OpenCode team provisioning live e2e', () => {
-  const liveDefaultModelIt =
-    process.env.OPENCODE_E2E_DEFAULT_MODEL_LAUNCH === '1' ? it : it.skip;
+  const liveDefaultModelIt = process.env.OPENCODE_E2E_DEFAULT_MODEL_LAUNCH === '1' ? it : it.skip;
   let tempDir: string;
   let tempClaudeRoot: string;
 
@@ -54,12 +61,27 @@ liveDescribe('OpenCode team provisioning live e2e', () => {
     setClaudeBasePathOverride(tempClaudeRoot);
   });
 
-  afterEach(async () => {
+  afterEach(async ({ task }) => {
     setClaudeBasePathOverride(null);
+    if (
+      task.result?.state === 'fail' &&
+      process.env.OPENCODE_E2E_OWNED_PROJECT_PATH === PROJECT_PATH
+    ) {
+      console.info('Preserved failed OpenCode smoke state', { tempDir });
+      return;
+    }
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
-  it('creates and stops a pure OpenCode team through TeamProvisioningService using the live runtime adapter', async () => {
+  it('creates an OpenCode team, completes an assigned file task, and stops the live runtime', async () => {
+    // This task may write only into the wrapper-owned disposable project.
+    expect(path.isAbsolute(PROJECT_PATH)).toBe(true);
+    expect(process.env.OPENCODE_E2E_OWNED_PROJECT_PATH).toBe(PROJECT_PATH);
+    expect(await fs.realpath(PROJECT_PATH)).not.toBe(await fs.realpath(process.cwd()));
+    const proofToken = randomUUID();
+    const proofPath = path.join(PROJECT_PATH, `task-proof-${proofToken}.txt`);
+    const proofContent = `opencode-task-proof:${proofToken}\n`;
+    await expect(fs.lstat(proofPath)).rejects.toMatchObject({ code: 'ENOENT' });
     const selectedModel = process.env.OPENCODE_E2E_MODEL?.trim() || DEFAULT_MODEL;
     const orchestratorCli =
       process.env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH?.trim() || DEFAULT_ORCHESTRATOR_CLI;
@@ -69,7 +91,7 @@ liveDescribe('OpenCode team provisioning live e2e', () => {
     const bridgeEnv = {
       ...createStableBridgeEnv(),
       PATH: withBunOnPath(process.env.PATH ?? ''),
-      XDG_DATA_HOME: path.join(tempDir, 'xdg-data'),
+      XDG_DATA_HOME: process.env.XDG_DATA_HOME ?? path.join(tempDir, 'xdg-data'),
       AGENT_TEAMS_MCP_CLAUDE_DIR: tempClaudeRoot,
       CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND: mcpLaunchSpec.command,
       CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: mcpLaunchSpec.args[0] ?? '',
@@ -128,14 +150,22 @@ liveDescribe('OpenCode team provisioning live e2e', () => {
       );
 
       expect(runId).toBeTruthy();
+      await waitUntil(async () => {
+        const last = progressEvents.at(-1);
+        if (last?.state === 'failed') {
+          throw new Error(
+            `Team ${teamName} run ${runId} provisioning failed: ${JSON.stringify(safeProgress(last))}`
+          );
+        }
+        return last?.state === 'ready';
+      }, 180_000);
       const progressDump = progressEvents
         .map((progress) =>
           [
             progress.state,
-            progress.message,
+            safeProgress(progress).message,
             progress.messageSeverity,
-            progress.error,
-            progress.cliLogsTail,
+            safeProgress(progress).error,
           ]
             .filter(Boolean)
             .join(' | ')
@@ -192,24 +222,92 @@ liveDescribe('OpenCode team provisioning live e2e', () => {
         },
       });
 
+      const taskReader = new TeamTaskReader();
+      const task = await new TeamDataService().createTask(teamName, {
+        subject: `Live file proof ${proofToken}`,
+        owner: 'alice',
+        startImmediately: true,
+        prompt: [
+          `Work only inside ${PROJECT_PATH}.`,
+          `Create the regular file ${proofPath}.`,
+          `Its exact UTF-8 content must be ${JSON.stringify(proofContent)} (including the final newline).`,
+          'Do not modify any other project file. Do not delegate this task.',
+          'After writing and reading back the file, complete this assigned task with task_complete.',
+        ].join('\n'),
+      });
+      expect(task.id).toBeTruthy();
+      expect(task.owner).toBe('alice');
+      // Submit once: after an uncertain delivery result only observe, never redispatch.
+      const relay = await svc.relayInboxFileToLiveRecipient(teamName, 'alice');
+      expect(
+        relay.kind === 'native_member_noop' ||
+          relay.relayed > 0 ||
+          relay.lastDelivery?.accepted === true ||
+          relay.lastDelivery?.delivered === true ||
+          relay.lastDelivery?.responsePending === true
+      ).toBe(true);
+      await waitUntil(
+        async () => {
+          const observed = (await taskReader.getTasks(teamName)).find(({ id }) => id === task.id);
+          if (observed?.status !== 'completed') return false;
+          expect(observed).toMatchObject({ id: task.id, owner: 'alice', status: 'completed' });
+          try {
+            expect((await fs.lstat(proofPath)).isFile()).toBe(true);
+            expect(await fs.readFile(proofPath, 'utf8')).toBe(proofContent);
+            return true;
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+            throw error;
+          }
+        },
+        300_000,
+        2_000
+      );
+      console.info('OpenCode live task proof', {
+        teamName,
+        runId,
+        taskId: task.id,
+        owner: 'alice',
+        model: selectedModel,
+        status: 'completed',
+        proofFile: path.basename(proofPath),
+      });
+
       await svc.stopTeam(teamName);
       await waitUntil(async () => {
         const laneIndex = await readOpenCodeRuntimeLaneIndex(getTeamsBasePath(), teamName);
         return Object.keys(laneIndex.lanes).length === 0;
       }, 90_000);
+    } catch (error) {
+      const diagnostics = {
+        teamName,
+        error: safeDiagnostic(error instanceof Error ? error.message : String(error)),
+        progress: progressEvents.slice(-30).map(safeProgress),
+      };
+      // Keep bounded, redacted evidence separately from raw runtime state. No env/auth or CLI tail.
+      await fs
+        .writeFile(
+          path.join(tempDir, 'provisioning-failure.json'),
+          `${JSON.stringify(diagnostics, null, 2)}\n`
+        )
+        .catch(() => undefined);
+      console.info('OpenCode smoke failure', JSON.stringify(diagnostics));
+      throw new Error(diagnostics.error ?? 'OpenCode smoke failed; see preserved diagnostics');
     } finally {
       await svc.stopTeam(teamName).catch(() => undefined);
-      await readinessBridge
-        .cleanupOpenCodeHosts({
+      // Only the wrapper's fresh project has exclusive host ownership.
+      if (process.env.OPENCODE_E2E_OWNED_PROJECT_PATH === PROJECT_PATH) {
+        const cleanup = await readinessBridge.cleanupOpenCodeHosts({
           reason: 'opencode-team-provisioning-live-e2e-cleanup',
           mode: 'force',
           projectPath: PROJECT_PATH,
           staleAgeMs: null,
           leaseStaleAgeMs: null,
-        })
-        .catch(() => undefined);
+        });
+        assertOpenCodeSmokeCleanup(cleanup, PROJECT_PATH);
+      }
     }
-  }, 300_000);
+  }, 780_000);
 
   liveDefaultModelIt(
     'creates and stops a pure OpenCode team when all OpenCode model selections are Default',
@@ -217,7 +315,9 @@ liveDescribe('OpenCode team provisioning live e2e', () => {
       const orchestratorCli =
         process.env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH?.trim() || DEFAULT_ORCHESTRATOR_CLI;
       await assertExecutable(orchestratorCli);
-      const projectPath = path.join(tempDir, 'default-model-project');
+      const projectPath =
+        process.env.OPENCODE_E2E_DEFAULT_MODEL_PROJECT_PATH ??
+        path.join(tempDir, 'default-model-project');
       await fs.mkdir(projectPath, { recursive: true });
       await fs.writeFile(
         path.join(projectPath, 'opencode.json'),
@@ -228,7 +328,7 @@ liveDescribe('OpenCode team provisioning live e2e', () => {
       const bridgeEnv = {
         ...createStableBridgeEnv(),
         PATH: withBunOnPath(process.env.PATH ?? ''),
-        XDG_DATA_HOME: path.join(tempDir, 'xdg-data-default-model'),
+        XDG_DATA_HOME: process.env.XDG_DATA_HOME ?? path.join(tempDir, 'xdg-data-default-model'),
         AGENT_TEAMS_MCP_CLAUDE_DIR: tempClaudeRoot,
         CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND: mcpLaunchSpec.command,
         CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: mcpLaunchSpec.args[0] ?? '',
@@ -283,10 +383,9 @@ liveDescribe('OpenCode team provisioning live e2e', () => {
           .map((progress) =>
             [
               progress.state,
-              progress.message,
+              safeProgress(progress).message,
               progress.messageSeverity,
-              progress.error,
-              progress.cliLogsTail,
+              safeProgress(progress).error,
             ]
               .filter(Boolean)
               .join(' | ')
@@ -338,10 +437,9 @@ liveDescribe('OpenCode team provisioning live e2e', () => {
           .map((progress) =>
             [
               progress.state,
-              progress.message,
+              safeProgress(progress).message,
               progress.messageSeverity,
-              progress.error,
-              progress.cliLogsTail,
+              safeProgress(progress).error,
             ]
               .filter(Boolean)
               .join(' | ')
@@ -379,15 +477,14 @@ liveDescribe('OpenCode team provisioning live e2e', () => {
         }, 90_000);
       } finally {
         await svc.stopTeam(teamName).catch(() => undefined);
-        await readinessBridge
-          .cleanupOpenCodeHosts({
-            reason: 'opencode-team-default-model-live-e2e-cleanup',
-            mode: 'force',
-            projectPath,
-            staleAgeMs: null,
-            leaseStaleAgeMs: null,
-          })
-          .catch(() => undefined);
+        const cleanup = await readinessBridge.cleanupOpenCodeHosts({
+          reason: 'opencode-team-default-model-live-e2e-cleanup',
+          mode: 'force',
+          projectPath,
+          staleAgeMs: null,
+          leaseStaleAgeMs: null,
+        });
+        assertOpenCodeSmokeCleanup(cleanup, projectPath);
       }
     },
     300_000
@@ -453,12 +550,11 @@ function withBunOnPath(pathValue: string): string {
 }
 
 function createStableBridgeEnv(): NodeJS.ProcessEnv {
-  const realHome = os.userInfo().homedir;
   const env = applyOpenCodeAutoUpdatePolicy({ ...process.env });
   return {
     ...env,
-    HOME: realHome,
-    USERPROFILE: realHome,
+    HOME: process.env.HOME ?? os.homedir(),
+    USERPROFILE: process.env.USERPROFILE ?? os.homedir(),
   };
 }
 
@@ -472,4 +568,18 @@ function hasOpenCodeRuntimeHandle(member: {
     (typeof member.runtimePid === 'number' && member.runtimePid > 0) ||
     (typeof member.runtimeSessionId === 'string' && member.runtimeSessionId.trim().length > 0)
   );
+}
+
+function safeDiagnostic(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return boundedDiagnosticString(String(redactSentryEvent(value)), 2_000);
+}
+
+function safeProgress(progress: TeamProvisioningProgress) {
+  return {
+    state: progress.state,
+    message: safeDiagnostic(progress.message),
+    error: safeDiagnostic(progress.error),
+    messageSeverity: progress.messageSeverity,
+  };
 }

--- a/test/main/services/team/assertOpenCodeSmokeCleanup.test.ts
+++ b/test/main/services/team/assertOpenCodeSmokeCleanup.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import { OpenCodeReadinessBridge } from '../../../../src/main/services/team/opencode/bridge/OpenCodeReadinessBridge';
+
+import { assertOpenCodeSmokeCleanup } from './assertOpenCodeSmokeCleanup';
+
+import type { OpenCodeCleanupHostsCommandData } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeCommandContract';
+
+const project = '/owned/project';
+const result = (): OpenCodeCleanupHostsCommandData => ({
+  cleaned: 0,
+  remaining: 0,
+  hosts: [],
+  diagnostics: [],
+});
+
+describe('owned smoke cleanup evidence', () => {
+  it('rejects the readiness bridge fallback even when remaining is zero', async () => {
+    const adapter = new OpenCodeReadinessBridge({
+      execute: async () => ({
+        ok: false,
+        schemaVersion: 1,
+        requestId: 'mock',
+        command: 'opencode.cleanupHosts',
+        completedAt: '',
+        durationMs: 0,
+        error: { kind: 'timeout', message: 'mock timeout', retryable: false },
+        diagnostics: [],
+      }),
+    });
+    const awaited = await adapter.cleanupOpenCodeHosts({
+      reason: 'test',
+      projectPath: project,
+      mode: 'force',
+    });
+    expect(awaited.remaining).toBe(0);
+    expect(() => assertOpenCodeSmokeCleanup(awaited, project)).toThrow(/not confirmed/);
+  });
+  it('rejects remaining hosts and failed/kept owned-host actions', () => {
+    expect(() => assertOpenCodeSmokeCleanup({ ...result(), remaining: 1 }, project)).toThrow();
+    for (const action of [
+      'failed',
+      'kept_active',
+      'kept_leased',
+      'kept_recent',
+      'kept_filtered',
+    ] as const) {
+      expect(() =>
+        assertOpenCodeSmokeCleanup(
+          {
+            ...result(),
+            hosts: [
+              {
+                hostKey: 'owned',
+                projectPath: project,
+                pid: 123,
+                port: 42,
+                action,
+                reason: '',
+                leaseCount: 0,
+              },
+            ],
+          },
+          project
+        )
+      ).toThrow();
+    }
+  });
+  it('accepts positive stopped evidence and leaves filtered unrelated hosts alone', () => {
+    assertOpenCodeSmokeCleanup(result(), project);
+    for (const action of ['disposed', 'removed_dead'] as const) {
+      assertOpenCodeSmokeCleanup(
+        {
+          ...result(),
+          hosts: [
+            {
+              hostKey: 'owned',
+              projectPath: project,
+              pid: 123,
+              port: 42,
+              action,
+              reason: '',
+              leaseCount: 0,
+            },
+          ],
+        },
+        project
+      );
+    }
+    assertOpenCodeSmokeCleanup(
+      {
+        ...result(),
+        hosts: [
+          {
+            hostKey: 'other',
+            projectPath: '/other',
+            pid: 123,
+            port: 42,
+            action: 'kept_filtered',
+            reason: '',
+            leaseCount: 0,
+          },
+        ],
+      },
+      project
+    );
+  });
+});

--- a/test/main/services/team/assertOpenCodeSmokeCleanup.ts
+++ b/test/main/services/team/assertOpenCodeSmokeCleanup.ts
@@ -1,0 +1,23 @@
+import type { OpenCodeCleanupHostsCommandData } from '../../../../src/main/services/team/opencode/bridge/OpenCodeBridgeCommandContract';
+
+/** A resolved bridge call is not evidence that owned persistent hosts stopped. */
+export function assertOpenCodeSmokeCleanup(
+  result: OpenCodeCleanupHostsCommandData,
+  ownedProjectPath: string
+): void {
+  if (
+    !result ||
+    result.remaining !== 0 ||
+    !Array.isArray(result.diagnostics) ||
+    result.diagnostics.length !== 0 ||
+    !Array.isArray(result.hosts) ||
+    result.hosts.some(
+      (host) =>
+        host.projectPath === ownedProjectPath &&
+        host.action !== 'disposed' &&
+        host.action !== 'removed_dead'
+    )
+  ) {
+    throw new Error('OpenCode smoke-owned host cleanup was not confirmed; preserve run state');
+  }
+}

--- a/test/scripts/proveOpenCodeTeamProvisioning.test.mjs
+++ b/test/scripts/proveOpenCodeTeamProvisioning.test.mjs
@@ -1,0 +1,432 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  runProvisioningSmoke,
+  TEST_PROJECT_MARKER,
+  TEST_PROJECT_MARKER_CONTENT,
+} from '../../scripts/prove-opencode-team-provisioning.mjs';
+
+const modelEnv = {
+  OPENCODE_E2E_MODEL: 'test-provider/test-model',
+  CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH: process.execPath,
+};
+
+test('preflight and downstream receive identical selection and isolated environment', async () => {
+  let input;
+  const status = await runProvisioningSmoke({
+    sourceEnv: {
+      ...modelEnv,
+      HOME: '/caller-home',
+      OPENCODE_CONFIG: '/caller-config',
+      CLAUDE_DEV_RUNTIME_ROOT: '/source-runtime',
+    },
+    log() {},
+    preflight: async (value) => {
+      input = value;
+      assert.notEqual(value.projectPath, value.repoRoot);
+      assert.equal(value.preserveSandboxDataHome, true);
+      assert.equal(value.useManagedRuntimeModels, true);
+      assert.equal(value.env.OPENCODE_E2E_USE_REAL_APP_CREDENTIALS, undefined);
+      assert.ok(fs.statSync(value.projectPath).isDirectory());
+      assert.deepEqual(value.requiredModels, [modelEnv.OPENCODE_E2E_MODEL]);
+      assert.equal(value.env.OPENCODE_E2E_PROJECT_PATH, value.projectPath);
+      assert.notEqual(value.env.HOME, '/caller-home');
+      assert.equal(value.env.OPENCODE_CONFIG, undefined);
+      assert.equal(
+        value.env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH,
+        path.resolve('/source-runtime/cli-source')
+      );
+      return { ok: true };
+    },
+    spawn: (command, args, options) => {
+      assert.equal(command, process.execPath);
+      assert.deepEqual(args, [
+        path.join(input.repoRoot, 'node_modules/vitest/vitest.mjs'),
+        'run',
+        '--maxWorkers=1',
+        'test/main/services/team/OpenCodeTeamProvisioning.live.test.ts',
+      ]);
+      assert.equal(options.cwd, input.repoRoot);
+      assert.equal(options.env, input.env);
+      return { status: 0 };
+    },
+  });
+  assert.equal(status, 0);
+  assert.equal(fs.existsSync(input.projectPath), false);
+  assert.equal(fs.existsSync(input.env.HOME), false);
+});
+
+test('invalid target or model fails before preflight or spawn', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'unmarked-test-project-'));
+  let calls = 0;
+  try {
+    for (const sourceEnv of [
+      {},
+      { ...modelEnv, OPENCODE_E2E_PROJECT_PATH: '' },
+      { ...modelEnv, OPENCODE_E2E_PROJECT_PATH: 'relative-test' },
+      { ...modelEnv, OPENCODE_E2E_PROJECT_PATH: root },
+    ]) {
+      await assert.rejects(
+        runProvisioningSmoke({
+          sourceEnv,
+          preflight: async () => {
+            calls++;
+          },
+          spawn: () => {
+            calls++;
+          },
+        })
+      );
+    }
+    assert.equal(calls, 0);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('marked caller project survives spawn failure; explicit built launcher is preserved', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'caller-project-'));
+  fs.writeFileSync(path.join(root, TEST_PROJECT_MARKER), TEST_PROJECT_MARKER_CONTENT);
+  let home;
+  try {
+    await assert.rejects(
+      runProvisioningSmoke({
+        sourceEnv: {
+          ...modelEnv,
+          OPENCODE_E2E_PROJECT_PATH: root,
+          CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH: '/built/cli',
+        },
+        log() {},
+        preflight: async ({ env }) => {
+          home = env.HOME;
+          assert.notEqual(env.OPENCODE_E2E_PROJECT_PATH, root);
+          assert.equal(path.dirname(env.OPENCODE_E2E_PROJECT_PATH), fs.realpathSync(root));
+          assert.equal(env.OPENCODE_E2E_OWNED_PROJECT_PATH, env.OPENCODE_E2E_PROJECT_PATH);
+          assert.equal(env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH, '/built/cli');
+          return { ok: true };
+        },
+        spawn: () => {
+          throw new Error('mock spawn failure');
+        },
+      }),
+      /mock spawn failure/
+    );
+    assert.equal(fs.existsSync(path.join(root, TEST_PROJECT_MARKER)), true);
+    assert.equal(fs.existsSync(home), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('unavailable preflight fails proof and cleans its resources without launching test', async () => {
+  let project;
+  const status = await runProvisioningSmoke({
+    sourceEnv: modelEnv,
+    log() {},
+    preflight: async ({ projectPath }) => {
+      project = projectPath;
+      return { ok: false, reason: 'test unavailable' };
+    },
+    spawn: () => {
+      assert.fail('must not spawn');
+    },
+  });
+  assert.equal(status, 1);
+  assert.equal(fs.existsSync(project), false);
+});
+
+test('default lane preflights its own project with the selected model and same env', async () => {
+  const inputs = [];
+  await runProvisioningSmoke({
+    sourceEnv: {
+      ...modelEnv,
+      OPENCODE_E2E_DEFAULT_MODEL_LAUNCH: '1',
+      OPENAI_API_KEY: 'unapproved-inherited',
+      OPENCODE_E2E_TEST_CREDENTIALS_JSON: '{"ZAI_API_KEY":"explicit-test-fixture"}',
+    },
+    log() {},
+    preflight: async (input) => {
+      inputs.push(input);
+      return { ok: true };
+    },
+    spawn: (_command, _args, { env }) => {
+      assert.equal(inputs.length, 2);
+      assert.equal(inputs[1].projectPath, env.OPENCODE_E2E_DEFAULT_MODEL_PROJECT_PATH);
+      assert.notEqual(inputs[0].projectPath, inputs[1].projectPath);
+      for (const input of inputs) {
+        assert.equal(input.env, env);
+        assert.deepEqual(input.requiredModels, [modelEnv.OPENCODE_E2E_MODEL]);
+      }
+      assert.deepEqual(
+        JSON.parse(fs.readFileSync(path.join(inputs[1].projectPath, 'opencode.json'), 'utf8')),
+        { model: modelEnv.OPENCODE_E2E_MODEL, small_model: modelEnv.OPENCODE_E2E_MODEL }
+      );
+      assert.equal(env.OPENAI_API_KEY, undefined);
+      assert.equal(env.ZAI_API_KEY, 'explicit-test-fixture');
+      assert.equal(env.OPENCODE_E2E_TEST_CREDENTIALS_JSON, undefined);
+      return { status: 0 };
+    },
+  });
+  for (const input of inputs) assert.equal(fs.existsSync(input.projectPath), false);
+});
+
+test('invalid credential input fails before any preflight or spawn without revealing secrets', async () => {
+  for (const value of ['{"HOME":"secret"}', '{"ZAI_API_KEY":42}', 'secret', 'null', '[]']) {
+    await assert.rejects(
+      runProvisioningSmoke({
+        sourceEnv: { ...modelEnv, OPENCODE_E2E_TEST_CREDENTIALS_JSON: value },
+        preflight: async () => assert.fail('preflight must not run'),
+        spawn: () => assert.fail('spawn must not run'),
+      }),
+      (error) =>
+        !error.message.includes('secret') && error.message.includes('TEST_CREDENTIALS_JSON')
+    );
+  }
+});
+
+test('all binary aliases normalize to the identical canonical binary for preflight and launcher', async () => {
+  for (const binaryEnv of [
+    { OPENCODE_BIN: process.execPath },
+    { OPENCODE_BIN_PATH: process.execPath },
+    {
+      CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH: ` ${process.execPath} `,
+      OPENCODE_BIN_PATH: '/ignored/opencode',
+      OPENCODE_BIN: '/also-ignored/opencode',
+    },
+  ]) {
+    const expected =
+      binaryEnv.CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH?.trim() ||
+      binaryEnv.OPENCODE_BIN_PATH ||
+      binaryEnv.OPENCODE_BIN;
+    let preflightEnv;
+    await runProvisioningSmoke({
+      sourceEnv: { OPENCODE_E2E_MODEL: modelEnv.OPENCODE_E2E_MODEL, ...binaryEnv },
+      log() {},
+      preflight: async ({ env }) => {
+        preflightEnv = env;
+        assert.equal(env.CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH, expected);
+        return { ok: true };
+      },
+      spawn: (_command, _args, { env }) => {
+        assert.equal(env, preflightEnv);
+        assert.equal(env.CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH, expected);
+        assert.equal(env.OPENCODE_BIN_PATH, undefined);
+        assert.equal(env.OPENCODE_BIN, undefined);
+        return { status: 0 };
+      },
+    });
+  }
+});
+
+test('shared preflight ignores ambient data home unless sandbox preservation is explicit', async () => {
+  const { __opencodeLivePreflightTestHooks: hooks } =
+    await import('../../scripts/lib/opencode-live-preflight.mjs');
+  const env = { XDG_DATA_HOME: '/caller-data' };
+  assert.equal(hooks.shouldPreserveSandboxDataHome({}, env), false);
+  assert.equal(hooks.shouldPreserveSandboxDataHome({ preserveSandboxDataHome: true }, env), true);
+  assert.equal(hooks.shouldPreserveSandboxDataHome({ preserveSandboxDataHome: true }, {}), false);
+});
+
+test('failed downstream preserves only owned state for targeted host cleanup', async () => {
+  let ownedRoot;
+  let project;
+  try {
+    const status = await runProvisioningSmoke({
+      sourceEnv: modelEnv,
+      log() {},
+      preflight: async ({ env, projectPath }) => {
+        ownedRoot = path.dirname(env.HOME);
+        project = projectPath;
+        return { ok: true };
+      },
+      spawn: () => ({ status: 1 }),
+    });
+    assert.equal(status, 1);
+    assert.ok(fs.existsSync(ownedRoot));
+    assert.ok(fs.existsSync(project));
+  } finally {
+    if (ownedRoot) fs.rmSync(ownedRoot, { recursive: true, force: true });
+  }
+});
+
+test('absent or relative binary fails before preflight and spawn', async () => {
+  for (const binaryEnv of [
+    {},
+    { OPENCODE_BIN: 'opencode' },
+    { OPENCODE_BIN_PATH: './opencode' },
+    { CLAUDE_MULTIMODEL_OPENCODE_BIN_PATH: 'relative/opencode' },
+  ]) {
+    await assert.rejects(
+      runProvisioningSmoke({
+        sourceEnv: { OPENCODE_E2E_MODEL: modelEnv.OPENCODE_E2E_MODEL, ...binaryEnv },
+        preflight: async () => assert.fail('preflight must not run'),
+        spawn: () => assert.fail('spawn must not run'),
+      }),
+      /explicit absolute OpenCode binary/
+    );
+  }
+});
+
+test('auth fixture seeds only selected provider and never forwards source path/blob', async () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-auth-fixture-'));
+  const sourcePath = path.join(fixtureRoot, 'source.json');
+  const selected = { type: 'oauth', refresh: 'selected-refresh-fixture', expires: 0 };
+  const source = JSON.stringify({
+    'test-provider': selected,
+    unrelated: { type: 'api', key: 'unrelated-secret-fixture' },
+  });
+  fs.writeFileSync(sourcePath, source);
+  let target;
+  const logs = [];
+  try {
+    await runProvisioningSmoke({
+      sourceEnv: { ...modelEnv, OPENCODE_E2E_TEST_AUTH_PATH: sourcePath },
+      log: (line) => logs.push(line),
+      preflight: async ({ env }) => {
+        target = path.join(env.XDG_DATA_HOME, 'opencode', 'auth.json');
+        assert.deepEqual(JSON.parse(fs.readFileSync(target, 'utf8')), {
+          'test-provider': selected,
+        });
+        if (process.platform !== 'win32') assert.equal(fs.statSync(target).mode & 0o777, 0o600);
+        assert.equal(env.OPENCODE_E2E_TEST_AUTH_PATH, undefined);
+        for (const forbidden of [
+          sourcePath,
+          'selected-refresh-fixture',
+          'unrelated-secret-fixture',
+        ])
+          assert.equal(JSON.stringify(env).includes(forbidden), false);
+        return { ok: true };
+      },
+      spawn: () => {
+        fs.writeFileSync(target, '{"test-provider":{"type":"oauth","access":"rotated-fixture"}}');
+        return { status: 0 };
+      },
+    });
+    assert.equal(fs.readFileSync(sourcePath, 'utf8'), source);
+    assert.equal(fs.existsSync(target), false);
+    for (const forbidden of [sourcePath, 'selected-refresh-fixture', 'unrelated-secret-fixture'])
+      assert.equal(logs.join('\n').includes(forbidden), false);
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('malformed or missing selected auth fails before preflight/spawn without source details', async () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-auth-fixture-'));
+  const sourcePath = path.join(fixtureRoot, 'private-source.json');
+  try {
+    for (const source of [
+      'secret-malformed-json',
+      '{}',
+      '{"test-provider":null}',
+      '{"test-provider":{"type":"oauth"}}',
+      '{"test-provider":{"type":"api","key":""}}',
+    ]) {
+      fs.writeFileSync(sourcePath, source);
+      await assert.rejects(
+        runProvisioningSmoke({
+          sourceEnv: { ...modelEnv, OPENCODE_E2E_TEST_AUTH_PATH: sourcePath },
+          preflight: async () => assert.fail('preflight must not run'),
+          spawn: () => assert.fail('spawn must not run'),
+        }),
+        (error) =>
+          error.message.includes('valid selected-provider') &&
+          !error.message.includes(sourcePath) &&
+          !error.message.includes('secret-malformed-json')
+      );
+      assert.equal(fs.readFileSync(sourcePath, 'utf8'), source);
+    }
+    await assert.rejects(
+      runProvisioningSmoke({
+        sourceEnv: { ...modelEnv, OPENCODE_E2E_TEST_AUTH_PATH: 'relative-auth.json' },
+      }),
+      /valid selected-provider/
+    );
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('auth import accepts api keys and access-only OAuth records', async () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-auth-fixture-'));
+  const sourcePath = path.join(fixtureRoot, 'source.json');
+  try {
+    for (const entry of [
+      { type: 'api', key: 'fixture-api' },
+      { type: 'oauth', access: 'fixture-access' },
+    ]) {
+      fs.writeFileSync(sourcePath, JSON.stringify({ 'test-provider': entry }));
+      await runProvisioningSmoke({
+        sourceEnv: { ...modelEnv, OPENCODE_E2E_TEST_AUTH_PATH: sourcePath },
+        log() {},
+        preflight: async ({ env }) => {
+          assert.deepEqual(
+            JSON.parse(
+              fs.readFileSync(path.join(env.XDG_DATA_HOME, 'opencode', 'auth.json'), 'utf8')
+            ),
+            { 'test-provider': entry }
+          );
+          return { ok: true };
+        },
+        spawn: () => ({ status: 0 }),
+      });
+    }
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('managed model catalog selection is independent of real app credential access', async () => {
+  const { __opencodeLivePreflightTestHooks: hooks } =
+    await import('../../scripts/lib/opencode-live-preflight.mjs');
+  const sandboxEnv = {
+    XDG_DATA_HOME: '/owned/data',
+    CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH: process.execPath,
+  };
+  assert.equal(
+    hooks.shouldUseManagedRuntimeModels({ useManagedRuntimeModels: true }, sandboxEnv),
+    true
+  );
+  assert.equal(hooks.shouldUseManagedAppCredentials(sandboxEnv), false);
+  assert.equal(hooks.shouldUseManagedRuntimeModels({}, sandboxEnv), false);
+  assert.equal(
+    hooks.shouldUseManagedRuntimeModels(
+      {},
+      { ...sandboxEnv, OPENCODE_E2E_USE_REAL_APP_CREDENTIALS: '1' }
+    ),
+    true
+  );
+  assert.equal(
+    hooks.shouldPreserveSandboxDataHome({ useManagedRuntimeModels: true }, sandboxEnv),
+    false
+  );
+  assert.equal(
+    hooks.shouldPreserveSandboxDataHome(
+      { useManagedRuntimeModels: true, preserveSandboxDataHome: true },
+      sandboxEnv
+    ),
+    true
+  );
+});
+
+test('missing local Vitest entrypoint fails before preflight or spawn without installing', async () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'missing-vitest-fixture-'));
+  try {
+    await assert.rejects(
+      runProvisioningSmoke({
+        sourceEnv: modelEnv,
+        vitestEntryPath: path.join(fixtureRoot, 'missing-vitest.mjs'),
+        preflight: async () => assert.fail('preflight must not run'),
+        spawn: () => assert.fail('spawn must not run'),
+      }),
+      /Existing local Vitest entrypoint is required/
+    );
+    assert.deepEqual(fs.readdirSync(fixtureRoot), []);
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/test/scripts/proveOpenCodeTeamProvisioning.test.mjs
+++ b/test/scripts/proveOpenCodeTeamProvisioning.test.mjs
@@ -60,8 +60,11 @@ test('preflight and downstream receive identical selection and isolated environm
   assert.equal(fs.existsSync(input.env.HOME), false);
 });
 
-test('invalid target or model fails before preflight or spawn', async () => {
+test('invalid target or model fails before allocation, preflight or spawn', async (t) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'unmarked-test-project-'));
+  const allocation = t.mock.method(fs, 'mkdtempSync', () => {
+    assert.fail('invalid inputs must not allocate owned state');
+  });
   let calls = 0;
   try {
     for (const sourceEnv of [
@@ -83,6 +86,7 @@ test('invalid target or model fails before preflight or spawn', async () => {
       );
     }
     assert.equal(calls, 0);
+    assert.equal(allocation.mock.callCount(), 0);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -92,6 +96,7 @@ test('marked caller project survives spawn failure; explicit built launcher is p
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'caller-project-'));
   fs.writeFileSync(path.join(root, TEST_PROJECT_MARKER), TEST_PROJECT_MARKER_CONTENT);
   let home;
+  let ownedProject;
   try {
     await assert.rejects(
       runProvisioningSmoke({
@@ -103,6 +108,7 @@ test('marked caller project survives spawn failure; explicit built launcher is p
         log() {},
         preflight: async ({ env }) => {
           home = env.HOME;
+          ownedProject = env.OPENCODE_E2E_OWNED_PROJECT_PATH;
           assert.notEqual(env.OPENCODE_E2E_PROJECT_PATH, root);
           assert.equal(path.dirname(env.OPENCODE_E2E_PROJECT_PATH), fs.realpathSync(root));
           assert.equal(env.OPENCODE_E2E_OWNED_PROJECT_PATH, env.OPENCODE_E2E_PROJECT_PATH);
@@ -116,27 +122,52 @@ test('marked caller project survives spawn failure; explicit built launcher is p
       /mock spawn failure/
     );
     assert.equal(fs.existsSync(path.join(root, TEST_PROJECT_MARKER)), true);
-    assert.equal(fs.existsSync(home), false);
+    assert.equal(fs.existsSync(home), true);
+    assert.equal(fs.existsSync(ownedProject), true);
   } finally {
+    if (home) fs.rmSync(path.dirname(home), { recursive: true, force: true });
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
 
-test('unavailable preflight fails proof and cleans its resources without launching test', async () => {
-  let project;
-  const status = await runProvisioningSmoke({
-    sourceEnv: modelEnv,
-    log() {},
-    preflight: async ({ projectPath }) => {
-      project = projectPath;
-      return { ok: false, reason: 'test unavailable' };
-    },
-    spawn: () => {
-      assert.fail('must not spawn');
-    },
-  });
-  assert.equal(status, 1);
-  assert.equal(fs.existsSync(project), false);
+test('failed managed preflight preserves both lane projects and host diagnostics', async (t) => {
+  for (const throws of [false, true]) {
+    await t.test(throws ? 'thrown preflight' : 'unavailable preflight', async (t) => {
+      let ownedRoot;
+      const projects = [];
+      const logs = [];
+      t.after(() => {
+        if (ownedRoot) fs.rmSync(ownedRoot, { recursive: true, force: true });
+      });
+      const run = runProvisioningSmoke({
+        sourceEnv: { ...modelEnv, OPENCODE_E2E_DEFAULT_MODEL_LAUNCH: '1' },
+        log: (line) => logs.push(line),
+        preflight: async ({ projectPath, env, useManagedRuntimeModels }) => {
+          ownedRoot = path.dirname(env.HOME);
+          projects.push(projectPath);
+          assert.equal(useManagedRuntimeModels, true);
+          fs.writeFileSync(path.join(projectPath, 'host-diagnostics.json'), '{"testOnly":true}');
+          if (projects.length === 1) return { ok: true };
+          if (throws) throw new Error('mock preflight failure');
+          return { ok: false, reason: 'test unavailable' };
+        },
+        spawn: () => assert.fail('must not spawn'),
+      });
+      if (throws) await assert.rejects(run, /mock preflight failure/);
+      else assert.equal(await run, 1);
+      assert.equal(projects.length, 2);
+      assert.ok(fs.existsSync(ownedRoot));
+      for (const project of projects) {
+        assert.equal(
+          fs.readFileSync(path.join(project, 'host-diagnostics.json'), 'utf8'),
+          '{"testOnly":true}'
+        );
+      }
+      assert.ok(
+        logs.some((line) => line.includes('preserving owned state') && line.includes(ownedRoot))
+      );
+    });
+  }
 });
 
 test('default lane preflights its own project with the selected model and same env', async () => {
@@ -231,25 +262,71 @@ test('shared preflight ignores ambient data home unless sandbox preservation is 
   assert.equal(hooks.shouldPreserveSandboxDataHome({ preserveSandboxDataHome: true }, {}), false);
 });
 
-test('failed downstream preserves only owned state for targeted host cleanup', async () => {
-  let ownedRoot;
-  let project;
+test('downstream cleanup requires proven success and never owns the marked caller parent', async (t) => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-cleanup-TEST-'));
+  const sourcePath = path.join(fixtureRoot, 'auth.json');
+  const source = '{"test-provider":{"type":"api","key":"cleanup-test-fixture"}}';
+  fs.writeFileSync(sourcePath, source);
+  fs.writeFileSync(path.join(fixtureRoot, TEST_PROJECT_MARKER), TEST_PROJECT_MARKER_CONTENT);
   try {
-    const status = await runProvisioningSmoke({
-      sourceEnv: modelEnv,
-      log() {},
-      preflight: async ({ env, projectPath }) => {
-        ownedRoot = path.dirname(env.HOME);
-        project = projectPath;
-        return { ok: true };
-      },
-      spawn: () => ({ status: 1 }),
-    });
-    assert.equal(status, 1);
-    assert.ok(fs.existsSync(ownedRoot));
-    assert.ok(fs.existsSync(project));
+    for (const [name, result, expectedStatus] of [
+      ['failed exit', { status: 1 }, 1],
+      ['spawn error', { status: null, error: new Error('mock spawn error') }],
+      ['spawn error with zero status', { status: 0, error: new Error('mock spawn error') }],
+      ['signaled child', { status: null, signal: 'SIGTERM' }, 1],
+      ['null status', { status: null }, 1],
+      ['absent status', {}, 1],
+      ['successful exit', { status: 0 }, 0],
+    ]) {
+      await t.test(name, async (t) => {
+        let ownedRoot;
+        let project;
+        let importedAuth;
+        const logs = [];
+        t.after(() => {
+          if (ownedRoot) fs.rmSync(ownedRoot, { recursive: true, force: true });
+          if (project) fs.rmSync(project, { recursive: true, force: true });
+        });
+        const run = runProvisioningSmoke({
+          sourceEnv: {
+            ...modelEnv,
+            OPENCODE_E2E_PROJECT_PATH: fixtureRoot,
+            OPENCODE_E2E_TEST_AUTH_PATH: sourcePath,
+          },
+          log: (line) => logs.push(line),
+          preflight: async ({ env, projectPath }) => {
+            ownedRoot = path.dirname(env.HOME);
+            project = projectPath;
+            importedAuth = path.join(env.XDG_DATA_HOME, 'opencode', 'auth.json');
+            assert.equal(fs.readFileSync(importedAuth, 'utf8'), source);
+            fs.writeFileSync(path.join(project, 'host-state.json'), '{"testOnly":true}');
+            return { ok: true };
+          },
+          spawn: () => result,
+        });
+        if (result.error) await assert.rejects(run, (error) => error === result.error);
+        else assert.equal(await run, expectedStatus);
+        const shouldPreserve = expectedStatus !== 0;
+        assert.equal(fs.existsSync(ownedRoot), shouldPreserve);
+        assert.equal(fs.existsSync(project), shouldPreserve);
+        assert.equal(fs.existsSync(importedAuth), shouldPreserve);
+        if (shouldPreserve) {
+          assert.equal(
+            fs.readFileSync(path.join(project, 'host-state.json'), 'utf8'),
+            '{"testOnly":true}'
+          );
+          assert.ok(logs.some((line) => line.includes(ownedRoot) && line.includes(project)));
+        }
+        assert.equal(fs.readFileSync(sourcePath, 'utf8'), source);
+        assert.equal(
+          fs.readFileSync(path.join(fixtureRoot, TEST_PROJECT_MARKER), 'utf8'),
+          TEST_PROJECT_MARKER_CONTENT
+        );
+        assert.equal(logs.join('\n').includes('cleanup-test-fixture'), false);
+      });
+    }
   } finally {
-    if (ownedRoot) fs.rmSync(ownedRoot, { recursive: true, force: true });
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
   }
 });
 
@@ -281,12 +358,14 @@ test('auth fixture seeds only selected provider and never forwards source path/b
   });
   fs.writeFileSync(sourcePath, source);
   let target;
+  let ownedRoot;
   const logs = [];
   try {
     await runProvisioningSmoke({
       sourceEnv: { ...modelEnv, OPENCODE_E2E_TEST_AUTH_PATH: sourcePath },
       log: (line) => logs.push(line),
       preflight: async ({ env }) => {
+        ownedRoot = path.dirname(env.HOME);
         target = path.join(env.XDG_DATA_HOME, 'opencode', 'auth.json');
         assert.deepEqual(JSON.parse(fs.readFileSync(target, 'utf8')), {
           'test-provider': selected,
@@ -311,6 +390,7 @@ test('auth fixture seeds only selected provider and never forwards source path/b
     for (const forbidden of [sourcePath, 'selected-refresh-fixture', 'unrelated-secret-fixture'])
       assert.equal(logs.join('\n').includes(forbidden), false);
   } finally {
+    if (ownedRoot) fs.rmSync(ownedRoot, { recursive: true, force: true });
     fs.rmSync(fixtureRoot, { recursive: true, force: true });
   }
 });
@@ -354,6 +434,7 @@ test('malformed or missing selected auth fails before preflight/spawn without so
 test('auth import accepts api keys and access-only OAuth records', async () => {
   const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-auth-fixture-'));
   const sourcePath = path.join(fixtureRoot, 'source.json');
+  const ownedRoots = [];
   try {
     for (const entry of [
       { type: 'api', key: 'fixture-api' },
@@ -364,6 +445,7 @@ test('auth import accepts api keys and access-only OAuth records', async () => {
         sourceEnv: { ...modelEnv, OPENCODE_E2E_TEST_AUTH_PATH: sourcePath },
         log() {},
         preflight: async ({ env }) => {
+          ownedRoots.push(path.dirname(env.HOME));
           assert.deepEqual(
             JSON.parse(
               fs.readFileSync(path.join(env.XDG_DATA_HOME, 'opencode', 'auth.json'), 'utf8')
@@ -376,6 +458,7 @@ test('auth import accepts api keys and access-only OAuth records', async () => {
       });
     }
   } finally {
+    for (const root of ownedRoots) fs.rmSync(root, { recursive: true, force: true });
     fs.rmSync(fixtureRoot, { recursive: true, force: true });
   }
 });
@@ -413,8 +496,11 @@ test('managed model catalog selection is independent of real app credential acce
   );
 });
 
-test('missing local Vitest entrypoint fails before preflight or spawn without installing', async () => {
+test('missing local Vitest entrypoint fails before allocation, preflight or spawn without installing', async (t) => {
   const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'missing-vitest-fixture-'));
+  const allocation = t.mock.method(fs, 'mkdtempSync', () => {
+    assert.fail('missing Vitest must not allocate owned state');
+  });
   try {
     await assert.rejects(
       runProvisioningSmoke({
@@ -425,6 +511,7 @@ test('missing local Vitest entrypoint fails before preflight or spawn without in
       }),
       /Existing local Vitest entrypoint is required/
     );
+    assert.equal(allocation.mock.callCount(), 0);
     assert.deepEqual(fs.readdirSync(fixtureRoot), []);
   } finally {
     fs.rmSync(fixtureRoot, { recursive: true, force: true });


### PR DESCRIPTION
The provisioning smoke wrapper could run preflight in the repository root, restore the real HOME in the downstream test, or validate a different OpenCode binary from the one it launched. Use fresh owned test projects and one explicit environment/model/binary across both phases, with credentials supplied only through the test input.

Verify the result of persistent-host cleanup before removing sandbox roots. Bridge failure diagnostics and remaining hosts fail the run and preserve owned state for targeted cleanup. Explicit marked project paths are parents of fresh run projects, never cleanup targets themselves.

Validation:24 wrapper tests and10 preflight/cleanup tests passed. Independent review found no outstanding defects. Failed or thrown preflight and spawn outcomes now preserve owned state until successful downstream completion is proven. Tests cover the real bridge cleanup failure adaptation. Real provider E2E is tracked separately and is not claimed by mocked tests.

The primary live test now requires one completed Alice task and an exact unique file. Copilot reached the real model probe but returned unsupported-model, so successful task E2E is still pending. The larger-than-original smoke diff includes sandbox/auth/cleanup negative tests and task proof, not production feature changes.

Runtime fix and release: https://github.com/777genius/agent_teams_orchestrator/pull/68
Refs #504


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live OpenCode provisioning supports managed runtime model selection and configurable sandbox data-home preservation.
  * Binary and environment configuration can be supplied through supported environment settings.

* **Bug Fixes**
  * Improved validation prevents invalid models, binaries, credentials, and test targets from starting provisioning.
  * Cleanup verification detects incomplete or failed resource cleanup.
  * Failure diagnostics are redacted to avoid exposing sensitive command output.

* **Tests**
  * Expanded coverage for provisioning, cleanup, environment isolation, authentication fixtures, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->