### PR TITLE
test(opencode): qualify pinned draft runtime on Windows

### DIFF
--- a/.github/workflows/windows-backfill-diagnostic.yml
+++ b/.github/workflows/windows-backfill-diagnostic.yml
@@ -2,6 +2,19 @@ name: Windows packaged backfill diagnostic
 
 on:
   workflow_dispatch:
+    inputs:
+      runtime_version:
+        description: 'Manual qualification: exact X.Y.Z (no v); leave all three blank for shipped 0.0.87'
+        type: string
+        required: false
+      runtime_archive_sha256:
+        description: 'Required with runtime_version: exact Windows x64 ZIP SHA256 (64 hex)'
+        type: string
+        required: false
+      runtime_source_sha:
+        description: 'Required with runtime_version: exact embedded COMMIT_SHA (40 hex)'
+        type: string
+        required: false
   pull_request:
     paths:
       - 'test/main/services/team/OpenCodePackagedBackfill.windows.test.ts'
@@ -50,6 +63,37 @@ jobs:
             ConvertTo-Json | Set-Content "$env:WINDOWS_BACKFILL_EVIDENCE_DIR/preflight.json" -Encoding utf8
           if (-not $IsWindows) { throw 'Actual Windows is mandatory' }
 
+      - name: Validate runtime qualification tuple before downloads
+        id: runtime
+        env:
+          INPUT_RUNTIME_VERSION: ${{ inputs.runtime_version }}
+          INPUT_RUNTIME_ARCHIVE_SHA256: ${{ inputs.runtime_archive_sha256 }}
+          INPUT_RUNTIME_SOURCE_SHA: ${{ inputs.runtime_source_sha }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $version = $env:INPUT_RUNTIME_VERSION
+          $digest = $env:INPUT_RUNTIME_ARCHIVE_SHA256
+          $source = $env:INPUT_RUNTIME_SOURCE_SHA
+          $custom = ($version -ne '' -and $null -ne $version) -or ($digest -ne '' -and $null -ne $digest) -or ($source -ne '' -and $null -ne $source)
+          if ($custom) {
+            if ($env:GITHUB_EVENT_NAME -ne 'workflow_dispatch') { throw 'Custom runtime requires workflow_dispatch' }
+            if ($version -cnotmatch '\A(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\z' -or
+                $digest -notmatch '\A[a-fA-F0-9]{64}\z' -or $source -notmatch '\A[a-fA-F0-9]{40}\z') {
+              throw 'Supply all three: exact X.Y.Z version, 64-hex archive SHA256, and 40-hex source SHA'
+            }
+            $digest = $digest.ToLowerInvariant()
+            $source = $source.ToLowerInvariant()
+          } else {
+            # Immutable original PR/manual defaults; custom qualification never updates these pins.
+            $version = '0.0.87'
+            $digest = 'f4f36d3f3697fcb3208e7bfc784829a447d8c7faf65570479fa0b4a92ed1ef5d'
+            $source = ''
+          }
+          "custom=$($custom.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+          "WINDOWS_BACKFILL_RUNTIME_VERSION=$version" >> $env:GITHUB_ENV
+          "WINDOWS_BACKFILL_RUNTIME_ARCHIVE_SHA256=$digest" >> $env:GITHUB_ENV
+          "WINDOWS_BACKFILL_RUNTIME_SOURCE_SHA=$source" >> $env:GITHUB_ENV
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -94,19 +138,29 @@ jobs:
         timeout-minutes: 6
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Download and verify the exact public shipped archive before extraction
+      - name: Download and verify the selected archive before extraction
         timeout-minutes: 4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Additional credential only for validated manual qualification; never for PR downloads.
+          GH_TOKEN: ${{ github.event_name == 'workflow_dispatch' && steps.runtime.outputs.custom == 'true' && secrets.RUNTIME_BUILD_DISPATCH_TOKEN || '' }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $archive = Join-Path $env:RUNNER_TEMP 'agent-teams-runtime-win32-x64-v0.0.87.zip'
-          $url = 'https://github.com/777genius/agent_teams_orchestrator_binaries/releases/download/runtime-v0.0.87/agent-teams-runtime-win32-x64-v0.0.87.zip'
-          $expected = 'f4f36d3f3697fcb3208e7bfc784829a447d8c7faf65570479fa0b4a92ed1ef5d'
-          $provenance = @{ status = 'downloading'; url = $url; expectedArchiveSha256 = $expected; appSourceSha = (git rev-parse HEAD); supportSha = $env:WINDOWS_BACKFILL_SUPPORT_SHA; runtimeBuildSourceSha = $null }
+          $requestedVersion = $env:WINDOWS_BACKFILL_RUNTIME_VERSION
+          $expectedSource = $env:WINDOWS_BACKFILL_RUNTIME_SOURCE_SHA
+          $custom = -not [string]::IsNullOrEmpty($expectedSource)
+          if ($custom -and [string]::IsNullOrEmpty($env:GH_TOKEN)) { throw 'Manual qualification requires RUNTIME_BUILD_DISPATCH_TOKEN' }
+          $tag = "runtime-v$requestedVersion"
+          $asset = "agent-teams-runtime-win32-x64-v$requestedVersion.zip"
+          $archive = Join-Path $env:RUNNER_TEMP $asset
+          $url = "https://github.com/777genius/agent_teams_orchestrator_binaries/releases/download/$tag/$asset"
+          $expected = $env:WINDOWS_BACKFILL_RUNTIME_ARCHIVE_SHA256
+          $mode = if ($custom) { 'manual-qualification' } else { 'shipped-default' }
+          $provenance = @{ status = 'downloading'; mode = $mode; runtimeVersion = $requestedVersion; expectedRuntimeSourceSha = $expectedSource; url = $url; expectedArchiveSha256 = $expected; appSourceSha = (git rev-parse HEAD); supportSha = $env:WINDOWS_BACKFILL_SUPPORT_SHA; runtimeBuildSourceSha = $null }
           $provenance | ConvertTo-Json | Set-Content "$env:WINDOWS_BACKFILL_EVIDENCE_DIR/release.json" -Encoding utf8
-          gh release download runtime-v0.0.87 --repo 777genius/agent_teams_orchestrator_binaries --pattern agent-teams-runtime-win32-x64-v0.0.87.zip --dir $env:RUNNER_TEMP --clobber
-          if ($LASTEXITCODE -ne 0) { throw 'Shipped release download failed' }
+          # gh supports authenticated draft assets; repository, tag prefix and asset shape are fixed.
+          gh release download $tag --repo 777genius/agent_teams_orchestrator_binaries --pattern $asset --dir $env:RUNNER_TEMP --clobber
+          if ($LASTEXITCODE -ne 0) { throw 'Runtime release download failed' }
           $actual = (Get-FileHash -LiteralPath $archive -Algorithm SHA256).Hash.ToLowerInvariant()
           $provenance.archiveSha256 = $actual
           $provenance.status = 'archive-downloaded'
@@ -121,7 +175,8 @@ jobs:
           $runtimeDir = Split-Path -Parent $binary
           $runtimeSha = (Get-Content -Raw -LiteralPath (Join-Path $runtimeDir 'COMMIT_SHA')).Trim()
           $version = (Get-Content -Raw -LiteralPath (Join-Path $runtimeDir 'VERSION')).Trim()
-          if ($runtimeSha -notmatch '^[a-f0-9]{40}$' -or $version -ne '0.0.87') { throw 'Release metadata mismatch' }
+          if ($runtimeSha -cnotmatch '\A[a-f0-9]{40}\z' -or $version -cne $requestedVersion) { throw 'Release metadata mismatch' }
+          if ($custom -and $runtimeSha -cne $expectedSource) { throw 'Runtime COMMIT_SHA mismatch' }
           $provenance.runtimeBuildSourceSha = $runtimeSha
           $provenance.executableSha256 = $exeHash
           $provenance.executableArchiveMember = [IO.Path]::GetRelativePath($extract, $binary).Replace('\', '/')

--- a/test/main/services/team/OpenCodePackagedBackfill.windows.test.ts
+++ b/test/main/services/team/OpenCodePackagedBackfill.windows.test.ts
@@ -137,8 +137,10 @@ describe('Windows packaged backfill eligibility', () => {
   });
 });
 
+const suiteName = 'actual app client / packaged Windows runtime';
+
 describe.skipIf(Boolean(unavailable))(
-  `actual app client / packaged Windows runtime${unavailable ? ` (${unavailable})` : ''}`,
+  unavailable ? `${suiteName} (${unavailable})` : suiteName,
   () => {
     for (const [id, shape] of [
       ['ascii', 'ascii'],

--- a/test/main/services/team/OpenCodePackagedBackfill.windows.test.ts
+++ b/test/main/services/team/OpenCodePackagedBackfill.windows.test.ts
@@ -26,6 +26,11 @@ import {
 import { describe, expect, it } from 'vitest';
 
 const ARCHIVE_SHA256 = 'f4f36d3f3697fcb3208e7bfc784829a447d8c7faf65570479fa0b4a92ed1ef5d';
+// Workflow validates the all-or-none tuple before downloading. Retain the original
+// standalone defaults and recheck the selected archive/metadata before any invocation.
+const runtimeVersion = process.env.WINDOWS_BACKFILL_RUNTIME_VERSION ?? '0.0.87';
+const runtimeArchiveSha256 = process.env.WINDOWS_BACKFILL_RUNTIME_ARCHIVE_SHA256 ?? ARCHIVE_SHA256;
+const runtimeSourceSha = process.env.WINDOWS_BACKFILL_RUNTIME_SOURCE_SHA;
 const binaryInput = process.env.WINDOWS_BACKFILL_EXE;
 const evidenceDir = process.env.WINDOWS_BACKFILL_EVIDENCE_DIR;
 const supportRoot = process.env.WINDOWS_BACKFILL_SUPPORT_ROOT;
@@ -133,7 +138,7 @@ describe('Windows packaged backfill eligibility', () => {
 });
 
 describe.skipIf(Boolean(unavailable))(
-  `actual app client / shipped Windows runtime${unavailable ? ` (${unavailable})` : ''}`,
+  `actual app client / packaged Windows runtime${unavailable ? ` (${unavailable})` : ''}`,
   () => {
     for (const [id, shape] of [
       ['ascii', 'ascii'],
@@ -148,7 +153,8 @@ describe.skipIf(Boolean(unavailable))(
           arch: process.arch,
           nodeVersion: process.version,
           referenceAppSha: 'e413d5420625a21f3c78f883e1b45f414f474f61',
-          runtimeRelease: 'runtime-v0.0.87',
+          runtimeRelease: `runtime-v${runtimeVersion}`,
+          qualificationMode: runtimeSourceSha ? 'manual-qualification' : 'shipped-default',
           // Populated from COMMIT_SHA inside the hash-verified release archive.
           runtimeBuildSourceSha: null,
           shape,
@@ -225,7 +231,8 @@ describe.skipIf(Boolean(unavailable))(
           const archive = process.env.WINDOWS_BACKFILL_ARCHIVE;
           expect(archive, 'Set WINDOWS_BACKFILL_ARCHIVE to the verified release zip').toBeTruthy();
           report.archiveSha256 = sha256(readFileSync(archive!));
-          expect(report.archiveSha256).toBe(ARCHIVE_SHA256);
+          expect(runtimeArchiveSha256).toMatch(/^[a-f0-9]{64}$/);
+          expect(report.archiveSha256).toBe(runtimeArchiveSha256);
           expect(path.isAbsolute(binaryInput!)).toBe(true);
           expect(path.extname(binaryInput!).toLowerCase()).toBe('.exe');
           report.executableSha256 = sha256(readFileSync(binaryInput!));
@@ -239,7 +246,13 @@ describe.skipIf(Boolean(unavailable))(
             'utf8'
           ).trim();
           expect(report.runtimeBuildSourceSha).toMatch(/^[a-f0-9]{40}$/);
-          expect(readFileSync(path.join(runtimeDir, 'VERSION'), 'utf8').trim()).toBe('0.0.87');
+          if (runtimeSourceSha) {
+            expect(runtimeSourceSha).toMatch(/^[a-f0-9]{40}$/);
+            expect(report.runtimeBuildSourceSha).toBe(runtimeSourceSha);
+          }
+          expect(readFileSync(path.join(runtimeDir, 'VERSION'), 'utf8').trim()).toBe(
+            runtimeVersion
+          );
           root = mkdtempSync(path.join(os.tmpdir(), 'app-backfill-'));
           const caseRoot = path.join(root, shape);
           const binDir = path.join(caseRoot, 'bin');

--- a/test/workflows/windowsBackfillWorkflow.test.ts
+++ b/test/workflows/windowsBackfillWorkflow.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+// Static workflow contract checks. These do not claim PowerShell/Windows execution.
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+const text = readFileSync('.github/workflows/windows-backfill-diagnostic.yml', 'utf8');
+const workflow = parse(text);
+const job = workflow.jobs['packaged-backfill'];
+const steps = job.steps as {
+  name?: string;
+  id?: string;
+  run?: string;
+  env?: Record<string, string>;
+}[];
+const validation = steps.find((step) => step.id === 'runtime')!;
+const download = steps.find((step) => step.name?.startsWith('Download and verify'))!;
+const integration = readFileSync(
+  'test/main/services/team/OpenCodePackagedBackfill.windows.test.ts',
+  'utf8'
+);
+
+// Exercise the literal .NET regex bodies with equivalent absolute JS anchors.
+const patterns = [...validation.run!.matchAll(/-c?notmatch '([^']+)'/g)].map(
+  ([, pattern]) => new RegExp(pattern.replace('\\A', '^').replace('\\z', '$(?![\\s\\S])'))
+);
+
+describe('Windows draft backfill workflow contract', () => {
+  it('exposes only an optional all-or-none manual tuple, validated before checkout/download', () => {
+    expect(Object.keys(workflow.on.workflow_dispatch.inputs)).toEqual([
+      'runtime_version',
+      'runtime_archive_sha256',
+      'runtime_source_sha',
+    ]);
+    for (const input of Object.values(workflow.on.workflow_dispatch.inputs)) {
+      expect(input).toMatchObject({ type: 'string', required: false });
+    }
+    expect(steps.indexOf(validation)).toBe(1);
+    expect(validation.run).toContain("$env:GITHUB_EVENT_NAME -ne 'workflow_dispatch'");
+    expect(validation.run).toContain("$custom = ($version -ne ''");
+    expect(validation.run).toContain("$digest -ne ''");
+    expect(validation.run).toContain("$source -ne ''");
+    expect(validation.run).toContain("$version = '0.0.87'");
+    expect(validation.run).toContain(
+      "$digest = 'f4f36d3f3697fcb3208e7bfc784829a447d8c7faf65570479fa0b4a92ed1ef5d'"
+    );
+    for (const step of steps) expect(step.run ?? '').not.toMatch(/\$\{\{\s*inputs\./);
+  });
+
+  it('rejects partial tuples and unsafe/non-exact input shapes', () => {
+    expect(patterns).toHaveLength(3);
+    const valid = ['0.0.88', 'a'.repeat(64), 'B'.repeat(40)];
+    expect(patterns.every((pattern, i) => pattern.test(valid[i]))).toBe(true);
+    for (let mask = 1; mask < 7; mask++) {
+      expect(patterns.every((pattern, i) => pattern.test(mask & (1 << i) ? valid[i] : ''))).toBe(
+        false
+      );
+    }
+    for (const value of [
+      'v0.0.88',
+      'latest',
+      '01.2.3',
+      '../0.0.88',
+      '0.0.88*',
+      '0.0.88\n',
+      '0.0.88\r\n',
+      ' 0.0.88',
+      '0.0.88; whoami',
+      '$(whoami)',
+      '0.0.88/asset',
+    ]) {
+      expect(patterns[0].test(value), value).toBe(false);
+    }
+    for (const [index, size] of [
+      [1, 64],
+      [2, 40],
+    ]) {
+      for (const value of [
+        'a'.repeat(size - 1),
+        'a'.repeat(size + 1),
+        'g'.repeat(size),
+        `${'a'.repeat(size)}\n`,
+      ]) {
+        expect(patterns[index].test(value)).toBe(false);
+      }
+    }
+  });
+
+  it('confines draft credentials and keeps repository, tag and asset construction fixed', () => {
+    expect(job.if).toBe(
+      "github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository"
+    );
+    expect(workflow.permissions).toEqual({ contents: 'read' });
+    expect(download.env!.GH_TOKEN).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && steps.runtime.outputs.custom == 'true' && secrets.RUNTIME_BUILD_DISPATCH_TOKEN || '' }}"
+    );
+    expect(download.run).toContain(
+      'if ($custom -and [string]::IsNullOrEmpty($env:GH_TOKEN)) { throw'
+    );
+    expect(download.run).toContain('$tag = "runtime-v$requestedVersion"');
+    expect(download.run).toContain(
+      '$asset = "agent-teams-runtime-win32-x64-v$requestedVersion.zip"'
+    );
+    expect(download.run).toContain(
+      'gh release download $tag --repo 777genius/agent_teams_orchestrator_binaries --pattern $asset'
+    );
+    expect(text).not.toMatch(/pull_request_target|gh release (create|edit|upload)|contents: write/);
+    expect(job.env.WINDOWS_BACKFILL_SUPPORT_SHA).toBe('391ce5c8915951e1c412c84ff2970ab9065e4ac6');
+  });
+
+  it('gates extraction and execution on archive and embedded metadata and records selected provenance', () => {
+    const script = download.run!;
+    expect(script.indexOf('if ($actual -ne $expected) { throw')).toBeLessThan(
+      script.indexOf('Expand-Archive')
+    );
+    expect(script).toContain('$version -cne $requestedVersion');
+    expect(script).toContain('if ($custom -and $runtimeSha -cne $expectedSource) { throw');
+    expect(script.indexOf("throw 'Runtime COMMIT_SHA mismatch'")).toBeLessThan(
+      script.indexOf('"WINDOWS_BACKFILL_EXE=')
+    );
+    expect(script).toContain('expectedRuntimeSourceSha = $expectedSource');
+    expect(script).toContain("'manual-qualification' } else { 'shipped-default'");
+    expect(integration).toContain('expect(report.archiveSha256).toBe(runtimeArchiveSha256)');
+    expect(integration).toContain('expect(report.runtimeBuildSourceSha).toBe(runtimeSourceSha)');
+    expect(integration).toContain('runtimeRelease: `runtime-v${runtimeVersion}`');
+    expect(integration).toContain('const result = await delegate.run(input)');
+  });
+});


### PR DESCRIPTION
The Windows packaged backfill diagnostic was fixed to runtime 0.0.87, so it could not qualify a newer draft before publication. Manual runs now accept an all-or-none version, archive SHA256 and source SHA tuple, download from the fixed runtime repository, and verify the archive and embedded metadata before execution. Existing shipped defaults and all nine client operations remain unchanged.

Validation: six focused checks passed on Linux; three native Windows cases skipped as expected. Actionlint, formatting and independent review passed on patch f280d18584ce491989e07ca9629d575a1525545f18037f4959b4f92f43c0993b. Full TypeScript validation is deferred to CI after the hosted check stalled under memory pressure. Actual qualification against the next draft is still pending.

This change does not publish releases or modify updater behavior. Related recovery qualification: #630 and #631.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Windows packaged backfill diagnostics support manually qualifying a custom runtime version, archive checksum, and source revision.
  - Runs record whether they use the shipped or manually qualified runtime, including runtime provenance.
  - Runtime downloads and metadata checks adapt to the selected version and verify its version, checksum, and source revision.

- **Bug Fixes**
  - Validation now rejects incomplete or incorrectly formatted custom runtime details and safely falls back to the shipped runtime defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->