### PR TITLE
test(teams): account for optional secondary retry intent

### DIFF
--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningRosterMutationLock.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningRosterMutationLock.test.ts
@@ -200,6 +200,6 @@ describe('team provisioning roster mutation lock', () => {
     await expect(service.restartMember('lock-team', 'worker')).resolves.toBeUndefined();
 
     expect(stopFlow).toHaveBeenCalledOnce();
-    expect(restart).toHaveBeenCalledWith('lock-team', 'worker');
+    expect(restart).toHaveBeenCalledWith('lock-team', 'worker', undefined);
   });
 });


### PR DESCRIPTION
Updates the roster recovery assertion for the optional secondary retry argument. Production code is unchanged. All six roster mutation lock tests pass; the preceding full run passed all other test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated rollback recovery test expectations to reflect the current member restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->