### PR TITLE
fix(teams): preserve configured models in Edit Team

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ overrides:
   serialize-javascript: 7.0.5
   shell-quote: 1.10.0
   simple-git: 3.36.0
-  smol-toml: 1.6.1
+  smol-toml: 1.8.0
   srvx: 0.11.13
   svgo: 4.1.0
   tar: 7.5.22
@@ -10154,8 +10154,8 @@ packages:
     resolution: {integrity: sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==}
     engines: {node: '>=20.0.0'}
 
-  smol-toml@1.6.1:
-    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
     engines: {node: '>= 18'}
 
   sonic-boom@4.2.1:
@@ -20105,7 +20105,7 @@ snapshots:
       oxc-resolver: 11.16.4
       picocolors: 1.1.1
       picomatch: 4.0.4
-      smol-toml: 1.6.1
+      smol-toml: 1.8.0
       strip-json-comments: 5.0.3
       typescript: 5.9.3
       zod: 4.3.6
@@ -22865,7 +22865,7 @@ snapshots:
 
   smob@1.6.1: {}
 
-  smol-toml@1.6.1: {}
+  smol-toml@1.8.0: {}
 
   sonic-boom@4.2.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,7 +79,7 @@ overrides:
   'serialize-javascript': '7.0.5'
   'shell-quote': '1.10.0'
   'simple-git': '3.36.0'
-  'smol-toml': '1.6.1'
+  'smol-toml': '1.8.0'
   'srvx': '0.11.13'
   'svgo': '4.1.0'
   'tar': '7.5.22'

--- a/src/renderer/components/team/dialogs/EditTeamDialog.tsx
+++ b/src/renderer/components/team/dialogs/EditTeamDialog.tsx
@@ -37,6 +37,7 @@ import { Loader2 } from 'lucide-react';
 import {
   buildEditTeamMemberRosterSnapshot,
   buildEditTeamSourceSnapshot,
+  getEditTeamConfiguredMember,
   getLiveRosterIdentityChanges,
   getMembersRequiringRuntimeRestart,
 } from './editTeamRuntimeChanges';
