### PR TITLE
chore(release): prepare 2.14.1 with Cursor and teammate recovery fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,8 +474,9 @@ jobs:
           exit 1
 
   verify-public-runtime:
-    name: verify public runtime (${{ matrix.platform }})
+    name: verify runtime (${{ matrix.platform }})
     needs: prepare-runtime
+    if: ${{ always() && (needs.prepare-runtime.result == 'success' || (inputs.publish_release && inputs.reuse_existing_draft_assets)) }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
     strategy:
@@ -505,7 +506,16 @@ jobs:
       - name: Verify runtime lock pins on the release ref
         run: node ./scripts/ci/verify-runtime-lock.mjs
 
+      - name: Verify draft runtime archive before packaging
+        if: ${{ !inputs.publish_release }}
+        env:
+          GH_TOKEN: ${{ secrets.RUNTIME_BUILD_DISPATCH_TOKEN }}
+        run: |
+          node ./scripts/stage-runtime.mjs --platform ${{ matrix.platform }}
+          node ./scripts/ci/verify-staged-runtime-version.mjs
+
       - name: Verify anonymous runtime bootstrap before packaging
+        if: ${{ inputs.publish_release }}
         run: node ./scripts/ci/verify-public-runtime-bootstrap.mjs
 
   release-mac:
@@ -990,9 +1000,10 @@ jobs:
         run: node scripts/ci/promote-existing-draft.mjs
 
   promote-existing-draft:
+    needs: verify-public-runtime
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.reuse_existing_draft_assets }}
+    if: ${{ !cancelled() && github.event_name == 'workflow_dispatch' && inputs.reuse_existing_draft_assets && needs.verify-public-runtime.result == 'success' }}
 
     steps:
       - name: Checkout release promotion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,6 +498,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Require the selected release tag to match the workflow commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "refs/tags/$RELEASE_TAG"
+          test "$(git rev-parse FETCH_HEAD^{commit})" = "$GITHUB_SHA"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -28,49 +28,54 @@ Before publishing:
 - Confirm version numbers, runtime gates, asset names, and download links.
 - Keep the body in this document identical to the GitHub release body.
 
-## Draft: v2.13.3 (2026-09-07)
+## Draft: v2.14.0 (2026-09-08)
 
