### PR TITLE
chore(release): prepare 2.13.2 with OpenCode runtime fixes

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -28,6 +28,73 @@ Before publishing:
 - Confirm version numbers, runtime gates, asset names, and download links.
 - Keep the body in this document identical to the GitHub release body.
 
+## Draft: v2.13.2 (2026-09-07)
+
+GitHub release: [v2.13.2](https://github.com/777genius/agent-teams-ai/releases/tag/v2.13.2).
+
+Target branch: `main`.
+
+Runtime gate:
+
+- Agent Teams runtime: `v0.0.84`.
+- Terminal Platform runtime: `v0.3.3`.
+
+Draft body source for GitHub release:
+
+<!-- RELEASE_BODY_START v2.13.2 -->
+This update fixes OpenCode startup checks and makes provider sign-in failures easier to identify.
+
+### Fixes
+
+- Stop valid OpenCode settings managed by the app from incorrectly blocking model checks.
+- Show the provider's sign-in error when it rejects access with a 401 response.
+- Reuse newly started OpenCode servers without incorrectly reporting that their settings have changed.
+
+### Downloads
+
+<table>
+<tr>
+<td align="center">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.2/Agent.Teams.AI-2.13.2-arm64.dmg">
+    <img src="https://img.shields.io/badge/macOS_Apple_Silicon-.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
+  </a>
+  <br />
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.2/Agent.Teams.AI-2.13.2-x64.dmg">
+    <img src="https://img.shields.io/badge/macOS_Intel-.dmg-434343?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel" />
+  </a>
+</td>
+<td align="center">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.2/Agent.Teams.AI.Setup.2.13.2.exe">
+    <img src="https://img.shields.io/badge/Windows_x64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64" />
+  </a>
+  <br />
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.2/Agent.Teams.AI.Setup.2.13.2-arm64.exe">
+    <img src="https://img.shields.io/badge/Windows_ARM64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows ARM64" />
+  </a>
+  <br />
+  <sub>May trigger SmartScreen - click "More info" then "Run anyway"</sub>
+  <br />
+  <sub>Run normally. Administrator mode may be needed only if the app reports a specific OpenCode symlink or permission error.</sub>
+</td>
+<td align="center">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.2/Agent.Teams.AI-2.13.2.AppImage">
+    <img src="https://img.shields.io/badge/Linux-Download_.AppImage-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AppImage" />
+  </a>
+  <br />
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.2/agent-teams-ai_2.13.2_amd64.deb">
+    <img src="https://img.shields.io/badge/.deb-E95420?style=flat-square&logo=ubuntu" alt=".deb" />
+  </a>&nbsp;
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.2/agent-teams-ai-2.13.2.x86_64.rpm">
+    <img src="https://img.shields.io/badge/.rpm-294172?style=flat-square&logo=redhat" alt=".rpm" />
+  </a>&nbsp;
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.2/agent-teams-ai-2.13.2.pacman">
+    <img src="https://img.shields.io/badge/.pacman-1793D1?style=flat-square&logo=archlinux" alt=".pacman" />
+  </a>
+</td>
+</tr>
+</table>
+<!-- RELEASE_BODY_END v2.13.2 -->
+
 ## Published: v2.13.1 (2026-09-07)
 
 GitHub release: [v2.13.1](https://github.com/777genius/agent-teams-ai/releases/tag/v2.13.1).

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,40 +1,40 @@
 {
-  "version": "0.0.83",
+  "version": "0.0.84",
   "cliVersion": "2.1.251",
-  "sourceRef": "v0.0.83",
+  "sourceRef": "v0.0.84",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator_binaries",
-  "releaseTag": "runtime-v0.0.83",
+  "releaseTag": "runtime-v0.0.84",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.83.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.84.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "721eb68cbc9066297bcddc77741cf6ee7f3bf32f5c27cd50a879921fa23651bb"
+      "sha256": "aa9dce8e909329c35e0999e974dcf3d117890339151bdbe76fc80c4e1325d5b2"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.83.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.84.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "5b4b6e1f3d042709f2e86a0e0b0ec599113fec6179db5782e6a456fa94d81d21"
+      "sha256": "13c38430e29c1149652c534fab51df09f36f8577e52b74abb1c9cce429cf3e02"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.83.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.84.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "851f36a196d4b09ab4ca074010bc2e69fed1d1c95526aa3d8c375476ad1426f4"
+      "sha256": "7df001b29d0f2d3243fe742eda091bceefc41fa8658e2a97289cfc284d2af5c7"
     },
     "win32-arm64": {
-      "file": "agent-teams-runtime-win32-arm64-v0.0.83.zip",
+      "file": "agent-teams-runtime-win32-arm64-v0.0.84.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "50d37b3f71dabab427ace081e3addf318160dd9d5bb7148bc3af5080ea7083e3"
+      "sha256": "ecd9a76a8f1b37e5030e6a11925b94de2115eda8a7a3192d7e6421ff29031fe1"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.83.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.84.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "696b57cce43406c6d9fb4972bba44427cb5f1f6126ee9ac449c27c578ef2444e"
+      "sha256": "43a48497a06593984fe5b7239817f387a31ed913739fcd2721f64ca7f7cb90ac"
     }
   }
 }


### PR DESCRIPTION
Package runtime 0.0.84 in app 2.13.2 so valid managed OpenCode configuration no longer fails before the model check, provider 401/403 failures keep their authentication meaning, and fresh retained hosts use the correct configuration fingerprint.

The runtime source is b567c93a3f424e5d23301cbce5f6f7ade8273c18, released as v0.0.84. All five archive hashes match the published manifest, checksum file and GitHub asset digests. Runtime CI, all platform builds and anonymous-download verification passed. App package validation remains in the release workflow.

Z.AI validation reached provider HTTP401 using a deliberately invalid disposable test key. Copilot gpt-5-mini returns model_not_supported; successful Copilot tasks and repair of the reported existing Windows upgrade state are not claimed.

Refs #504
Runtime fix: https://github.com/777genius/agent_teams_orchestrator/pull/68
Sandbox proof harness: https://github.com/777genius/agent-teams-ai/pull/604


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added versioned downloads for macOS, Windows, and Linux.
  - Improved reuse of existing OpenCode servers for smoother workflows.

- **Bug Fixes**
  - Improved startup and settings validation for OpenCode.
  - Enhanced reporting for provider authentication errors, including clearer handling of 401 responses.

- **Documentation**
  - Added draft release notes for version 2.13.2, including runtime compatibility details and platform downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->