@@ -72,7 +73,9 @@ interface EditTeamDialogProps {
 }
 
 function membersToDrafts(members: ResolvedTeamMember[]) {
-  return createMemberDraftsFromInputs(filterEditableMemberInputs(members));
+  return createMemberDraftsFromInputs(
+    filterEditableMemberInputs(members).map(getEditTeamConfiguredMember)
+  );
 }
 
 function deriveTeammateWorktreeDefault(members: readonly ResolvedTeamMember[]): boolean {

--- a/src/renderer/components/team/dialogs/editTeamRuntimeChanges.ts
+++ b/src/renderer/components/team/dialogs/editTeamRuntimeChanges.ts
@@ -8,10 +8,29 @@ import type {
   EffortLevel,
   ResolvedTeamMember,
   TeamFastMode,
+  TeamMemberConfiguredRuntimeSettings,
   TeamProviderBackendId,
   TeamProviderId,
   TeamProvisioningMemberInput,
 } from '@shared/types';
+
+// Edit canonical overrides, including absent keys, rather than a historical launch projection.
+export function getEditTeamConfiguredMember<
+  T extends {
+    configuredRuntimeSettings?: TeamMemberConfiguredRuntimeSettings;
+  },
+>(member: T): T {
+  const settings = member.configuredRuntimeSettings;
+  if (settings === undefined) return member;
+  return {
+    ...member,
+    providerId: settings.providerId,
+    providerBackendId: settings.providerBackendId,
+    model: settings.model,
+    effort: settings.effort,
+    fastMode: settings.fastMode,
+  };
+}
 
 function normalizeRestartSensitiveMemberContract(member: {
   role?: string;
@@ -73,7 +92,9 @@ export function getMembersRequiringRuntimeRestart(params: {
       continue;
     }
 
-    const previousRuntime = normalizeRestartSensitiveMemberContract(previousMember);
+    const previousRuntime = normalizeRestartSensitiveMemberContract(
+      getEditTeamConfiguredMember(previousMember)
+    );
     const nextRuntime = normalizeRestartSensitiveMemberContract(nextMember);
     if (
       previousRuntime.role !== nextRuntime.role ||
@@ -184,7 +205,11 @@ export function buildEditTeamMemberRosterSnapshot(
   members: readonly (ResolvedTeamMember | TeamProvisioningMemberInput)[]
 ): string {
   const normalizedMembers = members
-    .map(normalizeEditableMemberSnapshot)
+    .map((member) =>
+      normalizeEditableMemberSnapshot(
+        'configuredRuntimeSettings' in member ? getEditTeamConfiguredMember(member) : member
+      )
+    )
     .filter((member): member is NonNullable<typeof member> => member !== null)
     .sort((a, b) => a.name.localeCompare(b.name));
 

--- a/test/renderer/components/team/dialogs/EditTeamDialog.configuredSettings.test.ts
+++ b/test/renderer/components/team/dialogs/EditTeamDialog.configuredSettings.test.ts
@@ -152,6 +152,12 @@ const sourceMembers = () =>
     { name: 'legacy', providerId: 'opencode', model: 'legacy/model', effort: 'high' },
   ] as ResolvedTeamMember[];
 
+function readDrafts(host: HTMLElement) {
+  const text = host.querySelector('[data-testid="drafts"]')?.textContent;
+  if (typeof text !== 'string') throw new Error('Expected rendered drafts');
+  return JSON.parse(text);
+}
+
 describe('EditTeamDialog canonical settings', () => {
   afterEach(() => {
     document.body.innerHTML = '';
@@ -198,7 +204,7 @@ describe('EditTeamDialog canonical settings', () => {
   it('shows canonical 5.3, inherited blanks and legacy fallback without changing effective display data', async () => {
     const { host, root, members } = await setup();
     try {
-      const drafts = JSON.parse(host.querySelector('[data-testid="drafts"]')!.textContent);
+      const drafts = readDrafts(host);
       expect(drafts[1].model).toBe('zai-coding-plan/glm-5.3');
       expect(drafts[2]).toMatchObject({ model: '' });
       for (const key of ['providerId', 'effort', 'providerBackendId', 'fastMode']) {
@@ -258,7 +264,7 @@ describe('EditTeamDialog canonical settings', () => {
       expect(api.teams.replaceMembers).not.toHaveBeenCalled();
       await render(members, false);
       await render();
-      const drafts = JSON.parse(host.querySelector('[data-testid="drafts"]')!.textContent);
+      const drafts = readDrafts(host);
       expect(drafts[0].model).toBe('');
       expect(drafts[1].model).toBe('zai-coding-plan/glm-5.3');
     } finally {

--- a/test/renderer/components/team/dialogs/EditTeamDialog.configuredSettings.test.ts
+++ b/test/renderer/components/team/dialogs/EditTeamDialog.configuredSettings.test.ts
@@ -5,10 +5,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@renderer/api', () => ({
   api: {
     teams: {
-      updateConfig: vi.fn(async () => {}),
-      replaceMembers: vi.fn(async () => {}),
-      removeMember: vi.fn(async () => {}),
-      restartMember: vi.fn(async () => {}),
+      updateConfig: vi.fn(() => Promise.resolve()),
+      replaceMembers: vi.fn(() => Promise.resolve()),
+      removeMember: vi.fn(() => Promise.resolve()),
+      restartMember: vi.fn(() => Promise.resolve()),
     },
   },
 }));
@@ -121,7 +121,7 @@ vi.mock('@renderer/hooks/useTheme', () => ({
 }));
 
 vi.mock('@renderer/hooks/useFileListCacheWarmer', () => ({
-  useFileListCacheWarmer: () => {},
+  useFileListCacheWarmer: () => undefined,
 }));
 
 vi.mock('@renderer/constants/teamColors', () => ({
@@ -149,8 +149,7 @@ const sourceMembers = () =>
       model: 'gpt-5.2',
       effort: 'high',
       providerBackendId: 'codex-native',
-      fastMode: 'on',
-      runtimeModel: 'observed-model',
+      selectedFastMode: 'on',
       configuredRuntimeSettings: {},
     },
     { name: 'legacy', providerId: 'opencode', model: 'legacy/model', effort: 'high' },
@@ -171,7 +170,7 @@ describe('EditTeamDialog canonical settings', () => {
     const onClose = vi.fn();
     const members = sourceMembers();
     const render = async (currentMembers = members, open = true) => {
-      await act(async () => {
+      await act(() => {
         root.render(
           React.createElement(EditTeamDialog, {
             open,
@@ -192,7 +191,7 @@ describe('EditTeamDialog canonical settings', () => {
     const click = async (text: string) => {
       const button = Array.from(host.querySelectorAll('button')).find((b) => b.textContent === text);
       expect(button).toBeTruthy();
-      await act(async () => button!.click());
+      await act(() => button!.click());
     };
     await render();
     return { host, root, render, click, members, onClose };
@@ -214,7 +213,7 @@ describe('EditTeamDialog canonical settings', () => {
       });
       expect(members[1].model).toBe('zai-coding-plan/glm-5.2');
     } finally {
-      await act(async () => root.unmount());
+      await act(() => root.unmount());
     }
   });
 
@@ -236,7 +235,7 @@ describe('EditTeamDialog canonical settings', () => {
       });
       expect(api.teams.restartMember).not.toHaveBeenCalled();
     } finally {
-      await act(async () => root.unmount());
+      await act(() => root.unmount());
     }
   });
 
@@ -247,7 +246,7 @@ describe('EditTeamDialog canonical settings', () => {
       expect(api.teams.updateConfig).toHaveBeenCalledOnce();
       expect(api.teams.replaceMembers).not.toHaveBeenCalled();
     } finally {
-      await act(async () => root.unmount());
+      await act(() => root.unmount());
     }
   });
 
@@ -265,7 +264,7 @@ describe('EditTeamDialog canonical settings', () => {
       expect(drafts[0].model).toBe('');
       expect(drafts[1].model).toBe('zai-coding-plan/glm-5.3');
     } finally {
-      await act(async () => root.unmount());
+      await act(() => root.unmount());
     }
   });
 
@@ -287,7 +286,7 @@ describe('EditTeamDialog canonical settings', () => {
                         model: 'new/canonical',
                       },
                     }
-                  : { model: 'new/effective', runtimeModel: 'new/observed' }),
+                  : { model: 'new/effective' }),
               }
         );
         await render(refreshed);
@@ -303,7 +302,7 @@ describe('EditTeamDialog canonical settings', () => {
           );
         }
       } finally {
-        await act(async () => root.unmount());
+        await act(() => root.unmount());
       }
     }
   );

--- a/test/renderer/components/team/dialogs/EditTeamDialog.configuredSettings.test.ts
+++ b/test/renderer/components/team/dialogs/EditTeamDialog.configuredSettings.test.ts
@@ -1,0 +1,310 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@renderer/api', () => ({
+  api: {
+    teams: {
+      updateConfig: vi.fn(async () => {}),
+      replaceMembers: vi.fn(async () => {}),
+      removeMember: vi.fn(async () => {}),
+      restartMember: vi.fn(async () => {}),
+    },
+  },
+}));
+
+vi.mock('@renderer/components/team/members/MembersEditorSection', async () => ({
+  MembersEditorSection: ({
+    members,
+    onChange,
+  }: {
+    members: import('@renderer/components/team/members/membersEditorTypes').MemberDraft[];
+    onChange: (
+      members: import('@renderer/components/team/members/membersEditorTypes').MemberDraft[]
+    ) => void;
+  }) =>
+    React.createElement(
+      'div',
+      null,
+      React.createElement('pre', { 'data-testid': 'drafts' }, JSON.stringify(members)),
+      ...(['role', 'runtime'] as const).map((field) =>
+        React.createElement(
+          'button',
+          {
+            key: field,
+            onClick: () =>
+              onChange(
+                members.map((member, index) =>
+                  index !== 0
+                    ? member
+                    : {
+                        ...member,
+                        ...(field === 'role'
+                          ? { roleSelection: 'Developer' }
+                          : { model: 'edited/model' }),
+                      }
+                )
+              ),
+          },
+          `change-member-${field}`
+        )
+      )
+    ),
+  ...(await vi.importActual<typeof import('@renderer/components/team/members/membersEditorUtils')>(
+    '@renderer/components/team/members/membersEditorUtils'
+  )),
+}));
+
+vi.mock('@renderer/components/team/members/MemberDraftRow', () => ({
+  MemberDraftRow: ({
+    member,
+    lockedRoleLabel,
+    lockedModelAction,
+  }: {
+    member: { name: string };
+    lockedRoleLabel?: string;
+    lockedModelAction?: {
+      label: string;
+      onClick: () => void;
+    };
+  }) =>
+    React.createElement(
+      'div',
+      null,
+      member.name,
+      lockedRoleLabel ? ` ${lockedRoleLabel}` : '',
+      lockedModelAction
+        ? React.createElement(
+            'button',
+            {
+              type: 'button',
+              'data-testid': 'lead-runtime-action',
+              onClick: lockedModelAction.onClick,
+            },
+            lockedModelAction.label
+          )
+        : null
+    ),
+}));
+
+vi.mock('@renderer/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    type,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    type?: 'button' | 'submit' | 'reset';
+    disabled?: boolean;
+  }) => React.createElement('button', { type: type ?? 'button', onClick, disabled }, children),
+}));
+
+vi.mock('@renderer/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? React.createElement('div', null, children) : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  DialogDescription: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  DialogFooter: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  DialogHeader: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  DialogTitle: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+}));
+
+vi.mock('@renderer/hooks/useTheme', () => ({
+  useTheme: () => ({ isLight: false }),
+}));
+
+vi.mock('@renderer/hooks/useFileListCacheWarmer', () => ({
+  useFileListCacheWarmer: () => {},
+}));
+
+vi.mock('@renderer/constants/teamColors', () => ({
+  getTeamColorSet: () => ({ border: '#22c55e' }),
+  getThemedBadge: () => '#0f172a',
+}));
+
+import { EditTeamDialog } from '@renderer/components/team/dialogs/EditTeamDialog';
+import { api } from '@renderer/api';
+
+import type { ResolvedTeamMember } from '@shared/types';
+
+const sourceMembers = () =>
+  [
+    { name: 'other', role: 'Reviewer' },
+    {
+      name: 'zai-one',
+      providerId: 'opencode',
+      model: 'zai-coding-plan/glm-5.2',
+      configuredRuntimeSettings: { providerId: 'opencode', model: 'zai-coding-plan/glm-5.3' },
+    },
+    {
+      name: 'inherited',
+      providerId: 'codex',
+      model: 'gpt-5.2',
+      effort: 'high',
+      providerBackendId: 'codex-native',
+      fastMode: 'on',
+      runtimeModel: 'observed-model',
+      configuredRuntimeSettings: {},
+    },
+    { name: 'legacy', providerId: 'opencode', model: 'legacy/model', effort: 'high' },
+  ] as ResolvedTeamMember[];
+
+describe('EditTeamDialog canonical settings', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  async function setup() {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+    const onClose = vi.fn();
+    const members = sourceMembers();
+    const render = async (currentMembers = members, open = true) => {
+      await act(async () => {
+        root.render(
+          React.createElement(EditTeamDialog, {
+            open,
+            teamName: 'sandbox-team',
+            currentName: 'Sandbox',
+            currentDescription: '',
+            currentColor: 'blue',
+            currentMembers,
+            onClose,
+            onSaved: vi.fn(),
+            onChangeLeadRuntime: vi.fn(),
+            isTeamAlive: false,
+            leadMember: { name: 'team-lead', providerId: 'opencode' } as ResolvedTeamMember,
+          })
+        );
+      });
+    };
+    const click = async (text: string) => {
+      const button = Array.from(host.querySelectorAll('button')).find((b) => b.textContent === text);
+      expect(button).toBeTruthy();
+      await act(async () => button!.click());
+    };
+    await render();
+    return { host, root, render, click, members, onClose };
+  }
+
+  it('shows canonical 5.3, inherited blanks and legacy fallback without changing effective display data', async () => {
+    const { host, root, members } = await setup();
+    try {
+      const drafts = JSON.parse(host.querySelector('[data-testid="drafts"]')!.textContent!);
+      expect(drafts[1].model).toBe('zai-coding-plan/glm-5.3');
+      expect(drafts[2]).toMatchObject({ model: '' });
+      for (const key of ['providerId', 'effort', 'providerBackendId', 'fastMode']) {
+        expect(drafts[2][key]).toBeUndefined();
+      }
+      expect(drafts[3]).toMatchObject({
+        providerId: 'opencode',
+        model: 'legacy/model',
+        effort: 'high',
+      });
+      expect(members[1].model).toBe('zai-coding-plan/glm-5.2');
+    } finally {
+      await act(async () => root.unmount());
+    }
+  });
+
+  it('saving another member role preserves canonical and inherited settings in the actual replace payload', async () => {
+    const { root, click } = await setup();
+    try {
+      await click('change-member-role');
+      await click('Save');
+      expect(api.teams.replaceMembers).toHaveBeenCalledOnce();
+      const payload = vi.mocked(api.teams.replaceMembers).mock.calls[0][1];
+      expect(payload.members[0]).toMatchObject({ name: 'other', role: 'Developer' });
+      expect(payload.members[1]).toMatchObject({ model: 'zai-coding-plan/glm-5.3' });
+      expect(payload.members[2]).toEqual({ name: 'inherited', role: undefined });
+      expect(payload.members[3]).toMatchObject({ model: 'legacy/model' });
+      expect(api.teams.updateConfig).toHaveBeenCalledWith('sandbox-team', {
+        name: 'Sandbox',
+        description: '',
+        color: 'blue',
+      });
+      expect(api.teams.restartMember).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => root.unmount());
+    }
+  });
+
+  it('does not replace unchanged canonical roster for a settings-only save', async () => {
+    const { root, click } = await setup();
+    try {
+      await click('Save');
+      expect(api.teams.updateConfig).toHaveBeenCalledOnce();
+      expect(api.teams.replaceMembers).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => root.unmount());
+    }
+  });
+
+  it('Cancel discards edits without persistence and reopening restores canonical settings', async () => {
+    const { root, host, click, render, members, onClose } = await setup();
+    try {
+      await click('change-member-runtime');
+      await click('Cancel');
+      expect(onClose).toHaveBeenCalledOnce();
+      expect(api.teams.updateConfig).not.toHaveBeenCalled();
+      expect(api.teams.replaceMembers).not.toHaveBeenCalled();
+      await render(members, false);
+      await render();
+      const drafts = JSON.parse(host.querySelector('[data-testid="drafts"]')!.textContent!);
+      expect(drafts[0].model).toBe('');
+      expect(drafts[1].model).toBe('zai-coding-plan/glm-5.3');
+    } finally {
+      await act(async () => root.unmount());
+    }
+  });
+
+  it.each(['canonical', 'effective'] as const)(
+    'handles %s source changes while a draft is open',
+    async (change) => {
+      const { root, host, click, render, members } = await setup();
+      try {
+        await click('change-member-role');
+        const refreshed = members.map((member) =>
+          member.name !== 'zai-one'
+            ? member
+            : {
+                ...member,
+                ...(change === 'canonical'
+                  ? {
+                      configuredRuntimeSettings: {
+                        providerId: 'opencode' as const,
+                        model: 'new/canonical',
+                      },
+                    }
+                  : { model: 'new/effective', runtimeModel: 'new/observed' }),
+              }
+        );
+        await render(refreshed);
+        await click('Save');
+        if (change === 'canonical') {
+          expect(api.teams.updateConfig).not.toHaveBeenCalled();
+          expect(api.teams.replaceMembers).not.toHaveBeenCalled();
+          expect(host.textContent).toContain('Team settings changed while this dialog was open');
+        } else {
+          expect(api.teams.replaceMembers).toHaveBeenCalledOnce();
+          expect(vi.mocked(api.teams.replaceMembers).mock.calls[0][1].members[1].model).toBe(
+            'zai-coding-plan/glm-5.3'
+          );
+        }
+      } finally {
+        await act(async () => root.unmount());
+      }
+    }
+  );
+});

--- a/test/renderer/components/team/dialogs/EditTeamDialog.configuredSettings.test.ts
+++ b/test/renderer/components/team/dialogs/EditTeamDialog.configuredSettings.test.ts
@@ -34,16 +34,13 @@ vi.mock('@renderer/components/team/members/MembersEditorSection', async () => ({
             key: field,
             onClick: () =>
               onChange(
-                members.map((member, index) =>
-                  index !== 0
-                    ? member
-                    : {
-                        ...member,
-                        ...(field === 'role'
-                          ? { roleSelection: 'Developer' }
-                          : { model: 'edited/model' }),
-                      }
-                )
+                [
+                  {
+                    ...members[0],
+                    ...(field === 'role' ? { roleSelection: 'Developer' } : { model: 'edited/model' }),
+                  },
+                  ...members.slice(1),
+                ]
               ),
           },
           `change-member-${field}`
@@ -186,12 +183,13 @@ describe('EditTeamDialog canonical settings', () => {
             leadMember: { name: 'team-lead', providerId: 'opencode' } as ResolvedTeamMember,
           })
         );
+        return Promise.resolve();
       });
     };
     const click = async (text: string) => {
       const button = Array.from(host.querySelectorAll('button')).find((b) => b.textContent === text);
       expect(button).toBeTruthy();
-      await act(() => button!.click());
+      await act(() => Promise.resolve(button!.click()));
     };
     await render();
     return { host, root, render, click, members, onClose };
@@ -200,7 +198,7 @@ describe('EditTeamDialog canonical settings', () => {
   it('shows canonical 5.3, inherited blanks and legacy fallback without changing effective display data', async () => {
     const { host, root, members } = await setup();
     try {
-      const drafts = JSON.parse(host.querySelector('[data-testid="drafts"]')!.textContent!);
+      const drafts = JSON.parse(host.querySelector('[data-testid="drafts"]')!.textContent);
       expect(drafts[1].model).toBe('zai-coding-plan/glm-5.3');
       expect(drafts[2]).toMatchObject({ model: '' });
       for (const key of ['providerId', 'effort', 'providerBackendId', 'fastMode']) {
@@ -213,7 +211,7 @@ describe('EditTeamDialog canonical settings', () => {
       });
       expect(members[1].model).toBe('zai-coding-plan/glm-5.2');
     } finally {
-      await act(() => root.unmount());
+      await act(() => Promise.resolve(root.unmount()));
     }
   });
 
@@ -235,7 +233,7 @@ describe('EditTeamDialog canonical settings', () => {
       });
       expect(api.teams.restartMember).not.toHaveBeenCalled();
     } finally {
-      await act(() => root.unmount());
+      await act(() => Promise.resolve(root.unmount()));
     }
   });
 
@@ -246,7 +244,7 @@ describe('EditTeamDialog canonical settings', () => {
       expect(api.teams.updateConfig).toHaveBeenCalledOnce();
       expect(api.teams.replaceMembers).not.toHaveBeenCalled();
     } finally {
-      await act(() => root.unmount());
+      await act(() => Promise.resolve(root.unmount()));
     }
   });
 
@@ -260,11 +258,11 @@ describe('EditTeamDialog canonical settings', () => {
       expect(api.teams.replaceMembers).not.toHaveBeenCalled();
       await render(members, false);
       await render();
-      const drafts = JSON.parse(host.querySelector('[data-testid="drafts"]')!.textContent!);
+      const drafts = JSON.parse(host.querySelector('[data-testid="drafts"]')!.textContent);
       expect(drafts[0].model).toBe('');
       expect(drafts[1].model).toBe('zai-coding-plan/glm-5.3');
     } finally {
-      await act(() => root.unmount());
+      await act(() => Promise.resolve(root.unmount()));
     }
   });
 
