### PR TITLE
docs(opencode): record launch authority decision and qualification

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -28,7 +28,7 @@ Before publishing:
 - Confirm version numbers, runtime gates, asset names, and download links.
 - Keep the body in this document identical to the GitHub release body.
 
-## Draft: v2.13.2 (2026-09-07)
+## Released: v2.13.2 (2026-09-07)
 
 GitHub release: [v2.13.2](https://github.com/777genius/agent-teams-ai/releases/tag/v2.13.2).
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -47,7 +47,7 @@ This update fixes OpenCode startup checks and makes provider sign-in failures ea
 ### Fixes
 
 - Stop valid OpenCode settings managed by the app from incorrectly blocking model checks.
-- Show the provider's sign-in error when it rejects access with a 401 response.
+- Show the provider's sign-in error when it rejects access with a 401 or 403 response.
 - Reuse newly started OpenCode servers without incorrectly reporting that their settings have changed.
 
 ### Downloads

--- a/docs/team-management/opencode-launch-authority-contract-plan.md
+++ b/docs/team-management/opencode-launch-authority-contract-plan.md
@@ -1,6 +1,6 @@
 # OpenCode: план устойчивой проверки контракта запуска
 
-Дата: 2026-09-07. Статус: контракт реализован и выпущен в runtime `v0.0.84`, [PR #68](https://github.com/777genius/agent_teams_orchestrator/pull/68), commit `b567c93a3f424e5d23301cbce5f6f7ade8273c18`. Frontend PR #604 и release PR #605 merged. App `v2.13.2` остаётся draft; выполняется Linux recovery. Актуальная доставка и незавершённая приёмка зафиксированы в конце документа.
+Дата: 2026-09-07. Статус: контракт реализован и выпущен в runtime `v0.0.84`, [PR #68](https://github.com/777genius/agent_teams_orchestrator/pull/68), commit `b567c93a3f424e5d23301cbce5f6f7ade8273c18`. Frontend PR #604 и release PR #605 merged. App [v2.13.2](https://github.com/777genius/agent-teams-ai/releases/tag/v2.13.2) опубликован; Linux recovery и updater guard прошли. Актуальная доставка и незавершённая приёмка зафиксированы в конце документа.
 
 Разделы 1–15 сохраняют принятый план, исходные оценки и исследованные версии до реализации. Их формулировки «актуальный main», «перед реализацией» и порядок PR относятся к тому этапу; они не означают, что уже выпущенный контракт нужно реализовать повторно.
 
@@ -52,7 +52,7 @@ Runtime исследован по отдельной копии исходник
 
 | Факт | Следствие |
 | --- | --- |
-| R1:67–170: helper возвращает `profile | null`, callback диагностики изолирован | Сохранить return contract; ошибка наблюдаемости не меняет допуск |
+| R1:67–170: helper возвращает `profile \| null`, callback диагностики изолирован | Сохранить return contract; ошибка наблюдаемости не меняет допуск |
 | R2:1333–1359: приложение импортирует `provider/model/small_model/plugin`; provider subtree сохраняется целиком | Нельзя проверять только curated baseURL и забыть custom SDK options/credentials |
 | R2:2520–2545: импорт глубоко объединяется с managed config, затем применяются overrides и isolation | Ожидание строится из окончательного prepared config, не непосредственно из каталога |
 | R2:757: model-limit override заменяет `limit`, в том числе может убрать старый `input` | Нельзя восстановить старый limit из каталога при сравнении |
@@ -358,7 +358,8 @@ Runtime использует Bun и не имеет frontend `pnpm typecheck` sc
 - [x] Ровно один необходимый `/agent` GET, никаких новых provider inventory GET, calibration hosts, authority caches, registry migrations или зависимостей.
 - [x] Focused CI действительно исполняет новые tests на Linux и Windows (run34149790888, SHA3595a929).
 - [x] Conformance evidence двух pinned OpenCode версий получено в полной тестовой изоляции.
-- [ ] Curated live launch и packaged proof зафиксированы; Z.AI и Windows имеют отдельный честный status.
+- [x] Packaged release `v2.13.2` опубликован и проверен; отрицательная Z.AI-приёмка и Windows CI имеют отдельный status.
+- [ ] Успешный curated/mixed live launch и Copilot task/file proof зафиксированы.
 - [x] Независимое review выполнено на конечном production SHA3595a929 и version-only delta be27add1; исходные чужие изменения не затронуты.
 - [x] Broad fingerprint defect и неизвестные будущие runtime-root поля явно записаны как оставшиеся ограничения.
 
@@ -395,10 +396,10 @@ Runtime ссылки привязаны к exact release SHA; путь и стр
 - **Runtime выпущен:** [PR #68](https://github.com/777genius/agent_teams_orchestrator/pull/68) merged в `b567c93a3f424e5d23301cbce5f6f7ade8273c18`, source tag `v0.0.84`; [публичные бинарники](https://github.com/777genius/agent_teams_orchestrator_binaries/releases/tag/runtime-v0.0.84). Все пять платформ собраны; manifest/GitHub digests, anonymous download gate и native app bootstrap проверены. [Runtime build run](https://github.com/777genius/agent_teams_orchestrator/actions/runs/34150738449).
 - **Проверки контракта:** final focused suite 645 tests / 3253 assertions, dev/production builds; новых typecheck ошибок относительно baseline нет. [CI run 34149790888](https://github.com/777genius/agent_teams_orchestrator/actions/runs/34149790888) на `3595a929` завершил все шесть jobs, включая полный Windows authority suite и conformance. Production-код release head совпадает с этим проверенным срезом. Linux conformance покрывает pinned OpenCode 1.18.4/1.18.29, inline/file и auto/manual с настоящим permission engine и MCP; у локальной macOS-проверки сохранено ограничение системной изоляции.
 - **Frontend интегрирован:** [PR #604](https://github.com/777genius/agent-teams-ai/pull/604), merge `3d7c427064053badf6c5412edc006fe980d67fe4`, изолирует wrapper и cleanup; 24 wrapper tests прошли. [PR #605](https://github.com/777genius/agent-teams-ai/pull/605), merge `906395bc7cf846b2c3debc8271e4853fb7173e5f`, закрепляет runtime assets и служит основанием tag `v2.13.2`.
-- **App пока draft:** в [исходном release run](https://github.com/777genius/agent-teams-ai/actions/runs/34151777575) Windows/macOS собраны; Linux дважды сообщил smoke OK, но завис на удерживаемых descendant pipes. Выполняется отдельный [Linux recovery run 34155202396](https://github.com/777genius/agent-teams-ai/actions/runs/34155202396). Packaged qualification, финальная публикация и updater guard пока не завершены.
+- **App опубликован:** [v2.13.2](https://github.com/777genius/agent-teams-ai/releases/tag/v2.13.2), source `906395bc7cf846b2c3debc8271e4853fb7173e5f`. Windows/macOS проверены в [исходном release run](https://github.com/777genius/agent-teams-ai/actions/runs/34151777575); [Linux recovery](https://github.com/777genius/agent-teams-ai/actions/runs/34155202396) прошёл с pinned внешним smoke helper после упаковки неизменного tag source. Все 12 исходных Windows/macOS assets сохранены по ID/size/digest. [Promotion run](https://github.com/777genius/agent-teams-ai/actions/runs/34156281715) проверил SHA-256 десяти основных файлов и выпустил релиз; updater guard подтвердил public/latest/updater-ready в CI и повторно после выпуска. Исправление smoke для будущих сборок отдельно слито в [PR #606](https://github.com/777genius/agent-teams-ai/pull/606).
 - **Z.AI: отрицательная приёмка выполнена.** По уточнённому запросу пользователя действующих credentials нет. Один canary опубликованного darwin-arm64 runtime с заведомо неверным disposable key прошёл config gate и получил настоящий HTTP 401; task dispatch отсутствовал, cleanup подтверждён. Обработка реального 401/403 envelope проверена. Это отказ авторизации, не успешное authenticated task E2E.
 - **Copilot: положительная приёмка не выполнена.** Прежний config blocker устранён, но execution probe и отдельная диагностика `/responses` получили `model_not_supported`. Причина account/limits не установлена; task/file E2E не засчитан.
 - **Windows: отдельный дефект исправлен, исходный инцидент не доказан.** Fresh `launch_runtime` теперь сохраняет managed fingerprint для strict adoption. Persisted algorithms и wire schema не менялись; старые несовпадающие live-записи остаются fail-closed. Registry wipe/migration не добавлены. Причина и исправление именно пользовательского upgrade-инцидента без его artifacts остаются неподтверждёнными.
-- **Оставшиеся требования:** успешный curated/mixed secondary-lane canary, Copilot assigned-task/file proof, полная packaged qualification и проверка исходного Windows-состояния. Broad fingerprint order и неизвестные будущие runtime-root поля остаются отдельными ограничениями исходного плана.
+- **Оставшиеся требования:** успешный curated/mixed secondary-lane canary, Copilot assigned-task/file proof и проверка исходного Windows-состояния. Broad fingerprint order и неизвестные будущие runtime-root поля остаются отдельными ограничениями исходного плана.
 
 Независимые технические ревью production-изменений выполнены; зелёный ReviewRouter gate не заявляется, поскольку его provider отклонил запуск из-за quota. Runtime/provisioning проверки выполнялись только в новых TEST/temp проектах. Исходные dirty checkout и пользовательские auth stores сохранены. Локальный архив содержит redacted canary/conformance artifacts; проверяемые PR, CI и release-ссылки приведены выше.

--- a/docs/team-management/opencode-launch-authority-contract-plan.md
+++ b/docs/team-management/opencode-launch-authority-contract-plan.md
@@ -1,0 +1,404 @@
+# OpenCode: план устойчивой проверки контракта запуска
+
+Дата: 2026-09-07. Статус: контракт реализован и выпущен в runtime `v0.0.84`, [PR #68](https://github.com/777genius/agent_teams_orchestrator/pull/68), commit `b567c93a3f424e5d23301cbce5f6f7ade8273c18`. Frontend PR #604 и release PR #605 merged. App `v2.13.2` остаётся draft; выполняется Linux recovery. Актуальная доставка и незавершённая приёмка зафиксированы в конце документа.
+
+Разделы 1–15 сохраняют принятый план, исходные оценки и исследованные версии до реализации. Их формулировки «актуальный main», «перед реализацией» и порядок PR относятся к тому этапу; они не означают, что уже выпущенный контракт нужно реализовать повторно.
+
+## Уточнение по результатам настоящего E2E (2026-09-07)
+
+Полный helper с настоящим OpenCode и подключённым MCP опроверг первоначальное предположение о порядке `/config.permission`. Обе pinned-версии загружают config с `propertyOrder: original`, но Effect HTTP response encoder сериализует известные permission keys перед неизвестным `*`. Исполняемый порядок в `/agent` остаётся правильным. Это не inline/file различие. Прежняя локальная ordered `/config` проверка блокировала исправный запуск.
+
+План исправлен: один дополнительный свежий `/agent` read, точный managed policy tail после универсального reset и проверенный Truncate exception. Запрет дополнительных inventory reads сужен до `/config/providers`; требование не воспроизводить upstream defaults остаётся. Старое conformance evidence доказывает значения и effective rules, но не порядок JSON-ключей `/config`.
+
+## 1. Решение и граница задачи
+
+Заменить сравнение произвольного JSON выбранного провайдера на небольшой положительный контракт поддержанных настроек запуска. Встроить его в существующий `refreshSelectedProfileAuthority()`, сохранить остальные проверки, проверять порядок исполняемых permissions через `/agent` и закрыть обнаруженные пробелы cancellation.
+
+В production не добавлять калибровочный OpenCode host, загрузку upstream schema, сохранённый T0 baseline, новый registry, общий semantic-diff framework или свой движок permissions. Не добавлять зависимости.
+
+Контракт отвечает на вопрос: «сохранились ли поддержанные приложением настройки данного подготовленного запуска?» Он не обещает доказать всё внутреннее поведение произвольного OpenCode/plugin через информационные API.
+
+Исходный [разбор инцидента](opencode-selected-config-authority.md) сохраняет ценность как история и эмпирические наблюдения. Его рекомендации calibration-first в разделах 9 и 13 заменяются этим планом. Успешный Z.AI E2E и Windows-проверка из исходного документа по-прежнему не считаются выполненными.
+
+Оценка после аудита: 🎯 уверенность 8/10, 🛡️ надёжность в описанной границе 8/10, 🧠 сложность 5/10. Полный основной runtime-срез с тестами и CI: ориентировочно 1 000–1 600 changed LOC. Безопасный frontend smoke-wrapper и conformance fixtures оцениваются отдельно; это не обещание уложить все платформенные проверки в прежние 600–950 строк.
+
+### Сравнение трёх подходов
+
+1. **Положительный контракт + существующий execution proof (рекомендуется).** 🎯 8/10 · 🛡️ 8/10 · 🧠 5/10. Основной runtime-срез примерно 1 000–1 600 changed LOC с тестами/CI. Явно защищает поддержанное намерение; неизвестные будущие root-поля требуют расширения контракта. Нет второго production host.
+2. **Изолированная калибровка + проверки критичных свойств.** 🎯 7/10 · 🛡️ 8/10 · 🧠 8/10. Предварительно 1 800–3 000 changed LOC с тестами. Лучше переносит нормализацию, но добавляет lifecycle, изоляцию и cache invalidation; одинаковое исчезновение критичного поля в эталоне и live всё равно требует отдельной проверки намерения. Ключ version × config недостаточен при зависимости от env, файлов, plugins и каталога.
+3. **Сохранить hotfix и квалифицировать поддержанные версии.** 🎯 9/10 как временное исправление · 🛡️ 5/10 на будущих релизах · 🧠 2/10. Дополнительно примерно 100–250 changed LOC тестов/CI. Минимальный риск текущего изменения, но список исключений остаётся и проблема повторится.
+
+Оценки LOC приблизительные, не включают generated artifacts и развёртывание внешней CI-инфраструктуры. Baseline T0/T1 отдельно не входит в тройку: он обнаруживает изменение, но не доказывает допустимость исходного состояния.
+
+## 2. На каком коде основан план
+
+Исследование выполнено без запуска runtime, provisioning, model requests или тестов на пользовательских проектах.
+
+| Источник | Зафиксированная версия |
+| --- | --- |
+| Runtime `777genius/agent_teams_orchestrator`, актуальный `main` | `9247cbb08db7d6d5130635face0f89e9f69f65fb`, `v0.0.83` |
+| Hotfix инцидента | PR #66, merge `49d44c33c6b28df8f540c60f187271a3e91b2b0e` |
+| Frontend `777genius/agent-teams-ai`, актуальный `main` | `8c74f8705b1975cbae0316f176b681247ccbc90d`; `runtime.lock.json` указывает `0.0.83` |
+| OpenCode `1.18.29` | `16747470f976aca3d362ad730bcd3fe82ecc2c9a` |
+| OpenCode `1.18.4` | `49c69c5ed3ccf706b61b3febb43c8aaff7f8325e` |
+
+Runtime исследован по отдельной копии исходников из `git archive` точного SHA. Локальный runtime checkout находится на `fix/opencode-session-relaunch-followup` и содержит незакоммиченные Cursor-изменения. Локальный frontend checkout также отличается от опубликованного `main`. Их нельзя принимать за release evidence или включать в реализацию попутно.
+
+Перед реализацией заново прочитать актуальный `main` и delta от этих SHA. Для кода создать отдельный чистый checkout/worktree от актуального основания; не переключать и не очищать существующие рабочие ветки. Имена новых веток выбирать по правилам репозитория, без `codex/`. При связанном issue сохранять `Refs` в commit и ссылку в PR; не выдумывать номер issue.
+
+## 3. Подтверждённые факты, влияющие на дизайн
+
+Ссылки R1–R12 и U1–U6 расшифрованы в конце документа. Номера строк относятся к зафиксированным SHA.
+
+| Факт | Следствие |
+| --- | --- |
+| R1:67–170: helper возвращает `profile | null`, callback диагностики изолирован | Сохранить return contract; ошибка наблюдаемости не меняет допуск |
+| R2:1333–1359: приложение импортирует `provider/model/small_model/plugin`; provider subtree сохраняется целиком | Нельзя проверять только curated baseURL и забыть custom SDK options/credentials |
+| R2:2520–2545: импорт глубоко объединяется с managed config, затем применяются overrides и isolation | Ожидание строится из окончательного prepared config, не непосредственно из каталога |
+| R2:757: model-limit override заменяет `limit`, в том числе может убрать старый `input` | Нельзя восстановить старый limit из каталога при сравнении |
+| R3:313–395: strict provisioning намеренно не получает provider/agent inventory | `snapshot.configProviders === null` здесь штатно; нельзя объявлять inventory уже доступным |
+| R4:2656/2672/3399 и R5:685: helper используется в readiness, strict launch и повторных действиях сессии | Допустить ровно один параллельный `/agent` read; не добавлять provider inventory |
+| R5:682–685: stop намеренно обходит live authority | Недоступный MCP не должен препятствовать abort/status/SSE |
+| R6:1221/1466/1613: поле `resolvedConfigFingerprint` содержит разные домены на selected и broad путях | Не записывать новый contract digest или broad digest в существующий selected hash |
+| R1:147–148: `contractConfigIdentity` относится к полному MCP config | Это не hash всего `selectedConfig`; его алгоритм не менять |
+| R4:3434–3492: production strict launch использует свежий nonce proof на retained host | Сохранять fresh proof; reusable wire proof не превращать в baseline |
+| U2:1937–1998: без explicit `small_model` возможен автоматический выбор по family/date/plugin | Одной selected model для защиты provider-конфига недостаточно |
+| U2:185: cost участвует в authless OpenCode model filtering | Cost, family и release_date нельзя все вместе объявить декоративной metadata |
+| U3/U4: permission order значим; U4 дописывает служебный allow для Truncate.GLOB | Не сортировать rules; сравнивать только доказанный reset-tail, не весь upstream defaults prefix |
+| R2:2141 и R6:240: текущие generic fingerprints теряют порядок permission maps/arrays | Проверять actual ordered `/agent` rules локально; broad digest требует отдельного compatibility-решения |
+| R11: CI запускает task-change-ledger и dev build | Зелёный существующий CI не доказывает selected authority; нужен focused job |
+
+Дополнительные ограничения:
+
+- `kiro` и `cursor-acp` запрещены для strict launch/probe на исследованном release (R2:1954). Этот план не включает их поддержку. Их статические curated-конфиги можно покрыть pure tests, но не считать успешный launch обязательным или разрешённым этим изменением.
+- Наличие 11 моделей в `/config/providers` при 7 в `/config` не означает, что нынешний comparator сравнивал эти два списка. Он сравнивает `/config` с prepared config. Эти источники нужно строго различать.
+- `runLaunchWithProvisioningSnapshot()` с reusable execution proof не имеет production callers в исследованном коде. Не строить дизайн вокруг оптимизации этого legacy пути.
+
+## 4. Инварианты и честные ограничения
+
+### 4.1 Обязательные инварианты
+
+1. Expected contract формируется из подготовленного намерения, до первого asynchronous read; ни одно expected значение не берётся из live response.
+2. Неизвестный результат, malformed обязательное поле, mismatch или cancellation не дают разрешения на следующие действия.
+3. Никакого directional subset внутри permissions, options, headers, variants или MCP.
+4. Имя provider, model IDs с вложенными `/`, profile scope, auth, project behavior и точные session/run/lease/CAS проверки сохраняются.
+5. Точный MCP config binding включает command argument order, environment и URL. `connected` сам по себе недостаточен.
+6. Успешный refresh не переписывает host registry, session store, исходный prepared config, capability hash или execution proof.
+7. Stop сохраняет существующее исключение из live checks и точную проверку адресуемого процесса/сессии.
+8. Никаких provider requests, установки plugins или запуска дополнительного host внутри comparator.
+
+### 4.2 Граница положительного provider-контракта
+
+Поддержанные runtime-поля проверяются явно. Произвольные неизвестные root-поля provider/model не входят в новую live-проекцию, но остаются в исходном config и существующих source/scope/managed fingerprints.
+
+Это осознанное сужение прежнего «любой JSON drift = ошибка». Не называть неизвестные поля автоматически безопасными: будущая версия OpenCode или plugin может придать им смысл. Поддержка новой runtime-root возможности требует расширения контракта и conformance test.
+
+Одновременно невозможно строго проверять любые неизвестные root-поля, допускать их удаление upstream и не иметь schema oracle, provenance или исключений. Выбран положительный контракт. Не добавлять строгий residual bag: он вернёт исходный баг для imported `structured_output`.
+
+Произвольные plugin effects, mutable approvals OpenCode и скрытые SDK defaults не доказаны равенством `/config`. Доверие к их интерпретации устанавливается на проверенных версиях conformance-проверками. Не обещать универсальную совместимость с любым будущим бинарём и не вводить без необходимости жёсткий production version allowlist.
+
+## 5. Точная форма provider-контракта
+
+Предлагаемый небольшой модуль: `src/services/opencode/OpenCodeLaunchProviderContract.ts`. Две чистые операции: построить проекцию из config и сравнить expected/live. Названия функций можно уточнить при реализации; отдельные service classes, registries и dependency containers не нужны.
+
+| Область | Защищённые значения |
+| --- | --- |
+| Selected provider entry | Presence, корректная object shape |
+| Provider | `api`, `npm`, `env`, `id`, `whitelist`, `blacklist` |
+| Provider options | Весь `options` object с произвольными вложенными ключами |
+| Configured models | Presence `models` и точное множество его ключей |
+| Каждая configured model | `id`; вложенные `provider.api`, `provider.npm` |
+| Непрозрачные model bags | Полностью `options`, `headers`, `variants` |
+| Model runtime descriptor | `limit`, `family`, `release_date`, `status`, `attachment`, `reasoning`, `temperature`, `tool_call`, `interleaved`, `modalities`, `cost` |
+| Верхние selectors | Существующие проверки `model` и `small_model`; квалификация selected model отдельно |
+
+Правила реализации:
+
+- Контракт применяется ко всем selected providers, включая imported/custom. Никакого `if providerId === 'zai-coding-plan'`.
+- Вложенные supported structures вроде `limit`, `cost`, `modalities`, `interleaved` имеют проверенную JSON shape. Сравнивать заданные структуры полностью; не терять `limit.input`, model header или параметры variant.
+- В opaque bags сохранять неизвестные ключи и типы: `options.route`, custom endpoint/header, `options.environment`, credentials и SDK-specific flags могут менять выполнение. Не использовать рекурсивную проекцию по списку известных SDK options.
+- Обычные object keys сравнивать независимо от порядка; array order сохранять. Не считать весь JSON деревом unordered collections.
+- Различать `absent`, `null`, `{}`, `[]` и реальные значения. Expected absent не означает «принимаем любой live». Не превращать invalid object в `{}` через permissive `asRecord`.
+- Для обязательного expected поля потеря live presence всегда mismatch. Не восстанавливать live SDK/endpoint/limit из expected или models.dev.
+- Встроенный provider может отсутствовать в `/config` с обеих сторон. Это допустимый state; его динамическую реализацию подтверждает существующий execution proof в своей ограниченной области.
+- Проверять **все configured models** selected provider. Добавление даже `models.extra = {}` в `/config` создаёт исполнимый маршрут; добавление/удаление ключа отклоняется.
+- Пополнение expanded inventory в `/config/providers` не является изменением configured model set. Этот endpoint не участвует в новом refresh.
+- Production comparator не содержит строк `structured_output` или `CONFIG_DROPPED_MODEL_FIELDS`. Поле может оставаться в исходном каталоге и regression fixtures.
+
+### 5.1 Environment, secrets и fingerprint helpers
+
+Expected строится после merge/overrides/isolation из `profile.managedConfig` и retained `profile.env`, не из текущего `process.env`.
+
+Нельзя без проверки использовать `buildManagedConfigFingerprint()` как единственный comparator новой проекции: его generic normalization исключает любой вложенный `environment` и remote `url`. Для transport bags это может потерять значимое значение. Нельзя менять этот общий helper в рамках задачи: от него зависят существующие сохранённые identities.
+
+Нужна локальная JSON-value comparison для contract, сохраняющая все выбранные значения. Не переносить в неё `resolveIdentityEnvironment`, `redactConfigIdentity` или `secretIdentity`: они поддерживают дополнительный `${...}` синтаксис, маскируют/хешируют ссылки и нормализуют URL query. Это identity-policy, а не точное значение, полученное OpenCode. Старые helpers и golden vectors оставить неизменными.
+
+Для expected-only подстановки повторить только маленькое правило U6, проверенное на обоих pinned SHA: один проход `{env:...}` по тому же сериализованному JSON, который передан как `OPENCODE_CONFIG_CONTENT`, затем JSON parse. Использовать только captured retained env, без fallback к новому ambient process.env. Missing/empty env превращается в пустую строку как у pinned upstream; требование к непустому endpoint/credential проверяется отдельно. Invalid JSON после подстановки не авторизуется. Это учитывает, что upstream подставляет текст до parsing, в том числе в ключах; нельзя молча заменить его другим recursive value resolver.
+
+Live response не интерполировать повторно. `${...}` не считать OpenCode-подстановкой. Если значение env само содержит `{env:OTHER}`, повторный проход не выполнять. Не сортировать query parameters, не удалять fragment и не нормализовать endpoint URL новым comparator. Значения secrets допустимы только в памяти; не добавлять их в diagnostic/fixtures/logs или persistent cache.
+
+Обязательная matrix: literal secret; `{env:...}` для route/secret; отсутствующее и пустое env; изменение ambient env при неизменном retained env; URL query и routing headers; вложенный `environment`; literal `{env:...}` в live; env value с ещё одной ссылкой; повторяющиеся query parameters в разном порядке; подстановка, делающая JSON невалидным. Live value не используется для заполнения expected.
+
+Не расширять поддержку `{file:...}` и иных внешних подстановок новым файловым resolver внутри comparator. U6 выполняет file substitution после env, поэтому ссылка на файл может появиться и из env value. Если защищённое expected значение требует такого чтения, сохранять fail-closed результат и явно классифицировать этот сценарий как неподтверждённую совместимость. Это ограничение должно попасть в release evidence, если затрагивает проверяемую конфигурацию.
+
+## 6. Остальная конфигурация и permissions
+
+Не заменять весь `selectedConfig()` одним permissive contract. В основном срезе меняется provider comparison; остальные существующие проверки сохраняются:
+
+- `model`, `small_model`, `plugin`, `default_agent`;
+- весь `/config.agent`, включая prompt/options и неизвестные добавления в managed names;
+- top-level `permission`, `command`, `share`, `snapshot`, `autoupdate`;
+- отдельное полное MCP comparison.
+
+Не разрешать дополнительные `/config.agent` records, project prompt или injected command попутно. App safe import и реальный OpenCode load имеют разные источники: raw project/.opencode/managed config может пережить inline deep merge. Текущие негативные тесты защищают эту границу.
+
+### 6.1 Effective managed permission check
+
+`/config` сохраняет строгую проверку значений, presence, mode, tools, prompt/options и неизвестных добавлений, но его object key order не является доказательством исполнения. Source raw snapshot сохраняет порядок и не изменяется.
+
+Добавить один `client.listAgents()` параллельно существующим чтениям, с тем же deadline/abort. Для трёх canonical agents `teammate`, `teammate-bootstrap`, `teammate-model-probe`:
+
+1. До await построить ordered expected rules из captured raw config. Поддержанная политика начинается `{permission: '*', pattern: '*', action: 'deny'|'ask'}`. Текущие auto/manual/bootstrap/probe удовлетворяют этому условию.
+2. В live требовать ровно одну запись каждого managed name и корректный массив rules. Modes и остальные agent values продолжают защищаться `/config` comparison.
+3. Найти последний universal reset в live rules и сравнить весь tail: точные expected rules в исходном порядке плюс ровно один upstream Truncate allow для `path.join(profile.env.XDG_DATA_HOME, 'opencode', 'tool-output', '*')`.
+4. Missing/duplicate agent, неверный reset action, перестановка nested rules, лишнее/удалённое правило после reset и неправильный/лишний Truncate exception отклоняются.
+5. Prefix до universal reset не сравнивается: по подтверждённой last-match семантике универсальное правило перекрывает все предыдущие правила для любого permission/pattern. Это доказанная граница, а не permissive поиск произвольной подпоследовательности.
+6. Не создавать evaluator, catalogue upstream defaults или сохранённый baseline. Иные managed policies без universal reset и неожиданные root permissions в prepared launch config отклонять как неподдержанные. Реальный safe import root permission не принимает; не расширять эту поддержку искусственными fixtures.
+
+Сохранить адаптации absent command ↔ `{}` и absent agent options ↔ `{}`. Не восстанавливать потерянные live permission/tools. `/config` key reordering с правильными `/agent` rules принимается; изменение реального порядка rules отклоняется.
+
+### 6.2 Граница гарантии
+
+Служебный Truncate allow не означает общий доступ к внешним каталогам: допускается только точная известная exception rule для captured isolated data path. Mutable approvals и произвольные plugin effects не доказываются этим API. Новые suffix rules требуют явного compatibility review; неизвестный prefix уже перекрыт universal reset.
+
+Причина изменения плана подтверждена pinned source: [Effect HTTP encoder](https://github.com/Effect-TS/effect-smol/blob/cd7ab658994104bd6fe8f841f1440bea32c387f5/packages/effect/src/unstable/httpapi/HttpApiBuilder.ts#L636), OpenCode Permission Config StructWithRest и реальные file/inline probes. Транспорт config и алгоритмы persisted fingerprints не меняются.
+
+## 7. Алгоритм refresh и cancellation
+
+Сохранить orchestration flow; добавить ровно одно свежее `/agent` чтение для необходимого effective policy evidence.
+
+1. До первого await проверить selected model/scope и срок выполнения; снять глубокую локальную копию raw expected config/env и используемых identity fields, затем построить provider/permission contract.
+2. Проверить целостность prepared config относительно существующего managed fingerprint. Это не заменяет отдельную ordered permission check.
+3. Выполнить чтения: `/config`, `/agent`, MCP status через `attachIfMissing:false`, project metadata и scope. Новый reader не запускает attach/connect/repair.
+4. Проверить deadline; валидировать shape полученного `/config` до проекции.
+5. Выполнить прежние MCP checks, новый provider contract, effective managed permission tails и сохранённые остальные config checks. Убрать provider из старого полного JSON/fingerprint comparison, иначе оно повторно отвергнет уже разрешённую metadata normalization. При этом сохранить `provider` как допустимое имя поля в диагностике нового validator. Не передавать новую проекцию обратно в helper, удаляющий nested environment.
+6. Проверить scope token/config/auth identity и новое expected-behavior evidence.
+7. После последнего await ещё раз проверить deadline и сохранность захваченного prepared ожидания. Сравнить исходный config/env/identity с глубокой локальной raw-копией, сохраняя порядок permissions и все transport values. Старый managed fingerprint для этого недостаточен. Простого JSON.stringify тоже недостаточно для raw integrity: он теряет undefined-valued additions. Снимок должен сохранять presence и значимый порядок исходных значений. При изменении expected source не принимать обновлённое значение за новый эталон.
+8. Вернуть новый profile с обновлённым projectBehaviorFingerprint только при полном успехе. Не менять host/store/prepared object.
+
+Локальной копии/чистого contract достаточно; не нужен глобальный freeze всего HostManager или новая система ревизий. Старый fingerprint не доказывает исходный порядок policy до входа в helper: доверенной точкой остаётся подготовка профиля, а helper защищает захваченное намерение своего вызова. Promise.all не является атомарным снимком сервера. Проверки ловят расхождения в существующих контрольных точках, а не доказывают невозможность любого промежуточного изменения.
+
+В `OpenCodeBridgeCommandHandler` оба readiness refresh сейчас не получают `phaseContext`. Обернуть их существующим `runtimeDeadline.runPhase('post_probe_refresh', ...)` и передать context в helper. Strict launch callback уже передаёт context; не заводить второй deadline и не менять cleanup reserve.
+
+Для bounded completion недостаточно проверки после await: ожидание auth/behavior evidence должно прерываться существующим abort-race helper даже при зависшей операции, не создавая нового deadline. Late rejection должен быть обработан. Дисковые metadata/auth reads могут завершиться после abort. Их поздние результаты не должны разрешить bootstrap/prompt/commit, обновить cache или переписать profile. Сохранить `profile | null` внутри helper и timeout/cancellation classification внешнего deadline wrapper.
+
+## 8. Call sites, persistence и reuse
+
+| Путь | Что проверить при интеграции |
+| --- | --- |
+| Selected readiness, R4:2656/2672 | До/после execution probe один retained host, прежнее expected-behavior намерение, общий deadline |
+| Strict launch closure, R4:3399 | Повторные проверки вокруг MCP/model proof, reuse, materialization, bootstrap и commit остаются |
+| Session reuse, R5:649–745 | Exact store identity до/после live read и после retain lease; replacement не получает старый prompt |
+| Send/reconcile/preview/refresh | Real checker работает; один `/agent` read, нет provider inventory и лишних writes |
+| OAuth refresh, R5:886–904 | Сохраняется refresh auth -> prepare нового профиля при необходимости -> authority; не разрешать произвольный auth drift |
+| Stop | Обходит live/MCP checks, но не exact session/run/process identity |
+| Persistent adoption | Сохраняет selected managed fingerprint domain и старые sealed records |
+
+Не менять `OpenCodeExecutionProof` schema 1, expected-behavior v2, wire fields, TTL, capability snapshot IDs или host/session registry format. Не вызывать `refreshResolvedConfigFingerprint()` на selected path. Не использовать существующий MCP proof cache или readiness cache как authority baseline.
+
+Не добавлять `getConfigProviders()` в refresh. `listAgents()` теперь обязателен для fresh effective permissions; ответ не используется как baseline. Проверка model identity и фактический запрос остаются задачей existing execution proof. Остальные дополнительные API используются только в изолированном compatibility harness.
+
+## 9. Обязательная тестовая матрица
+
+Expected fixtures строятся независимо из намерения. Live fixtures отражают зафиксированные ответы бинаря, но не служат expected baseline. Не обновлять golden fixtures автоматически из текущего live при падении теста.
+
+| ID | Сценарий | Результат |
+| --- | --- | --- |
+| P01 | Existing imported DeepInfra model с `structured_output`; live удалил поле | Accept без production drop-list |
+| P02 | Добавлено/удалено неподдержанное model root annotation | Supported contract unchanged; accept с описанной границей гарантии |
+| P03 | Изменён/удалён/добавлен защищённый provider/model field | Reject |
+| P04 | Неизвестный вложенный ключ в `options/headers/variants` изменён | Reject |
+| P05 | Endpoint query, header, npm, API model alias, credentials, `options.environment` изменены | Reject |
+| P06 | Configured model добавлена/удалена, включая `extra:{}` | Reject |
+| P07 | Expanded `/config/providers` inventory содержит больше моделей | Не влияет на refresh; никаких provider inventory reads |
+| P08 | Unselected configured model family/date/status/cost/route изменены при absent small_model | Reject |
+| P09 | Model limits после overrides совпадают; затем context/input/output изменён | Accept, затем reject |
+| P10 | Builtin provider absent на обеих сторонах; nested model ID | Сохранить supported поведение и canonical parsing |
+| P11 | Absent/null/object/array/empty string/malformed protected shape | Не маскировать различия; malformed обязательные значения reject |
+| P12 | Перестановка обычных object keys / значимого array order | Accept / reject соответственно |
+| A01 | Teammate auto/manual, bootstrap и probe на двух версиях | Текущие управляемые конфигурации проходят |
+| A02 | `/config` key reorder при правильном effective tail; затем перестановка actual `/agent` rules/nested patterns | Accept, затем reject |
+| A03 | Пропали agent/mode/permission/emitted tools | Reject; live adapter не восстанавливает потерю |
+| A04 | Prompt/options/unknown managed-agent field/top-level permission/command injection | Существующие negatives остаются reject |
+| A05 | Agent options={} и command={} штатные defaults | Accept без изменения prepared/evidence |
+| L01 | MCP name/config/URL/env/command order/connection/tool-proof mismatch | Reject до следующих member effects |
+| L02 | Scope/auth/project changed before/after proof или bootstrap | Reject; ранее committed member сохраняется |
+| L03 | Abort во время HTTP и последнего auth read, late resolve/reject | Zero downstream effects и late writes; bounded completion |
+| L04 | Prepared input изменился во время await: только permission order, nested environment, remote URL либо retained env | Reject по raw-копии; не переопределять ожидание live-значением |
+| L05 | Send/reconcile/preview/refresh повторяются на selected session | Sealed record и hash domains не меняются |
+| L06 | Store replacement during retain; stale session reuse | Старый prompt не отправлен; нет незаметного создания replacement session |
+| L07 | Real selected persistent adoption через новый manager/process | Тот же host/session, реальный reader, без broad fingerprint rewrite |
+| L08 | Stop после disconnect MCP/config drift | Точная адресуемая сессия останавливается по существующему stop contract |
+| D01 | Callback бросает; ошибка содержит secret; hostile key/value | Fail-closed; diagnostic не содержит исходных данных |
+
+Pure provider fixtures покрывают Z.AI, MiniMax, Kimi, три Xiaomi региона, Atlas, Copilot, builtin provider и imported custom provider. Kiro/Cursor покрываются как data fixtures с сохранением их текущего unsupported launch status.
+
+Не ослаблять существующий тест `refreshes selected config/project/auth/MCP authority and fails closed on each mutation`. Дополнять его matrix и сохранять imported DeepInfra regression: он доказывает отсутствие привязки решения к одному curated provider.
+
+Ограничения текущих тестов, которые нужно закрыть:
+
+- Bridge tests и `OpenCodeIssue443PersistentCommand.test-support.ts` часто stub'ят сам authority helper. Они не доказывают новый comparator.
+- `OpenCodeSelectedSessionAuthority.test.ts` использует настоящий helper, но mock HostManager. Он не доказывает реальный registry adoption.
+- Добавить один bounded sandbox integration сценарий с real checker и реальным create/adopt путем HostManager против тестового HTTP OpenCode server. Это не требует LLM или реальных credentials.
+
+## 10. Безопасный harness и live evidence
+
+### 10.1 Обнаруженная проблема существующего wrapper
+
+В актуальном frontend `scripts/prove-opencode-team-provisioning.mjs` default project = repoRoot, default model = `opencode/big-pickle`. Более того, preflight вызывается как `preflightOpenCodeLiveEnvironment({ repoRoot })`, без сформированного `env`, sandbox projectPath и requiredModels. Одного `OPENCODE_E2E_PROJECT_PATH` сейчас недостаточно: preflight всё равно может запустить OpenCode в реальном repoRoot.
+
+Перед использованием этого wrapper исправить узкий путь:
+
+- Создавать новый sandbox project либо требовать явно тестовый target; не fallback на repository root.
+- Передавать preflight те же `env`, `projectPath`, `requiredModels`, которые получит тест.
+- Проверить в тесте argv/cwd/env preflight и downstream launcher.
+- Устранить downstream восстановление `os.userInfo().homedir`: оно обходит изоляцию wrapper. Preflight и live test должны сохранять согласованные HOME/XDG roots, а не создавать разные credential/config contexts.
+- Отдельно обработать optional `OPENCODE_E2E_DEFAULT_MODEL_LAUNCH`: его модель, requiredModels и test roots должны соответствовать именно этому сценарию; основной curated canary не подменяется big-pickle.
+- Для test credentials явно задать разрешённый источник; не возвращать настоящий HOME и не копировать весь пользовательский auth profile ради прохождения проверки.
+- Невалидная sandbox-конфигурация останавливает запуск до spawn.
+- Cleanup удаляет только созданные этим run директории и процессы. Не удалять чужие профили, teams или shared hosts.
+
+Это самостоятельный небольшой frontend PR. Pure runtime contract tests от него не зависят; зависимы только live проверки через этот wrapper. Если используется новый самостоятельный sandbox conformance harness, опасный wrapper не запускать и его исправление не превращать в блокер для независимых тестов.
+
+### 10.2 Два уровня доказательства
+
+**Conformance без model inference:** на новых test-only проектах получить реальные `/config`, `/config/providers`, `/agent`, `/mcp` для OpenCode 1.18.4 и 1.18.29; запустить наш реальный checker. Зафиксировать фактическую binary identity, OS, fixture input и redacted results. Начальная матрица: обе версии на Linux/чистом CI, актуальная из этих версий на Windows и macOS; полный декартов продукт не требуется без нового платформенного риска.
+
+Изолировать project/cwd и HOME/USERPROFILE/APPDATA/LOCALAPPDATA/XDG roots/TMP. Исключить унаследованные OPENCODE config/permission overrides, пользовательские auth/plugin paths и чтение родительского проекта. Системные managed settings и `{file:...}` не устраняются одной сменой HOME: выполнять эталонные probes на чистом disposable runner, проверять отсутствие посторонних config sources. Не выдавать локальный temp HOME за полноценную изоляцию.
+
+Тестовые provider/MCP endpoints направлять на локальные fixtures; не выполнять запросы к реальным customer identities. Пробы с plugins отдельно контролируют init/install/connect effects. Для permission conformance использовать настоящий pinned upstream evaluator/test harness или безопасную фактическую engine-обработку запроса. Самописная копия evaluator не является независимым доказательством.
+
+**End-to-end с моделью:** один плановый canary на реально доступном curated provider с managed block; отдельно Z.AI с действующей разрешённой тестовой подпиской. Проверить selected readiness, strict launch, managed bootstrap, сообщение, reconnect/adoption и stop; хотя бы один смешанный запуск сохраняет secondary-lane semantics. После сборки проверить нужный packaged artifact, не только source launcher.
+
+Если Z.AI auth недоступна, сохранить provider failure отдельно от authority result. Не считать 401 успешным Z.AI E2E, не подменять его OpenRouter/big-pickle и не делать автоматические повторные inference-запросы после неопределённого результата.
+
+Отсутствующий binary/credential и skipped live test не превращаются в passed gate. Live-подтверждение публикуется отдельно от unit/fixture evidence.
+
+## 11. Порядок реализации и review budget
+
+### PR A: основной runtime-контракт
+
+Основание: актуальный runtime main. Один когерентный ownership scope: selected authority, его тесты и focused CI.
+
+1. Добавить pure provider contract и независимые mutation tests P01–P12.
+2. Снять expected до первого await, заменить provider comparison, удалить `CONFIG_DROPPED_MODEL_FIELDS` и `normalizeSelectedProviderModels()`.
+3. Добавить effective `/agent` permission check, сохранив закрытые остальные config проверки и две существующие адаптации defaults.
+4. Подключить deadline к readiness calls, final expiry check и защиту от позднего успеха.
+5. Дополнить реальные helper/session tests и real reader + adoption sandbox integration.
+6. Добавить focused CI job на Linux и Windows для этой области; сохранить pinned Bun/lockfile и существующие CI jobs.
+7. Провести независимый review exact patch/SHA и focused verification. Не требовать повторного полного CI без новых изменений или недоказанного риска.
+
+Цель 1 000–1 600 changed LOC, ориентир до 2 000 без отдельно объяснённых fixtures. Если объём растёт из-за broad fingerprints/plugin migration/framework, вернуть scope к этому контракту. Не разделять validator и необходимые negative tests на разные merge points.
+
+### PR B: безопасный frontend live-wrapper, при использовании существующего пути
+
+Ориентировочно 80–180 строк с focused tests. Может выполняться независимо от PR A. Сохраняет корректный runtime source path для dev и exact built artifact для release smoke.
+
+### Финальная qualification
+
+На exact runtime SHA PR A выполнить conformance и curated canary через безопасный путь. Сохранить исходные fixtures/evidence рядом с тестами или в принятом artifact location, без credentials. Проверить binary SHA/версию и реально запускаемый launcher.
+
+Runtime PR можно review/merge как отдельный доказанный срез; полнота доставки требует заявленной qualification. Не объявлять исправление Windows/Z.AI доказанным только из-за merged PR.
+
+### Отдельная последующая задача: broad fingerprint order
+
+R6 рекурсивно сортирует `/agent` arrays. Это подтверждённый дефект, но алгоритм используется legacy migration/adoption и persisted broad digests. Не менять его незаметно внутри PR A.
+
+Для отдельного fix потребуется сортировать только явно unordered внешние коллекции, сохранять вложенный порядок, выбрать policy для старых unversioned digests и проверить leases/PID reuse/stop. Не заменять старый digest новым после одного health success. Этот follow-up не является зависимостью selected provider-контракта, который намеренно не использует broad digest.
+
+## 12. Команды проверки
+
+Выполняются при реализации из отдельного sandbox/test checkout; в исследовании этого плана не запускались. Имена нового файла являются частью предлагаемого изменения.
+
+```bash
+bun test src/services/opencode/OpenCodeLaunchProviderContract.test.ts src/services/opencode/OpenCodeProvisioningProbe.test.ts src/services/opencode/OpenCodeSelectedSessionAuthority.test.ts
+
+bun test src/services/opencode/OpenCodeBridgeCommandHandler.test.ts src/services/opencode/OpenCodeStrictLaunchCoordinator.test.ts src/services/opencode/OpenCodeHostManager.test.ts src/services/opencode/OpenCodeRuntimeDeadline.test.ts
+
+bun test src/services/opencode/OpenCodeProfileManager.test.ts src/services/opencode/OpenCodeSessionBridge.test.ts src/services/opencode/OpenCodeExpectedBehaviorFingerprint.test.ts src/services/opencode/OpenCodeExecutionProof.test.ts src/services/opencode/OpenCodeCuratedSubscriptionCatalog.test.ts
+
+bun run build:dev
+```
+
+Runtime использует Bun и не имеет frontend `pnpm typecheck` script. Для быстрого TS preflight применим `tsc7 --noEmit`, если он поддерживает текущий tsconfig; fallback на pinned local compiler без изменения tsconfig ради инструмента. Зафиксировать baseline существующих ошибок отдельно, не выдавать фильтрацию ошибок за полный зелёный typecheck. Финальные repository gates имеют приоритет.
+
+Новый focused CI script должен включить также добавленные deadline/adoption test files, если они выделены отдельно. Не запускать весь `src/services/opencode` glob без проверки opt-in live tests и побочных эффектов.
+
+Для frontend wrapper использовать focused Node tests либо существующий Vitest harness по типу модуля. При symlink node_modules не запускать команды, способные неявно переустановить общие зависимости: использовать прямой существующий entrypoint или отдельную frozen установку в TEST checkout. Production package проверяется `bun run build`/release workflow по действующим правилам, а не `cli-dev` вместо production launcher.
+
+## 13. Диагностика, выпуск и rollback
+
+Сохранить совместимые `selected_config_match` + безопасные top-level field names; frontend уже отображает их. Если нужен дополнительный reason, только закрытый enum, без значений, dynamic object keys, URLs, model blobs, env или provider error text. `exception` продолжает показывать безопасный error class. Проверить, что callback exception не разрешает запуск и не ломает отказ.
+
+В этой задаче не добавлять feature flag, отключающий проверку безопасности, или fallback «принять live». Откат основного comparator - обычный revert PR A. Persisted host/session/evidence форматы не меняются, поэтому не требуется очистка пользовательского состояния ради rollback.
+
+При будущем выпуске: новый runtime tag/artifacts -> frontend `runtime.lock.json` с verified digests -> проверка packaged build -> поддержанный publish flow. Не менять pin и не публиковать релизы во время написания/согласования плана. Release canary использует только явно тестовые проекты/identities.
+
+Если окончательный patch всё-таки изменяет fingerprint domain или persistent wire schema, этот rollback-раздел больше неверен: остановить расширение scope и обновить план до реализации такой миграции.
+
+## 14. Критерии завершения
+
+- [x] Ни одного production списка schema-dropped model fields; imported DeepInfra hotfix regression проходит без него.
+- [x] Все configured model runtime descriptors и opaque SDK bags защищены; selected-only упрощение не внесено.
+- [x] Дополнительный expanded catalog не вызывает fail; дополнительный configured route вызывает fail.
+- [x] Порядок permissions защищён по `/agent` reset-tail, без доверия порядку `/config` и без смены persisted fingerprint algorithms.
+- [x] Existing provider limits/agent options/prompt/command/MCP/auth/scope/project negatives сохранены.
+- [x] Helper остаётся `profile | null`; ошибка/abort/late result не приводит к member effects или writes.
+- [x] Reuse/adoption/preview/reconcile/send проверены реальным reader, включая свежие effective policies; stop работает при недоступном MCP.
+- [x] Ровно один необходимый `/agent` GET, никаких новых provider inventory GET, calibration hosts, authority caches, registry migrations или зависимостей.
+- [x] Focused CI действительно исполняет новые tests на Linux и Windows (run34149790888, SHA3595a929).
+- [x] Conformance evidence двух pinned OpenCode версий получено в полной тестовой изоляции.
+- [ ] Curated live launch и packaged proof зафиксированы; Z.AI и Windows имеют отдельный честный status.
+- [x] Независимое review выполнено на конечном production SHA3595a929 и version-only delta be27add1; исходные чужие изменения не затронуты.
+- [x] Broad fingerprint defect и неизвестные будущие runtime-root поля явно записаны как оставшиеся ограничения.
+
+## 15. Проверенные исходники
+
+Runtime ссылки привязаны к exact release SHA; путь и строка в тексте выше относятся к нему.
+
+- R1: [OpenCodeSelectedProfileAuthority](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/src/services/opencode/OpenCodeSelectedProfileAuthority.ts).
+- R2: [OpenCodeProfileManager](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/src/services/opencode/OpenCodeProfileManager.ts).
+- R3: [OpenCodeProvisioningProbe](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/src/services/opencode/OpenCodeProvisioningProbe.ts).
+- R4: [OpenCodeBridgeCommandHandler](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/src/services/opencode/OpenCodeBridgeCommandHandler.ts).
+- R5: [OpenCodeSessionBridge](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/src/services/opencode/OpenCodeSessionBridge.ts).
+- R6: [OpenCodeHostManager](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/src/services/opencode/OpenCodeHostManager.ts).
+- R7: [OpenCodeCuratedSubscriptionCatalog](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/src/services/opencode/OpenCodeCuratedSubscriptionCatalog.ts).
+- R8: [ProvisioningProbe tests](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/src/services/opencode/OpenCodeProvisioningProbe.test.ts).
+- R9: [SelectedSessionAuthority tests](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/src/services/opencode/OpenCodeSelectedSessionAuthority.test.ts).
+- R10: [ExecutionProbe](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/src/services/opencode/OpenCodeExecutionProbe.ts).
+- R11: [Runtime CI](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/.github/workflows/ci.yml).
+- R12: [Runtime deadline](https://github.com/777genius/agent_teams_orchestrator/blob/9247cbb08db7d6d5130635face0f89e9f69f65fb/src/services/opencode/OpenCodeRuntimeDeadline.ts).
+- U1: [OpenCode provider schema](https://github.com/anomalyco/opencode/blob/16747470f976aca3d362ad730bcd3fe82ecc2c9a/packages/core/src/v1/config/provider.ts).
+- U2: [OpenCode provider resolution/SDK/small model](https://github.com/anomalyco/opencode/blob/16747470f976aca3d362ad730bcd3fe82ecc2c9a/packages/opencode/src/provider/provider.ts).
+- U3: [Permission schema/order](https://github.com/anomalyco/opencode/blob/16747470f976aca3d362ad730bcd3fe82ecc2c9a/packages/core/src/v1/config/permission.ts), [actual evaluation](https://github.com/anomalyco/opencode/blob/16747470f976aca3d362ad730bcd3fe82ecc2c9a/packages/opencode/src/permission/index.ts).
+- U4: [Agent normalization](https://github.com/anomalyco/opencode/blob/16747470f976aca3d362ad730bcd3fe82ecc2c9a/packages/core/src/v1/config/agent.ts), [effective agents/default exceptions](https://github.com/anomalyco/opencode/blob/16747470f976aca3d362ad730bcd3fe82ecc2c9a/packages/opencode/src/agent/agent.ts).
+- U5: [Config load/merge order](https://github.com/anomalyco/opencode/blob/16747470f976aca3d362ad730bcd3fe82ecc2c9a/packages/opencode/src/config/config.ts).
+- U6: [Текстовая env/file substitution](https://github.com/anomalyco/opencode/blob/16747470f976aca3d362ad730bcd3fe82ecc2c9a/packages/opencode/src/config/variable.ts).
+- F1: [Frontend smoke wrapper](https://github.com/777genius/agent-teams-ai/blob/8c74f8705b1975cbae0316f176b681247ccbc90d/scripts/prove-opencode-team-provisioning.mjs), [preflight](https://github.com/777genius/agent-teams-ai/blob/8c74f8705b1975cbae0316f176b681247ccbc90d/scripts/lib/opencode-live-preflight.mjs).
+
+При дальнейшей работе сначала проверить delta от выпущенного runtime `v0.0.84`. Исследованные, но не воспроизведённые live риски остаются тестовыми обязательствами, а не уже доказанными исправлениями.
+
+Дополнительная пользовательская приёмка: отдельный Copilot E2E на `github-copilot/gpt-5-mini` из отчёта, с запуском команды, выполнением задачи и проверяемым файлом в новом sandbox. Provider/config gate alone не считается успехом.
+
+## Доставка и оставшаяся приёмка (2026-09-07)
+
+- **Runtime выпущен:** [PR #68](https://github.com/777genius/agent_teams_orchestrator/pull/68) merged в `b567c93a3f424e5d23301cbce5f6f7ade8273c18`, source tag `v0.0.84`; [публичные бинарники](https://github.com/777genius/agent_teams_orchestrator_binaries/releases/tag/runtime-v0.0.84). Все пять платформ собраны; manifest/GitHub digests, anonymous download gate и native app bootstrap проверены. [Runtime build run](https://github.com/777genius/agent_teams_orchestrator/actions/runs/34150738449).
+- **Проверки контракта:** final focused suite 645 tests / 3253 assertions, dev/production builds; новых typecheck ошибок относительно baseline нет. [CI run 34149790888](https://github.com/777genius/agent_teams_orchestrator/actions/runs/34149790888) на `3595a929` завершил все шесть jobs, включая полный Windows authority suite и conformance. Production-код release head совпадает с этим проверенным срезом. Linux conformance покрывает pinned OpenCode 1.18.4/1.18.29, inline/file и auto/manual с настоящим permission engine и MCP; у локальной macOS-проверки сохранено ограничение системной изоляции.
+- **Frontend интегрирован:** [PR #604](https://github.com/777genius/agent-teams-ai/pull/604), merge `3d7c427064053badf6c5412edc006fe980d67fe4`, изолирует wrapper и cleanup; 24 wrapper tests прошли. [PR #605](https://github.com/777genius/agent-teams-ai/pull/605), merge `906395bc7cf846b2c3debc8271e4853fb7173e5f`, закрепляет runtime assets и служит основанием tag `v2.13.2`.
+- **App пока draft:** в [исходном release run](https://github.com/777genius/agent-teams-ai/actions/runs/34151777575) Windows/macOS собраны; Linux дважды сообщил smoke OK, но завис на удерживаемых descendant pipes. Выполняется отдельный [Linux recovery run 34155202396](https://github.com/777genius/agent-teams-ai/actions/runs/34155202396). Packaged qualification, финальная публикация и updater guard пока не завершены.
+- **Z.AI: отрицательная приёмка выполнена.** По уточнённому запросу пользователя действующих credentials нет. Один canary опубликованного darwin-arm64 runtime с заведомо неверным disposable key прошёл config gate и получил настоящий HTTP 401; task dispatch отсутствовал, cleanup подтверждён. Обработка реального 401/403 envelope проверена. Это отказ авторизации, не успешное authenticated task E2E.
+- **Copilot: положительная приёмка не выполнена.** Прежний config blocker устранён, но execution probe и отдельная диагностика `/responses` получили `model_not_supported`. Причина account/limits не установлена; task/file E2E не засчитан.
+- **Windows: отдельный дефект исправлен, исходный инцидент не доказан.** Fresh `launch_runtime` теперь сохраняет managed fingerprint для strict adoption. Persisted algorithms и wire schema не менялись; старые несовпадающие live-записи остаются fail-closed. Registry wipe/migration не добавлены. Причина и исправление именно пользовательского upgrade-инцидента без его artifacts остаются неподтверждёнными.
+- **Оставшиеся требования:** успешный curated/mixed secondary-lane canary, Copilot assigned-task/file proof, полная packaged qualification и проверка исходного Windows-состояния. Broad fingerprint order и неизвестные будущие runtime-root поля остаются отдельными ограничениями исходного плана.
+
+Независимые технические ревью production-изменений выполнены; зелёный ReviewRouter gate не заявляется, поскольку его provider отклонил запуск из-за quota. Runtime/provisioning проверки выполнялись только в новых TEST/temp проектах. Исходные dirty checkout и пользовательские auth stores сохранены. Локальный архив содержит redacted canary/conformance artifacts; проверяемые PR, CI и release-ссылки приведены выше.

--- a/docs/team-management/opencode-selected-config-authority.md
+++ b/docs/team-management/opencode-selected-config-authority.md
@@ -1,6 +1,6 @@
 # OpenCode Selected-Config Authority: Incident Context and Durable-Fix Options
 
-**Status:** historical incident and design exploration from the `v0.0.83` / app `v2.13.1` hotfix. The accepted positive launch contract is implemented in runtime `v0.0.84` ([PR #68](https://github.com/777genius/agent_teams_orchestrator/pull/68), commit `b567c93a3f424e5d23301cbce5f6f7ade8273c18`). App `v2.13.2` remains a draft pending Linux recovery and release verification.
+**Status:** historical incident and design exploration from the `v0.0.83` / app `v2.13.1` hotfix. The accepted positive launch contract is implemented in runtime `v0.0.84` ([PR #68](https://github.com/777genius/agent_teams_orchestrator/pull/68), commit `b567c93a3f424e5d23301cbce5f6f7ade8273c18`). App [v2.13.2](https://github.com/777genius/agent-teams-ai/releases/tag/v2.13.2) is published; Linux recovery and updater verification passed.
 
 **Current decision:** the calibration-first recommendations in sections 9 and 13 are superseded by the [accepted launch contract plan](opencode-launch-authority-contract-plan.md). It keeps an explicit supported-provider contract and checks effective permission order through `/agent`, without a production calibration host or persisted T0 baseline. The observations, alternatives and verification statements below describe the earlier hotfix investigation; current delivery evidence and outstanding acceptance are recorded at the end of the plan.
 
@@ -16,7 +16,7 @@
 
 After upgrading to app `v2.13.0`, **every** team containing an OpenCode member failed at the readiness gate before anything spawned. Reported on Windows 11, OpenCode runtime 1.18.29, provider Z.AI Coding Plan (`zai-coding-plan`, GLM models):
 
-```
+```text
 glm-5.3-flash - Selected model check failed: OpenCode readiness bridge failed:
 provider_error: OpenCode selected readiness host/config/auth/project/MCP authority
 is unavailable (selected_config_match:provider)
@@ -24,7 +24,7 @@ is unavailable (selected_config_match:provider)
 
 Launch trace:
 
-```
+```text
 [validating] Validating OpenCode team launch gate
 [spawning]   Starting OpenCode sessions through runtime adapter
 [failed]     OpenCode team launch failed readiness gate - configReady=true
@@ -188,7 +188,7 @@ Any durable fix must start by choosing a better comparison target, not by gettin
 
 Notation: `T` = OpenCode's opaque transformation; `managed` = the config we send; `user`/`project` = the user's and project's own OpenCode configs, which are **deliberately** merged in (there is an explicit comment in `OpenCodeProfileManager.ts` about keeping project/global plugin config untouched, and `readSafeOpenCodeRuntimeConfigImport()` merges `~/.config/opencode/opencode.json`, the XDG variant, and `OPENCODE_CONFIG_CONTENT`). So in general:
 
-```
+```text
 live = T(managed ⊕ user ⊕ project)
 ```
 

--- a/docs/team-management/opencode-selected-config-authority.md
+++ b/docs/team-management/opencode-selected-config-authority.md
@@ -1,0 +1,333 @@
+# OpenCode Selected-Config Authority: Incident Context and Durable-Fix Options
+
+**Status:** historical incident and design exploration from the `v0.0.83` / app `v2.13.1` hotfix. The accepted positive launch contract is implemented in runtime `v0.0.84` ([PR #68](https://github.com/777genius/agent_teams_orchestrator/pull/68), commit `b567c93a3f424e5d23301cbce5f6f7ade8273c18`). App `v2.13.2` remains a draft pending Linux recovery and release verification.
+
+**Current decision:** the calibration-first recommendations in sections 9 and 13 are superseded by the [accepted launch contract plan](opencode-launch-authority-contract-plan.md). It keeps an explicit supported-provider contract and checks effective permission order through `/agent`, without a production calibration host or persisted T0 baseline. The observations, alternatives and verification statements below describe the earlier hotfix investigation; current delivery evidence and outstanding acceptance are recorded at the end of the plan.
+
+**Audience:** an engineer or agent reviewing the incident and the alternatives considered before the accepted fix. This document is written to be self-contained: it explains the incident, the exact mechanics, everything that was verified empirically, the shipped hotfix and why it is deliberately tactical, every design option that was considered (including the ones rejected and *why*), and the traps waiting in each one.
+
+**Where the code lives:** the affected code is in the **private runtime repo** `777genius/agent_teams_orchestrator`, not in this frontend repo. The frontend only pins the runtime through `runtime.lock.json` and surfaces the resulting error text. This document lives here because `docs/team-management/` is the canonical home for Agent Teams runtime knowledge.
+
+---
+
+## 1. The incident
+
+### What users reported
+
+After upgrading to app `v2.13.0`, **every** team containing an OpenCode member failed at the readiness gate before anything spawned. Reported on Windows 11, OpenCode runtime 1.18.29, provider Z.AI Coding Plan (`zai-coding-plan`, GLM models):
+
+```
+glm-5.3-flash - Selected model check failed: OpenCode readiness bridge failed:
+provider_error: OpenCode selected readiness host/config/auth/project/MCP authority
+is unavailable (selected_config_match:provider)
+```
+
+Launch trace:
+
+```
+[validating] Validating OpenCode team launch gate
+[spawning]   Starting OpenCode sessions through runtime adapter
+[failed]     OpenCode team launch failed readiness gate - configReady=true
+```
+
+This blocked both all-OpenCode teams and mixed teams with an Anthropic lead (which worked on `v2.12.0`). It was a hard downgrade for OpenCode users.
+
+### What the reporter had already ruled out (all correct)
+
+- **Not stale retained fingerprints.** They fully cleared state: stopped app and OpenCode processes, deleted `%APPDATA%\agent-teams-ai\opencode-bridge`, `data\cache`, and every team's `launch-state` / `launch-failure-artifacts` / `.opencode-runtime`. An earlier "retained host/profile fingerprint mismatch" error disappeared and was replaced by this one.
+- **Not a host-registry mismatch.** After the failure, `host-registry.json` showed `managedConfigFingerprint == resolvedConfigFingerprint` on every registered host, yet the gate still failed. Their inference — that `selected_config_match:provider` compares against some *other* authority than the host registry — was exactly right.
+- **Not missing provider auth.** `opencode models zai-coding-plan` returned all 11 models instantly and `auth.json` contained `zai-coding-plan` credentials. Anthropic members in the same team passed their own model checks.
+- **Not team config.** Identical failure for a fresh team and for teams that worked the day before.
+
+They also asked whether this was a regression from the watermark fix `44390ec`. **It was not** — that commit (`fix(opencode): allow stop with stale runtime watermark`) touches the stop path and is unrelated.
+
+---
+
+## 2. Root cause
+
+### The mechanism, precisely
+
+`refreshSelectedProfileAuthority()` in
+`src/services/opencode/OpenCodeSelectedProfileAuthority.ts` is a strict, fail-closed readiness check. It compares a projection of **twelve** config fields between two sides:
+
+```ts
+const SELECTED_CONFIG_FIELDS = ['provider', 'model', 'small_model', 'plugin', 'agent',
+  'default_agent', 'permission', 'command', 'share', 'snapshot', 'autoupdate', 'mcp'] as const
+```
+
+- **Side A — the prediction:** `profile.managedConfig`, the config the app assembled and handed to the OpenCode server via the `OPENCODE_CONFIG_CONTENT` environment variable (see `OpenCodeProfileManager.ts`, the `env` block that sets `OPENCODE_CONFIG_CONTENT: JSON.stringify(managedConfig)`).
+- **Side B — reality:** the response of `GET /config` from the live OpenCode host.
+
+If the two fingerprints differ, the check rejects with `{ check: 'selected_config_match', fields: [...] }`, and `OpenCodeBridgeCommandHandler.ts` turns that into the user-visible `... authority is unavailable (selected_config_match:provider)`.
+
+**The flaw:** between side A and side B sits an opaque transformation. OpenCode merges our config with the user's and the project's config, runs the result through its Zod schema, adds defaults, and **silently drops any field its schema does not know**. Side A is a *prediction* of that transformation's output; side B is the output. Every mismatch between our prediction and OpenCode's actual normalization is a false rejection.
+
+### The specific trigger
+
+The curated catalog in `src/services/opencode/OpenCodeCuratedSubscriptionCatalog.ts` sets `structured_output: true` on **5 of the 7** `ZAI_CODING_PLAN_MODELS` (`glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.5-air`). OpenCode's config schema does not know `structured_output`, so `GET /config` returns those model entries **without** it, byte-identical otherwise.
+
+Result: for `zai-coding-plan` the `provider` block could never match. Since the diagnostic lists exactly the fields that differ, the user saw `selected_config_match:provider` and nothing else — the other eleven fields matched fine.
+
+**Deterministic and total:** it fails 100% of launches for that provider, on any OpenCode version, regardless of state resets. `structured_output` appears nowhere else in the catalog, so other curated providers (MiniMax, Kimi, Xiaomi, Kiro, Cursor) were unaffected.
+
+### Why the release pipeline missed it
+
+The check was introduced in runtime `v0.0.82` (PR #52, the mixed-provider e2e work of 2026-08-31). That e2e ran its live OpenCode leg on `opencode/big-pickle` — a **non-curated** provider. For a non-curated provider the managed `provider` block is empty (`{ [providerId]: null }` on both sides), so the comparison passes trivially. The Z.AI path — the one with a large managed provider block — was never exercised live. The same e2e report notes that its OpenAI route failed with a 401 and was explicitly *not* counted as verified.
+
+App `v2.12.0` pinned runtime `v0.0.73`, which predates the check entirely. `v2.13.0` pinned `v0.0.82`. That version jump is the whole regression.
+
+---
+
+## 3. Empirical evidence (all reproduced live, not inferred)
+
+Everything below was measured, not reasoned about. Reproduce it the same way if you need to re-establish trust.
+
+### 3.1 OpenCode drops the field — on both versions
+
+Started an isolated `opencode serve` (empty `HOME`/`XDG_*`, `OPENCODE_CONFIG_CONTENT` = the exact curated Z.AI managed block) and diffed the sent config against `GET /config`:
+
+- **1.18.29** (the reporter's version, installed from npm): provider blocks differ; the diff is exactly `structured_output` missing on 5 models; everything else identical.
+- **1.18.4** (the locally installed version): identical behavior.
+
+Conclusion: not version-specific. Applying the same field-strip to both sides made the blocks compare equal.
+
+### 3.2 The published schema confirms it
+
+`https://opencode.ai/config.json` returns HTTP 200 (~39 KB) and **does not contain** `structured_output`. So the schema is a faithful oracle for "which fields the server will keep" — relevant to Option C below.
+
+### 3.3 A/B in the real app (`pnpm dev:mcp`)
+
+Isolated data roots, frontend worktree at clean `origin/main`, same sandbox project, same key:
+
+| Run | Runtime | Result on `glm-5.3-flash` |
+|---|---|---|
+| A | stock `v0.0.82` | `selected_config_match:provider` — bug reproduced |
+| B | build with the fix | error gone; readiness proceeds to a real `401 Authentication Failed` |
+
+### 3.4 The remaining 401 is genuinely the provider's
+
+A direct HTTPS request to `api.z.ai/api/coding/paas/v4/chat/completions` with the user's stored key, bypassing the app entirely, returned `401 {"error":{"code":"1000","message":"Authentication Failed"}}`. The user's Z.AI subscription had lapsed. **This is not our defect**, and it is why an end-to-end successful launch *on Z.AI specifically* remains unverified.
+
+### 3.5 Full launch works after the fix
+
+On a working OpenCode provider (OpenRouter, `qwen/qwen3-coder-flash`): preflight reported "Selected model verified", and the team launched with `launchPhase: finished`, `teamLaunchState: clean_success`, 2/2 members confirmed, 0 failures. Repeated on the *packaged* `v2.13.1` build installed in `/Applications` (see §5).
+
+### 3.6 The config text does not describe the effective runtime
+
+Two measurements that reframe the whole problem — see §7:
+
+- `GET /config/providers` returned **11 models** for `zai-coding-plan` while the managed config declared **7**. The server merged the remote models.dev catalog on top. The UI shows 11, matching what the reporter saw.
+- `GET /agent` returns permissions in an **expanded rule form** — `[{permission, pattern, action}, ...]` — whereas the config expresses them as a map like `{'*': 'deny', 'agent-teams_*': 'allow'}`. The shapes are not comparable at all.
+
+---
+
+## 4. The shipped hotfix
+
+Commit `49d44c33` (PR #66), released as runtime `v0.0.83` → app `v2.13.1`.
+
+In `OpenCodeSelectedProfileAuthority.ts`:
+
+```ts
+// OpenCode's config schema silently drops model fields it does not know when it
+// serves GET /config (verified on 1.18.4 and 1.18.29), so managed catalog
+// metadata carrying them can never match the live config. Strip the same fields
+// from both sides; every field OpenCode actually keeps still fails closed.
+const CONFIG_DROPPED_MODEL_FIELDS = ['structured_output'] as const
+
+function normalizeSelectedProviderModels(provider: unknown): unknown { /* ... */ }
+```
+
+applied symmetrically inside `selectedConfig()` to the selected provider's `models` map. 24 lines of production code, 21 lines of test.
+
+**Test coverage:** the existing integration test in `OpenCodeProvisioningProbe.test.ts` (`refreshes selected config/project/auth/MCP authority and fails closed on each mutation`) gained a model carrying `structured_output` in its fixture, a positive case (live without the field still passes) and a negative case (mutating a model `limit` still rejects with `selected_config_match:provider`). Verified that removing the normalization makes the new positive case fail, so the regression is genuinely covered.
+
+**Test suites run green:** ProvisioningProbe + BridgeCommandHandler (214), SelectedSessionAuthority + ProfileManager + SessionStore + CuratedSubscriptionCatalog (119), SessionBridge (75).
+
+---
+
+## 5. Release verification (what the packaged build actually proved)
+
+The `v2.13.1` DMG was downloaded from the draft release, digest-verified against GitHub, signature and notarization checked (`accepted / Notarized Developer ID`), installed into `/Applications`, and launched on the **standard** profile (no `--user-data-dir` override; only `--remote-debugging-port` for automation, removed afterwards).
+
+On that packaged build:
+
+- Selecting Z.AI `glm-5.3-flash`: the `selected_config_match:provider` failure is **gone**; the only remaining blocker is the genuine `Authentication Failed`.
+- OpenCode-only team: `clean_success`, 2/2 members.
+- Mixed team (Anthropic Opus 4.8 lead + OpenCode `qwen/qwen3-coder-flash` member + Anthropic member): "Team launched - all 2 teammates joined", Running, OpenCode lanes created.
+
+The release then went out through the supported path (`publish_release=true` + `reuse_existing_draft_assets=true`) and `scripts/ci/verify-published-updater-release.sh` returned *"v2.13.1 is public, latest, and updater-ready"*.
+
+---
+
+## 6. Why the hotfix is tactical, and must not be treated as the solution
+
+`CONFIG_DROPPED_MODEL_FIELDS` is a hardcoded list of fields that a **third party's schema** happens to discard. It grows whenever upstream OpenCode changes, and nothing in our CI can predict that. It is the *third* compensation of this exact class already living in that one file:
+
+1. `normalizeSelectedAgentDefaults()` — "OpenCode 1.18.4 ConfigV1 agent.normalize adds empty options."
+2. `command: config.command === undefined ? {} : config.command` — "Config.load initializes absent commands to an empty map."
+3. `normalizeSelectedProviderModels()` — this incident.
+
+Three independent patches for the same underlying mistake is the signal that the design, not the list, is wrong. The next upstream release can add a fourth, and the failure mode is *total launch blockage for a provider*, discovered by users rather than by tests.
+
+---
+
+## 7. The deeper problem: we compare the wrong thing
+
+The check exists to guarantee a **behavioral** property: *the runtime is operating with the provider, model, permissions, and MCP transport we specified, and that has not changed.*
+
+It implements that guarantee as **textual comparison of a config document**. That proxy is wrong in two independent ways:
+
+1. **It is brittle** against a normalization we neither control nor can predict — the incident above.
+2. **It is not even sufficient.** The config text does not determine behavior: `GET /config/providers` reported 11 usable models where our config declared 7, because the server merges a remote catalog. And `GET /agent` reports the *effective* permissions in a different shape than the config expresses them. So the thing we compare is neither stable nor complete.
+
+Any durable fix must start by choosing a better comparison target, not by getting better at predicting the transformation.
+
+---
+
+## 8. Options considered
+
+Notation: `T` = OpenCode's opaque transformation; `managed` = the config we send; `user`/`project` = the user's and project's own OpenCode configs, which are **deliberately** merged in (there is an explicit comment in `OpenCodeProfileManager.ts` about keeping project/global plugin config untouched, and `readSafeOpenCodeRuntimeConfigImport()` merges `~/.config/opencode/opencode.json`, the XDG variant, and `OPENCODE_CONFIG_CONTENT`). So in general:
+
+```
+live = T(managed ⊕ user ⊕ project)
+```
+
+### Option A — Directional (subset) comparison + explicit critical-field assertions
+
+**Idea:** stop requiring equality. For every path we set in `managed`, require a match **only if that path exists in `live`**. A path absent from `live` means OpenCode does not know it, therefore it cannot affect behavior. Separately, require *presence* of the fields that carry our safety guarantees (`permission`, `mcp`, the selected `provider`, `model`, `agent`), so a silently-dropped critical field is a hard failure.
+
+**Why it is not "just another hardcoded list":** the list of *critical* fields is derived from our own security model. It changes when we change our requirements. The list of *dropped* fields is derived from upstream's Zod schema and changes on their release cadence. We control the first; we do not control the second. This distinction is the crux of the whole redesign — do not let a reviewer collapse the two.
+
+**Trap:** a field can vanish because it was *invalid*, not because it was unknown. If `permission` disappears that way, the teammate silently gets broader defaults. Hence the mandatory-presence rule above; without it this option is a security regression, not an improvement.
+
+**Effort:** ~40–60 lines of production code plus tests. **Reliability 9/10, confidence 8/10.**
+
+### Option B — Live baseline for subsequent re-checks
+
+**Idea:** stop predicting anything on re-checks. Snapshot the effective state once, at host start, after the start-time validation has passed. Every later `refreshSelectedProfileAuthority()` compares "reality at T0" against "reality at T1". Both sides are responses from the same server, so every normalization quirk — present and future — cancels out exactly.
+
+**What it catches:** any drift after launch, including drift in fields nobody thought to assert.
+
+**What it does NOT catch — the trap that makes this insufficient alone:** if the server started with the *wrong* config (our `OPENCODE_CONFIG_CONTENT` never applied, the user's config won, MCP or permissions substituted), the baseline records that wrong state as the reference and cheerfully confirms it forever. Baseline proves *"nothing changed"*, never *"we started correctly"*. It is a complement to A, never a replacement.
+
+**Implementation weight:** the baseline must be **persisted in `host-registry.json`**, otherwise an adopted persistent host after an app restart has nothing to compare against. That means serialization, record validation, and a registry format migration — this is where the cost is, not in the comparison itself.
+
+**Reliability 7/10 alone, 9/10 combined with A; confidence 9/10.**
+
+### Option C — Use the published JSON Schema as the oracle
+
+**Idea:** fetch `https://opencode.ai/config.json` and compute programmatically which fields will be discarded, instead of listing them.
+
+**Verified:** the schema is reachable (HTTP 200, ~39 KB) and genuinely lacks `structured_output`, so it *would* have predicted this incident.
+
+**Why it is not recommended as the foundation:** it introduces a network dependency in a launch-critical path; the published schema can drift from the actually-installed OpenCode binary's behavior (schema ≠ runtime); and it still leaves us in the business of predicting `T` rather than escaping it. Reasonable as a **test-time** source (e.g. a CI check that flags catalog fields the schema does not know), not as a runtime authority.
+
+**Reliability 5/10, confidence 6/10.**
+
+### Option D — Calibration probe: measure `T` instead of predicting it
+
+**Idea, and the strongest answer to "how do we do this with no hardcoded fields at all":** don't describe the normalization — *observe* it. Once per `(binary identity × managed-config hash)`, start OpenCode in **full isolation** (empty `HOME`/`XDG_*`, only our config on the input) and capture `GET /config`. That response is `T(managed)`: the canonical form of *our* config as seen by *this* version of OpenCode. Cache it keyed by that pair.
+
+Then compare `live` against `T(managed)` rather than against `managed`. Both sides have been through the same transformation, so every quirk cancels — including quirks that do not exist yet.
+
+**Feasibility is proven:** this is literally how the incident was diagnosed. Standing up an isolated `opencode serve` and reading `/config` took a couple of seconds per version.
+
+**Traps:**
+- The isolation must be *real*. If the calibration run can see the user's `~/.config/opencode/opencode.json` or an `XDG_CONFIG_HOME` leak, the user's settings get baked into the "canonical" reference and the check silently becomes meaningless.
+- The cache key must include the binary identity (there is already `resolveOpenCodeBinaryHostIdentity()` used for host keys) *and* the managed-config hash. Invalidation bugs here degrade to either constant re-probing (slow launches) or a stale reference (wrong verdicts).
+- Equality still will not hold against a real host, because the real host also merges `user ⊕ project`. So the comparison against a real `live` is still directional (`T(managed) ⊆ live`), and the strictness for critical fields still comes from Option A.
+
+**Reliability 9/10, confidence 8/10.** Cost: one short extra server start per configuration, amortized by the cache.
+
+### Option E — Fully isolate the launch profile (stop merging user/project config)
+
+**Idea:** run launch hosts with no user or project OpenCode config at all. Then `live == T(managed)` exactly, calibration becomes a clean equality check, and Option A's directional logic mostly disappears.
+
+**Why it is a product decision, not a technical one:** the merge is deliberate. Users' plugins, custom providers, and project-level OpenCode settings would stop applying to Agent Teams launches. Do not adopt this without an explicit product call.
+
+**Reliability 9/10 technically, confidence 6/10 overall because of the product risk.**
+
+### Option F — Keep the hotfix and do nothing else
+
+Works today, blocks nothing, and is honestly a defensible short-term position. But a fourth compensation is a matter of time, and the failure mode is user-visible total blockage of a provider.
+
+**Reliability 6/10, confidence 9/10.**
+
+---
+
+## 9. Historical recommended architecture (superseded)
+
+Three layers. They are complementary, not alternatives, and they should be built in this order because each is independently shippable.
+
+**Layer 1 — Calibration (Option D).** Removes knowledge of the normalization from the codebase entirely. Ship this first: on its own it makes `CONFIG_DROPPED_MODEL_FIELDS` obsolete, which is the thing the user explicitly objected to.
+
+**Layer 2 — Property assertions on effective state (Option A, upgraded).** Rather than diffing config documents, assert the guarantees against the endpoints that report *effective* state — `/config/providers`, `/agent`, `/mcp`. These are already fetched together in `OpenCodeHostManager.getResolvedConfigFingerprint()`, so the plumbing exists. Assertions to express: the selected provider is present with our endpoint; the selected model is actually available; the `teammate` agent exists and its effective permissions match what we configured; the `agent-teams` MCP server is present, connected, and on our transport; no foreign providers when scoped isolation is required.
+
+**Layer 3 — Baseline drift detection (Option B).** After layers 1–2 pass at start, snapshot the effective state and compare T0/T1 on every re-check. Covers whatever layer 2 forgot to assert.
+
+Together: no upstream field lists anywhere; the check finally examines what actually drives behavior; and completeness is preserved.
+
+**Combined reliability 9/10, confidence 8/10.**
+
+---
+
+## 10. Nuances, pitfalls and gotchas for whoever implements this
+
+- **Do not conflate the two lists.** "Fields upstream discards" (bad, uncontrolled) vs "fields we must guarantee" (fine, ours). Every review of this work will drift toward treating them as the same thing.
+- **Fail-closed is the existing contract.** `refreshSelectedProfileAuthority()` returns `profile | null` and the observability callback must not change that (`reject()` deliberately swallows `onRejection` exceptions). Preserve this.
+- **Diagnostics must not leak secrets.** The `exception` branch deliberately reports only an error *class*, with the comment "Never expose error messages/names: provider errors can include credentials or config." Any new diagnostic must hold that line — provider configs contain API keys.
+- **`selectedConfig()` is also used for `contractConfigIdentity`** comparison against the MCP tool-proof; check callers before changing its shape.
+- **The check runs twice per launch** — before and after the execution probe (`refreshedBefore` / `refreshedAfter` in `OpenCodeBridgeCommandHandler.ts` around line 2664). The "after" call produces the different message *"authority changed during execution proof"*. A baseline design must make clear which of the two establishes the reference.
+- **`host-registry.json`'s `resolvedConfigFingerprint` is a different thing** from this check and uses a different normalization. Their equality proves nothing here — this is exactly what confused the reporter, and it will confuse the next person too.
+- **Scoped isolation already rewrites the provider block.** `enforceScopedProviderIsolation()` reduces `config.provider` to just the selected provider and strips `model`/`small_model` that are not prefixed with it. Any comparison logic must run after that, on the same shape.
+- **Model limit overrides mutate the provider block too** (`applyOpenCodeModelLimitOverrides`), including per-model `limit`. Those are ours and must keep failing closed if the live side disagrees — the hotfix's negative test asserts exactly this.
+- **Do not regress the OpenCode secondary-lane semantics.** OpenCode teammates start after the lead's first successful turn; a missing OpenCode inbox during primary launch is not a bug (see `docs/team-management/debugging-agent-teams.md`).
+- **Reproducing the class of bug is cheap.** Start `opencode serve` with `XDG_CONFIG_HOME`/`XDG_DATA_HOME` pointed at empty temp dirs and `OPENCODE_CONFIG_CONTENT` set to a candidate managed config, then diff the config you sent against `GET /config`. Any field that disappears is a future incident.
+- **Curated providers that carry a managed `config` block** (and therefore share this exposure) are: `xiaomi-token-plan-{ams,sgp,cn}`, `minimax-coding-plan`, `zai-coding-plan`, `kimi-for-coding`, `kiro`, `cursor-acp`. Non-curated providers (OpenRouter, Vercel AI Gateway, OpenCode Zen…) have an empty managed provider block and pass the comparison trivially — which is precisely why they are useless as regression tests for this code path. **Any e2e intended to cover this must use a curated provider.**
+
+---
+
+## 11. Verified vs unverified
+
+**Verified:**
+- The root cause, on live OpenCode 1.18.4 and 1.18.29.
+- That the fix removes the false rejection, in dev and in the packaged `v2.13.1` build.
+- That the strict check still rejects genuine differences (mutated model `limit` → `selected_config_match:provider`).
+- Full team launch, OpenCode-only and mixed, on the packaged release build.
+- That the residual Z.AI failure is the provider's own 401, reproduced outside the app.
+
+**Unverified:**
+- A successful end-to-end launch **on Z.AI specifically** — the account's subscription had lapsed. Everything up to authentication is verified; the final hop is not.
+- Windows behavior. The reporter is on Windows 11; all verification here was macOS (arm64). The defect is platform-independent by construction (it is a string/JSON comparison), but the fix has not been observed on Windows.
+- Whether other curated providers carry fields the schema discards. Only `structured_output` was audited, and only within `zai-coding-plan`. A schema-vs-catalog sweep (Option C as a CI check) would answer this cheaply.
+
+---
+
+## 12. Key references
+
+Runtime repo `777genius/agent_teams_orchestrator`, all paths under `src/services/opencode/`:
+
+| Item | Location |
+|---|---|
+| The strict check | `OpenCodeSelectedProfileAuthority.ts` — `refreshSelectedProfileAuthority()`, `SELECTED_CONFIG_FIELDS` (line ~27), `CONFIG_DROPPED_MODEL_FIELDS` (line ~50) |
+| Error thrown to the user | `OpenCodeBridgeCommandHandler.ts` line ~2664 (`refreshedBefore`), line ~2680 (`refreshedAfter`) |
+| Managed config assembly, user/project merge, spawn env | `OpenCodeProfileManager.ts` — `buildManagedConfig()`, `readSafeOpenCodeRuntimeConfigImport()`, `enforceScopedProviderIsolation()`, `buildManagedConfigFingerprint()` |
+| Curated provider definitions (source of `structured_output`) | `OpenCodeCuratedSubscriptionCatalog.ts` — `ZAI_CODING_PLAN_MODELS` |
+| Effective-state endpoints already fetched together | `OpenCodeHostManager.ts` — `getResolvedConfigFingerprint()` (line ~1276): `/config`, `/config/providers`, `/agent`, `/mcp` |
+| Host identity / reuse key | `OpenCodeHostManager.ts` — `buildOpenCodeHostProfileIdentity()` |
+| Integration test to extend | `OpenCodeProvisioningProbe.test.ts` — "refreshes selected config/project/auth/MCP authority and fails closed on each mutation" |
+
+Fix commit: `49d44c33` (PR #66). Runtime release: `v0.0.83`. App release: `v2.13.1`. Frontend pin: `runtime.lock.json`.
+
+---
+
+## 13. Historical suggested first task (superseded)
+
+Build **Layer 1 (calibration)** behind the existing check, in this order:
+
+1. Add a calibration helper that starts OpenCode in genuine isolation with only the managed config, captures `GET /config`, and caches it under `(binary identity, managed-config hash)`. Assert in tests that no user/project config can reach it.
+2. Switch `selectedConfig()`'s comparison base from `managed` to the calibrated `T(managed)`, keeping the comparison directional against the real `live`.
+3. Delete `CONFIG_DROPPED_MODEL_FIELDS` and `normalizeSelectedProviderModels()`; the existing hotfix tests must still pass **without** them — that is the acceptance criterion proving calibration subsumes the hardcoded list.
+4. Keep `normalizeSelectedAgentDefaults()` and the `command` default until step 3's tests show calibration covers them too, then remove them the same way.
+
+Only then move to Layers 2 and 3.


### PR DESCRIPTION
The original incident analysis recommended calibration, but the shipped runtime now uses a bounded positive launch contract and effective permission checks. Publish both the historical investigation and the accepted plan so future changes start from the actual decision.

The delivery record links runtime0.0.84, its CI and the app release work. It keeps Z.AI negative authorization acceptance separate from unproven Copilot task execution and the original Windows upgrade incident. App2.13.2 is published. Linux recovery34155202396 and promotion34156281715 succeeded; the public/latest/updater-ready guard also passed independently after publication.

Validation: relative document links, Markdown table/fences and whitespace checked; independent technical review passed; runtime/app claims checked against the linked commits, releases and CI. Documentation only.

Refs #504
Related #604, #605, #606 and 777genius/agent_teams_orchestrator#68.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Provider sign-in errors are now shown when access is rejected with either a 401 or 403 response.

- **Documentation**
  - Added documentation covering provider configuration authority checks, launch readiness, verification procedures, troubleshooting, and release status.
  - Updated release documentation to reflect the expanded authentication error handling and mark version 2.13.2 as released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->