### PR TITLE
chore(release): prepare 2.14.0 draft with Cursor runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,8 +474,9 @@ jobs:
           exit 1
 
   verify-public-runtime:
-    name: verify public runtime (${{ matrix.platform }})
+    name: verify runtime (${{ matrix.platform }})
     needs: prepare-runtime
+    if: ${{ always() && (needs.prepare-runtime.result == 'success' || (inputs.publish_release && inputs.reuse_existing_draft_assets)) }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     strategy:
@@ -505,7 +506,16 @@ jobs:
       - name: Verify runtime lock pins on the release ref
         run: node ./scripts/ci/verify-runtime-lock.mjs
 
+      - name: Verify draft runtime archive before packaging
+        if: ${{ !inputs.publish_release }}
+        env:
+          GH_TOKEN: ${{ secrets.RUNTIME_BUILD_DISPATCH_TOKEN }}
+        run: |
+          node ./scripts/stage-runtime.mjs --platform ${{ matrix.platform }}
+          node ./scripts/ci/verify-staged-runtime-version.mjs
+
       - name: Verify anonymous runtime bootstrap before packaging
+        if: ${{ inputs.publish_release }}
         run: node ./scripts/ci/verify-public-runtime-bootstrap.mjs
 
   release-mac:
@@ -990,9 +1000,10 @@ jobs:
         run: node scripts/ci/promote-existing-draft.mjs
 
   promote-existing-draft:
+    needs: verify-public-runtime
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.reuse_existing_draft_assets }}
+    if: ${{ !cancelled() && github.event_name == 'workflow_dispatch' && inputs.reuse_existing_draft_assets && needs.verify-public-runtime.result == 'success' }}
 
     steps:
       - name: Checkout release promotion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,6 +498,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Require the selected release tag to match the workflow commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "refs/tags/$RELEASE_TAG"
+          test "$(git rev-parse FETCH_HEAD^{commit})" = "$GITHUB_SHA"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -28,49 +28,54 @@ Before publishing:
 - Confirm version numbers, runtime gates, asset names, and download links.
 - Keep the body in this document identical to the GitHub release body.
 
-## Draft: v2.13.3 (2026-09-07)
+## Draft: v2.14.0 (2026-09-08)
 
