### PR TITLE
fix(team): cancel unfinished watchdog work on force stop

### DIFF
--- a/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryFollowUpPolicy.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryFollowUpPolicy.ts
@@ -1,6 +1,7 @@
 import { deferOpenCodePromptDeliveryAttempt } from './OpenCodePromptDeliveryDeferral';
 import {
   isOpenCodePromptDeliveryCancelled,
+  isOpenCodePromptDeliveryWatchdogTerminal,
   isOpenCodePromptResponseStateResponded,
   OPENCODE_PROMPT_DELIVERY_SESSION_REFRESH_MAX_ATTEMPTS,
   type OpenCodePromptDeliveryLedgerRecord,
@@ -85,23 +86,7 @@ export function getOpenCodeDeliveryNextDelayMs(input: {
 export function isOpenCodePromptDeliveryWatchdogRecordTerminal(
   record: OpenCodePromptDeliveryLedgerRecord
 ): boolean {
-  if (record.status === 'failed_terminal') {
-    return true;
-  }
-  if (record.status !== 'responded') {
-    return false;
-  }
-  // A cancelled record is finished whatever it still owes: its run is gone, so
-  // re-arming a wake for it would ask a runtime that is no longer there.
-  if (isOpenCodePromptDeliveryCancelled(record)) {
-    return true;
-  }
-  // A responded record still owes the inbox read-commit until
-  // `inboxReadCommittedAt` is stamped: the reply proof can land through another
-  // channel after the relay pass that observed the response, and a record the
-  // watchdog treats as terminal is never re-armed - the unread inbox row then
-  // stays unread forever even though the member answered.
-  return Boolean(record.inboxReadCommittedAt);
+  return isOpenCodePromptDeliveryWatchdogTerminal(record);
 }
 
 export function isExplicitOpenCodeSessionRefreshStamp(reason: string | null | undefined): boolean {
@@ -306,8 +291,8 @@ export class OpenCodePromptDeliveryFollowUpPolicy {
         retry: true,
         ledgerRecord: input.ledgerRecord,
       });
-      // A 'responded' record keeps its status - it is already excluded from
-      // automatic selection, so only its durable deadline needs to move. Any
+      // A 'responded' record keeps its status: the watchdog can still finish
+      // its read commit without reopening automatic selection. Any
       // other status is parked as 'accepted' so the next wake observes instead
       // of dispatching; 'retry_scheduled' would spend another send.
       const ledgerRecord =

--- a/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryLedger.ts
+++ b/src/main/services/team/opencode/delivery/OpenCodePromptDeliveryLedger.ts
@@ -709,18 +709,14 @@ export class OpenCodePromptDeliveryLedgerStore {
   }
 
   /**
-   * Marks every record the automatic selection can still pick up as
-   * failed_terminal so the retry machinery (watchdog, due-attempt selection)
-   * stops re-attempting them.
+   * Marks every record with remaining delivery or watchdog work as
+   * failed_terminal so retries and read-commit follow-ups stop.
    *
-   * The guard is `isTerminalForAutomaticSelection`, the same predicate
-   * `listDue` and `getActiveForMember` filter by, so what this cancels is
-   * exactly what they can still return. A record that answered in plain text
-   * with no visible reply and no committed inbox read is not finished for that
-   * purpose whatever its status says, and a missing `nextAttemptAt` makes it
-   * due, so a status-only guard left the force stop with work still queued
-   * against it. Records the predicate calls terminal are history and keep the
-   * reason they ended.
+   * The guard is `isOpenCodePromptDeliveryWatchdogTerminal`: cancellation also
+   * covers watchdog read-commit work after a response has left automatic
+   * selection. This does not reopen materialized direct-send replies for
+   * `listDue` or `getActiveForMember`. Already-read terminal history keeps the
+   * reason it ended.
    *
    * The lane ledger outlives the run that wrote it, so the caller also says
    * which work is its own: see `isInCancellationScope`.
@@ -737,7 +733,7 @@ export class OpenCodePromptDeliveryLedgerStore {
     /**
      * Cancels a record created at or before this moment whatever its run, so a
      * caller that observed no run id still cancels the work that existed when
-     * it asked. Omitted means every selectable record is in scope.
+     * it asked. Omitted means all unfinished delivery and watchdog work is in scope.
      */
     createdAtOrBeforeMs?: number;
   }): Promise<{ cancelled: number; keptForLaterRun: number }> {
@@ -747,7 +743,7 @@ export class OpenCodePromptDeliveryLedgerStore {
     let keptForLaterRun = 0;
     await this.store.updateLocked((records) =>
       records.map((record) => {
-        if (isTerminalForAutomaticSelection(record)) {
+        if (isOpenCodePromptDeliveryWatchdogTerminal(record)) {
           return record;
         }
         if (!isInCancellationScope(record, ownedRunIds, createdAtOrBeforeMs)) {
@@ -983,6 +979,17 @@ function isTerminalForAutomaticSelection(record: OpenCodePromptDeliveryLedgerRec
     return false;
   }
   return record.status === 'failed_terminal' || record.status === 'responded';
+}
+
+export function isOpenCodePromptDeliveryWatchdogTerminal(
+  record: OpenCodePromptDeliveryLedgerRecord
+): boolean {
+  if (record.status === 'failed_terminal' || isOpenCodePromptDeliveryCancelled(record)) {
+    return true;
+  }
+  // Every response still owes the durable inbox read commit, regardless of
+  // which channel supplied the reply. Force Stop must fence that remaining work.
+  return record.status === 'responded' && Boolean(record.inboxReadCommittedAt);
 }
 
 /**

--- a/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.stalePending.test.ts
+++ b/src/main/services/team/opencode/delivery/__tests__/OpenCodeMemberMessageDeliveryService.stalePending.test.ts
@@ -15,6 +15,10 @@ import {
   type OpenCodePromptDeliveryLedgerRecord,
   type OpenCodePromptDeliveryLedgerStore,
 } from '../OpenCodePromptDeliveryLedger';
+import {
+  OpenCodePromptDeliveryWatchdogCoordinator,
+  type OpenCodePromptDeliveryWatchdogCoordinatorPorts,
+} from '../OpenCodePromptDeliveryWatchdogCoordinator';
 import { isOpenCodeDeliveryResponseReadCommitAllowed } from '../OpenCodePromptDeliveryReadCommitPolicy';
 import {
   isOpenCodePromptDeliveryStalePending,
@@ -178,6 +182,7 @@ interface Harness {
 
 function createHarness(input: {
   ledgerDir: string;
+  runtimeRunId?: () => string;
   observe?: () => Promise<OpenCodeTeamRuntimeMessageResult>;
   send?: () => Promise<OpenCodeTeamRuntimeMessageResult>;
   /** Defaults to the windows the production composition wires in. */
@@ -214,7 +219,7 @@ function createHarness(input: {
       () => ({ sendMessageToMember: send, observeMessageDelivery: observe }) as never
     ),
     readOpenCodeMemberDirectory: vi.fn(async () => ({
-      config: { name: TEAM, projectPath: '/repo', members: [] } as never,
+      config: { name: TEAM, projectPath: input.ledgerDir, members: [] } as never,
       teamMeta: null,
       metaMembers: [{ name: LEAD, providerId: 'opencode' as const }],
     })),
@@ -224,16 +229,16 @@ function createHarness(input: {
       laneId: PRIMARY_LANE.laneId,
       laneIdentity: PRIMARY_LANE,
       metaMember: { name: LEAD, providerId: 'opencode' as const },
-      memberRuntimeCwd: '/repo',
+      memberRuntimeCwd: input.ledgerDir,
     })),
     // Left undefined unless a test wires it, exactly like production today.
     readOpenCodeMemberContextUsage: input.readOpenCodeMemberContextUsage,
     stoppingSecondaryRuntimeTeams: { has: () => false },
-    readPersistedTeamProjectPath: vi.fn(() => '/repo'),
-    resolveDeliverableTrackedRuntimeRunId: vi.fn(() => 'run-1'),
+    readPersistedTeamProjectPath: vi.fn(() => input.ledgerDir),
+    resolveDeliverableTrackedRuntimeRunId: vi.fn(() => input.runtimeRunId?.() ?? 'run-1'),
     runs: { get: vi.fn(() => ({ mixedSecondaryLanes: [] })) },
-    getCurrentOpenCodeRuntimeRunId: vi.fn(() => 'run-1'),
-    resolveCurrentOpenCodeRuntimeRunId: vi.fn(async () => 'run-1'),
+    getCurrentOpenCodeRuntimeRunId: vi.fn(() => input.runtimeRunId?.() ?? 'run-1'),
+    resolveCurrentOpenCodeRuntimeRunId: vi.fn(async () => input.runtimeRunId?.() ?? 'run-1'),
     isOpenCodeRuntimeLaneIndexActive: vi.fn(async () => true),
     tryRecoverOpenCodeRuntimeLaneBeforeDelivery: vi.fn(async () => false),
     tryRecoverOpenCodeRuntimeLaneFromCommittedSessionBeforeDelivery: vi.fn(async () => false),
@@ -752,6 +757,80 @@ describe('combined stale settlement cancellation regression', () => {
       expect((await harness.ledger.list())[0].cancelledAt).toBeTruthy();
       expect(result).toMatchObject({ delivered: false, accepted: false, responsePending: false });
       expect(harness.notify).not.toHaveBeenCalled();
+    } finally {
+      await rm(ledgerDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('responded delivery Force Stop and relaunch', () => {
+  it('does not re-arm or observe an unread visible reply from the cancelled run', async () => {
+    const ledgerDir = await mkdtemp(join(tmpdir(), 'opencode-visible-cancel-relaunch-'));
+    try {
+      let runId = 'run-1';
+      const harness = createHarness({ ledgerDir, runtimeRunId: () => runId });
+      const seeded = await seedAcceptedPendingRecord(harness.ledger, userMessage, {
+        ageMinutes: 1,
+      });
+      await harness.ledger.applyObservation({
+        id: seeded.id,
+        responseObservation: pendingObservation({
+          state: 'responded_visible_message',
+          visibleReplyMessageId: 'vanished-destination-reply',
+          visibleReplyCorrelation: 'direct_child_message_send',
+          toolCallNames: ['message_send'],
+        }),
+        observedAt: new Date().toISOString(),
+      });
+      const schedule = vi.fn();
+      // Both the ledger scan and the unread-inbox recovery scan run against
+      // the real persisted record. The destination reply is no longer present.
+      const coordinator = new OpenCodePromptDeliveryWatchdogCoordinator({
+        watchdogScheduler: { isEnabled: () => true, schedule },
+        schedulePromptDeliveryWatchdog: schedule,
+        createLedger: () =>
+          createOpenCodePromptDeliveryLedgerStore({ filePath: join(ledgerDir, 'primary.json') }),
+        resolveMembersForRuntimeLane: async () => [LEAD],
+        getInboxMessages: async () => [
+          {
+            messageId: userMessage.messageId,
+            from: 'user',
+            text: userMessage.text,
+            timestamp: userMessage.inboxTimestamp,
+            read: false,
+          },
+        ],
+        hasStableInboxMessageId: () => true,
+        warn: vi.fn(),
+        getErrorMessage: String,
+      } as unknown as OpenCodePromptDeliveryWatchdogCoordinatorPorts);
+      expect(await coordinator.scanActiveLanes(TEAM, ['primary'])).toBe(1);
+      expect(schedule).toHaveBeenCalledOnce();
+      schedule.mockClear();
+      await expect(
+        harness.ledger.cancelNonTerminalRecords({
+          now: new Date().toISOString(),
+          reason: 'force_stop_requested: synthetic regression',
+          ownedRunIds: ['run-1'],
+          createdAtOrBeforeMs: Date.now(),
+        })
+      ).resolves.toEqual({ cancelled: 1, keptForLaterRun: 0 });
+      runId = 'run-2';
+      expect(await coordinator.scanActiveLanes(TEAM, ['primary'])).toBe(0);
+      expect(schedule).not.toHaveBeenCalled();
+      // A late watcher replay must also be fenced by the actual delivery path.
+      expect(await harness.service.deliver(TEAM, userMessage)).toMatchObject({
+        delivered: false,
+        accepted: false,
+        responsePending: false,
+      });
+      expect(harness.observe).not.toHaveBeenCalled();
+      expect(harness.send).not.toHaveBeenCalled();
+      expect((await harness.ledger.list())[0]).toMatchObject({
+        runId: 'run-1',
+        status: 'failed_terminal',
+        inboxReadCommittedAt: null,
+      });
     } finally {
       await rm(ledgerDir, { recursive: true, force: true });
     }

--- a/test/main/services/team/OpenCodePromptDeliveryLedger.test.ts
+++ b/test/main/services/team/OpenCodePromptDeliveryLedger.test.ts
@@ -1541,6 +1541,10 @@ describe('OpenCodePromptDeliveryLedger', () => {
       },
       observedAt: '2026-04-25T10:00:06.000Z',
     });
+    await store.markInboxReadCommitted({
+      id: answered.id,
+      committedAt: '2026-04-25T10:00:07.000Z',
+    });
     const alreadyFailed = await store.ensurePending({
       teamName: 'team-a',
       memberName: 'joe',
@@ -1580,7 +1584,7 @@ describe('OpenCodePromptDeliveryLedger', () => {
     });
   });
 
-  it('cancels a responded record the automatic selection can still pick up', async () => {
+  it('cancels both selectable responses and remaining watchdog read-commit work', async () => {
     const store = createStore();
     async function seedResponded(input: {
       memberName: string;
@@ -1651,7 +1655,7 @@ describe('OpenCodePromptDeliveryLedger', () => {
         now: '2026-04-25T10:05:00.000Z',
         reason: 'force_stop_requested: pending delivery cancelled by user force stop',
       })
-    ).resolves.toEqual({ cancelled: 1, keptForLaterRun: 0 });
+    ).resolves.toEqual({ cancelled: 2, keptForLaterRun: 0 });
 
     const after = new Map((await store.list()).map((record) => [record.id, record]));
     expect(after.get(stillSelectable)).toMatchObject({
@@ -1662,10 +1666,13 @@ describe('OpenCodePromptDeliveryLedger', () => {
     await expect(
       store.listDue({ now: new Date('2026-04-25T10:06:00.000Z'), limit: 10 })
     ).resolves.toEqual([]);
-    // Negative control: the two records the same predicate calls terminal are
-    // untouched, field for field.
+    // Already-read terminal history stays untouched, field for field.
     expect(after.get(committedRead)).toEqual(before.get(committedRead));
-    expect(after.get(visibleReply)).toEqual(before.get(visibleReply));
+    expect(after.get(visibleReply)).toMatchObject({
+      status: 'failed_terminal',
+      cancelledAt: '2026-04-25T10:05:00.000Z',
+      nextAttemptAt: null,
+    });
   });
 
   it('cancels only the work the stopping run owned', async () => {


### PR DESCRIPTION
Force Stop could leave a responded delivery eligible for watchdog recovery when its inbox read commit was still missing. Relaunching the team could then re-arm work from the stopped run.

Cancellation now uses the same terminal predicate as the watchdog. Normal message selection and existing run ownership filters stay unchanged. A regression test exercises the persisted ledger, watchdog scan and late delivery after cancellation and relaunch.

Validation: 288 distinct focused tests passed across the combined review-fix integration tree, pinned TypeScript 7 typecheck passed, and reverting the cancellation guard makes the new regression fail. These are service and filesystem integration checks; a live-provider Electron E2E was not run.

Refs #579


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Force Stop now prevents late monitoring activity from re-sending responses that are already visible.
  * Cancellation preserves required inbox-read commits while stopping further retry and monitoring work.
  * Responded records retain their status when proof observation resumes; other records are safely parked for follow-up processing.

* **Tests**
  * Expanded coverage for cancellation, relaunch, late monitoring activity, and visible replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->