### PR TITLE
fix(notifications): prevent historical comment replay on startup

### DIFF
--- a/src/renderer/store/team/teamGlobalTaskNotifications.ts
+++ b/src/renderer/store/team/teamGlobalTaskNotifications.ts
@@ -7,6 +7,11 @@ import {
   isTeamTaskNeedsFixActionable,
 } from '@shared/utils/teamTaskState';
 
+import {
+  captureContextScopedRequestEpoch,
+  captureContextScopedRequestEpochStartedAtMs,
+} from '../utils/contextScopedRequestEpoch';
+
 import type { AppConfig } from '@renderer/types/data';
 import type {
   GlobalTask,
@@ -23,6 +28,8 @@ const notifiedAllCompletedTeams = new Set<string>();
 const notifiedBlockedTaskKeys = new Set<string>();
 
 let isFirstFetchAllTasks = true;
+let notificationContextEpoch = captureContextScopedRequestEpoch();
+let commentHistoryCutoffMs = captureContextScopedRequestEpochStartedAtMs();
 
 interface TaskNotificationIndexes {
   readonly firstOldTaskByKey: ReadonlyMap<string, GlobalTask>;
@@ -40,6 +47,10 @@ export interface ProcessGlobalTaskNotificationsParams {
 }
 
 export function resetGlobalTaskNotificationTrackerForTests(): void {
+  resetGlobalTaskNotificationTracker();
+}
+
+function resetGlobalTaskNotificationTracker(historyCutoffMs = Date.now()): void {
   notifiedClarificationTaskKeys.clear();
   notifiedStatusChangeKeys.clear();
   notifiedCommentKeys.clear();
@@ -47,15 +58,25 @@ export function resetGlobalTaskNotificationTrackerForTests(): void {
   notifiedAllCompletedTeams.clear();
   notifiedBlockedTaskKeys.clear();
   isFirstFetchAllTasks = true;
+  notificationContextEpoch = captureContextScopedRequestEpoch();
+  commentHistoryCutoffMs = historyCutoffMs;
+}
+
+function synchronizeNotificationContext(): void {
+  if (notificationContextEpoch !== captureContextScopedRequestEpoch()) {
+    resetGlobalTaskNotificationTracker(captureContextScopedRequestEpochStartedAtMs());
+  }
 }
 
 export function consumeFirstGlobalTasksFetchFlag(): boolean {
+  synchronizeNotificationContext();
   const wasFirst = isFirstFetchAllTasks;
   isFirstFetchAllTasks = false;
   return wasFirst;
 }
 
 export function processGlobalTaskNotifications(params: ProcessGlobalTaskNotificationsParams): void {
+  synchronizeNotificationContext();
   const { oldTasks, newTasks, appConfig, teamByName, isInitialFetch } = params;
 
   if (isInitialFetch) {
@@ -308,18 +329,18 @@ function detectTaskCommentNotifications(
 ): void {
   for (const task of newTasks) {
     const oldTask = oldTaskIndexes.lastOldTaskByKey.get(getTaskNotificationKey(task));
-    const oldCommentCount = oldTask?.comments?.length ?? 0;
-    const newCommentCount = task.comments?.length ?? 0;
-
-    if (newCommentCount <= oldCommentCount) continue;
-
-    const newComments = (task.comments ?? []).slice(oldCommentCount);
-    for (const comment of newComments) {
-      if (comment.author === 'user') continue;
-
+    const oldCommentIds = new Set(oldTask?.comments?.map((comment) => comment.id));
+    for (const comment of task.comments ?? []) {
       const key = `${task.teamName}:${task.id}:${comment.id}`;
       if (notifiedCommentKeys.has(key)) continue;
       notifiedCommentKeys.add(key);
+
+      // Global snapshots can be partial (including the 500-task export limit).
+      // First observation is not proof of creation: remember hydrated history
+      // without recreating unread notifications or toasts for old comments.
+      if (oldCommentIds.has(comment.id) || comment.author === 'user') continue;
+      const createdAtMs = Date.parse(comment.createdAt);
+      if (!Number.isFinite(createdAtMs) || createdAtMs < commentHistoryCutoffMs) continue;
 
       if (comment.type === 'review_request') {
         showTaskReviewRequestedNotification(task, comment, !notifyEnabled);

--- a/src/renderer/store/utils/contextScopedRequestEpoch.ts
+++ b/src/renderer/store/utils/contextScopedRequestEpoch.ts
@@ -1,7 +1,12 @@
 let contextScopedRequestEpoch = 0;
+let contextScopedRequestEpochStartedAtMs = Date.now();
 
 export function captureContextScopedRequestEpoch(): number {
   return contextScopedRequestEpoch;
+}
+
+export function captureContextScopedRequestEpochStartedAtMs(): number {
+  return contextScopedRequestEpochStartedAtMs;
 }
 
 export function isContextScopedRequestEpochCurrent(epoch: number): boolean {
@@ -10,8 +15,10 @@ export function isContextScopedRequestEpochCurrent(epoch: number): boolean {
 
 export function invalidateContextScopedRequestEpoch(): void {
   contextScopedRequestEpoch += 1;
+  contextScopedRequestEpochStartedAtMs = Date.now();
 }
 
 export function resetContextScopedRequestEpochForTests(): void {
   contextScopedRequestEpoch = 0;
+  contextScopedRequestEpochStartedAtMs = Date.now();
 }

--- a/test/renderer/store/teamGlobalTaskNotifications.startup.test.ts
+++ b/test/renderer/store/teamGlobalTaskNotifications.startup.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  consumeFirstGlobalTasksFetchFlag,
+  processGlobalTaskNotifications,
+  resetGlobalTaskNotificationTrackerForTests,
+} from '../../../src/renderer/store/team/teamGlobalTaskNotifications';
+import { invalidateContextScopedRequestEpoch } from '../../../src/renderer/store/utils/contextScopedRequestEpoch';
+
+import type {
+  GlobalTask,
+  TaskComment,
+  TeamMessageNotificationData,
+} from '../../../src/shared/types';
+
+const { notify } = vi.hoisted(() => ({
+  notify: vi.fn(async (_data: TeamMessageNotificationData) => undefined),
+}));
+vi.mock('@renderer/api', () => ({ api: { teams: { showMessageNotification: notify } } }));
+
+const START = '2026-09-09T10:00:00.000Z';
+
+function comment(id: string, createdAt = '2026-09-09T08:00:00.000Z'): TaskComment {
+  return { id, author: 'removed-teammate', text: id, createdAt, type: 'regular' };
+}
+
+function task(comments: TaskComment[] = []): GlobalTask {
+  return {
+    id: 'test-task',
+    teamName: 'sandbox-team',
+    teamDisplayName: 'Sandbox Team',
+    subject: 'Test task',
+    status: 'pending',
+    createdAt: '2026-09-09T07:00:00.000Z',
+    comments,
+  } as GlobalTask;
+}
+
+function refresh(oldTasks: GlobalTask[], newTasks: GlobalTask[], isInitialFetch = false): void {
+  processGlobalTaskNotifications({
+    oldTasks,
+    newTasks,
+    isInitialFetch,
+    appConfig: null,
+    teamByName: {},
+  });
+}
+
+function commentToasts(): TeamMessageNotificationData[] {
+  return notify.mock.calls
+    .map(([notification]) => notification)
+    .filter((notification) => notification.teamEventType === 'task_comment');
+}
+
+describe('task comment startup history', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START);
+    resetGlobalTaskNotificationTrackerForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    notify.mockClear();
+    resetGlobalTaskNotificationTrackerForTests();
+  });
+
+  it('does not toast hours-old comments discovered after an empty startup snapshot', () => {
+    refresh([], [], true);
+    const historicalTask = task(Array.from({ length: 125 }, (_, i) => comment(`old-${i}`)));
+    refresh([], [historicalTask]);
+    expect(commentToasts()).toEqual([]);
+
+    vi.setSystemTime('2026-09-09T10:01:00.000Z');
+    const updated = task([...historicalTask.comments!, comment('new', new Date().toISOString())]);
+    refresh([historicalTask], [updated]);
+    expect(commentToasts().map((notification) => notification.target)).toEqual([
+      expect.objectContaining({ commentId: 'new' }),
+    ]);
+  });
+
+  it('silently hydrates old comments on an already visible task', () => {
+    const thin = task();
+    refresh([], [thin], true);
+    const full = task([comment('old')]);
+    refresh([thin], [full]);
+    expect(commentToasts()).toEqual([]);
+  });
+
+  it('keeps fresh comments when an old task first appears with mixed history', () => {
+    refresh([], [], true);
+    vi.setSystemTime('2026-09-09T10:01:00.000Z');
+    refresh([], [task([comment('old'), comment('new', new Date().toISOString())])]);
+    expect(commentToasts().map((notification) => notification.target)).toEqual([
+      expect.objectContaining({ commentId: 'new' }),
+    ]);
+  });
+
+  it('detects new comment IDs even when a stale snapshot has the same comment count', () => {
+    const before = task([comment('old')]);
+    refresh([], [before], true);
+    vi.setSystemTime('2026-09-09T10:01:00.000Z');
+    const after = task([comment('new', new Date().toISOString())]);
+    refresh([before], [after]);
+    refresh([after], [before]);
+    refresh([before], [after]);
+    expect(commentToasts().map((notification) => notification.target)).toEqual([
+      expect.objectContaining({ commentId: 'new' }),
+    ]);
+  });
+
+  it('does not replay history when the renderer notification tracker restarts', () => {
+    refresh([], [], true);
+    vi.setSystemTime('2026-09-09T10:01:00.000Z');
+    const created = task([comment('new', new Date().toISOString())]);
+    refresh([], [created]);
+    expect(commentToasts()).toHaveLength(1);
+
+    vi.setSystemTime('2026-09-09T11:00:00.000Z');
+    resetGlobalTaskNotificationTrackerForTests();
+    notify.mockClear();
+    refresh([], [], true);
+    refresh([], [created]);
+    expect(commentToasts()).toEqual([]);
+  });
+
+  it('resets the baseline on context changes before either projection or global refresh', () => {
+    expect(consumeFirstGlobalTasksFetchFlag()).toBe(true);
+    refresh([], [], true);
+    const otherContextTask = task([comment('other-context', '2026-09-09T10:30:00.000Z')]);
+    vi.setSystemTime('2026-09-09T11:00:00.000Z');
+    invalidateContextScopedRequestEpoch();
+    refresh([], [otherContextTask]);
+    expect(commentToasts()).toEqual([]);
+    expect(consumeFirstGlobalTasksFetchFlag()).toBe(true);
+    expect(consumeFirstGlobalTasksFetchFlag()).toBe(false);
+  });
+
+  it('does not treat malformed history timestamps or old review requests as new events', () => {
+    refresh([], [], true);
+    refresh(
+      [],
+      [task([comment('invalid', 'invalid'), { ...comment('review'), type: 'review_request' }])]
+    );
+    expect(notify.mock.calls.map(([notification]) => notification.teamEventType)).not.toContain(
+      'task_review_requested'
+    );
+    expect(commentToasts()).toEqual([]);
+  });
+
+  it('keeps comments created while the first context snapshot is still loading', () => {
+    refresh([], [], consumeFirstGlobalTasksFetchFlag());
+    vi.setSystemTime('2026-09-09T10:30:00.000Z');
+    invalidateContextScopedRequestEpoch();
+    const duringLoad = task([comment('during-load', '2026-09-09T10:31:00.000Z')]);
+
+    vi.setSystemTime('2026-09-09T10:32:00.000Z');
+    refresh([], [], consumeFirstGlobalTasksFetchFlag());
+    vi.setSystemTime('2026-09-09T10:33:00.000Z');
+    refresh([], [duringLoad]);
+    expect(commentToasts()).toMatchObject([{ target: { commentId: 'during-load' } }]);
+  });
+});

--- a/test/renderer/store/teamGlobalTaskNotifications.test.ts
+++ b/test/renderer/store/teamGlobalTaskNotifications.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   consumeFirstGlobalTasksFetchFlag,
@@ -86,7 +86,14 @@ function sentNotifications(): TeamMessageNotificationData[] {
 }
 
 describe('teamGlobalTaskNotifications', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-05-22T09:00:00.000Z');
+    resetGlobalTaskNotificationTrackerForTests();
+  });
+
   afterEach(() => {
+    vi.useRealTimers();
     hoisted.showMessageNotification.mockClear();
     resetGlobalTaskNotificationTrackerForTests();
   });


### PR DESCRIPTION
Partial startup snapshots can make existing tasks appear later and replay historical comments as new notifications, including comments by removed teammates. Track comment IDs and a context-start timestamp so historical hydration stays silent while genuinely new comments are delivered once. Existing unread notifications remain untouched.

Record the timestamp when a context changes so comments created while its first snapshot loads are not lost. Regression coverage includes partial/empty startup, restarts, reordered snapshots, malformed dates, and context switching.

Validation: full GitHub CI passed for 1d6e29c4f34b346e31de4c4124b455b2c5bff580, including both test shards, typecheck, all lint shards, and Windows task-change-ledger smoke. Independent subagent review found no actionable issues. CodeRabbit passed with cosmetic suggestions only. ReviewRouter was unavailable due to provider quota; it was not used as review evidence. No live Windows toast UI validation.
