### PR TITLE
docs(release): clarify 2.14.1 notes

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -48,13 +48,13 @@ Build teams with Cursor alongside your other AI providers, with clearer launch f
 ### What's New
 
 - Add Cursor agents to teams and let them exchange messages and complete assigned tasks.
-- Keep Cursor connections separate between profiles, so different accounts do not share the wrong endpoint.
+- Keep Cursor connections separate for each profile so requests reach the correct account.
 - Retry a failed OpenCode teammate individually without restarting the whole team.
 
 ### Fixes
 
 - Stop active Cursor shell commands when stopping their team.
-- Prevent accepted messages from replaying after a team stops.
+- Prevent already accepted messages from being sent again after stopping a team.
 - Keep stopping one team from interrupting other teams sharing an OpenCode server.
 - Recover failed team launches without reusing a stopped server or an outdated session.
 - Keep GPT-6 Astra visible in model selection after a temporary Codex catalog refresh failure.


### PR DESCRIPTION
Makes two release bullets clearer for users and keeps RELEASE.md identical to the GitHub release notes. Documentation only; the qualified application code and release tag remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified release notes for Cursor profile isolation.
  - Clarified Stop behavior.
  - Documented prevention of duplicate message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->