### PR TITLE
chore(release): pin runtime 0.0.85 for 2.13.3

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -28,6 +28,75 @@ Before publishing:
 - Confirm version numbers, runtime gates, asset names, and download links.
 - Keep the body in this document identical to the GitHub release body.
 
+## Draft: v2.13.3 (2026-09-07)
+
+GitHub release: [v2.13.3](https://github.com/777genius/agent-teams-ai/releases/tag/v2.13.3).
+
+Target branch: `main`.
+
+Runtime gate:
+
+- Agent Teams runtime: `v0.0.85`.
+- Terminal Platform runtime: `v0.3.3`.
+
+Release preparation: the host recovery fix merged in [runtime PR #69](https://github.com/777genius/agent_teams_orchestrator/pull/69), commit `c44a763b7ecca2ed67f58911501752552f5642d9`. [Runtime CI](https://github.com/777genius/agent_teams_orchestrator/actions/runs/34158064866) passed all six jobs after one Windows standalone API-read job retry. [Runtime release build](https://github.com/777genius/agent_teams_orchestrator/actions/runs/34158627878) succeeded; `runtime.lock.json` pins all five [published archives](https://github.com/777genius/agent_teams_orchestrator_binaries/releases/tag/runtime-v0.0.85) with matching manifest/GitHub SHA-256 digests. App packaging, qualification and publication remain pending.
+
+Draft body source for GitHub release:
+
+<!-- RELEASE_BODY_START v2.13.3 -->
+This update fixes team launch retries after a previously reused OpenCode server stops.
+
+### Fixes
+
+- Start a replacement OpenCode server on retry once previous sessions have released the stopped server.
+- Show a clear error while existing sessions still hold a stopped OpenCode server.
+- Avoid duplicate replacement servers when several team launches retry at the same time.
+
+### Downloads
+
+<table>
+<tr>
+<td align="center">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI-2.13.3-arm64.dmg">
+    <img src="https://img.shields.io/badge/macOS_Apple_Silicon-.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
+  </a>
+  <br />
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI-2.13.3-x64.dmg">
+    <img src="https://img.shields.io/badge/macOS_Intel-.dmg-434343?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel" />
+  </a>
+</td>
+<td align="center">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI.Setup.2.13.3.exe">
+    <img src="https://img.shields.io/badge/Windows_x64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64" />
+  </a>
+  <br />
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI.Setup.2.13.3-arm64.exe">
+    <img src="https://img.shields.io/badge/Windows_ARM64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows ARM64" />
+  </a>
+  <br />
+  <sub>May trigger SmartScreen - click "More info" then "Run anyway"</sub>
+  <br />
+  <sub>Run normally. Administrator mode may be needed only if the app reports a specific OpenCode symlink or permission error.</sub>
+</td>
+<td align="center">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI-2.13.3.AppImage">
+    <img src="https://img.shields.io/badge/Linux-Download_.AppImage-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AppImage" />
+  </a>
+  <br />
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/agent-teams-ai_2.13.3_amd64.deb">
+    <img src="https://img.shields.io/badge/.deb-E95420?style=flat-square&logo=ubuntu" alt=".deb" />
+  </a>&nbsp;
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/agent-teams-ai-2.13.3.x86_64.rpm">
+    <img src="https://img.shields.io/badge/.rpm-294172?style=flat-square&logo=redhat" alt=".rpm" />
+  </a>&nbsp;
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/agent-teams-ai-2.13.3.pacman">
+    <img src="https://img.shields.io/badge/.pacman-1793D1?style=flat-square&logo=archlinux" alt=".pacman" />
+  </a>
+</td>
+</tr>
+</table>
+<!-- RELEASE_BODY_END v2.13.3 -->
+
 ## Released: v2.13.2 (2026-09-07)
 
 GitHub release: [v2.13.2](https://github.com/777genius/agent-teams-ai/releases/tag/v2.13.2).

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,40 +1,40 @@
 {
-  "version": "0.0.84",
+  "version": "0.0.85",
   "cliVersion": "2.1.251",
-  "sourceRef": "v0.0.84",
+  "sourceRef": "v0.0.85",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator_binaries",
-  "releaseTag": "runtime-v0.0.84",
+  "releaseTag": "runtime-v0.0.85",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.84.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.85.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "aa9dce8e909329c35e0999e974dcf3d117890339151bdbe76fc80c4e1325d5b2"
+      "sha256": "1e3a2c85aea45628273f169cb1f99f01c29a1963444f98a3260f5336627dca8d"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.84.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.85.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "13c38430e29c1149652c534fab51df09f36f8577e52b74abb1c9cce429cf3e02"
+      "sha256": "07db8600449d18e57a6f60e866480c048474e5d6b335244691616b3ac90f8189"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.84.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.85.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "7df001b29d0f2d3243fe742eda091bceefc41fa8658e2a97289cfc284d2af5c7"
+      "sha256": "d045e5de9c202bf892194c61ba47b34555c12aeb46f1b986f824ae18fcdba3c9"
     },
     "win32-arm64": {
-      "file": "agent-teams-runtime-win32-arm64-v0.0.84.zip",
+      "file": "agent-teams-runtime-win32-arm64-v0.0.85.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "ecd9a76a8f1b37e5030e6a11925b94de2115eda8a7a3192d7e6421ff29031fe1"
+      "sha256": "f349408aab818b11adc6dc639f08d867f4dbcdcbc52f06b7bd433f22df6bd999"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.84.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.85.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "43a48497a06593984fe5b7239817f387a31ed913739fcd2721f64ca7f7cb90ac"
+      "sha256": "3fc570d5d42e7ff10ada59ba5207b7c75f9ce9a25411034e88c9684e1d54c068"
     }
   }
 }


### PR DESCRIPTION
Pin runtime 0.0.85 for app 2.13.3 so a stopped, previously adopted OpenCode server can be replaced on a later launch after its existing sessions release it. Retained sessions keep a clear failure until they drain; concurrent retries use the existing startup locks. Add matching user-facing release notes and versioned installer links.

Runtime implementation: https://github.com/777genius/agent_teams_orchestrator/pull/69, merged as c44a763b7ecca2ed67f58911501752552f5642d9. The source tag is v0.0.85 and its tree matches reviewed head 2af91f4a.

Validation: runtime CI https://github.com/777genius/agent_teams_orchestrator/actions/runs/34158064866 passed all six jobs after one Windows standalone API-read job retry. Windows authority coverage includes actual dead-child recovery (650 passed, 1 skipped, 3285 assertions); local focused verification passed 651 tests / 3301 assertions. The skip is not counted as passed.

Frontend verification: `node scripts/ci/verify-runtime-lock.mjs`, 19 runtime CLI-version tests, release-note links and `git diff --check` passed.

Pin validation: all five published 0.0.85 archives were downloaded independently; their computed SHA-256 values match the release manifest and GitHub asset digests, and each archive VERSION file is exactly 0.0.85; the manifest identifies source commit c44a763b7ecca2ed67f58911501752552f5642d9. Runtime release build https://github.com/777genius/agent_teams_orchestrator/actions/runs/34158627878 succeeded. Package version is assigned from the release tag; Terminal Platform remains at 0.3.3. App packaging and publication are separate follow-up steps.

Refs #504


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrying team launches after a reused OpenCode server stops.

* **Documentation**
  * Added draft release notes for version 2.13.3, including supported platform downloads and runtime requirements.

* **Chores**
  * Updated the bundled runtime to version 0.0.85 across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Independent technical review approved exact head `3a560ed7e59b68e0fa4eaa97e2ce362ca46e86b5`, diff SHA-256 `776b5bcc8c53c008bbfb94327f09a6218731b18c3c98e3ce27e2df6454066697`, with no actionable findings. CodeRabbit passed. ReviewRouter is unavailable because its Codex account quota is exhausted (`review_agent_quota_unavailable` / `provider_capacity_unavailable`, run34159123086); no successful ReviewRouter result is claimed.