-GitHub release: [v2.13.3](https://github.com/777genius/agent-teams-ai/releases/tag/v2.13.3).
-
-Target branch: `main`.
+Target branch: `main`, including Cursor integration and the merged team Stop and recovery fixes.
 
 Runtime gate:
 
-- Agent Teams runtime: `v0.0.85`.
+- Agent Teams runtime: `v0.0.87`, all five platform builds and exact-commit CI passed; pinned archive digests verified.
 - Terminal Platform runtime: `v0.3.3`.
 
-Release preparation: the host recovery fix merged in [runtime PR #69](https://github.com/777genius/agent_teams_orchestrator/pull/69), commit `c44a763b7ecca2ed67f58911501752552f5642d9`. [Runtime CI](https://github.com/777genius/agent_teams_orchestrator/actions/runs/34158064866) passed all six jobs after one Windows standalone API-read job retry. [Runtime release build](https://github.com/777genius/agent_teams_orchestrator/actions/runs/34158627878) succeeded; `runtime.lock.json` pins all five [published archives](https://github.com/777genius/agent_teams_orchestrator_binaries/releases/tag/runtime-v0.0.85) with matching manifest/GitHub SHA-256 digests. App packaging, qualification and publication remain pending.
+Draft preparation only. Publication and updater distribution require separate owner approval for v2.14.0. The previous v2.13.3 draft was removed; its historical tag is retained.
 
 Draft body source for GitHub release:
 
-<!-- RELEASE_BODY_START v2.13.3 -->
-This update fixes team launch retries after a previously reused OpenCode server stops.
+<!-- RELEASE_BODY_START v2.14.0 -->
+Build teams with Cursor alongside your other AI providers, with clearer launch failures and safer Stop behavior.
+
+### What's New
+
+- Add Cursor agents to teams and let them exchange messages and complete assigned tasks.
+- Keep Cursor connections separate between profiles, so different accounts do not share the wrong endpoint.
 
 ### Fixes
 
-- Start a replacement OpenCode server on retry once previous sessions have released the stopped server.
-- Show a clear error while existing sessions still hold a stopped OpenCode server.
-- Avoid duplicate replacement servers when several team launches retry at the same time.
+- Stop active Cursor shell commands when stopping their team.
+- Prevent accepted messages from replaying after a team stops.
+- Keep stopping one team from interrupting other teams sharing an OpenCode server.
+- Recover failed team launches without reusing a stopped server or an outdated session.
+- Cancel unfinished recovery work when force-stopping a team.
 
 ### Downloads
 
 <table>
 <tr>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI-2.13.3-arm64.dmg">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI-2.14.0-arm64.dmg">
     <img src="https://img.shields.io/badge/macOS_Apple_Silicon-.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
   </a>
   <br />
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI-2.13.3-x64.dmg">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI-2.14.0-x64.dmg">
     <img src="https://img.shields.io/badge/macOS_Intel-.dmg-434343?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel" />
   </a>
 </td>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI.Setup.2.13.3.exe">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI.Setup.2.14.0.exe">
     <img src="https://img.shields.io/badge/Windows_x64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64" />
   </a>
   <br />
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI.Setup.2.13.3-arm64.exe">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI.Setup.2.14.0-arm64.exe">
     <img src="https://img.shields.io/badge/Windows_ARM64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows ARM64" />
   </a>
   <br />
@@ -79,23 +84,23 @@ This update fixes team launch retries after a previously reused OpenCode server 
   <sub>Run normally. Administrator mode may be needed only if the app reports a specific OpenCode symlink or permission error.</sub>
 </td>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI-2.13.3.AppImage">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI-2.14.0.AppImage">
     <img src="https://img.shields.io/badge/Linux-Download_.AppImage-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AppImage" />
   </a>
   <br />
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/agent-teams-ai_2.13.3_amd64.deb">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/agent-teams-ai_2.14.0_amd64.deb">
     <img src="https://img.shields.io/badge/.deb-E95420?style=flat-square&logo=ubuntu" alt=".deb" />
   </a>&nbsp;
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/agent-teams-ai-2.13.3.x86_64.rpm">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/agent-teams-ai-2.14.0.x86_64.rpm">
     <img src="https://img.shields.io/badge/.rpm-294172?style=flat-square&logo=redhat" alt=".rpm" />
   </a>&nbsp;
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/agent-teams-ai-2.13.3.pacman">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/agent-teams-ai-2.14.0.pacman">
     <img src="https://img.shields.io/badge/.pacman-1793D1?style=flat-square&logo=archlinux" alt=".pacman" />
   </a>
 </td>
 </tr>
 </table>
-<!-- RELEASE_BODY_END v2.13.3 -->
+<!-- RELEASE_BODY_END v2.14.0 -->
 
 ## Released: v2.13.2 (2026-09-07)
 

--- a/docs/team-management/cursor-review-followups.md
+++ b/docs/team-management/cursor-review-followups.md
@@ -1,0 +1,13 @@
+# Cursor review follow-up, 2026-09-08
+
+The owner explicitly deferred non-critical findings to prioritize release preparation. Independent hosted review of frontend 504f6f60f and orchestrator 2f92ae2e established no new release blocker. Orchestrator review was bounded and does not replace the prior independent reviews and native qualification.
+
+## P2: recover a dead owner of the development bootstrap lock
+
+`ensureBootstrappedRuntime` now correctly validates and executes cached runtime versions under `.bootstrap.lock`. However, abrupt termination leaves its empty exclusive-create lock behind. Subsequent development launches wait 120 seconds and fail even with an intact warm payload. Before this change, a valid warm cache returned before lock acquisition. Packaged native team launch and Stop are not shown affected.
+
+Keep cache validation/version execution under the lock. Add ownership metadata and verified dead-owner recovery with serialized reclamation, or use a suitable existing owner-aware lock. Do not unlink merely by age or move execution outside the lock. Required regressions: dead-owner recovery returns a valid cache without download; live owner blocks execution; simultaneous reclaimers cannot both publish.
+
+Independent offline negative control compared actual base and current bootstrap functions against a valid fixture payload plus abandoned lock: base returns the cache, current code times out. Nine bounded cache/ledger/policy tests passed. The reviewer used a virtual clock and did not run the native runtime. A configured explicit runtime path is a development workaround; no automatic deletion of user cache locks was performed.
+
+Full reports were retained by the owner session under /tmp/cursor-review-20260908/INDEPENDENT_FRONTEND_REVIEW.md and INDEPENDENT_ORCHESTRATOR_REVIEW.md.

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,40 +1,40 @@
 {
-  "version": "0.0.85",
+  "version": "0.0.87",
   "cliVersion": "2.1.251",
-  "sourceRef": "v0.0.85",
+  "sourceRef": "v0.0.87",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator_binaries",
-  "releaseTag": "runtime-v0.0.85",
+  "releaseTag": "runtime-v0.0.87",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.85.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.87.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "1e3a2c85aea45628273f169cb1f99f01c29a1963444f98a3260f5336627dca8d"
+      "sha256": "3ce02d517a19685eeacde08e51f6c1b1b1fbd239b08cf96cd82f9bd8a12ad41d"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.85.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.87.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "07db8600449d18e57a6f60e866480c048474e5d6b335244691616b3ac90f8189"
+      "sha256": "5483b3e1f157c5b28ab3a59a8e7617e3f614a2f564f5ba77f1f7589bf646e3cd"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.85.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.87.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "d045e5de9c202bf892194c61ba47b34555c12aeb46f1b986f824ae18fcdba3c9"
+      "sha256": "7d335c727cc13d47bd280f8dc719eca3584a761954c050dcc354ea16f6de4175"
     },
     "win32-arm64": {
-      "file": "agent-teams-runtime-win32-arm64-v0.0.85.zip",
+      "file": "agent-teams-runtime-win32-arm64-v0.0.87.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "f349408aab818b11adc6dc639f08d867f4dbcdcbc52f06b7bd433f22df6bd999"
+      "sha256": "0d63d4704e018fb5c64e29213a5fc46e2099e4bc6f02e7496337f63e4356c12c"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.85.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.87.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "3fc570d5d42e7ff10ada59ba5207b7c75f9ce9a25411034e88c9684e1d54c068"
+      "sha256": "f4f36d3f3697fcb3208e7bfc784829a447d8c7faf65570479fa0b4a92ed1ef5d"
     }
   }
 }

