### PR TITLE
fix(settings): keep Claude auth modes available

### DIFF
--- a/src/renderer/components/runtime/ProviderRuntimeSettingsDialog.tsx
+++ b/src/renderer/components/runtime/ProviderRuntimeSettingsDialog.tsx
@@ -53,6 +53,7 @@ import {
   isCodexProviderRuntimeMissing,
   shouldOfferCodexRuntimeInstall,
 } from './codexRuntimeInstallAction';
+import { resolveProviderAuthModeUiState } from './providerAuthModeUiState';
 import {
   formatProviderAuthMethodLabelForProvider,
   formatProviderAuthModeLabelForProvider,
@@ -967,7 +968,6 @@ export const ProviderRuntimeSettingsDialog = ({
     void fetchApiKeys();
     void fetchApiKeyStorageStatus();
   }, [fetchApiKeyStorageStatus, fetchApiKeys, initialProviderId, open]);
-
   useEffect(() => {
     if (open) {
       return;
@@ -993,7 +993,6 @@ export const ProviderRuntimeSettingsDialog = ({
     setCodexCustomProviderError(null);
     setCodexCustomProviderStatus(null);
   }, [open]);
-
   useEffect(() => {
     setConnectionError(null);
     setRuntimeError(null);
@@ -1002,7 +1001,6 @@ export const ProviderRuntimeSettingsDialog = ({
     setCodexCustomProviderError(null);
     setCodexCustomProviderStatus(null);
   }, [selectedProviderId]);
-
   useEffect(() => {
     if (selectedProviderId === 'codex' && codexAccount.error) {
       setConnectionError(codexAccount.error);
@@ -1199,9 +1197,12 @@ export const ProviderRuntimeSettingsDialog = ({
     codexConnection?.login.status === 'starting' || codexConnection?.login.status === 'pending';
   const codexLoginAuthUrl = codexConnection?.login.authUrl ?? null;
   const codexLoginUserCode = codexConnection?.login.userCode ?? null;
-  const configurableAuthModes = selectedProvider?.connection?.configurableAuthModes ?? [];
-  const configuredAuthMode: CliProviderAuthMode | undefined =
-    selectedProvider?.connection?.configuredAuthMode ?? configurableAuthModes[0] ?? undefined;
+  const { configurableAuthModes, configuredAuthMode, anthropicCompatibleEndpointEnabled } =
+    resolveProviderAuthModeUiState(
+      selectedProvider,
+      appConfig?.providerConnections?.anthropic.authMode,
+      anthropicCompatibleConfig.enabled
+    );
   const connectionMethodCardOptions = selectedProvider
     ? getConnectionMethodCardOptions(selectedProvider, t, runtimeBackendSummaryText)
     : null;
@@ -1320,8 +1321,8 @@ export const ProviderRuntimeSettingsDialog = ({
       : false;
   const canRequestSubscriptionLogin =
     selectedProvider?.providerId === 'anthropic' &&
-    Boolean(selectedProvider.connection?.supportsOAuth && onRequestLogin) &&
-    selectedProvider.connection?.compatibleEndpoint?.enabled !== true &&
+    Boolean((selectedProvider.connection?.supportsOAuth ?? true) && onRequestLogin) &&
+    !anthropicCompatibleEndpointEnabled &&
     configuredAuthMode !== 'api_key' &&
     selectedProvider.statusMessage !== 'Checking...' &&
     (!selectedProvider?.authenticated || hasSubscriptionSession || configuredAuthMode === 'oauth');
@@ -1329,7 +1330,6 @@ export const ProviderRuntimeSettingsDialog = ({
     selectedProvider?.providerId === 'anthropic'
       ? (selectedProvider.connection?.compatibleEndpoint ?? null)
       : null;
-  const anthropicCompatibleEndpointEnabled = anthropicCompatibleEndpoint?.enabled === true;
   const anthropicCompatibleTokenConfigured = Boolean(
     selectedCompatibleToken || anthropicCompatibleEndpoint?.tokenConfigured
   );

--- a/src/renderer/components/runtime/providerAuthModeUiState.ts
+++ b/src/renderer/components/runtime/providerAuthModeUiState.ts
@@ -1,0 +1,28 @@
+import type { CliProviderAuthMode, CliProviderStatus } from '@shared/types';
+
+const ANTHROPIC_AUTH_MODES: CliProviderAuthMode[] = ['auto', 'oauth', 'api_key'];
+
+export function resolveProviderAuthModeUiState(
+  provider: CliProviderStatus | null,
+  configuredAnthropicAuthMode?: CliProviderAuthMode,
+  configuredCompatibleEndpointEnabled = false
+): {
+  configurableAuthModes: CliProviderAuthMode[];
+  configuredAuthMode: CliProviderAuthMode | undefined;
+  anthropicCompatibleEndpointEnabled: boolean;
+} {
+  const configurableAuthModes =
+    provider?.connection?.configurableAuthModes ??
+    (provider?.providerId === 'anthropic' ? ANTHROPIC_AUTH_MODES : []);
+  const configuredAuthMode =
+    provider?.connection?.configuredAuthMode ??
+    (provider?.providerId === 'anthropic'
+      ? configuredAnthropicAuthMode
+      : configurableAuthModes[0]) ??
+    configurableAuthModes[0];
+  const anthropicCompatibleEndpointEnabled =
+    provider?.providerId === 'anthropic' &&
+    (provider.connection?.compatibleEndpoint?.enabled ?? configuredCompatibleEndpointEnabled);
+
+  return { configurableAuthModes, configuredAuthMode, anthropicCompatibleEndpointEnabled };
+}

--- a/test/renderer/components/runtime/ProviderRuntimeSettingsDialog.test.ts
+++ b/test/renderer/components/runtime/ProviderRuntimeSettingsDialog.test.ts
@@ -691,6 +691,80 @@ describe('ProviderRuntimeSettingsDialog', () => {
     expect(onRefreshProvider).toHaveBeenCalledWith('anthropic', 'provider_change');
   });
 
+  it('keeps anthropic connection cards available when authoritative status omits connection metadata', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const onRefreshProvider = vi.fn(() => Promise.resolve(undefined));
+    storeState.appConfig.providerConnections.anthropic.authMode = 'oauth';
+
+    await act(async () => {
+      root.render(
+        React.createElement(ProviderRuntimeSettingsDialog, {
+          open: true,
+          onOpenChange: vi.fn(),
+          providers: [{ ...createAnthropicProvider(), connection: null }],
+          initialProviderId: 'anthropic',
+          onSelectBackend: vi.fn(),
+          onRefreshProvider,
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(host.textContent).toContain('Connection method');
+    expect(host.textContent).toContain('Auto');
+    expect(host.textContent).toContain('Anthropic subscription');
+    expect(host.textContent).toContain('API key');
+    expect(findButtonByText(host, 'Anthropic subscription').textContent).toContain('Selected');
+
+    await act(async () => {
+      findButtonByText(host, 'API key').click();
+      await Promise.resolve();
+    });
+
+    expect(storeState.updateConfig).toHaveBeenCalledWith('providerConnections', {
+      anthropic: { authMode: 'api_key' },
+    });
+    expect(onRefreshProvider).toHaveBeenCalledWith('anthropic', 'provider_change');
+  });
+
+  it('disables a persisted compatible endpoint when selecting an auth card without connection metadata', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    storeState.appConfig.providerConnections.anthropic.authMode = 'oauth';
+    storeState.appConfig.providerConnections.anthropic.compatibleEndpoint.enabled = true;
+
+    await act(async () => {
+      root.render(
+        React.createElement(ProviderRuntimeSettingsDialog, {
+          open: true,
+          onOpenChange: vi.fn(),
+          providers: [{ ...createAnthropicProvider(), connection: null }],
+          initialProviderId: 'anthropic',
+          onSelectBackend: vi.fn(),
+          onRefreshProvider: vi.fn(() => Promise.resolve(undefined)),
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(findButtonByText(host, 'Anthropic subscription').textContent).not.toContain('Selected');
+
+    await act(async () => {
+      findButtonByText(host, 'Anthropic subscription').click();
+      await Promise.resolve();
+    });
+
+    expect(storeState.updateConfig).toHaveBeenCalledWith('providerConnections', {
+      anthropic: {
+        authMode: 'oauth',
+        compatibleEndpoint: { enabled: false, baseUrl: '' },
+      },
+    });
+  });
+
   it('keeps a previously detected Bedrock route visible while switching back to Auto', async () => {
     const host = document.createElement('div');
     document.body.appendChild(host);


### PR DESCRIPTION
## Summary
- keep Claude connection mode cards visible when runtime status omits connection metadata
- derive the selected mode from persisted provider settings
- safely disable a persisted compatible endpoint when switching back to subscription or API auth

## Verification
- 37 focused ProviderRuntimeSettingsDialog tests
- pnpm typecheck
- focused fast lint
- source file size guard
- independent subagent review: no remaining P1/P2 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication settings for Anthropic providers when connection details are unavailable.
  - Authentication options remain visible and selectable, including Auto, subscription, and API key modes.
  - Selecting API key mode now correctly saves the choice and refreshes provider information.
  - Persisted compatible endpoint settings are now reflected correctly, including disabling the endpoint when switching to subscription authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->