### PR TITLE
fix(ci): finish packaged smoke cleanup before reporting success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -950,6 +950,7 @@ jobs:
         run: node ./scripts/electron-builder/verifyBundle.cjs "release/linux-unpacked" linux x64
 
       - name: Smoke packaged app (Linux)
+        timeout-minutes: 2
         run: xvfb-run -a node ./scripts/electron-builder/smokePackagedApp.cjs "release/linux-unpacked" linux
 
       - name: Upload assets to release

--- a/scripts/electron-builder/smokePackagedApp.cjs
+++ b/scripts/electron-builder/smokePackagedApp.cjs
@@ -280,6 +280,7 @@ async function main() {
   });
   child.once('spawn', () => console.log(`[smokePackagedApp] spawned: pid=${child.pid}`));
 
+  let startupError;
   try {
     const deadline = Date.now() + STARTUP_TIMEOUT_MS;
     let startupSeenAt = null;
@@ -321,10 +322,20 @@ async function main() {
           `Timed out after ${STARTUP_TIMEOUT_MS}ms waiting for packaged startup`
       );
     }
+  } catch (error) {
+    startupError = error;
+    throw error;
   } finally {
     // Every startup outcome must clean up descendants, including early exit or spawn failure.
     try {
       await terminateChild(child, closePromise, platform);
+    } catch (cleanupError) {
+      if (startupError) {
+        console.error(
+          `[smokePackagedApp] Startup failed before cleanup: ${startupError.stack || String(startupError)}`
+        );
+      }
+      throw cleanupError;
     } finally {
       if (log.trim()) console.log(`--- packaged app log ---\n${log.trim()}`);
     }

--- a/scripts/electron-builder/smokePackagedApp.cjs
+++ b/scripts/electron-builder/smokePackagedApp.cjs
@@ -173,63 +173,65 @@ function findExecutable(bundlePath, platform) {
   fail(`Unsupported platform: ${platform}`);
 }
 
-function waitForProcessClose(child, exitPromise, timeoutMs) {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return Promise.resolve(true);
-  }
-
+function waitForProcessClose(closePromise, timeoutMs) {
   let timeoutId;
   const timeoutPromise = new Promise((resolve) => {
     timeoutId = setTimeout(() => resolve(false), timeoutMs);
   });
-  return Promise.race([exitPromise.then(() => true), timeoutPromise]).finally(() => {
+  return Promise.race([closePromise.then(() => true), timeoutPromise]).finally(() => {
     if (timeoutId) {
       clearTimeout(timeoutId);
     }
   });
 }
 
-async function terminateChild(child, exitPromise, platform) {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return;
-  }
+async function terminateChild(child, closePromise, platform, timeoutMs = SHUTDOWN_TIMEOUT_MS) {
+  // POSIX callers must spawn detached: only this smoke-owned process group is signalled.
+  // The leader may already have exited while descendants still hold its output pipes.
+  const signalOwnedGroup = (signal) => {
+    if (!child.pid) return; // Failed spawn: no owned process exists.
+    try {
+      process.kill(-child.pid, signal);
+    } catch (error) {
+      if (error.code !== 'ESRCH') throw error;
+    }
+  };
 
-  if (platform === 'win32' && child.pid) {
-    await new Promise((resolve) => {
+  if (platform === 'win32') {
+    if (child.pid && child.exitCode === null && child.signalCode === null) {
       const killer = spawn('taskkill.exe', ['/pid', String(child.pid), '/T', '/F'], {
         stdio: 'ignore',
       });
-      killer.once('error', resolve);
-      killer.once('close', resolve);
-    });
-  } else {
-    const pid = child.pid;
-    if (pid) {
-      try {
-        process.kill(-pid, 'SIGTERM');
-      } catch {
-        child.kill();
+      const killerDone = new Promise((resolve) => {
+        killer.once('error', resolve);
+        killer.once('close', resolve);
+      });
+      if (!(await waitForProcessClose(killerDone, timeoutMs))) {
+        killer.kill();
+        throw new Error(`Timed out after ${timeoutMs}ms waiting for taskkill.exe`);
       }
-    } else {
-      child.kill();
     }
+  } else {
+    signalOwnedGroup('SIGTERM');
   }
 
-  const closed = await waitForProcessClose(child, exitPromise, SHUTDOWN_TIMEOUT_MS);
-  if (!closed && child.exitCode === null && child.signalCode === null) {
-    if (child.pid && platform !== 'win32') {
-      try {
-        process.kill(-child.pid, 'SIGKILL');
-      } catch {
-        child.kill('SIGKILL');
-      }
-    } else {
-      child.kill('SIGKILL');
-    }
-    const killed = await waitForProcessClose(child, exitPromise, SHUTDOWN_TIMEOUT_MS);
-    if (!killed && child.exitCode === null && child.signalCode === null) {
-      throw new Error(`Timed out after ${SHUTDOWN_TIMEOUT_MS}ms waiting for packaged app to exit`);
-    }
+  if (await waitForProcessClose(closePromise, timeoutMs)) {
+    // A descendant with redirected stdio can outlive close. Stop any remaining
+    // members of our group before reporting success, even when no pipes remain.
+    if (platform !== 'win32') signalOwnedGroup('SIGKILL');
+    return;
+  }
+  console.error(`[smokePackagedApp] shutdown grace expired: pid=${child.pid}; forcing cleanup`);
+  if (platform === 'win32') {
+    child.kill('SIGKILL');
+  } else {
+    signalOwnedGroup('SIGKILL');
+  }
+  if (!(await waitForProcessClose(closePromise, timeoutMs))) {
+    throw new Error(
+      `Timed out after ${timeoutMs}ms waiting for packaged app stdio to close: ` +
+        `pid=${child.pid} exitCode=${child.exitCode} signal=${child.signalCode}`
+    );
   }
 }
 
@@ -264,48 +266,70 @@ async function main() {
   });
 
   const exitPromise = new Promise((resolve) => {
-    child.on('exit', (code, signal) => resolve({ code, signal }));
+    child.once('error', (error) => resolve({ error }));
+    child.once('exit', (code, signal) => {
+      console.log(`[smokePackagedApp] leader exit: code=${code} signal=${signal}`);
+      resolve({ code, signal });
+    });
   });
+  const closePromise = new Promise((resolve) => {
+    child.once('close', () => {
+      console.log(`[smokePackagedApp] stdio closed: pid=${child.pid}`);
+      resolve();
+    });
+  });
+  child.once('spawn', () => console.log(`[smokePackagedApp] spawned: pid=${child.pid}`));
 
-  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
-  let startupSeenAt = null;
-  let storageVerificationError = null;
-  while (Date.now() < deadline) {
-    if (FAILURE_PATTERNS.some((pattern) => pattern.test(log))) {
-      await terminateChild(child, exitPromise, platform);
-      fail('Detected startup failure pattern', log);
-    }
+  try {
+    const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+    let startupSeenAt = null;
+    let storageVerificationError = null;
+    let startupVerified = false;
+    while (Date.now() < deadline) {
+      if (FAILURE_PATTERNS.some((pattern) => pattern.test(log))) {
+        throw new Error('Detected startup failure pattern');
+      }
 
-    if (startupSeenAt === null && REQUIRED_LOG_MARKERS.every((marker) => log.includes(marker))) {
-      startupSeenAt = Date.now();
-    }
+      if (startupSeenAt === null && REQUIRED_LOG_MARKERS.every((marker) => log.includes(marker))) {
+        startupSeenAt = Date.now();
+        console.log('[smokePackagedApp] renderer ready');
+      }
 
-    if (startupSeenAt !== null && Date.now() - startupSeenAt >= POST_STARTUP_STABLE_MS) {
-      storageVerificationError = getInternalStorageVerificationError(userDataDir, log);
-      if (storageVerificationError === null) {
-        await terminateChild(child, exitPromise, platform);
-        console.log(`[smokePackagedApp] OK ${platform}: ${bundlePath}`);
-        return;
+      if (startupSeenAt !== null && Date.now() - startupSeenAt >= POST_STARTUP_STABLE_MS) {
+        storageVerificationError = getInternalStorageVerificationError(userDataDir, log);
+        if (storageVerificationError === null) {
+          startupVerified = true;
+          break;
+        }
+      }
+
+      const exit = await Promise.race([
+        exitPromise,
+        new Promise((resolve) => setTimeout(() => resolve(null), 250)),
+      ]);
+      if (exit) {
+        if (exit.error) throw exit.error;
+        throw new Error(
+          `Packaged app exited before startup completed: code=${exit.code} signal=${exit.signal}`
+        );
       }
     }
 
-    const exit = await Promise.race([
-      exitPromise,
-      new Promise((resolve) => setTimeout(() => resolve(null), 250)),
-    ]);
-    if (exit) {
-      fail(
-        `Packaged app exited before startup completed: code=${exit.code} signal=${exit.signal}`,
-        log
+    if (!startupVerified) {
+      throw new Error(
+        storageVerificationError ||
+          `Timed out after ${STARTUP_TIMEOUT_MS}ms waiting for packaged startup`
       );
     }
+  } finally {
+    // Every startup outcome must clean up descendants, including early exit or spawn failure.
+    try {
+      await terminateChild(child, closePromise, platform);
+    } finally {
+      if (log.trim()) console.log(`--- packaged app log ---\n${log.trim()}`);
+    }
   }
-
-  await terminateChild(child, exitPromise, platform);
-  if (startupSeenAt !== null && storageVerificationError) {
-    fail(storageVerificationError, log);
-  }
-  fail(`Timed out after ${STARTUP_TIMEOUT_MS}ms waiting for packaged startup`, log);
+  console.log(`[smokePackagedApp] OK ${platform}: ${bundlePath}`);
 }
 
 if (require.main === module) {

--- a/scripts/electron-builder/smokePackagedApp.cjs
+++ b/scripts/electron-builder/smokePackagedApp.cjs
@@ -1,7 +1,7 @@
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { spawn } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
 
 const STARTUP_TIMEOUT_MS = Number(process.env.PACKAGED_SMOKE_TIMEOUT_MS ?? 30_000);
 const POST_STARTUP_STABLE_MS = Number(process.env.PACKAGED_SMOKE_STABLE_MS ?? 8_000);
@@ -185,6 +185,30 @@ function waitForProcessClose(closePromise, timeoutMs) {
   });
 }
 
+async function waitForOwnedGroupExit(groupId, timeoutMs) {
+  if (!groupId) return; // Failed spawn has no owned process group.
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const result = spawnSync('ps', ['-ax', '-o', 'pgid=,stat='], {
+      encoding: 'utf8',
+      timeout: Math.max(1, deadline - Date.now()),
+    });
+    if (result.error) throw result.error;
+    if (result.status !== 0) throw new Error('Unable to verify packaged app process group cleanup');
+    // Orphans may remain as zombies until PID 1 reaps them; they cannot execute
+    // or retain open pipes, so waiting for their PIDs to vanish would hang CI.
+    const running = result.stdout.split('\n').some((line) => {
+      const match = /^\s*(\d+)\s+(\S+)/.exec(line);
+      return match && Number(match[1]) === groupId && !/^[ZX]/.test(match[2]);
+    });
+    if (!running) return;
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for packaged app process group ${groupId}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, Math.min(25, deadline - Date.now())));
+  }
+}
+
 async function terminateChild(child, closePromise, platform, timeoutMs = SHUTDOWN_TIMEOUT_MS) {
   // POSIX callers must spawn detached: only this smoke-owned process group is signalled.
   // The leader may already have exited while descendants still hold its output pipes.
@@ -218,7 +242,10 @@ async function terminateChild(child, closePromise, platform, timeoutMs = SHUTDOW
   if (await waitForProcessClose(closePromise, timeoutMs)) {
     // A descendant with redirected stdio can outlive close. Stop any remaining
     // members of our group before reporting success, even when no pipes remain.
-    if (platform !== 'win32') signalOwnedGroup('SIGKILL');
+    if (platform !== 'win32') {
+      signalOwnedGroup('SIGKILL');
+      await waitForOwnedGroupExit(child.pid, timeoutMs);
+    }
     return;
   }
   console.error(`[smokePackagedApp] shutdown grace expired: pid=${child.pid}; forcing cleanup`);
@@ -233,6 +260,7 @@ async function terminateChild(child, closePromise, platform, timeoutMs = SHUTDOW
         `pid=${child.pid} exitCode=${child.exitCode} signal=${child.signalCode}`
     );
   }
+  if (platform !== 'win32') await waitForOwnedGroupExit(child.pid, timeoutMs);
 }
 
 async function main() {

--- a/test/main/build/fixtures/packaged-smoke-process-TEST.cjs
+++ b/test/main/build/fixtures/packaged-smoke-process-TEST.cjs
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const { spawn, spawnSync } = require('node:child_process');
 const [mode, scriptPath] = process.argv.slice(2);
 const { terminateChild } = require(scriptPath)._internal;
+const silentDescendant = mode === 'silent-descendant' || mode === 'delayed-kill';
 const descendantSource = `
   process.on('SIGTERM', () => {});
   // Last-resort fixture lifetime, even if the outer test runner is interrupted.
@@ -19,7 +20,7 @@ const leaderSource =
     : `
   const descendant = require('node:child_process').spawn(process.execPath,
     ['-e', ${JSON.stringify(descendantSource)}],
-    { stdio: ['ignore', ${JSON.stringify(mode === 'silent-descendant' ? 'ignore' : 'inherit')}, ${JSON.stringify(mode === 'silent-descendant' ? 'ignore' : 'inherit')}, 'ipc'] });
+    { stdio: ['ignore', ${JSON.stringify(silentDescendant ? 'ignore' : 'inherit')}, ${JSON.stringify(silentDescendant ? 'ignore' : 'inherit')}, 'ipc'] });
   descendant.once('message', () => {
     console.log('descendant-pid:' + descendant.pid);
     console.log('fixture-ready');
@@ -52,7 +53,7 @@ const watchdog = setTimeout(() => {
   console.error('TEST watchdog expired');
   process.exitCode = 1;
   cleanup();
-}, 3000);
+}, 7000);
 async function run() {
   await new Promise((resolve, reject) => {
     let log = '';
@@ -69,26 +70,40 @@ async function run() {
     await exited;
     assert.equal(closeSeen, false);
   }
-  await terminateChild(child, closed, process.platform, 100);
+  const originalKill = process.kill;
+  if (mode === 'delayed-kill') {
+    process.kill = (pid, signal) => {
+      if (pid === -child.pid && signal === 'SIGKILL') {
+        // Model asynchronous signal delivery without letting the fixture escape cleanup.
+        setTimeout(() => {
+          try {
+            originalKill.call(process, pid, signal);
+          } catch (error) {
+            if (error.code !== 'ESRCH') throw error;
+          }
+        }, 75);
+        return true;
+      }
+      return originalKill.call(process, pid, signal);
+    };
+  }
+  try {
+    await terminateChild(child, closed, process.platform, 2000);
+  } finally {
+    process.kill = originalKill;
+  }
   assert.equal(closeSeen, true);
   assert.equal(child.stdout.readableEnded, true);
   assert.equal(child.stderr.readableEnded, true);
-  if (mode === 'silent-descendant') {
+  if (silentDescendant) {
     assert.ok(descendantPid);
-    // Orphans can remain as zombies until Linux PID 1 reaps them. Verify they
-    // cannot execute, rather than mistaking an unreaped PID for a live process.
-    const deadline = Date.now() + 1000;
-    let running = true;
-    while (running && Date.now() < deadline) {
-      const status = spawnSync('ps', ['-p', String(descendantPid), '-o', 'stat='], {
-        encoding: 'utf8',
-      });
-      assert.ifError(status.error);
-      assert.ok(status.status === 0 || status.status === 1);
-      running = status.stdout.trim() !== '' && !status.stdout.trim().startsWith('Z');
-      if (running) await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-    assert.equal(running, false, 'silent descendant survived shutdown');
+    const status = spawnSync('ps', ['-p', String(descendantPid), '-o', 'stat='], {
+      encoding: 'utf8',
+    });
+    assert.ifError(status.error);
+    assert.ok(status.status === 0 || status.status === 1);
+    const state = status.stdout.trim();
+    assert.ok(state === '' || /^[ZX]/.test(state), 'silent descendant survived shutdown');
   }
   console.log('cleanup verified: close=true');
 }

--- a/test/main/build/fixtures/packaged-smoke-process-TEST.cjs
+++ b/test/main/build/fixtures/packaged-smoke-process-TEST.cjs
@@ -1,0 +1,103 @@
+// Disposable Node-only fixture. Never launches Electron, an agent, or a user project.
+const assert = require('node:assert/strict');
+const { spawn, spawnSync } = require('node:child_process');
+const [mode, scriptPath] = process.argv.slice(2);
+const { terminateChild } = require(scriptPath)._internal;
+const descendantSource = `
+  process.on('SIGTERM', () => {});
+  // Last-resort fixture lifetime, even if the outer test runner is interrupted.
+  setTimeout(() => process.exit(1), 6000);
+  process.send('ready');
+  process.disconnect();
+`;
+const leaderSource =
+  mode === 'normal'
+    ? `
+  console.log('fixture-ready');
+  setTimeout(() => process.exit(1), 6000);
+`
+    : `
+  const descendant = require('node:child_process').spawn(process.execPath,
+    ['-e', ${JSON.stringify(descendantSource)}],
+    { stdio: ['ignore', ${JSON.stringify(mode === 'silent-descendant' ? 'ignore' : 'inherit')}, ${JSON.stringify(mode === 'silent-descendant' ? 'ignore' : 'inherit')}, 'ipc'] });
+  descendant.once('message', () => {
+    console.log('descendant-pid:' + descendant.pid);
+    console.log('fixture-ready');
+    if (${JSON.stringify(mode)} === 'already-exited') process.exit(0);
+  });
+  setTimeout(() => process.exit(1), 6000);
+`;
+const child = spawn(process.execPath, ['-e', leaderSource], {
+  detached: true,
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+let closeSeen = false;
+let descendantPid;
+const exited = new Promise((resolve) => child.once('exit', resolve));
+const closed = new Promise((resolve) =>
+  child.once('close', () => {
+    closeSeen = true;
+    resolve();
+  })
+);
+const cleanup = () => {
+  if (!child.pid) return;
+  try {
+    process.kill(-child.pid, 'SIGKILL');
+  } catch (error) {
+    if (error.code !== 'ESRCH') throw error;
+  }
+};
+const watchdog = setTimeout(() => {
+  console.error('TEST watchdog expired');
+  process.exitCode = 1;
+  cleanup();
+}, 3000);
+async function run() {
+  await new Promise((resolve, reject) => {
+    let log = '';
+    child.once('error', reject);
+    child.stdout.on('data', (chunk) => {
+      log += chunk;
+      const pidMatch = /descendant-pid:(\d+)/.exec(log);
+      if (pidMatch) descendantPid = Number(pidMatch[1]);
+      if (log.includes('fixture-ready')) resolve();
+    });
+    child.stderr.resume();
+  });
+  if (mode === 'already-exited') {
+    await exited;
+    assert.equal(closeSeen, false);
+  }
+  await terminateChild(child, closed, process.platform, 100);
+  assert.equal(closeSeen, true);
+  assert.equal(child.stdout.readableEnded, true);
+  assert.equal(child.stderr.readableEnded, true);
+  if (mode === 'silent-descendant') {
+    assert.ok(descendantPid);
+    // Orphans can remain as zombies until Linux PID 1 reaps them. Verify they
+    // cannot execute, rather than mistaking an unreaped PID for a live process.
+    const deadline = Date.now() + 1000;
+    let running = true;
+    while (running && Date.now() < deadline) {
+      const status = spawnSync('ps', ['-p', String(descendantPid), '-o', 'stat='], {
+        encoding: 'utf8',
+      });
+      assert.ifError(status.error);
+      assert.ok(status.status === 0 || status.status === 1);
+      running = status.stdout.trim() !== '' && !status.stdout.trim().startsWith('Z');
+      if (running) await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(running, false, 'silent descendant survived shutdown');
+  }
+  console.log('cleanup verified: close=true');
+}
+run()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    cleanup();
+    clearTimeout(watchdog);
+  });

--- a/test/main/build/smokePackagedApp.test.ts
+++ b/test/main/build/smokePackagedApp.test.ts
@@ -159,7 +159,7 @@ describe.skipIf(process.platform === 'win32')('smokePackagedApp POSIX process cl
     }
   );
 
-  it.each(['success', 'early-exit', 'timeout', 'failure-pattern'])(
+  it.each(['success', 'early-exit', 'timeout', 'failure-pattern', 'failure-and-cleanup-error'])(
     'cleans inherited pipes on the full harness %s path',
     (mode) => {
       const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'packaged-harness-TEST-'));
@@ -176,12 +176,29 @@ describe.skipIf(process.platform === 'win32')('smokePackagedApp POSIX process cl
           child.once('message', () => {
             if (${JSON.stringify(mode)} === 'early-exit') process.exit(2);
             if (${JSON.stringify(mode)} === 'success') console.log('renderer did-finish-load');
-            if (${JSON.stringify(mode)} === 'failure-pattern') console.log('MODULE_NOT_FOUND');
+            if (${JSON.stringify(mode)}.startsWith('failure-')) console.log('MODULE_NOT_FOUND');
           });
           setTimeout(() => process.exit(1), 6000);
         `;
         fs.writeFileSync(path.join(sandbox, 'agent-teams-ai'), fixtureSource, { mode: 0o755 });
-        const result = spawnSync(process.execPath, [scriptPath, sandbox, 'linux'], {
+        const nodeArgs = [scriptPath, sandbox, 'linux'];
+        if (mode === 'failure-and-cleanup-error') {
+          const hookPath = path.join(sandbox, 'cleanup-error-TEST.cjs');
+          fs.writeFileSync(
+            hookPath,
+            `
+            const kill = process.kill;
+            process.kill = function(pid, signal) {
+              const result = kill.call(this, pid, signal);
+              // Deliver the real owned-group cleanup before injecting a diagnostic failure.
+              if (signal === 'SIGKILL') throw new Error('TEST cleanup failure');
+              return result;
+            };
+          `
+          );
+          nodeArgs.unshift('--require', hookPath);
+        }
+        const result = spawnSync(process.execPath, nodeArgs, {
           cwd: sandbox,
           encoding: 'utf8',
           timeout: 5_000,
@@ -199,9 +216,14 @@ describe.skipIf(process.platform === 'win32')('smokePackagedApp POSIX process cl
           'early-exit': 'Packaged app exited before startup completed: code=2',
           timeout: 'Timed out after 2000ms waiting for packaged startup',
           'failure-pattern': 'Detected startup failure pattern',
+          'failure-and-cleanup-error': 'Detected startup failure pattern',
         };
         if (mode !== 'success') expect(result.stderr).toContain(failureReasons[mode]);
-        expect(result.stdout).toContain('stdio closed');
+        if (mode === 'failure-and-cleanup-error') {
+          expect(result.stderr).toContain('TEST cleanup failure');
+        } else {
+          expect(result.stdout).toContain('stdio closed');
+        }
         expect(result.stdout.includes('[smokePackagedApp] OK')).toBe(mode === 'success');
         if (mode === 'success') {
           expect(result.stdout.indexOf('stdio closed')).toBeLessThan(

--- a/test/main/build/smokePackagedApp.test.ts
+++ b/test/main/build/smokePackagedApp.test.ts
@@ -142,7 +142,7 @@ describe.skipIf(process.platform === 'win32')('smokePackagedApp POSIX process cl
   );
   const fixturePath = path.resolve(import.meta.dirname, 'fixtures/packaged-smoke-process-TEST.cjs');
 
-  it.each(['normal', 'retained-pipes', 'already-exited', 'silent-descendant'])(
+  it.each(['normal', 'retained-pipes', 'already-exited', 'silent-descendant', 'delayed-kill'])(
     'closes %s fixture and lets its Node harness exit',
     (mode) => {
       const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'packaged-process-TEST-'));
@@ -150,7 +150,7 @@ describe.skipIf(process.platform === 'win32')('smokePackagedApp POSIX process cl
         const output = execFileSync(process.execPath, [fixturePath, mode, scriptPath], {
           cwd: sandbox,
           encoding: 'utf8',
-          timeout: 4_000,
+          timeout: 8_000,
         });
         expect(output).toContain('cleanup verified: close=true');
       } finally {
@@ -201,13 +201,13 @@ describe.skipIf(process.platform === 'win32')('smokePackagedApp POSIX process cl
         const result = spawnSync(process.execPath, nodeArgs, {
           cwd: sandbox,
           encoding: 'utf8',
-          timeout: 5_000,
+          timeout: 8_000,
           env: {
             ...process.env,
             TMPDIR: sandbox,
             PACKAGED_SMOKE_TIMEOUT_MS: '2000',
             PACKAGED_SMOKE_STABLE_MS: '0',
-            PACKAGED_SMOKE_SHUTDOWN_TIMEOUT_MS: '100',
+            PACKAGED_SMOKE_SHUTDOWN_TIMEOUT_MS: '2000',
           },
         });
         expect(result.error).toBeUndefined();
@@ -247,8 +247,8 @@ describe.skipIf(process.platform === 'win32')('smokePackagedApp POSIX process cl
       const result = spawnSync(process.execPath, [scriptPath, sandbox, 'linux'], {
         cwd: sandbox,
         encoding: 'utf8',
-        timeout: 4_000,
-        env: { ...process.env, PACKAGED_SMOKE_SHUTDOWN_TIMEOUT_MS: '100' },
+        timeout: 8_000,
+        env: { ...process.env, PACKAGED_SMOKE_SHUTDOWN_TIMEOUT_MS: '2000' },
       });
       expect(result.error).toBeUndefined();
       expect(result.status).toBe(1);

--- a/test/main/build/smokePackagedApp.test.ts
+++ b/test/main/build/smokePackagedApp.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import os from 'node:os';
@@ -9,15 +10,11 @@ import { describe, expect, it, vi } from 'vitest';
 interface SmokePackagedAppInternals {
   getInternalStorageVerificationError(userDataDir: string, log: string): string | null;
   terminateChild(
-    child: { exitCode: number | null; signalCode: string | null; kill: () => void },
-    exitPromise: Promise<unknown>,
+    child: { pid?: number; exitCode: number | null; signalCode: string | null; kill: () => void },
+    closePromise: Promise<unknown>,
     platform: string
   ): Promise<void>;
-  waitForProcessClose(
-    child: { exitCode: number | null; signalCode: string | null },
-    exitPromise: Promise<unknown>,
-    timeoutMs: number
-  ): Promise<boolean>;
+  waitForProcessClose(closePromise: Promise<unknown>, timeoutMs: number): Promise<boolean>;
 }
 
 interface SmokePackagedAppModule {
@@ -29,8 +26,7 @@ const requireFromTest: (id: string) => unknown = createRequire(import.meta.url);
 const smokePackagedApp = requireFromTest(
   '../../../scripts/electron-builder/smokePackagedApp.cjs'
 ) as SmokePackagedAppModule;
-const smokePackagedAppInternals =
-  smokePackagedApp._internal ?? smokePackagedApp.default?._internal;
+const smokePackagedAppInternals = smokePackagedApp._internal ?? smokePackagedApp.default?._internal;
 if (!smokePackagedAppInternals) {
   throw new Error('smokePackagedApp internals were not exported');
 }
@@ -104,9 +100,7 @@ describe('smokePackagedApp shutdown handling', () => {
     const exitPromise = new Promise((resolve) => {
       resolveExit = resolve;
     });
-    const child = { exitCode: null, signalCode: null };
-
-    const closed = waitForProcessClose(child, exitPromise, 1_000);
+    const closed = waitForProcessClose(exitPromise, 1_000);
     resolveExit({ code: 0, signal: null });
 
     await expect(closed).resolves.toBe(true);
@@ -116,8 +110,10 @@ describe('smokePackagedApp shutdown handling', () => {
     vi.useFakeTimers();
     try {
       const exitPromise = new Promise(() => undefined);
+      const signal = vi.spyOn(process, 'kill').mockReturnValue(true);
       const child = {
-        exitCode: null,
+        pid: 12345,
+        exitCode: 0,
         signalCode: null,
         kill: vi.fn(),
       };
@@ -128,11 +124,117 @@ describe('smokePackagedApp shutdown handling', () => {
       await vi.advanceTimersByTimeAsync(5_000);
 
       await rejection;
-      expect(child.kill).toHaveBeenCalledTimes(2);
-      expect(child.kill).toHaveBeenNthCalledWith(1);
-      expect(child.kill).toHaveBeenNthCalledWith(2, 'SIGKILL');
+      expect(signal).toHaveBeenCalledTimes(2);
+      expect(signal).toHaveBeenNthCalledWith(1, -12345, 'SIGTERM');
+      expect(signal).toHaveBeenNthCalledWith(2, -12345, 'SIGKILL');
+      expect(child.kill).not.toHaveBeenCalled();
     } finally {
+      vi.restoreAllMocks();
       vi.useRealTimers();
+    }
+  });
+});
+
+describe.skipIf(process.platform === 'win32')('smokePackagedApp POSIX process cleanup', () => {
+  const scriptPath = path.resolve(
+    import.meta.dirname,
+    '../../../scripts/electron-builder/smokePackagedApp.cjs'
+  );
+  const fixturePath = path.resolve(import.meta.dirname, 'fixtures/packaged-smoke-process-TEST.cjs');
+
+  it.each(['normal', 'retained-pipes', 'already-exited', 'silent-descendant'])(
+    'closes %s fixture and lets its Node harness exit',
+    (mode) => {
+      const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'packaged-process-TEST-'));
+      try {
+        const output = execFileSync(process.execPath, [fixturePath, mode, scriptPath], {
+          cwd: sandbox,
+          encoding: 'utf8',
+          timeout: 4_000,
+        });
+        expect(output).toContain('cleanup verified: close=true');
+      } finally {
+        fs.rmSync(sandbox, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it.each(['success', 'early-exit', 'timeout', 'failure-pattern'])(
+    'cleans inherited pipes on the full harness %s path',
+    (mode) => {
+      const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'packaged-harness-TEST-'));
+      try {
+        const fixtureSource = `#!${process.execPath}
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const userDataDir = process.argv.find(arg => arg.startsWith('--user-data-dir=')).split('=')[1];
+          fs.mkdirSync(path.join(userDataDir, 'storage'));
+          fs.writeFileSync(path.join(userDataDir, 'storage/app.db'), Buffer.from('SQLite format 3\\0'));
+          const child = require('node:child_process').spawn(process.execPath, ['-e',
+            "process.on('SIGTERM', () => {}); setTimeout(() => process.exit(1), 6000); process.send('ready'); process.disconnect();"
+          ], { stdio: ['ignore', 'inherit', 'inherit', 'ipc'] });
+          child.once('message', () => {
+            if (${JSON.stringify(mode)} === 'early-exit') process.exit(2);
+            if (${JSON.stringify(mode)} === 'success') console.log('renderer did-finish-load');
+            if (${JSON.stringify(mode)} === 'failure-pattern') console.log('MODULE_NOT_FOUND');
+          });
+          setTimeout(() => process.exit(1), 6000);
+        `;
+        fs.writeFileSync(path.join(sandbox, 'agent-teams-ai'), fixtureSource, { mode: 0o755 });
+        const result = spawnSync(process.execPath, [scriptPath, sandbox, 'linux'], {
+          cwd: sandbox,
+          encoding: 'utf8',
+          timeout: 5_000,
+          env: {
+            ...process.env,
+            TMPDIR: sandbox,
+            PACKAGED_SMOKE_TIMEOUT_MS: '2000',
+            PACKAGED_SMOKE_STABLE_MS: '0',
+            PACKAGED_SMOKE_SHUTDOWN_TIMEOUT_MS: '100',
+          },
+        });
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(mode === 'success' ? 0 : 1);
+        const failureReasons: Record<string, string> = {
+          'early-exit': 'Packaged app exited before startup completed: code=2',
+          timeout: 'Timed out after 2000ms waiting for packaged startup',
+          'failure-pattern': 'Detected startup failure pattern',
+        };
+        if (mode !== 'success') expect(result.stderr).toContain(failureReasons[mode]);
+        expect(result.stdout).toContain('stdio closed');
+        expect(result.stdout.includes('[smokePackagedApp] OK')).toBe(mode === 'success');
+        if (mode === 'success') {
+          expect(result.stdout.indexOf('stdio closed')).toBeLessThan(
+            result.stdout.indexOf('[smokePackagedApp] OK')
+          );
+        }
+      } finally {
+        fs.rmSync(sandbox, { recursive: true, force: true });
+      }
+    }
+  );
+
+  it('reports a failed executable spawn through cleanup without claiming success', () => {
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'packaged-spawn-TEST-'));
+    try {
+      fs.writeFileSync(
+        path.join(sandbox, 'agent-teams-ai'),
+        '#!/nonexistent-packaged-smoke-TEST-interpreter\n',
+        { mode: 0o755 }
+      );
+      const result = spawnSync(process.execPath, [scriptPath, sandbox, 'linux'], {
+        cwd: sandbox,
+        encoding: 'utf8',
+        timeout: 4_000,
+        env: { ...process.env, PACKAGED_SMOKE_SHUTDOWN_TIMEOUT_MS: '100' },
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('ENOENT');
+      expect(result.stdout).toContain('stdio closed');
+      expect(result.stdout).not.toContain('[smokePackagedApp] OK');
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
The Linux packaged smoke printed OK after 14 seconds but kept the release job alive for another 12 minutes. The shutdown helper returned after the Electron leader exited, while descendants could retain its output pipes. A disposable Node fixture reproduces the gap in the original helper.

Wait for stdio close, clean up only the detached POSIX group created by the smoke, and run cleanup for startup failures and failed spawns. Kill remaining owned group members even when they close their pipes, then verify that no live member remains. Ignore unreaped zombies when confirming shutdown. Preserve both startup and cleanup errors in diagnostics. Bound the Linux smoke step to two minutes. Windows keeps the existing taskkill approach with bounded waiting; complete descendant cleanup after an already-exited Windows leader is not claimed.

Validation: 17 focused tests passed, including real disposable Node process fixtures and exact startup failure causes; TypeScript passed; ESLint has no errors. Independent review verified silent descendants, delayed signal delivery, and realistic fixture cleanup deadlines. New regression scenarios failed against the previous helper. No real Electron app or user project was launched locally.

This is a follow-up for future workflow runs. The existing v2.13.2 tag is unchanged.

Refs #504
Related #605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved packaged-app smoke-test cleanup to reliably terminate applications and their child processes.
  - Added graceful shutdown with forced termination when processes do not exit within the timeout.
  - Improved handling and reporting of startup failures, process errors, and captured logs.
  - Added a two-minute timeout for the Linux packaged-app smoke test.

- **Tests**
  - Expanded coverage for cleanup, shutdown timeouts, inherited output streams, failed launches, and cleanup-error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