--- a/scripts/ci/verify-staged-runtime-version.mjs
+++ b/scripts/ci/verify-staged-runtime-version.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  getExpectedRuntimeCliVersion,
+  matchesRuntimeCliVersion,
+} from '../lib/runtime-cli-version.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const lock = JSON.parse(fs.readFileSync(path.join(root, 'runtime.lock.json'), 'utf8'));
+const platform = `${process.platform}-${process.arch}`;
+const asset = lock.assets[platform];
+if (!asset) throw new Error(`No runtime pin for ${platform}`);
+const binary = path.join(root, 'resources/runtime', asset.binaryName);
+const result = spawnSync(binary, ['--version'], { encoding: 'utf8', timeout: 30_000 });
+if (
+  result.error ||
+  result.status !== 0 ||
+  !matchesRuntimeCliVersion(result.stdout, getExpectedRuntimeCliVersion(lock))
+) {
+  throw new Error(
+    `Staged runtime version check failed for ${platform}: ${result.error?.message ?? result.status}`
+  );
+}
+console.log(`Verified staged runtime ${lock.version} for ${platform}`);


### PR DESCRIPTION
Prepare the v2.14.0 draft with Cursor integration and the latest merged team Stop/recovery fixes. Pin runtime v0.0.87 after all five platform builds, exact-commit runtime CI and manifest/GitHub SHA-256 verification.

Draft packaging verifies authenticated runtime archives and executable versions without publishing runtime binaries. Publication, including reuse of draft installers, retains anonymous runtime verification tied to the selected release tag. No publication is authorized.

Validation: runtime CI/build passed; macOS arm64 staged archive checksum and executable version passed; workflow formatting and independent technical review completed. Mixed-provider E2E and app packaging remain pending.

Refs #611


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stronger release validation to confirm runtime assets and release tags are consistent before publication.
  - Added platform-specific checks to verify staged runtime versions.

- **Updates**
  - Updated the bundled runtime to version 0.0.87 across macOS, Windows, and Linux.
  - Updated release documentation for version 2.14.0, including Cursor team integration, recovery improvements, runtime validation, and download links.

- **Documentation**
  - Added follow-up documentation covering runtime recovery considerations and known development-launch workarounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->