### PR TITLE
refactor(landing): extract download architecture toggle

### DIFF
--- a/landing/components/download/DownloadArchitectureToggle.vue
+++ b/landing/components/download/DownloadArchitectureToggle.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+defineProps<{
+  os: 'macos' | 'windows';
+}>();
+
+const downloadStore = useDownloadStore();
+</script>
+
+<template>
+  <div class="download-architecture-toggle" :aria-label="`${os} architecture`">
+    <template v-if="os === 'macos'">
+      <button
+        type="button"
+        class="download-architecture-toggle__option"
+        :class="{ 'download-architecture-toggle__option--active': downloadStore.macArch === 'arm64' }"
+        :aria-pressed="downloadStore.macArch === 'arm64'"
+        @click.stop="downloadStore.setMacArch('arm64')"
+      >
+        Apple Silicon
+      </button>
+      <button
+        type="button"
+        class="download-architecture-toggle__option"
+        :class="{ 'download-architecture-toggle__option--active': downloadStore.macArch === 'x64' }"
+        :aria-pressed="downloadStore.macArch === 'x64'"
+        @click.stop="downloadStore.setMacArch('x64')"
+      >
+        Intel
+      </button>
+    </template>
+    <template v-else>
+      <button
+        type="button"
+        class="download-architecture-toggle__option"
+        :class="{ 'download-architecture-toggle__option--active': downloadStore.windowsArch === 'x64' }"
+        :aria-pressed="downloadStore.windowsArch === 'x64'"
+        @click.stop="downloadStore.setWindowsArch('x64')"
+      >
+        64-bit
+      </button>
+      <button
+        type="button"
+        class="download-architecture-toggle__option"
+        :class="{ 'download-architecture-toggle__option--active': downloadStore.windowsArch === 'arm64' }"
+        :aria-pressed="downloadStore.windowsArch === 'arm64'"
+        @click.stop="downloadStore.setWindowsArch('arm64')"
+      >
+        ARM64
+      </button>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.download-architecture-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  margin-top: 10px;
+  padding: 3px;
+  max-width: 100%;
+  border: 1px solid rgba(0, 240, 255, 0.14);
+  border-radius: 10px;
+  background: rgba(0, 240, 255, 0.05);
+}
+
+.download-architecture-toggle__option {
+  min-width: 0;
+  padding: 5px 8px;
+  border: 0;
+  border-radius: 7px;
+  color: #8892b0;
+  background: transparent;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1.15;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.download-architecture-toggle__option:hover,
+.download-architecture-toggle__option--active {
+  color: #0a0a0f;
+  background: linear-gradient(135deg, #00f0ff, #39ff14);
+  box-shadow: 0 4px 14px rgba(0, 240, 255, 0.22);
+}
+
+:global(.v-theme--light) .download-architecture-toggle {
+  border-color: rgba(8, 145, 178, 0.16);
+  background: rgba(8, 145, 178, 0.06);
+}
+
+:global(.v-theme--light) .download-architecture-toggle__option {
+  color: #64748b;
+}
+
+:global(.v-theme--light) .download-architecture-toggle__option:hover,
+:global(.v-theme--light) .download-architecture-toggle__option--active {
+  color: #f8fbff;
+  text-shadow: 0 1px 8px rgba(15, 23, 42, 0.22);
+}
+
+@media (max-width: 960px) {
+  .download-architecture-toggle {
+    width: fit-content;
+  }
+}
+
+@media (max-width: 600px) {
+  .download-architecture-toggle {
+    width: 100%;
+  }
+
+  .download-architecture-toggle__option {
+    flex: 1;
+    padding-inline: 6px;
+  }
+}
+</style>

--- a/landing/components/sections/DownloadSection.vue
+++ b/landing/components/sections/DownloadSection.vue
@@ -323,28 +323,50 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
             <h3 class="download-section__card-label">{{ asset.label }}</h3>
             <span class="download-section__card-arch">{{ asset.archLabel }}</span>
             <div
-              v-if="asset.os === 'macos' && downloadStore.selectedId === asset.id"
-              class="download-section__mac-arch-toggle"
-              aria-label="macOS chip"
+              v-if="(asset.os === 'macos' || asset.os === 'windows') && downloadStore.selectedId === asset.id"
+              class="download-section__arch-toggle"
+              :aria-label="`${asset.label} architecture`"
             >
-              <button
-                type="button"
-                class="download-section__mac-arch-option"
-                :class="{ 'download-section__mac-arch-option--active': downloadStore.macArch === 'arm64' }"
-                :aria-pressed="downloadStore.macArch === 'arm64'"
-                @click.stop="downloadStore.setMacArch('arm64')"
-              >
-                Apple Silicon
-              </button>
-              <button
-                type="button"
-                class="download-section__mac-arch-option"
-                :class="{ 'download-section__mac-arch-option--active': downloadStore.macArch === 'x64' }"
-                :aria-pressed="downloadStore.macArch === 'x64'"
-                @click.stop="downloadStore.setMacArch('x64')"
-              >
-                Intel
-              </button>
+              <template v-if="asset.os === 'macos'">
+                <button
+                  type="button"
+                  class="download-section__arch-option"
+                  :class="{ 'download-section__arch-option--active': downloadStore.macArch === 'arm64' }"
+                  :aria-pressed="downloadStore.macArch === 'arm64'"
+                  @click.stop="downloadStore.setMacArch('arm64')"
+                >
+                  Apple Silicon
+                </button>
+                <button
+                  type="button"
+                  class="download-section__arch-option"
+                  :class="{ 'download-section__arch-option--active': downloadStore.macArch === 'x64' }"
+                  :aria-pressed="downloadStore.macArch === 'x64'"
+                  @click.stop="downloadStore.setMacArch('x64')"
+                >
+                  Intel
+                </button>
+              </template>
+              <template v-else>
+                <button
+                  type="button"
+                  class="download-section__arch-option"
+                  :class="{ 'download-section__arch-option--active': downloadStore.windowsArch === 'x64' }"
+                  :aria-pressed="downloadStore.windowsArch === 'x64'"
+                  @click.stop="downloadStore.setWindowsArch('x64')"
+                >
+                  64-bit
+                </button>
+                <button
+                  type="button"
+                  class="download-section__arch-option"
+                  :class="{ 'download-section__arch-option--active': downloadStore.windowsArch === 'arm64' }"
+                  :aria-pressed="downloadStore.windowsArch === 'arm64'"
+                  @click.stop="downloadStore.setWindowsArch('arm64')"
+                >
+                  ARM64
+                </button>
+              </template>
             </div>
           </div>
 
@@ -787,7 +809,7 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
   opacity: 0.7;
 }
 
-.download-section__mac-arch-toggle {
+.download-section__arch-toggle {
   display: inline-flex;
   align-items: center;
   gap: 3px;
@@ -799,7 +821,7 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
   background: rgba(0, 240, 255, 0.05);
 }
 
-.download-section__mac-arch-option {
+.download-section__arch-option {
   min-width: 0;
   padding: 5px 8px;
   border: 0;
@@ -817,8 +839,8 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
     box-shadow 0.2s ease;
 }
 
-.download-section__mac-arch-option:hover,
-.download-section__mac-arch-option--active {
+.download-section__arch-option:hover,
+.download-section__arch-option--active {
   color: #0a0a0f;
   background: linear-gradient(135deg, #00f0ff, #39ff14);
   box-shadow: 0 4px 14px rgba(0, 240, 255, 0.22);
@@ -930,17 +952,17 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
   color: #64748b;
 }
 
-.v-theme--light .download-section__mac-arch-toggle {
+.v-theme--light .download-section__arch-toggle {
   border-color: rgba(8, 145, 178, 0.16);
   background: rgba(8, 145, 178, 0.06);
 }
 
-.v-theme--light .download-section__mac-arch-option {
+.v-theme--light .download-section__arch-option {
   color: #64748b;
 }
 
-.v-theme--light .download-section__mac-arch-option:hover,
-.v-theme--light .download-section__mac-arch-option--active {
+.v-theme--light .download-section__arch-option:hover,
+.v-theme--light .download-section__arch-option--active {
   color: #f8fbff;
   text-shadow: 0 1px 8px rgba(15, 23, 42, 0.22);
 }
@@ -1021,7 +1043,7 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
     min-width: 0;
   }
 
-  .download-section__mac-arch-toggle {
+  .download-section__arch-toggle {
     width: fit-content;
   }
 
@@ -1077,12 +1099,12 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
     min-width: 0;
   }
 
-  .download-section__mac-arch-toggle {
+  .download-section__arch-toggle {
     grid-column: 1 / -1;
     width: 100%;
   }
 
-  .download-section__mac-arch-option {
+  .download-section__arch-option {
     flex: 1;
     padding-inline: 6px;
   }

--- a/landing/components/sections/DownloadSection.vue
+++ b/landing/components/sections/DownloadSection.vue
@@ -322,52 +322,10 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
           <div class="download-section__card-info">
             <h3 class="download-section__card-label">{{ asset.label }}</h3>
             <span class="download-section__card-arch">{{ asset.archLabel }}</span>
-            <div
+            <DownloadArchitectureToggle
               v-if="(asset.os === 'macos' || asset.os === 'windows') && downloadStore.selectedId === asset.id"
-              class="download-section__arch-toggle"
-              :aria-label="`${asset.label} architecture`"
-            >
-              <template v-if="asset.os === 'macos'">
-                <button
-                  type="button"
-                  class="download-section__arch-option"
-                  :class="{ 'download-section__arch-option--active': downloadStore.macArch === 'arm64' }"
-                  :aria-pressed="downloadStore.macArch === 'arm64'"
-                  @click.stop="downloadStore.setMacArch('arm64')"
-                >
-                  Apple Silicon
-                </button>
-                <button
-                  type="button"
-                  class="download-section__arch-option"
-                  :class="{ 'download-section__arch-option--active': downloadStore.macArch === 'x64' }"
-                  :aria-pressed="downloadStore.macArch === 'x64'"
-                  @click.stop="downloadStore.setMacArch('x64')"
-                >
-                  Intel
-                </button>
-              </template>
-              <template v-else>
-                <button
-                  type="button"
-                  class="download-section__arch-option"
-                  :class="{ 'download-section__arch-option--active': downloadStore.windowsArch === 'x64' }"
-                  :aria-pressed="downloadStore.windowsArch === 'x64'"
-                  @click.stop="downloadStore.setWindowsArch('x64')"
-                >
-                  64-bit
-                </button>
-                <button
-                  type="button"
-                  class="download-section__arch-option"
-                  :class="{ 'download-section__arch-option--active': downloadStore.windowsArch === 'arm64' }"
-                  :aria-pressed="downloadStore.windowsArch === 'arm64'"
-                  @click.stop="downloadStore.setWindowsArch('arm64')"
-                >
-                  ARM64
-                </button>
-              </template>
-            </div>
+              :os="asset.os"
+            />
           </div>
 
           <!-- Download button -->
@@ -809,43 +767,6 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
   opacity: 0.7;
 }
 
-.download-section__arch-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  margin-top: 10px;
-  padding: 3px;
-  max-width: 100%;
-  border: 1px solid rgba(0, 240, 255, 0.14);
-  border-radius: 10px;
-  background: rgba(0, 240, 255, 0.05);
-}
-
-.download-section__arch-option {
-  min-width: 0;
-  padding: 5px 8px;
-  border: 0;
-  border-radius: 7px;
-  color: #8892b0;
-  background: transparent;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.62rem;
-  font-weight: 700;
-  line-height: 1.15;
-  cursor: pointer;
-  transition:
-    background-color 0.2s ease,
-    color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.download-section__arch-option:hover,
-.download-section__arch-option--active {
-  color: #0a0a0f;
-  background: linear-gradient(135deg, #00f0ff, #39ff14);
-  box-shadow: 0 4px 14px rgba(0, 240, 255, 0.22);
-}
-
 /* Download button */
 .download-section__btn {
   display: inline-flex;
@@ -952,21 +873,6 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
   color: #64748b;
 }
 
-.v-theme--light .download-section__arch-toggle {
-  border-color: rgba(8, 145, 178, 0.16);
-  background: rgba(8, 145, 178, 0.06);
-}
-
-.v-theme--light .download-section__arch-option {
-  color: #64748b;
-}
-
-.v-theme--light .download-section__arch-option:hover,
-.v-theme--light .download-section__arch-option--active {
-  color: #f8fbff;
-  text-shadow: 0 1px 8px rgba(15, 23, 42, 0.22);
-}
-
 .v-theme--light .download-section__btn {
   color: #f8fbff;
   text-shadow: 0 1px 8px rgba(15, 23, 42, 0.34);
@@ -1043,10 +949,6 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
     min-width: 0;
   }
 
-  .download-section__arch-toggle {
-    width: fit-content;
-  }
-
   .download-section__card-indicator {
     justify-content: center;
     width: 100%;
@@ -1097,16 +999,6 @@ const linuxRobotBubble = computed(() => t('download.readyToStart'));
 
   .download-section__card-info {
     min-width: 0;
-  }
-
-  .download-section__arch-toggle {
-    grid-column: 1 / -1;
-    width: 100%;
-  }
-
-  .download-section__arch-option {
-    flex: 1;
-    padding-inline: 6px;
   }
 
   .download-section__card-label {

--- a/landing/components/sections/HeroSection.vue
+++ b/landing/components/sections/HeroSection.vue
@@ -92,10 +92,9 @@ const heroSlogan = computed(() => (
 ));
 
 const heroDownloadUrl = computed(() => {
-  const asset = downloadStore.selectedAsset;
+  const asset = selectedDownloadAsset.value;
   if (!asset) return latestReleaseUrl.value;
-  const arch = asset.os === "macos" ? downloadStore.macArch : asset.arch;
-  return resolve(asset.os, arch)?.url || releaseDownloadUrl(asset.fileName);
+  return resolve(asset.os, asset.resolvedArch)?.url || releaseDownloadUrl(asset.fileName);
 });
 
 const docsHref = computed(() => buildDocsHref({

--- a/landing/composables/useDownloadAssetPresentation.ts
+++ b/landing/composables/useDownloadAssetPresentation.ts
@@ -3,7 +3,8 @@ import { downloadAssets, type DownloadArch } from "~/data/downloads";
 type DownloadAsset = (typeof downloadAssets)[number];
 type DownloadAssetLike = Pick<DownloadAsset, "id" | "os" | "arch" | "archLabel">;
 
-export type PresentedDownloadAsset = DownloadAsset & {
+export type PresentedDownloadAsset = Omit<DownloadAsset, "archLabel" | "fileName"> & {
+  fileName: string;
   archLabel: string;
   actionSubtitle: string;
   resolvedArch: DownloadArch | "unknown";
@@ -13,14 +14,22 @@ export function useDownloadAssetPresentation() {
   const downloadStore = useDownloadStore();
 
   const getDownloadArch = (asset: Pick<DownloadAsset, "os" | "arch">): DownloadArch | "unknown" => (
-    asset.os === "macos" ? downloadStore.macArch : asset.arch
+    asset.os === "macos"
+      ? downloadStore.macArch
+      : asset.os === "windows"
+        ? downloadStore.windowsArch
+        : asset.arch
   );
 
   const getDownloadArchLabel = (asset: DownloadAssetLike) => {
-    if (asset.os === "macos" && downloadStore.isMacOs) {
+    if (asset.os === "macos") {
       if (downloadStore.macArch === "arm64") return "Apple Silicon";
       if (downloadStore.macArch === "x64") return "Intel";
       return asset.archLabel;
+    }
+
+    if (asset.os === "windows") {
+      return downloadStore.windowsArch === "arm64" ? "ARM64" : "64-bit";
     }
 
     return asset.archLabel;
@@ -41,6 +50,9 @@ export function useDownloadAssetPresentation() {
 
   const presentDownloadAsset = (asset: DownloadAsset): PresentedDownloadAsset => ({
     ...asset,
+    fileName: asset.os === "windows" && downloadStore.windowsArch === "arm64"
+      ? "Agent.Teams.AI.Setup-arm64.exe"
+      : asset.fileName,
     archLabel: getDownloadArchLabel(asset),
     actionSubtitle: getDownloadActionSubtitle(asset),
     resolvedArch: getDownloadArch(asset),

--- a/landing/data/downloads.ts
+++ b/landing/data/downloads.ts
@@ -11,20 +11,12 @@ export const downloadAssets = [
     fileName: 'Agent.Teams.AI-arm64.dmg',
   },
   {
-    id: 'windows-x64',
+    id: 'windows',
     os: 'windows',
-    arch: 'x64',
+    arch: 'universal',
     label: 'Windows',
-    archLabel: '64-bit',
+    archLabel: '64-bit / ARM64',
     fileName: 'Agent.Teams.AI.Setup.exe',
-  },
-  {
-    id: 'windows-arm64',
-    os: 'windows',
-    arch: 'arm64',
-    label: 'Windows',
-    archLabel: 'ARM64',
-    fileName: 'Agent.Teams.AI.Setup-arm64.exe',
   },
   {
     id: 'linux-appimage',

--- a/landing/stores/download.test.ts
+++ b/landing/stores/download.test.ts
@@ -25,7 +25,7 @@ describe("landing download store", () => {
     platformMocks.detectPlatform.mockReturnValue("windows");
   });
 
-  it.each(["windows-x64", "linux-appimage"])(
+  it.each(["windows", "linux-appimage"])(
     "preserves a manual %s selection while Windows architecture detection is pending",
     async (selectedId) => {
       const detection = deferred<"arm64">();
@@ -55,5 +55,32 @@ describe("landing download store", () => {
     expect(store.os).toBe("macos");
     expect(store.arch).toBe("x64");
     expect(store.selectedId).toBe("macos");
+  });
+
+  it("selects the unified Windows card and preserves a manual Windows architecture", () => {
+    const store = useDownloadStore();
+
+    store.setWindowsArch("arm64");
+
+    expect(store.os).toBe("windows");
+    expect(store.arch).toBe("arm64");
+    expect(store.windowsArch).toBe("arm64");
+    expect(store.selectedId).toBe("windows");
+  });
+
+  it("preserves a manual Windows architecture while macOS detection is pending", async () => {
+    platformMocks.detectPlatform.mockReturnValue("macos");
+    const detection = deferred<"x64">();
+    platformMocks.detectMacArchFromNavigator.mockReturnValue(detection.promise);
+    const store = useDownloadStore();
+
+    const initialization = store.init();
+    store.setWindowsArch("arm64");
+    detection.resolve("x64");
+    await initialization;
+
+    expect(store.os).toBe("windows");
+    expect(store.windowsArch).toBe("arm64");
+    expect(store.selectedId).toBe("windows");
   });
 });

--- a/landing/stores/download.ts
+++ b/landing/stores/download.ts
@@ -12,6 +12,8 @@ export const useDownloadStore = defineStore("download", {
   state: () => ({
     os: "unknown" as DownloadOs | "unknown",
     arch: "unknown" as DownloadArch | "unknown",
+    macArchSelection: "unknown" as "arm64" | "x64" | "unknown",
+    windowsArchSelection: "x64" as "arm64" | "x64",
     archSource: "auto" as "auto" | "manual",
     initialized: false,
     selectionSource: "auto" as "auto" | "manual",
@@ -22,11 +24,11 @@ export const useDownloadStore = defineStore("download", {
     selectedAsset(state) {
       return downloadAssets.find((asset) => asset.id === state.selectedId);
     },
-    isMacOs(state): boolean {
-      return state.os === "macos";
-    },
     macArch(state): "arm64" | "x64" | "unknown" {
-      return state.arch === "arm64" || state.arch === "x64" ? state.arch : "unknown";
+      return state.macArchSelection;
+    },
+    windowsArch(state): "arm64" | "x64" {
+      return state.windowsArchSelection;
     }
   },
   actions: {
@@ -42,18 +44,20 @@ export const useDownloadStore = defineStore("download", {
         const detectedArch = await detectMacArchFromNavigator(navigator);
         if (this.archSource === "auto" && this.os === "macos") {
           this.arch = detectedArch === "arm64" || detectedArch === "x64" ? detectedArch : "unknown";
+          this.macArchSelection = this.arch;
         }
       } else if (this.os === "windows") {
         const detectedArch = await detectArchFromNavigator(navigator);
         if (this.archSource === "auto" && this.os === "windows") {
           this.arch = detectedArch === "arm64" ? "arm64" : "x64";
+          this.windowsArchSelection = this.arch;
         }
       } else if (this.os === "linux") {
         this.arch = "x64";
       }
 
       if (this.selectionSource === "auto") {
-        this.selectedId = selectDetectedDownloadAssetId(this.os, this.arch);
+        this.selectedId = selectDetectedDownloadAssetId(this.os);
       }
     },
     setSelected(id: string) {
@@ -63,9 +67,18 @@ export const useDownloadStore = defineStore("download", {
     setMacArch(arch: "arm64" | "x64") {
       this.os = "macos";
       this.arch = arch;
+      this.macArchSelection = arch;
       this.archSource = "manual";
       this.selectionSource = "manual";
       this.selectedId = "macos";
+    },
+    setWindowsArch(arch: "arm64" | "x64") {
+      this.os = "windows";
+      this.arch = arch;
+      this.windowsArchSelection = arch;
+      this.archSource = "manual";
+      this.selectionSource = "manual";
+      this.selectedId = "windows";
     }
   }
 });

--- a/landing/utils/downloadSelection.d.mts
+++ b/landing/utils/downloadSelection.d.mts
@@ -1,6 +1,5 @@
-import type { DownloadArch, DownloadOs } from '../data/downloads';
+import type { DownloadOs } from '../data/downloads';
 
 export function selectDetectedDownloadAssetId(
   os: DownloadOs | 'unknown',
-  arch: DownloadArch | 'unknown',
 ): string;

--- a/landing/utils/downloadSelection.mjs
+++ b/landing/utils/downloadSelection.mjs
@@ -1,5 +1,5 @@
-export const selectDetectedDownloadAssetId = (os, arch) => {
-  if (os === 'windows') return arch === 'arm64' ? 'windows-arm64' : 'windows-x64';
+export const selectDetectedDownloadAssetId = (os) => {
+  if (os === 'windows') return 'windows';
   if (os === 'macos') return 'macos';
   if (os === 'linux') return 'linux-appimage';
   return '';

--- a/scripts/ci/source-file-size-baseline.json
+++ b/scripts/ci/source-file-size-baseline.json
@@ -8,7 +8,7 @@
     "landing/assets/styles/cyberpunk-hero.scss": 2343,
     "landing/components/layout/AppHeader.vue": 949,
     "landing/components/sections/ComparisonSection.vue": 1168,
-    "landing/components/sections/DownloadSection.vue": 1110,
+    "landing/components/sections/DownloadSection.vue": 1024,
     "landing/product-docs/.vitepress/config.ts": 829,
     "packages/agent-graph/src/canvas/draw-agents.ts": 1201,
     "packages/agent-graph/src/layout/stableSlots.ts": 2963,

--- a/test/landing/downloadSelection.test.ts
+++ b/test/landing/downloadSelection.test.ts
@@ -4,18 +4,17 @@ import { describe, expect, it } from 'vitest';
 import { selectDetectedDownloadAssetId } from '../../landing/utils/downloadSelection.mjs';
 
 describe('landing detected download selection', () => {
-  it('selects the native Windows installer from the detected architecture', () => {
-    expect(selectDetectedDownloadAssetId('windows', 'arm64')).toBe('windows-arm64');
-    expect(selectDetectedDownloadAssetId('windows', 'x64')).toBe('windows-x64');
+  it('selects the unified Windows card for detected Windows systems', () => {
+    expect(selectDetectedDownloadAssetId('windows')).toBe('windows');
   });
 
-  it('uses Windows x64 only as the unknown-architecture fallback', () => {
-    expect(selectDetectedDownloadAssetId('windows', 'unknown')).toBe('windows-x64');
+  it('keeps the unified Windows card when architecture detection is unavailable', () => {
+    expect(selectDetectedDownloadAssetId('windows')).toBe('windows');
   });
 
   it('keeps the existing platform defaults and ignores unknown operating systems', () => {
-    expect(selectDetectedDownloadAssetId('macos', 'arm64')).toBe('macos');
-    expect(selectDetectedDownloadAssetId('linux', 'x64')).toBe('linux-appimage');
-    expect(selectDetectedDownloadAssetId('unknown', 'unknown')).toBe('');
+    expect(selectDetectedDownloadAssetId('macos')).toBe('macos');
+    expect(selectDetectedDownloadAssetId('linux')).toBe('linux-appimage');
+    expect(selectDetectedDownloadAssetId('unknown')).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- extract the download architecture switch from the frozen legacy download section
- lower the source-size ratchet from 1110 to 1024 lines
- preserve the merged Windows x64/ARM64 behavior and styles

## Verification
- source file size guard
- focused landing tests
- focused ESLint
- landing production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added architecture selection for both macOS and Windows downloads.
  * Windows users can choose between ARM64 and 64-bit installers from the download card.
  * Download links and installer names now reflect the selected architecture.

* **Bug Fixes**
  * Improved download selection to preserve architecture choices and provide the correct installer for detected or manually selected devices.
  * Standardized Windows downloads under a single download option while retaining architecture-specific selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->