-GitHub release: [v2.13.3](https://github.com/777genius/agent-teams-ai/releases/tag/v2.13.3).
-
-Target branch: `main`.
+Target branch: `main`, including Cursor integration and the merged team Stop and recovery fixes.
 
 Runtime gate:
 
-- Agent Teams runtime: `v0.0.85`.
+- Agent Teams runtime: `v0.0.87`, all five platform builds and exact-commit CI passed; pinned archive digests verified.
 - Terminal Platform runtime: `v0.3.3`.
 
-Release preparation: the host recovery fix merged in [runtime PR #69](https://github.com/777genius/agent_teams_orchestrator/pull/69), commit `c44a763b7ecca2ed67f58911501752552f5642d9`. [Runtime CI](https://github.com/777genius/agent_teams_orchestrator/actions/runs/34158064866) passed all six jobs after one Windows standalone API-read job retry. [Runtime release build](https://github.com/777genius/agent_teams_orchestrator/actions/runs/34158627878) succeeded; `runtime.lock.json` pins all five [published archives](https://github.com/777genius/agent_teams_orchestrator_binaries/releases/tag/runtime-v0.0.85) with matching manifest/GitHub SHA-256 digests. App packaging, qualification and publication remain pending.
+Draft preparation only. Publication and updater distribution require separate owner approval for v2.14.0. The previous v2.13.3 draft was removed; its historical tag is retained.
 
 Draft body source for GitHub release:
 
-<!-- RELEASE_BODY_START v2.13.3 -->
-This update fixes team launch retries after a previously reused OpenCode server stops.
+<!-- RELEASE_BODY_START v2.14.0 -->
+Build teams with Cursor alongside your other AI providers, with clearer launch failures and safer Stop behavior.
+
+### What's New
+
+- Add Cursor agents to teams and let them exchange messages and complete assigned tasks.
+- Keep Cursor connections separate between profiles, so different accounts do not share the wrong endpoint.
 
 ### Fixes
 
-- Start a replacement OpenCode server on retry once previous sessions have released the stopped server.
-- Show a clear error while existing sessions still hold a stopped OpenCode server.
-- Avoid duplicate replacement servers when several team launches retry at the same time.
+- Stop active Cursor shell commands when stopping their team.
+- Prevent accepted messages from replaying after a team stops.
+- Keep stopping one team from interrupting other teams sharing an OpenCode server.
+- Recover failed team launches without reusing a stopped server or an outdated session.
+- Cancel unfinished recovery work when force-stopping a team.
 
 ### Downloads
 
 <table>
 <tr>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI-2.13.3-arm64.dmg">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI-2.14.0-arm64.dmg">
     <img src="https://img.shields.io/badge/macOS_Apple_Silicon-.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
   </a>
   <br />
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI-2.13.3-x64.dmg">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI-2.14.0-x64.dmg">
     <img src="https://img.shields.io/badge/macOS_Intel-.dmg-434343?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel" />
   </a>
 </td>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI.Setup.2.13.3.exe">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI.Setup.2.14.0.exe">
     <img src="https://img.shields.io/badge/Windows_x64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64" />
   </a>
   <br />
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI.Setup.2.13.3-arm64.exe">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI.Setup.2.14.0-arm64.exe">
     <img src="https://img.shields.io/badge/Windows_ARM64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows ARM64" />
   </a>
   <br />
@@ -79,23 +84,23 @@ This update fixes team launch retries after a previously reused OpenCode server 
   <sub>Run normally. Administrator mode may be needed only if the app reports a specific OpenCode symlink or permission error.</sub>
 </td>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/Agent.Teams.AI-2.13.3.AppImage">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI-2.14.0.AppImage">
     <img src="https://img.shields.io/badge/Linux-Download_.AppImage-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AppImage" />
   </a>
   <br />
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/agent-teams-ai_2.13.3_amd64.deb">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/agent-teams-ai_2.14.0_amd64.deb">
     <img src="https://img.shields.io/badge/.deb-E95420?style=flat-square&logo=ubuntu" alt=".deb" />
   </a>&nbsp;
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/agent-teams-ai-2.13.3.x86_64.rpm">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/agent-teams-ai-2.14.0.x86_64.rpm">
     <img src="https://img.shields.io/badge/.rpm-294172?style=flat-square&logo=redhat" alt=".rpm" />
   </a>&nbsp;
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.13.3/agent-teams-ai-2.13.3.pacman">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/agent-teams-ai-2.14.0.pacman">
     <img src="https://img.shields.io/badge/.pacman-1793D1?style=flat-square&logo=archlinux" alt=".pacman" />
   </a>
 </td>
 </tr>
 </table>
-<!-- RELEASE_BODY_END v2.13.3 -->
+<!-- RELEASE_BODY_END v2.14.0 -->
 
 ## Released: v2.13.2 (2026-09-07)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -28,7 +28,7 @@ Before publishing:
 - Confirm version numbers, runtime gates, asset names, and download links.
 - Keep the body in this document identical to the GitHub release body.
 
-## Draft: v2.14.0 (2026-09-08)
+## Draft: v2.14.1 (2026-09-08)
 
 Target branch: `main`, including Cursor integration and the merged team Stop and recovery fixes.
 
@@ -37,17 +37,19 @@ Runtime gate:
 - Agent Teams runtime: `v0.0.87`, all five platform builds and exact-commit CI passed; pinned archive digests verified.
 - Terminal Platform runtime: `v0.3.3`.
 
-Draft preparation only. Publication and updater distribution require separate owner approval for v2.14.0. The previous v2.13.3 draft was removed; its historical tag is retained.
+Owner approved publication of v2.14.1 after the fresh draft passes the required release checks. Supersedes the v2.14.0 draft with the latest frontend fixes; historical tags are retained.
 
 Draft body source for GitHub release:
 
-<!-- RELEASE_BODY_START v2.14.0 -->
+<!-- RELEASE_BODY_START v2.14.1 -->
+
 Build teams with Cursor alongside your other AI providers, with clearer launch failures and safer Stop behavior.
 
 ### What's New
 
 - Add Cursor agents to teams and let them exchange messages and complete assigned tasks.
 - Keep Cursor connections separate between profiles, so different accounts do not share the wrong endpoint.
+- Retry a failed OpenCode teammate individually without restarting the whole team.
 
 ### Fixes
 
@@ -55,27 +57,27 @@ Build teams with Cursor alongside your other AI providers, with clearer launch f
 - Prevent accepted messages from replaying after a team stops.
 - Keep stopping one team from interrupting other teams sharing an OpenCode server.
 - Recover failed team launches without reusing a stopped server or an outdated session.
-- Cancel unfinished recovery work when force-stopping a team.
+- Keep GPT-6 Astra visible in model selection after a temporary Codex catalog refresh failure.
 
 ### Downloads
 
 <table>
 <tr>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI-2.14.0-arm64.dmg">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.1/Agent.Teams.AI-2.14.1-arm64.dmg">
     <img src="https://img.shields.io/badge/macOS_Apple_Silicon-.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
   </a>
   <br />
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI-2.14.0-x64.dmg">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.1/Agent.Teams.AI-2.14.1-x64.dmg">
     <img src="https://img.shields.io/badge/macOS_Intel-.dmg-434343?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel" />
   </a>
 </td>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI.Setup.2.14.0.exe">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.1/Agent.Teams.AI.Setup.2.14.1.exe">
     <img src="https://img.shields.io/badge/Windows_x64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64" />
   </a>
   <br />
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI.Setup.2.14.0-arm64.exe">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.1/Agent.Teams.AI.Setup.2.14.1-arm64.exe">
     <img src="https://img.shields.io/badge/Windows_ARM64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows ARM64" />
   </a>
   <br />
@@ -84,23 +86,23 @@ Build teams with Cursor alongside your other AI providers, with clearer launch f
   <sub>Run normally. Administrator mode may be needed only if the app reports a specific OpenCode symlink or permission error.</sub>
 </td>
 <td align="center">
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/Agent.Teams.AI-2.14.0.AppImage">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.1/Agent.Teams.AI-2.14.1.AppImage">
     <img src="https://img.shields.io/badge/Linux-Download_.AppImage-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AppImage" />
   </a>
   <br />
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/agent-teams-ai_2.14.0_amd64.deb">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.1/agent-teams-ai_2.14.1_amd64.deb">
     <img src="https://img.shields.io/badge/.deb-E95420?style=flat-square&logo=ubuntu" alt=".deb" />
   </a>&nbsp;
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/agent-teams-ai-2.14.0.x86_64.rpm">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.1/agent-teams-ai-2.14.1.x86_64.rpm">
     <img src="https://img.shields.io/badge/.rpm-294172?style=flat-square&logo=redhat" alt=".rpm" />
   </a>&nbsp;
-  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.0/agent-teams-ai-2.14.0.pacman">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.1/agent-teams-ai-2.14.1.pacman">
     <img src="https://img.shields.io/badge/.pacman-1793D1?style=flat-square&logo=archlinux" alt=".pacman" />
   </a>
 </td>
 </tr>
 </table>
-<!-- RELEASE_BODY_END v2.14.0 -->
+<!-- RELEASE_BODY_END v2.14.1 -->
 
 ## Released: v2.13.2 (2026-09-07)
 
@@ -116,6 +118,7 @@ Runtime gate:
 Draft body source for GitHub release:
 
 <!-- RELEASE_BODY_START v2.13.2 -->
+
 This update fixes OpenCode startup checks and makes provider sign-in failures easier to identify.
 
 ### Fixes
@@ -183,6 +186,7 @@ Runtime gate:
 Draft body source for GitHub release:
 
 <!-- RELEASE_BODY_START v2.13.1 -->
+
 Fixes team launches for Z.AI Coding Plan models. On 2.13.0 their model check always failed, which blocked every team that included an OpenCode member.
 
 ### Fixes
@@ -250,6 +254,7 @@ Runtime gate:
 Draft body source for GitHub release:
 
 <!-- RELEASE_BODY_START v2.13.0 -->
+
 This update makes mixed-provider teams easier to set up and manage, with clearer model checks and fixes for startup, task delivery, and duplicate messages.
 
 ### What's New
@@ -334,6 +339,7 @@ Runtime gate:
 Draft body source for GitHub release:
 
 <!-- RELEASE_BODY_START v2.12.0 -->
+
 Use self-hosted OpenAI-compatible models with team members.
 
 ### What's New
@@ -413,6 +419,7 @@ Runtime gate:
 Draft body source for GitHub release:
 
 <!-- RELEASE_BODY_START v2.11.0 -->
+
 This release focuses on fixes and stability.
 
 ### Fixes and Stability
@@ -1510,18 +1517,18 @@ Group entries by type: `What's New` > `Improvements` > `Bug Fixes` > `Breaking C
 
 electron-builder generates these artifacts per platform:
 
-| Platform        | Versioned Name                       | Stable Name (for /latest/download) | Compatibility Alias                |
-| --------------- | ------------------------------------ | ---------------------------------- | ---------------------------------- |
-| macOS arm64 DMG | `Agent.Teams.AI-<VER>-arm64.dmg`     | `Agent.Teams.AI-arm64.dmg`         | `Claude-Agent-Teams-UI-arm64.dmg`  |
-| macOS x64 DMG   | `Agent.Teams.AI-<VER>-x64.dmg`       | `Agent.Teams.AI-x64.dmg`           | `Claude-Agent-Teams-UI-x64.dmg`    |
-| macOS arm64 ZIP | `Agent.Teams.AI-<VER>-arm64-mac.zip` | -                                  | -                                  |
-| macOS x64 ZIP   | `Agent.Teams.AI-<VER>-x64-mac.zip`   | -                                  | -                                  |
-| Windows x64     | `Agent.Teams.AI.Setup.<VER>.exe`     | `Agent.Teams.AI.Setup.exe`         | `Claude-Agent-Teams-UI-Setup.exe`  |
-| Windows ARM64   | `Agent.Teams.AI.Setup.<VER>-arm64.exe` | `Agent.Teams.AI.Setup-arm64.exe` | -                                  |
-| Linux AppImage  | `Agent.Teams.AI-<VER>.AppImage`      | `Agent.Teams.AI.AppImage`          | `Claude-Agent-Teams-UI.AppImage`   |
-| Linux deb       | `agent-teams-ai_<VER>_amd64.deb`     | `agent-teams-ai-amd64.deb`         | `Claude-Agent-Teams-UI-amd64.deb`  |
-| Linux rpm       | `agent-teams-ai-<VER>.x86_64.rpm`    | `agent-teams-ai-x86_64.rpm`        | `Claude-Agent-Teams-UI-x86_64.rpm` |
-| Linux pacman    | `agent-teams-ai-<VER>.pacman`        | `agent-teams-ai.pacman`            | `Claude-Agent-Teams-UI.pacman`     |
+| Platform        | Versioned Name                         | Stable Name (for /latest/download) | Compatibility Alias                |
+| --------------- | -------------------------------------- | ---------------------------------- | ---------------------------------- |
+| macOS arm64 DMG | `Agent.Teams.AI-<VER>-arm64.dmg`       | `Agent.Teams.AI-arm64.dmg`         | `Claude-Agent-Teams-UI-arm64.dmg`  |
+| macOS x64 DMG   | `Agent.Teams.AI-<VER>-x64.dmg`         | `Agent.Teams.AI-x64.dmg`           | `Claude-Agent-Teams-UI-x64.dmg`    |
+| macOS arm64 ZIP | `Agent.Teams.AI-<VER>-arm64-mac.zip`   | -                                  | -                                  |
+| macOS x64 ZIP   | `Agent.Teams.AI-<VER>-x64-mac.zip`     | -                                  | -                                  |
+| Windows x64     | `Agent.Teams.AI.Setup.<VER>.exe`       | `Agent.Teams.AI.Setup.exe`         | `Claude-Agent-Teams-UI-Setup.exe`  |
+| Windows ARM64   | `Agent.Teams.AI.Setup.<VER>-arm64.exe` | `Agent.Teams.AI.Setup-arm64.exe`   | -                                  |
+| Linux AppImage  | `Agent.Teams.AI-<VER>.AppImage`        | `Agent.Teams.AI.AppImage`          | `Claude-Agent-Teams-UI.AppImage`   |
+| Linux deb       | `agent-teams-ai_<VER>_amd64.deb`       | `agent-teams-ai-amd64.deb`         | `Claude-Agent-Teams-UI-amd64.deb`  |
+| Linux rpm       | `agent-teams-ai-<VER>.x86_64.rpm`      | `agent-teams-ai-x86_64.rpm`        | `Claude-Agent-Teams-UI-x86_64.rpm` |
+| Linux pacman    | `agent-teams-ai-<VER>.pacman`          | `agent-teams-ai.pacman`            | `Claude-Agent-Teams-UI.pacman`     |
 
 ## Stable Download Links
 

--- a/docs/team-management/cursor-review-followups.md
+++ b/docs/team-management/cursor-review-followups.md
@@ -1,0 +1,13 @@
+# Cursor review follow-up, 2026-09-08
+
+The owner explicitly deferred non-critical findings to prioritize release preparation. Independent hosted review of frontend 504f6f60f and orchestrator 2f92ae2e established no new release blocker. Orchestrator review was bounded and does not replace the prior independent reviews and native qualification.
+
+## P2: recover a dead owner of the development bootstrap lock
+
+`ensureBootstrappedRuntime` now correctly validates and executes cached runtime versions under `.bootstrap.lock`. However, abrupt termination leaves its empty exclusive-create lock behind. Subsequent development launches wait 120 seconds and fail even with an intact warm payload. Before this change, a valid warm cache returned before lock acquisition. Packaged native team launch and Stop are not shown affected.
+
+Keep cache validation/version execution under the lock. Add ownership metadata and verified dead-owner recovery with serialized reclamation, or use a suitable existing owner-aware lock. Do not unlink merely by age or move execution outside the lock. Required regressions: dead-owner recovery returns a valid cache without download; live owner blocks execution; simultaneous reclaimers cannot both publish.
+
+Independent offline negative control compared actual base and current bootstrap functions against a valid fixture payload plus abandoned lock: base returns the cache, current code times out. Nine bounded cache/ledger/policy tests passed. The reviewer used a virtual clock and did not run the native runtime. A configured explicit runtime path is a development workaround; no automatic deletion of user cache locks was performed.
+
+Full reports were retained by the owner session under /tmp/cursor-review-20260908/INDEPENDENT_FRONTEND_REVIEW.md and INDEPENDENT_ORCHESTRATOR_REVIEW.md.

--- a/docs/team-management/cursor-review-followups.md
+++ b/docs/team-management/cursor-review-followups.md
@@ -11,3 +11,15 @@ Keep cache validation/version execution under the lock. Add ownership metadata a
 Independent offline negative control compared actual base and current bootstrap functions against a valid fixture payload plus abandoned lock: base returns the cache, current code times out. Nine bounded cache/ledger/policy tests passed. The reviewer used a virtual clock and did not run the native runtime. A configured explicit runtime path is a development workaround; no automatic deletion of user cache locks was performed.
 
 Full reports were retained by the owner session under /tmp/cursor-review-20260908/INDEPENDENT_FRONTEND_REVIEW.md and INDEPENDENT_ORCHESTRATOR_REVIEW.md.
+
+## P2: observe accepted Cursor messages without preparing the profile again
+
+The four-provider sandbox run `mixed-four-e2e-0908` (`ecf81fce-d2a3-4f65-8e42-353f6fa1201d`) completed Astra -> SuperGrok -> Z AI -> Cursor -> Astra, all five tasks, four provider files and the final ACK. Runtime source was `847aea485640b8dc5579656eec081dd660bb764a` (v0.0.87), frontend `87d3901ff14dd5714d46f73ce39be087d6cedced`. Anthropic was explicitly skipped because its account quota was exhausted.
+
+Cursor delivery observation reported terminal timeouts despite accepted prompts continuing and completing. Existing-session observation enters full scope/profile preparation, including native status checks, inside a 20-second host_start deadline. The session also recorded managed_config_changed:mcp,provider. The exact operation consuming the deadline remains unproven. Do not replay accepted prompts based on this diagnostic alone.
+
+Follow-up: observe the existing owned session without preparing or creating a host, preserving team/run/session/PID identity checks. Report configuration changes separately. Regressions should cover slow native status with a responsive existing endpoint, no new host, and no repeated accepted prompt.
+
+SuperGrok initially hit a held file lock before provider dispatch, then a strict scope mismatch during recovery. A narrow retry succeeded. The precise lock owner was not established; credential rotation is a hypothesis, not a confirmed cause. Strict authority checks remain unchanged.
+
+Local evidence: `/tmp/mixed-five-e2e-20260908/evidence/four-provider-proof.json`. The owned test team was stopped after completion.

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,40 +1,40 @@
 {
-  "version": "0.0.85",
+  "version": "0.0.87",
   "cliVersion": "2.1.251",
-  "sourceRef": "v0.0.85",
+  "sourceRef": "v0.0.87",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator_binaries",
-  "releaseTag": "runtime-v0.0.85",
+  "releaseTag": "runtime-v0.0.87",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.85.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.87.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "1e3a2c85aea45628273f169cb1f99f01c29a1963444f98a3260f5336627dca8d"
+      "sha256": "3ce02d517a19685eeacde08e51f6c1b1b1fbd239b08cf96cd82f9bd8a12ad41d"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.85.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.87.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "07db8600449d18e57a6f60e866480c048474e5d6b335244691616b3ac90f8189"
+      "sha256": "5483b3e1f157c5b28ab3a59a8e7617e3f614a2f564f5ba77f1f7589bf646e3cd"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.85.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.87.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "d045e5de9c202bf892194c61ba47b34555c12aeb46f1b986f824ae18fcdba3c9"
+      "sha256": "7d335c727cc13d47bd280f8dc719eca3584a761954c050dcc354ea16f6de4175"
     },
     "win32-arm64": {
-      "file": "agent-teams-runtime-win32-arm64-v0.0.85.zip",
+      "file": "agent-teams-runtime-win32-arm64-v0.0.87.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "f349408aab818b11adc6dc639f08d867f4dbcdcbc52f06b7bd433f22df6bd999"
+      "sha256": "0d63d4704e018fb5c64e29213a5fc46e2099e4bc6f02e7496337f63e4356c12c"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.85.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.87.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "3fc570d5d42e7ff10ada59ba5207b7c75f9ce9a25411034e88c9684e1d54c068"
+      "sha256": "f4f36d3f3697fcb3208e7bfc784829a447d8c7faf65570479fa0b4a92ed1ef5d"
     }
   }
 }

--- a/scripts/ci/verify-staged-runtime-version.mjs
+++ b/scripts/ci/verify-staged-runtime-version.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  getExpectedRuntimeCliVersion,
+  matchesRuntimeCliVersion,
+} from '../lib/runtime-cli-version.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const lock = JSON.parse(fs.readFileSync(path.join(root, 'runtime.lock.json'), 'utf8'));
+const platform = `${process.platform}-${process.arch}`;
+const asset = lock.assets[platform];
+if (!asset) throw new Error(`No runtime pin for ${platform}`);
+const binary = path.join(root, 'resources/runtime', asset.binaryName);
+const result = spawnSync(binary, ['--version'], { encoding: 'utf8', timeout: 30_000 });
+if (
+  result.error ||
+  result.status !== 0 ||
+  !matchesRuntimeCliVersion(result.stdout, getExpectedRuntimeCliVersion(lock))
+) {
+  throw new Error(
+    `Staged runtime version check failed for ${platform}: ${result.error?.message ?? result.status}`
+  );
+}
+console.log(`Verified staged runtime ${lock.version} for ${platform}`);

--- a/src/main/ipc/teams.ts
+++ b/src/main/ipc/teams.ts
@@ -4151,7 +4151,8 @@ async function handleGetAgentRuntime(
 async function handleRestartMember(
   _event: IpcMainInvokeEvent,
   teamName: unknown,
-  memberName: unknown
+  memberName: unknown,
+  expectedSecondary?: unknown
 ): Promise<IpcResult<void>> {
   const validatedTeamName = validateTeamName(teamName);
   if (!validatedTeamName.valid) {
@@ -4161,11 +4162,15 @@ async function handleRestartMember(
   if (!validatedMemberName.valid) {
     return { success: false, error: validatedMemberName.error ?? 'Invalid memberName' };
   }
+  if (expectedSecondary !== undefined && typeof expectedSecondary !== 'boolean') {
+    return { success: false, error: 'Invalid expectedSecondary' };
+  }
   return wrapTeamHandler('restartMember', async () => {
     try {
       await getTeamMemberLifecycleApi().restartMember(
         validatedTeamName.value!,
-        validatedMemberName.value!
+        validatedMemberName.value!,
+        ...(expectedSecondary === undefined ? [] : [expectedSecondary])
       );
     } finally {
       getTeamDataService().invalidateMessageFeed(validatedTeamName.value!);

--- a/src/main/services/runtime/providerStatusCheckContract.ts
+++ b/src/main/services/runtime/providerStatusCheckContract.ts
@@ -261,7 +261,18 @@ export function mergeProviderStatusDisplayEvidence(
   );
   const displayPairRetained = displayPair.models === current.models;
   const launchUnproved = !hasAuthoritativeLaunchEvidence || catalogRetained || displayPairRetained;
-  const retainedCatalog = incoming.modelCatalog ?? current.modelCatalog ?? null;
+  // If a transient Codex fallback retains the previous flat model list, retain
+  // its catalog too. Otherwise the card and picker describe different models.
+  // This is stale display evidence only; launchUnproved still revokes launch.
+  const retainCodexDisplayCatalog =
+    incoming.providerId === 'codex' &&
+    incoming.statusCheckOutcome === 'transient_error' &&
+    incoming.modelCatalog?.source === 'static-fallback' &&
+    current.modelCatalog?.source === 'app-server' &&
+    displayPairRetained;
+  const retainedCatalog = retainCodexDisplayCatalog
+    ? current.modelCatalog
+    : (incoming.modelCatalog ?? current.modelCatalog ?? null);
   const modelCatalog =
     retainedCatalog && launchUnproved
       ? { ...retainedCatalog, status: 'stale' as const }

--- a/src/main/services/team/contracts/TeamProvisioningApis.ts
+++ b/src/main/services/team/contracts/TeamProvisioningApis.ts
@@ -179,7 +179,7 @@ export interface TeamMemberLifecycleApi {
     options?: { reason?: TeamLiveRosterAttachReason }
   ): Promise<void>;
   detachLiveRosterMember(teamName: string, memberName: string): Promise<void>;
-  restartMember(teamName: string, memberName: string): Promise<void>;
+  restartMember(teamName: string, memberName: string, expectedSecondary?: boolean): Promise<void>;
   retryFailedOpenCodeSecondaryLanes(
     teamName: string
   ): Promise<RetryFailedOpenCodeSecondaryLanesResult>;

--- a/src/main/services/team/provisioning/OpenCodeAggregatePrimaryRestartPolicy.ts
+++ b/src/main/services/team/provisioning/OpenCodeAggregatePrimaryRestartPolicy.ts
@@ -87,11 +87,41 @@ export async function waitForAggregatePrimaryRestart(input: {
   return restart.runId;
 }
 
+export function assertSecondaryRetryOwned(
+  run:
+    | {
+        processKilled: boolean;
+        cancelRequested: boolean;
+        mixedSecondaryLanes: readonly { member: { name: string } }[];
+      }
+    | null
+    | undefined,
+  memberName: string
+): void {
+  const tracked =
+    run &&
+    !run.processKilled &&
+    !run.cancelRequested &&
+    run.mixedSecondaryLanes.some(
+      (lane) => lane.member.name.trim().toLowerCase() === memberName.trim().toLowerCase()
+    );
+  if (!tracked) {
+    throw new Error(
+      `Secondary lane for teammate "${memberName}" is no longer tracked; refusing aggregate primary restart`
+    );
+  }
+}
+
 export function resolveAggregatePrimaryRestartCandidate(input: {
   runtimeRun?: { runId: string; providerId: string };
   run: ProvisioningRun | null;
   memberName: string;
+  expectedSecondary?: boolean;
 }): { runId: string; run: ProvisioningRun | null } | null {
+  if (input.expectedSecondary) {
+    assertSecondaryRetryOwned(input.run, input.memberName);
+    return null;
+  }
   if (input.runtimeRun?.providerId !== 'opencode') return null;
   if (!input.run || input.run.processKilled || input.run.cancelRequested) {
     return { runId: input.runtimeRun.runId, run: null };

--- a/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
@@ -1,3 +1,4 @@
+import { assertSecondaryRetryOwned } from './OpenCodeAggregatePrimaryRestartPolicy';
 import {
   listTmuxPaneRuntimeInfoForCurrentPlatform,
   sendKeysToTmuxPaneForCurrentPlatform,
@@ -268,35 +269,27 @@ export class TeamProvisioningMemberLifecycleController {
     this.restartUseCases = useCases.restart ?? {};
     this.openCodeRetryUseCases = useCases.openCodeRetry ?? {};
   }
-
   private get runs(): TeamProvisioningMemberLifecycleHost['runs'] {
     return this.host.runs;
   }
-
   private get runtimeAdapterRunByTeam(): TeamProvisioningMemberLifecycleHost['runtimeAdapterRunByTeam'] {
     return this.host.runtimeAdapterRunByTeam;
   }
-
   private get failedOpenCodeSecondaryRetryInFlightByTeam(): TeamProvisioningMemberLifecycleHost['failedOpenCodeSecondaryRetryInFlightByTeam'] {
     return this.host.failedOpenCodeSecondaryRetryInFlightByTeam;
   }
-
   private get mcpConfigBuilder(): TeamProvisioningMemberLifecycleHost['mcpConfigBuilder'] {
     return this.host.mcpConfigBuilder;
   }
-
   private get membersMetaStore(): TeamProvisioningMemberLifecycleHost['membersMetaStore'] {
     return this.host.membersMetaStore;
   }
-
   private get teamMetaStore(): TeamProvisioningMemberLifecycleHost['teamMetaStore'] {
     return this.host.teamMetaStore;
   }
-
   private get launchStateStore(): TeamProvisioningMemberLifecycleHost['launchStateStore'] {
     return this.host.launchStateStore;
   }
-
   private getRunTrackedCwd(run: ProvisioningRun | null | undefined): string | null {
     return this.host.getRunTrackedCwd(run);
   }
@@ -1229,15 +1222,6 @@ export class TeamProvisioningMemberLifecycleController {
     return isMemberLifecycleOperationInProgressError(error);
   }
 
-  private async runMemberLifecycleOperation<T>(
-    teamName: string,
-    memberName: string,
-    kind: MemberLifecycleOperationKind,
-    operation: () => Promise<T>
-  ): Promise<T> {
-    return await this.runMemberLifecycleOperationInternal(teamName, memberName, kind, operation);
-  }
-
   async runMemberLifecycleOperationInternal<T>(
     teamName: string,
     memberName: string,
@@ -1358,7 +1342,7 @@ export class TeamProvisioningMemberLifecycleController {
     options?: { reason?: LiveRosterAttachReason }
   ): Promise<void> {
     const seam = this.actionUseCases.attachLiveRosterMember;
-    return this.runMemberLifecycleOperation(
+    return this.runMemberLifecycleOperationInternal(
       teamName,
       memberName,
       this.getLiveRosterAttachLifecycleKind(options?.reason),
@@ -1568,8 +1552,14 @@ export class TeamProvisioningMemberLifecycleController {
 
   async detachLiveRosterMember(teamName: string, memberName: string): Promise<void> {
     const seam = this.actionUseCases.detachLiveRosterMember;
-    return this.runMemberLifecycleOperation(teamName, memberName, 'primary_member_removed', () =>
-      seam ? seam(teamName, memberName) : this.detachLiveRosterMemberUnlocked(teamName, memberName)
+    return this.runMemberLifecycleOperationInternal(
+      teamName,
+      memberName,
+      'primary_member_removed',
+      () =>
+        seam
+          ? seam(teamName, memberName)
+          : this.detachLiveRosterMemberUnlocked(teamName, memberName)
     );
   }
 
@@ -1643,11 +1633,18 @@ export class TeamProvisioningMemberLifecycleController {
     }
   }
 
-  async restartMember(teamName: string, memberName: string): Promise<void> {
+  async restartMember(
+    teamName: string,
+    memberName: string,
+    expectedSecondary?: boolean
+  ): Promise<void> {
     const seam = this.actionUseCases.restartMember;
-    return this.runMemberLifecycleOperation(teamName, memberName, 'manual_restart', () =>
-      seam ? seam(teamName, memberName) : this.restartMemberUnlocked(teamName, memberName)
-    );
+    return this.runMemberLifecycleOperationInternal(teamName, memberName, 'manual_restart', () => {
+      if (expectedSecondary) {
+        assertSecondaryRetryOwned(this.runs.get(this.getAliveRunId(teamName) ?? ''), memberName);
+      }
+      return seam ? seam(teamName, memberName) : this.restartMemberUnlocked(teamName, memberName);
+    });
   }
 
   private async restartMemberUnlocked(teamName: string, memberName: string): Promise<void> {
@@ -2155,7 +2152,7 @@ export class TeamProvisioningMemberLifecycleController {
       }
 
       try {
-        await this.runMemberLifecycleOperation(
+        await this.runMemberLifecycleOperationInternal(
           teamName,
           candidate.memberName,
           'opencode_retry',
@@ -2293,7 +2290,7 @@ export class TeamProvisioningMemberLifecycleController {
 
   async skipMemberForLaunch(teamName: string, memberName: string): Promise<void> {
     const seam = this.actionUseCases.skipMemberForLaunch;
-    return this.runMemberLifecycleOperation(teamName, memberName, 'skip_for_launch', () =>
+    return this.runMemberLifecycleOperationInternal(teamName, memberName, 'skip_for_launch', () =>
       seam ? seam(teamName, memberName) : this.skipMemberForLaunchInternal(teamName, memberName)
     );
   }
@@ -2450,7 +2447,7 @@ export class TeamProvisioningMemberLifecycleController {
     memberName: string,
     options?: { reason?: 'member_added' | 'member_updated' | 'manual_restart' }
   ): Promise<void> {
-    return this.runMemberLifecycleOperation(
+    return this.runMemberLifecycleOperationInternal(
       teamName,
       memberName,
       this.getOpenCodeReattachLifecycleKind(options?.reason),
@@ -2629,8 +2626,11 @@ export class TeamProvisioningMemberLifecycleController {
   }
 
   async detachOpenCodeOwnedMemberLane(teamName: string, memberName: string): Promise<void> {
-    return this.runMemberLifecycleOperation(teamName, memberName, 'opencode_member_removed', () =>
-      this.detachOpenCodeOwnedMemberLaneUnlocked(teamName, memberName)
+    return this.runMemberLifecycleOperationInternal(
+      teamName,
+      memberName,
+      'opencode_member_removed',
+      () => this.detachOpenCodeOwnedMemberLaneUnlocked(teamName, memberName)
     );
   }
 

--- a/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
@@ -1,4 +1,3 @@
-import { assertSecondaryRetryOwned } from './OpenCodeAggregatePrimaryRestartPolicy';
 import {
   listTmuxPaneRuntimeInfoForCurrentPlatform,
   sendKeysToTmuxPaneForCurrentPlatform,
@@ -31,6 +30,7 @@ import { ClaudeBinaryResolver } from '../ClaudeBinaryResolver';
 import { getConfiguredCliFlavor } from '../cliFlavor';
 import { sanitizeProcessRuntimeEventFilePrefix } from '../ProcessBootstrapTransportEvidence';
 import { createPersistedLaunchSnapshot } from '../TeamLaunchStateEvaluator';
+import { assertSecondaryRetryOwned } from './OpenCodeAggregatePrimaryRestartPolicy';
 
 import {
   createAppendDirectProcessRuntimeEventUseCase,

--- a/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningMemberLifecycle.ts
@@ -30,8 +30,8 @@ import { ClaudeBinaryResolver } from '../ClaudeBinaryResolver';
 import { getConfiguredCliFlavor } from '../cliFlavor';
 import { sanitizeProcessRuntimeEventFilePrefix } from '../ProcessBootstrapTransportEvidence';
 import { createPersistedLaunchSnapshot } from '../TeamLaunchStateEvaluator';
-import { assertSecondaryRetryOwned } from './OpenCodeAggregatePrimaryRestartPolicy';
 
+import { assertSecondaryRetryOwned } from './OpenCodeAggregatePrimaryRestartPolicy';
 import {
   createAppendDirectProcessRuntimeEventUseCase,
   type DirectProcessRuntimeEventInput,

--- a/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryFacade.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningOpenCodeAggregatePrimaryFacade.ts
@@ -122,7 +122,6 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
     const pendingTeamOperation = this.teamOpLocks.get(teamName);
     return pendingTeamOperation ? pendingTeamOperation.then(operation) : operation();
   }
-
   protected async waitForMemberLifecycleOperations(teamName: string): Promise<void> {
     await waitForAggregateMemberLifecycleOperations({
       teamName,
@@ -130,7 +129,6 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
       failedLaneRetries: this.failedOpenCodeSecondaryRetryInFlightByTeam.entries(),
     });
   }
-
   protected collectFailedOpenCodeSecondaryRetryCandidates(
     run: MemberLifecycleProvisioningRun
   ): ReturnType<
@@ -140,7 +138,6 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
       run
     );
   }
-
   private beginOpenCodeAggregatePrimaryRestart(
     teamName: string,
     memberName: string,
@@ -154,17 +151,21 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
       memberLifecycleCompletions: this.memberLifecycleCompletionByKey,
     });
   }
-
   private isOpenCodeAggregatePrimaryRestartCandidate(
     teamName: string,
-    memberName: string
+    memberName: string,
+    expectedSecondary?: boolean
   ): { runId: string; run: ProvisioningRun | null } | null {
     const runtimeRun = this.runtimeAdapterRunByTeam.get(teamName);
     const aliveRunId = this.runTracking.getAliveRunId(teamName);
     const run = aliveRunId ? (this.runs.get(aliveRunId) ?? null) : null;
-    return resolveAggregatePrimaryRestartCandidate({ runtimeRun, run, memberName });
+    return resolveAggregatePrimaryRestartCandidate({
+      runtimeRun,
+      run,
+      memberName,
+      expectedSecondary,
+    });
   }
-
   /**
    * Delivery-time recovery for a lead whose lane never committed a session.
    * Serialized behind any in-flight team operation; every refusal gate lives in
@@ -595,7 +596,11 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
     );
   }
 
-  override async restartMember(teamName: string, memberName: string): Promise<void> {
+  override async restartMember(
+    teamName: string,
+    memberName: string,
+    expectedSecondary?: boolean
+  ): Promise<void> {
     return this.runAfterInFlightTeamOperation(teamName, async () => {
       const activeRestart = this.openCodeAggregatePrimaryRestartByTeam.get(
         teamName.trim().toLowerCase()
@@ -605,9 +610,17 @@ export abstract class TeamProvisioningOpenCodeAggregatePrimaryFacade extends Tea
           `OpenCode aggregate primary restart for teammate "${activeRestart.memberName}" is already in progress for team "${teamName}"`
         );
       }
-      const candidate = this.isOpenCodeAggregatePrimaryRestartCandidate(teamName, memberName);
+      const candidate = this.isOpenCodeAggregatePrimaryRestartCandidate(
+        teamName,
+        memberName,
+        expectedSecondary
+      );
       if (!candidate) {
-        return this.memberLifecycleController.restartMember(teamName, memberName);
+        return this.memberLifecycleController.restartMember(
+          teamName,
+          memberName,
+          expectedSecondary
+        );
       }
 
       const restart = this.beginOpenCodeAggregatePrimaryRestart(

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningMemberLifecycleStaleRun.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningMemberLifecycleStaleRun.test.ts
@@ -277,6 +277,41 @@ function createHost(
 }
 
 describe('TeamProvisioningMemberLifecycle stale run guards', () => {
+  it('rechecks secondary ownership after waiting for the member lifecycle lock', async () => {
+    const run = createRun({ name: 'Worker', role: 'Developer', providerId: 'opencode' });
+    let aliveRunId: string | null = run.runId;
+    let release!: () => void;
+    const lock = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const host = createHost(run, { getAliveRunId: () => aliveRunId });
+    run.mixedSecondaryLanes.push(
+      host.createMixedSecondaryLaneStateForMember(run, {
+        name: 'Worker',
+        role: 'Developer',
+        providerId: 'opencode',
+      })
+    );
+    const restart = vi.fn(async () => undefined);
+    const controller = new TeamProvisioningMemberLifecycleController(
+      host,
+      {
+        ...immediateOperationUseCases,
+        async runMemberLifecycleOperation(_teamName, _memberName, _kind, operation) {
+          await lock;
+          return operation();
+        },
+      },
+      { actions: { restartMember: restart } }
+    );
+    const pending = controller.restartMember('team-a', 'Worker', true);
+    aliveRunId = null;
+    release();
+    await expect(pending).rejects.toThrow('refusing aggregate primary restart');
+    expect(restart).not.toHaveBeenCalled();
+    expect(spawnCli).not.toHaveBeenCalled();
+  });
+
   it('does not spawn a primary-owned attach after the active run changes during config reads', async () => {
     const member: TeamCreateRequest['members'][number] = {
       name: 'Worker',

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregatePrimaryFacade.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningOpenCodeAggregatePrimaryFacade.test.ts
@@ -190,6 +190,28 @@ class TestOpenCodeAggregatePrimaryFacade extends TeamProvisioningOpenCodeAggrega
 }
 
 describe('TeamProvisioningOpenCodeAggregatePrimaryFacade', () => {
+  it('rejects stale secondary retry intent without stopping primary or healthy siblings', async () => {
+    const stop = vi.fn();
+    const facade = new TestOpenCodeAggregatePrimaryFacade();
+    facade.setRuntimeAdapterRegistry(
+      new TeamRuntimeAdapterRegistry([
+        { providerId: 'opencode', stop } as unknown as TeamLaunchRuntimeAdapter,
+      ])
+    );
+    const run = createRun();
+    facade.trackRun(run, {
+      runId: run.runId,
+      providerId: 'opencode',
+      cwd: '/safe-test-workspace/alpha',
+    });
+    await expect(facade.restartMember(run.teamName, 'Worker', true)).rejects.toThrow(
+      'refusing aggregate primary restart'
+    );
+    expect(stop).not.toHaveBeenCalled();
+    expect(facade.launchedMemberNames).toEqual([]);
+    expect(run.processKilled).toBe(false);
+  });
+
   it('keeps aggregate primary restart ownership visible to shutdown coordination', () => {
     const facade = new TestOpenCodeAggregatePrimaryFacade();
     facade.trackAggregatePrimaryRestartForShutdown('Restart-Team');

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1230,8 +1230,13 @@ const electronAPI: ElectronAPI = {
         teamName
       );
     },
-    restartMember: async (teamName: string, memberName: string) => {
-      return invokeIpcWithResult<void>(TEAM_RESTART_MEMBER, teamName, memberName);
+    restartMember: async (teamName: string, memberName: string, expectedSecondary?: boolean) => {
+      return invokeIpcWithResult<void>(
+        TEAM_RESTART_MEMBER,
+        teamName,
+        memberName,
+        ...(expectedSecondary === undefined ? [] : [expectedSecondary])
+      );
     },
     skipMemberForLaunch: async (teamName: string, memberName: string) => {
       return invokeIpcWithResult<void>(TEAM_SKIP_MEMBER_FOR_LAUNCH, teamName, memberName);

--- a/src/renderer/components/runtime/ProviderModelBadges.tsx
+++ b/src/renderer/components/runtime/ProviderModelBadges.tsx
@@ -211,7 +211,10 @@ export const ProviderModelBadges = ({
       getRuntimeAwareTeamModelBadgeLabel(providerId, model, providerStatus) ??
       formatModelBadgeLabel(providerId, model);
     const recentlyReleased =
-      (providerId === 'codex' && model === 'gpt-6-astra') || isRecentlyReleasedModel(catalogModel);
+      (providerId === 'codex' &&
+        model === 'gpt-6-astra' &&
+        !catalogModel?.metadata?.releaseDate?.trim()) ||
+      isRecentlyReleasedModel(catalogModel);
     const catalogModelIsFree = isCatalogModelFree(model, providerStatus);
     const hasFollowingModel = index < displayedModels.length - 1;
     const title = [

--- a/src/renderer/components/team/TeamDetailView.tsx
+++ b/src/renderer/components/team/TeamDetailView.tsx
@@ -2174,8 +2174,12 @@ export const TeamDetailView = memo(function TeamDetailView({
     openLaunchDialog(data?.isAlive && !isTeamProvisioning ? 'relaunch' : 'launch');
   }, [data?.isAlive, isTeamProvisioning, openLaunchDialog]);
   const handleRestartMember = useCallback(
-    async (memberName: string): Promise<void> => {
-      await restartMember(teamName, memberName);
+    async (memberName: string, expectedSecondary?: boolean): Promise<void> => {
+      await restartMember(
+        teamName,
+        memberName,
+        ...(expectedSecondary === undefined ? [] : [expectedSecondary])
+      );
     },
     [restartMember, teamName]
   );

--- a/src/renderer/components/team/members/MemberCard.tsx
+++ b/src/renderer/components/team/members/MemberCard.tsx
@@ -108,7 +108,7 @@ interface MemberCardProps {
   onSendMessage?: () => void;
   onAssignTask?: () => void;
   onEditMember?: () => void;
-  onRestartMember?: (memberName: string) => Promise<void> | void;
+  onRestartMember?: (memberName: string, expectedSecondary?: boolean) => Promise<void> | void;
   onSkipMemberForLaunch?: (memberName: string) => Promise<void> | void;
   onRestoreMember?: (memberName: string) => Promise<void> | void;
 }
@@ -959,12 +959,14 @@ export const MemberCard = memo(function MemberCard({
     : null;
   const hasLiveLaunchControls =
     isTeamAlive === true || isTeamProvisioning === true || isLaunchSettling === true;
+  const isOpenCodeSecondary =
+    member.providerId === 'opencode' && (runtimeEntry?.laneKind ?? member.laneKind) === 'secondary';
   const hasRestartMemberControl =
     !isRemoved &&
     !isLeadMember(member) &&
     Boolean(onRestartMember) &&
     hasLiveLaunchControls &&
-    runtimeEntry?.restartable !== false;
+    (runtimeEntry?.restartable !== false || (isFailedLaunch && isOpenCodeSecondary));
   const openCodeRelaunchActionable = isOpenCodeRelaunchActionable({
     member,
     spawnEntry,
@@ -1011,13 +1013,13 @@ export const MemberCard = memo(function MemberCard({
   const handleRestartMember = async (event: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
     event.preventDefault();
     event.stopPropagation();
-    if (!onRestartMember || retryingLaunch) {
-      return;
-    }
+    if (!onRestartMember || retryingLaunch) return;
     setRetryLaunchError(null);
     setRetryingLaunch(true);
     try {
-      await onRestartMember(member.name);
+      await (isOpenCodeSecondary
+        ? onRestartMember(member.name, true)
+        : onRestartMember(member.name));
     } catch (error) {
       setRetryLaunchError(error instanceof Error ? error.message : restartActionErrorFallback);
     } finally {

--- a/src/renderer/components/team/members/MemberList.tsx
+++ b/src/renderer/components/team/members/MemberList.tsx
@@ -64,7 +64,7 @@ interface MemberListProps {
   onAssignTask?: (member: ResolvedTeamMember) => void;
   onEditMember?: (member: ResolvedTeamMember) => void;
   onOpenTask?: (taskId: string) => void;
-  onRestartMember?: (memberName: string) => Promise<void> | void;
+  onRestartMember?: (memberName: string, expectedSecondary?: boolean) => Promise<void> | void;
   onSkipMemberForLaunch?: (memberName: string) => Promise<void> | void;
   onRestoreMember?: (memberName: string) => Promise<void> | void;
 }
@@ -681,7 +681,7 @@ interface MemberCardRowProps {
   onSendMessage?: (member: ResolvedTeamMember) => void;
   onAssignTask?: (member: ResolvedTeamMember) => void;
   onEditMember?: (member: ResolvedTeamMember) => void;
-  onRestartMember?: (memberName: string) => Promise<void> | void;
+  onRestartMember?: (memberName: string, expectedSecondary?: boolean) => Promise<void> | void;
   onSkipMemberForLaunch?: (memberName: string) => Promise<void> | void;
   onRestoreMember?: (memberName: string) => Promise<void> | void;
 }

--- a/src/renderer/store/slices/teamSlice.ts
+++ b/src/renderer/store/slices/teamSlice.ts
@@ -1626,7 +1626,7 @@ export interface TeamSlice {
     request: AddTaskCommentRequest
   ) => Promise<TaskComment>;
   addMember: (teamName: string, request: AddMemberRequest) => Promise<void>;
-  restartMember: (teamName: string, memberName: string) => Promise<void>;
+  restartMember: typeof api.teams.restartMember;
   skipMemberForLaunch: (teamName: string, memberName: string) => Promise<void>;
   removeMember: (teamName: string, memberName: string) => Promise<void>;
   restoreMember: (teamName: string, memberName: string) => Promise<void>;
@@ -4113,10 +4113,11 @@ export const createTeamSlice: StateCreator<AppState, [], [], TeamSlice> = (set, 
     await unwrapIpc('team:addMember', () => api.teams.addMember(teamName, request));
     await get().refreshTeamData(teamName);
   },
-
-  restartMember: async (teamName: string, memberName: string) => {
+  restartMember: async (teamName, memberName, expectedSecondary) => {
     try {
-      await unwrapIpc('team:restartMember', () => api.teams.restartMember(teamName, memberName));
+      await unwrapIpc('team:restartMember', () =>
+        api.teams.restartMember(teamName, memberName, expectedSecondary)
+      );
     } finally {
       await Promise.allSettled([
         get().refreshTeamMessagesHead(teamName),

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -580,7 +580,11 @@ export interface TeamsAPI extends TeamMemberSettingsApi {
   retryFailedOpenCodeSecondaryLanes: (
     teamName: string
   ) => Promise<RetryFailedOpenCodeSecondaryLanesResult>;
-  restartMember: (teamName: string, memberName: string) => Promise<void>;
+  restartMember: (
+    teamName: string,
+    memberName: string,
+    expectedSecondary?: boolean
+  ) => Promise<void>;
   skipMemberForLaunch: (teamName: string, memberName: string) => Promise<void>;
   softDeleteTask: (teamName: string, taskId: string) => Promise<void>;
   restoreTask: (teamName: string, taskId: string) => Promise<void>;

--- a/test/main/ipc/teams.test.ts
+++ b/test/main/ipc/teams.test.ts
@@ -6347,6 +6347,16 @@ describe('ipc teams handlers', () => {
       vi.mocked(console.error).mockClear();
     });
 
+    it('validates and forwards isolated secondary restart intent', async () => {
+      const handler = handlers.get(TEAM_RESTART_MEMBER)!;
+      const invalid = await handler({} as never, 'my-team', 'alice', 'true');
+      expect(invalid).toEqual({ success: false, error: 'Invalid expectedSecondary' });
+      expect(teamHandlerMocks.restartMember).not.toHaveBeenCalled();
+      const result = await handler({} as never, 'my-team', 'alice', true);
+      expect(result).toEqual({ success: true, data: undefined });
+      expect(teamHandlerMocks.restartMember).toHaveBeenCalledWith('my-team', 'alice', true);
+    });
+
     it('blocks live replaceMembers when a member migrates from primary runtime ownership to OpenCode', async () => {
       const handler = handlers.get(TEAM_REPLACE_MEMBERS)!;
       service.getTeamData.mockResolvedValueOnce({

--- a/test/main/services/runtime/providerStatusCheckContract.test.ts
+++ b/test/main/services/runtime/providerStatusCheckContract.test.ts
@@ -520,3 +520,61 @@ describe('provider status check contract', () => {
     ).toBe(true);
   });
 });
+
+describe('Codex transient catalog display consistency', () => {
+  function codexStatus(modelId: string, source: 'app-server' | 'static-fallback') {
+    const seed = providerStatus();
+    return providerStatus({
+      providerId: 'codex',
+      models: [modelId],
+      modelCatalog: {
+        ...seed.modelCatalog!,
+        providerId: 'codex',
+        source,
+        defaultModelId: modelId,
+        defaultLaunchModel: modelId,
+        models: [{ ...seed.modelCatalog!.models[0], id: modelId, launchModel: modelId, source }],
+      },
+    });
+  }
+
+  it('retains Astra consistently in card and picker after a timeout without granting launch', () => {
+    const current = codexStatus('gpt-6-astra', 'app-server');
+    const incoming = {
+      ...codexStatus('gpt-5.5', 'static-fallback'),
+      statusCheckOutcome: 'transient_error' as const,
+      statusCheckErrorCode: 'timeout' as const,
+    };
+    const merged = mergeProviderStatusDisplayEvidence(incoming, current);
+    expect(merged.models).toEqual(['gpt-6-astra']);
+    expect(merged.modelCatalog?.models.map((model) => model.id)).toEqual(merged.models);
+    expect(merged.modelCatalog?.source).toBe('app-server');
+    expect(merged.modelCatalog?.status).toBe('stale');
+    expect(merged.modelCatalogRefreshState).toBe('error');
+    expect(merged.authenticated).toBe(false);
+    expect(merged.capabilities.teamLaunch).toBe(false);
+    expect(isProviderModelCatalogExactReady(merged)).toBe(false);
+  });
+
+  it('accepts a fresh authoritative catalog that no longer lists Astra', () => {
+    const merged = mergeProviderStatusDisplayEvidence(
+      codexStatus('gpt-5.5', 'app-server'),
+      codexStatus('gpt-6-astra', 'app-server')
+    );
+    expect(merged.models).toEqual(['gpt-5.5']);
+    expect(merged.modelCatalog?.models.map((model) => model.id)).toEqual(merged.models);
+    expect(merged.modelCatalog?.status).toBe('ready');
+    expect(merged.capabilities.teamLaunch).toBe(true);
+  });
+
+  it('does not invent live models when only a static fallback was previously known', () => {
+    const current = codexStatus('gpt-5.5', 'static-fallback');
+    const merged = mergeProviderStatusDisplayEvidence(
+      { ...current, statusCheckOutcome: 'transient_error', statusCheckErrorCode: 'timeout' },
+      current
+    );
+    expect(merged.models).toEqual(['gpt-5.5']);
+    expect(merged.modelCatalog?.source).toBe('static-fallback');
+    expect(merged.capabilities.teamLaunch).toBe(false);
+  });
+});

--- a/test/main/services/team/OpenCodeAggregatePrimaryRestartPolicy.test.ts
+++ b/test/main/services/team/OpenCodeAggregatePrimaryRestartPolicy.test.ts
@@ -1,4 +1,8 @@
-import { clearCancelledAggregateRestartState } from '@main/services/team/provisioning/OpenCodeAggregatePrimaryRestartPolicy';
+import type { ProvisioningRun } from '@main/services/team/provisioning/TeamProvisioningRunModel';
+import {
+  clearCancelledAggregateRestartState,
+  resolveAggregatePrimaryRestartCandidate,
+} from '@main/services/team/provisioning/OpenCodeAggregatePrimaryRestartPolicy';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('OpenCodeAggregatePrimaryRestartPolicy', () => {
@@ -42,5 +46,48 @@ describe('OpenCodeAggregatePrimaryRestartPolicy', () => {
       ['run-current', launchError],
       ['run-current', primaryError],
     ]);
+  });
+});
+
+describe('secondary retry isolation', () => {
+  const run = {
+    runId: 'run-current',
+    processKilled: false,
+    cancelRequested: false,
+    mixedSecondaryLanes: [{ member: { name: 'alice' } }, { member: { name: 'bob' } }],
+  } as ProvisioningRun;
+  it('routes a tracked failed secondary to member-only recovery without modifying siblings', () => {
+    const before = structuredClone(run);
+    expect(
+      resolveAggregatePrimaryRestartCandidate({
+        runtimeRun: { runId: run.runId, providerId: 'opencode' },
+        run,
+        memberName: 'alice',
+        expectedSecondary: true,
+      })
+    ).toBeNull();
+    expect(run).toEqual(before);
+  });
+  it.each([null, { ...run, mixedSecondaryLanes: [] }, { ...run, processKilled: true }])(
+    'rejects stale secondary ownership before aggregate routing (%j)',
+    (candidate) => {
+      expect(() =>
+        resolveAggregatePrimaryRestartCandidate({
+          runtimeRun: { runId: run.runId, providerId: 'opencode' },
+          run: candidate,
+          memberName: 'alice',
+          expectedSecondary: true,
+        })
+      ).toThrow('refusing aggregate primary restart');
+    }
+  );
+  it('preserves primary member routing', () => {
+    expect(
+      resolveAggregatePrimaryRestartCandidate({
+        runtimeRun: { runId: run.runId, providerId: 'opencode' },
+        run,
+        memberName: 'primary-member',
+      })
+    ).toEqual({ runId: run.runId, run });
   });
 });

--- a/test/renderer/components/team/members/MemberCard.test.ts
+++ b/test/renderer/components/team/members/MemberCard.test.ts
@@ -1884,3 +1884,59 @@ describe('MemberCard starting-state visuals', () => {
     });
   });
 });
+
+describe('MemberCard failed secondary retry', () => {
+  it.each([
+    { laneKind: 'secondary', persisted: false, lead: false, alive: true, visible: true },
+    { laneKind: 'secondary', persisted: true, lead: false, alive: true, visible: true },
+    { laneKind: 'primary', persisted: false, lead: false, alive: true, visible: false },
+    { laneKind: undefined, persisted: false, lead: false, alive: true, visible: false },
+    { laneKind: 'secondary', persisted: false, lead: true, alive: true, visible: false },
+    { laneKind: 'secondary', persisted: false, lead: false, alive: false, visible: false },
+  ] as const)('preserves scope and retry eligibility: %j', async (scenario) => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const onRestartMember = vi.fn(async () => undefined);
+    await act(async () => {
+      root.render(
+        React.createElement(MemberCard, {
+          member: {
+            ...member,
+            providerId: 'opencode',
+            agentType: scenario.lead ? 'team-lead' : 'reviewer',
+            laneKind: scenario.persisted ? scenario.laneKind : undefined,
+          },
+          memberColor: 'blue',
+          isTeamAlive: scenario.alive,
+          spawnStatus: 'error',
+          spawnLaunchState: 'failed_to_start',
+          spawnRuntimeAlive: false,
+          spawnEntry: failedSpawnEntry,
+          runtimeEntry: {
+            memberName: 'alice',
+            providerId: 'opencode',
+            alive: false,
+            restartable: false,
+            laneKind: scenario.persisted ? undefined : scenario.laneKind,
+            updatedAt: '2026-04-24T12:00:00.000Z',
+          },
+          onRestartMember,
+        })
+      );
+    });
+    const button = host.querySelector<HTMLButtonElement>('[aria-label="Relaunch OpenCode"]');
+    expect(Boolean(button)).toBe(scenario.visible);
+    if (button) {
+      await act(async () => {
+        button.click();
+      });
+      expect(onRestartMember).toHaveBeenCalledExactlyOnceWith('alice', true);
+    }
+    await act(async () => {
+      root.unmount();
+    });
+    host.remove();
+  });
+});

--- a/test/renderer/store/teamSlice.test.ts
+++ b/test/renderer/store/teamSlice.test.ts
@@ -5319,7 +5319,7 @@ describe('teamSlice actions', () => {
 
     await store.getState().restartMember('my-team', 'alice');
 
-    expect(hoisted.restartMember).toHaveBeenCalledWith('my-team', 'alice');
+    expect(hoisted.restartMember).toHaveBeenCalledWith('my-team', 'alice', undefined);
     expect(store.getState().memberSpawnStatusesByTeam['my-team']).toEqual({
       alice: expect.objectContaining({ status: 'spawning', launchState: 'starting' }),
     });


### PR DESCRIPTION
Prepares v2.14.1 with Cursor integration, current runtime 0.0.87, and the latest frontend fixes. Codex now retains a consistent model catalog after transient refresh failures, and failed OpenCode secondary teammates can be retried individually with protection against group restart during Stop.

Validation: mixed Astra/SuperGrok/Z AI/Cursor sandbox completed all tasks and final ACK; Anthropic skipped with owner approval due quota. Focused catalog, UI, IPC, lifecycle and race tests passed, along with typecheck, source-size and independent technical review. Draft packaging runs against the immutable v2.14.1 tag; owner authorized publication after qualification. Supersedes PR #613.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Relaunch OpenCode” option for failed secondary team members, even when the overall runtime cannot be restarted.
  - Updated the runtime to version 0.0.87.

- **Bug Fixes**
  - Prevented stale secondary retry requests from restarting the wrong runtime or affecting active team members.
  - Improved Codex model display consistency during temporary catalog fallback conditions.
  - Corrected detection of recently released GPT-6 Astra models.

- **Documentation**
  - Updated release notes with Cursor support and improvements to stopping, recovery, retries, and model catalog handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->