@@ -302,7 +300,7 @@ describe('EditTeamDialog canonical settings', () => {
           );
         }
       } finally {
-        await act(() => root.unmount());
+        await act(() => Promise.resolve(root.unmount()));
       }
     }
   );


### PR DESCRIPTION
General Edit Team initialized editable member settings from a historical launch snapshot. After saving glm-5.3, an unrelated roster edit could silently write glm-5.2 back into configuration.

Initialize drafts and edit conflict/restart comparisons from configured runtime overrides, preserving absent keys as inheritance. Existing live-team restrictions and the lead relaunch path remain intact.

Validation: six new renderer regressions reproduce five failures on the base. All 109 focused renderer tests pass, including existing launch and live-team guards. Full typecheck and CI are pending; independent hosted review follows this exact commit.

CI also exposed GHSA-7w5x-hrqm-74c2 in the pre-existing knip > smol-toml override. Update that dev-only override and matching lock entries from 1.6.1 to the registry latest stable 1.8.0 (patched >=1.7.1). No new dependencies; Node requirement stays >=18. Frozen installation and audit remain required CI gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Team member editing now consistently displays and preserves configured runtime settings, including provider, model, effort, and fast-mode preferences.
  - Runtime setting comparisons and roster snapshots now reflect configured overrides accurately.
  - Saving edits based on configured runtime settings now maintains the correct member roster and draft values.
  - The editor more reliably distinguishes canonical configuration changes from effective runtime changes when determining whether a restart warning is needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->