### PR TITLE
fix(smoke): retain private OAuth state after cleanup

### DIFF
--- a/scripts/prove-opencode-full-team.mjs
+++ b/scripts/prove-opencode-full-team.mjs
@@ -37,33 +37,6 @@ export function allocateSmokeOwnedRoot(prefix, platform = process.platform, temp
   return fs.realpathSync(fs.mkdtempSync(path.join(parent, prefix)));
 }
 
-export function preserveSelectedOAuth(initialJson, isolatedAuthPath) {
-  const initial = JSON.parse(initialJson);
-  const current = JSON.parse(fs.readFileSync(isolatedAuthPath, 'utf8'));
-  let rotated = false;
-  const nonempty = (value) => typeof value === 'string' && value.trim().length > 0;
-  const selected = {};
-  for (const [provider, before] of Object.entries(initial)) {
-    const after = current?.[provider];
-    if (!after || after.type !== before.type ||
-        (before.type === 'api' && !nonempty(after.key)) ||
-        (before.type === 'oauth' &&
-          ((!nonempty(after.access) && !nonempty(after.refresh)) ||
-           (nonempty(before.refresh) && !nonempty(after.refresh))))) {
-      throw new Error('Selected auth recovery unavailable');
-    }
-    selected[provider] = after;
-    if (before.type === 'oauth' &&
-        (before.access !== after.access || before.refresh !== after.refresh)) rotated = true;
-  }
-  if (!rotated) return null;
-  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-team-auth-handoff-'));
-  fs.chmodSync(directory, 0o700);
-  const destination = path.join(directory, 'auth.json');
-  fs.writeFileSync(destination, JSON.stringify(selected), { mode: 0o600, flag: 'wx' });
-  return destination;
-}
-
 // These keys are owned by the wrappers, never authorized by manifest contents.
 const OPTIONAL_ENV_KEYS = [
   'PATH', 'Path', 'SystemRoot', 'WINDIR', 'COMSPEC', 'PATHEXT', 'LANG', 'LC_ALL',
@@ -303,6 +276,7 @@ export async function runFullTeamSmoke({
   fs.accessSync(runtimeCli, fs.constants.X_OK);
   fs.accessSync(binaryPath, fs.constants.X_OK);
   let selectedAuth;
+  let hasSelectedOAuth = false;
   if (sourceEnv.OPENCODE_E2E_TEST_AUTH_PATH !== undefined) {
     try {
       const sourcePath = sourceEnv.OPENCODE_E2E_TEST_AUTH_PATH.trim();
@@ -328,6 +302,7 @@ export async function runFullTeamSmoke({
         )
       )
         throw new Error();
+      hasSelectedOAuth = entry.type === 'oauth';
       selectedAuth = JSON.stringify({ [provider]: entry });
     } catch {
       // Never attach filesystem/JSON errors: they can contain the source path or token text.
@@ -338,7 +313,6 @@ export async function runFullTeamSmoke({
   }
   const ownedRoot = allocateSmokeOwnedRoot('opencode-full-team-');
   let ownedProject;
-  let isolatedAuthPath;
   let exitStatus = 1;
   const proofDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-full-team-proof-'));
   let completedSuccessfully = false;
@@ -386,7 +360,7 @@ export async function runFullTeamSmoke({
     if (selectedAuth !== undefined) {
       const authDirectory = path.join(env.XDG_DATA_HOME, 'opencode');
       fs.mkdirSync(authDirectory, { recursive: true, mode: 0o700 });
-      isolatedAuthPath = path.join(authDirectory, 'auth.json');
+      const isolatedAuthPath = path.join(authDirectory, 'auth.json');
       fs.writeFileSync(isolatedAuthPath, selectedAuth, {
         mode: 0o600,
         flag: 'wx',
@@ -447,20 +421,16 @@ export async function runFullTeamSmoke({
     }
     exitStatus = result.status ?? 1;
   } finally {
-    if (isolatedAuthPath) {
-      try {
-        const handoff = preserveSelectedOAuth(selectedAuth, isolatedAuthPath);
-        if (handoff) log(`Rotated selected auth retained privately: ${handoff}`);
-      } catch {
-        completedSuccessfully = false;
-        log(`Auth handoff not confirmed; retaining owned state for recovery: ${ownedRoot}`);
-      }
-    }
     // The caller's marked project is never owned by this wrapper.
     // Preflight can already start managed hosts; retain their state until success is proven.
     if (!completedSuccessfully) {
       log(
         `Smoke failed; preserving owned state for targeted cleanup: ${ownedRoot}, project ${ownedProject}`
+      );
+    } else if (hasSelectedOAuth) {
+      // Custody is based on selected inputs, not raw token changes or runtime authority.
+      log(
+        `Smoke passed; owned OAuth state retained: ${ownedRoot}, project ${ownedProject}. No credential export performed; reuse requires normal runtime admission.`
       );
     } else {
       if (ownedProject) fs.rmSync(ownedProject, { recursive: true, force: true });

--- a/scripts/prove-opencode-mixed-team.mjs
+++ b/scripts/prove-opencode-mixed-team.mjs
@@ -15,7 +15,6 @@ import {
   assertOwnedSmokeEnvironment,
   isCompleteSmokeProof,
   ISOLATED_PATH_KEYS,
-  preserveSelectedOAuth,
   writeSmokeOwnership,
 } from './prove-opencode-full-team.mjs';
 
@@ -82,6 +81,7 @@ export async function runMixedTeamSmoke({
   fs.accessSync(runtimeCli, fs.constants.X_OK);
   fs.accessSync(binaryPath, fs.constants.X_OK);
   let selectedAuth;
+  let hasSelectedOAuth = false;
   if (sourceEnv.OPENCODE_E2E_TEST_AUTH_PATH !== undefined) {
     try {
       const sourcePath = sourceEnv.OPENCODE_E2E_TEST_AUTH_PATH.trim();
@@ -110,6 +110,7 @@ export async function runMixedTeamSmoke({
         )
           throw new Error();
         if (provider === 'xai' && entry.type !== 'oauth') throw new Error();
+        if (entry.type === 'oauth') hasSelectedOAuth = true;
         selected[provider] = entry;
       }
       selectedAuth = JSON.stringify(selected);
@@ -122,7 +123,6 @@ export async function runMixedTeamSmoke({
   }
   const ownedRoot = allocateSmokeOwnedRoot('opencode-mixed-team-');
   let ownedProject;
-  let isolatedAuthPath;
   const proofDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'opencode-mixed-team-proof-'));
   let completedSuccessfully = false;
   let exitStatus = 1;
@@ -168,7 +168,7 @@ export async function runMixedTeamSmoke({
     if (selectedAuth !== undefined) {
       const authDirectory = path.join(env.XDG_DATA_HOME, 'opencode');
       fs.mkdirSync(authDirectory, { recursive: true, mode: 0o700 });
-      isolatedAuthPath = path.join(authDirectory, 'auth.json');
+      const isolatedAuthPath = path.join(authDirectory, 'auth.json');
       fs.writeFileSync(isolatedAuthPath, selectedAuth, {
         mode: 0o600,
         flag: 'wx',
@@ -229,21 +229,15 @@ export async function runMixedTeamSmoke({
     }
     exitStatus = result.status ?? 1;
   } finally {
-    // A provider may rotate single-use OAuth refresh tokens during this one run.
-    // Preserve only selected credentials privately before deleting the isolated home.
-    if (isolatedAuthPath) {
-      try {
-        const handoff = preserveRotatedSelectedOAuth(selectedAuth, isolatedAuthPath);
-        if (handoff) log(`Rotated selected auth retained privately: ${handoff}`);
-      } catch {
-        completedSuccessfully = false;
-        log(`Auth handoff not confirmed; retaining owned state for recovery: ${ownedRoot}`);
-      }
-    }
     // Preflight can already start managed hosts; retain their state until success is proven.
     if (!completedSuccessfully) {
       log(
         `Smoke failed; preserving owned state for targeted cleanup: ${ownedRoot}, project ${ownedProject}`
+      );
+    } else if (hasSelectedOAuth) {
+      // Custody is based on selected inputs, not raw token changes or runtime authority.
+      log(
+        `Smoke passed; owned OAuth state retained: ${ownedRoot}, project ${ownedProject}. No credential export performed; reuse requires normal runtime admission.`
       );
     } else {
       if (ownedProject) fs.rmSync(ownedProject, { recursive: true, force: true });
@@ -251,10 +245,6 @@ export async function runMixedTeamSmoke({
     }
   }
   return completedSuccessfully ? 0 : exitStatus || 1;
-}
-
-export function preserveRotatedSelectedOAuth(initialJson, isolatedAuthPath) {
-  return preserveSelectedOAuth(initialJson, isolatedAuthPath);
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/test/scripts/proveOpenCodeFullTeam.test.mjs
+++ b/test/scripts/proveOpenCodeFullTeam.test.mjs
@@ -68,7 +68,7 @@ function fixture() {
     auth,
     JSON.stringify({
       selected: { type: 'api', key: 'synthetic-secret' },
-      unrelated: { type: 'api', key: 'unrelated-synthetic-secret' },
+      unrelated: { type: 'oauth', access: 'unrelated-synthetic-secret' },
     })
   );
   fs.writeFileSync(path.join(root, 'vitest.mjs'), '// synthetic entry; never executed');
@@ -277,54 +277,6 @@ test('incomplete full proof cannot authorize state deletion', async () => {
   } finally { cleanup(input); fs.rmSync(root, { recursive: true, force: true }); }
 });
 
-test('full runner preserves rotated selected OAuth before deleting successful state', async () => {
-  const { root, env } = fixture();
-  let input, handoff;
-  const selected = { type: 'oauth', access: 'synthetic-access', refresh: 'synthetic-refresh' };
-  fs.writeFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, JSON.stringify({ selected }));
-  try {
-    const status = await runFullTeamSmoke({
-      vitestEntryPath: path.join(root, 'vitest.mjs'), sourceEnv: env,
-      log(message) { if (message.startsWith('Rotated selected auth retained privately: ')) handoff = message.slice(message.indexOf(': ') + 2); },
-      preflight: async (value) => { input = value; return { ok: true }; },
-      spawn: (_command, _args, { env: runEnv }) => {
-        fs.writeFileSync(path.join(runEnv.XDG_DATA_HOME, 'opencode/auth.json'),
-          JSON.stringify({ selected: { ...selected, refresh: 'synthetic-rotated' } }));
-        fs.writeFileSync(path.join(runEnv.OPENCODE_E2E_PROOF_DIRECTORY, 'proof.json'), JSON.stringify(passingProof()));
-        return { status: 0 };
-      },
-    });
-    assert.equal(status, 0);
-    assert.equal(fs.existsSync(input.env.HOME), false);
-    assert.equal(JSON.parse(fs.readFileSync(handoff, 'utf8')).selected.refresh, 'synthetic-rotated');
-    if (process.platform !== 'win32') assert.equal(fs.statSync(handoff).mode & 0o777, 0o600);
-    assert.equal(fs.readFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, 'utf8'), JSON.stringify({ selected }));
-  } finally {
-    if (handoff) fs.rmSync(path.dirname(handoff), { recursive: true, force: true });
-    cleanup(input); fs.rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test('full runner retains state and fails if OAuth recovery is incomplete', async () => {
-  const { root, env } = fixture();
-  let input;
-  fs.writeFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, JSON.stringify({ selected:
-    { type: 'oauth', access: 'synthetic-access', refresh: 'synthetic-refresh' } }));
-  try {
-    const status = await runFullTeamSmoke({
-      vitestEntryPath: path.join(root, 'vitest.mjs'), sourceEnv: env, log() {},
-      preflight: async (value) => { input = value; return { ok: true }; },
-      spawn: (_command, _args, { env: runEnv }) => {
-        fs.writeFileSync(path.join(runEnv.XDG_DATA_HOME, 'opencode/auth.json'), JSON.stringify({ selected: { type: 'oauth' } }));
-        fs.writeFileSync(path.join(runEnv.OPENCODE_E2E_PROOF_DIRECTORY, 'proof.json'), JSON.stringify(passingProof()));
-        return { status: 0 };
-      },
-    });
-    assert.equal(status, 1);
-    assert.ok(fs.existsSync(input.env.HOME));
-  } finally { cleanup(input); fs.rmSync(root, { recursive: true, force: true }); }
-});
-
 test('uncertain child effects are submitted once, redacted and retained for targeted cleanup', async () => {
   const { root, env } = fixture();
   let input;
@@ -486,3 +438,95 @@ test('explicit TEST parent permits only its fresh owned child and survives succe
     cleanup(input); fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+// Opaque custody fixtures deliberately model no runtime authority or admission rules.
+function custodySnapshot(target) {
+  const stat = fs.lstatSync(target);
+  return { mode: stat.mode, ino: stat.ino, dev: stat.dev,
+    contents: stat.isDirectory()
+      ? Object.fromEntries(fs.readdirSync(target).sort().map((name) => [name, custodySnapshot(path.join(target, name))]))
+      : fs.readFileSync(target).toString('base64') };
+}
+
+for (const raw of ['unchanged', 'unchanged-internal', 'rotated', 'missing', 'malformed', 'empty']) {
+  for (const outcome of ['passed', 'preflight-failed', 'preflight-threw', 'child-failed', 'child-threw',
+    'terminated', 'missing-proof', 'cleanup-missing', 'stop-missing']) {
+    test(`Full OAuth custody: ${raw}, ${outcome}`, async () => {
+      const { root, env } = fixture();
+      const store = JSON.parse(fs.readFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, 'utf8'));
+      store.selected = { type: 'oauth', access: 'synthetic-C0', refresh: 'synthetic-refresh' };
+      const original = JSON.stringify(store);
+      fs.writeFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, original);
+      fs.writeFileSync(path.join(root, TEST_PROJECT_MARKER), TEST_PROJECT_MARKER_CONTENT);
+      if (raw !== 'unchanged-internal') env.OPENCODE_E2E_PROJECT_PATH = root;
+      let input, before, projectBefore, spawns = 0;
+      const logs = [];
+      const handoffsBefore = fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('opencode-team-auth-handoff-'));
+      const stage = (value) => {
+        input = value;
+        const runEnv = value.env;
+        for (const [key, name] of [
+          ['XDG_DATA_HOME', 'sidecar'], ['XDG_STATE_HOME', 'receipt'], ['HOME', 'nativehistory'],
+          ['CLAUDE_MULTIMODEL_DATA_HOME', 'fence'], ['CLAUDE_MULTIMODEL_CACHE_HOME', 'ledger'],
+          ['TMPDIR', 'profiles'],
+        ]) fs.writeFileSync(path.join(runEnv[key], name), `opaque-synthetic-${name}\0`, { mode: 0o600 });
+        fs.writeFileSync(path.join(value.projectPath, 'identity'), 'synthetic-project', { mode: 0o600 });
+        const auth = path.join(runEnv.XDG_DATA_HOME, 'opencode/auth.json');
+        if (raw === 'missing') fs.unlinkSync(auth);
+        if (raw === 'malformed') fs.writeFileSync(auth, '{synthetic-invalid');
+        if (raw === 'empty') fs.writeFileSync(auth, '{}');
+        if (raw === 'rotated') {
+          const selected = JSON.parse(fs.readFileSync(auth, 'utf8'));
+          selected.selected.refresh = 'synthetic-rotated';
+          fs.writeFileSync(auth, JSON.stringify(selected));
+        }
+        before = custodySnapshot(runEnv.OPENCODE_E2E_OWNED_ROOT);
+        projectBefore = custodySnapshot(value.projectPath);
+      };
+      try {
+        const run = runFullTeamSmoke({ sourceEnv: env, vitestEntryPath: path.join(root, 'vitest.mjs'),
+          log: (message) => logs.push(message),
+          preflight: async (value) => {
+            stage(value);
+            if (outcome === 'preflight-threw') throw new Error('synthetic-preflight-error');
+            return { ok: outcome !== 'preflight-failed' };
+          },
+          spawn: () => {
+            spawns++;
+            if (outcome === 'child-threw') throw new Error('synthetic-child-error');
+            if (outcome !== 'missing-proof') {
+              const proof = passingProof();
+              if (outcome === 'cleanup-missing') delete proof.cleanupConfirmed;
+              if (outcome === 'stop-missing') delete proof.finalStopConfirmed;
+              fs.writeFileSync(path.join(input.env.OPENCODE_E2E_PROOF_DIRECTORY, 'proof.json'), JSON.stringify(proof));
+            }
+            return { status: outcome === 'child-failed' ? 7 : outcome === 'terminated' ? null : 0,
+              stderr: 'synthetic-provider-error' };
+          },
+        });
+        if (['preflight-threw', 'child-threw', 'missing-proof', 'cleanup-missing', 'stop-missing'].includes(outcome))
+          await assert.rejects(run);
+        else assert.equal(await run, outcome === 'passed' ? 0 : outcome === 'child-failed' ? 7 : 1);
+        assert.equal(spawns, outcome.startsWith('preflight-') ? 0 : 1);
+        assert.deepEqual(custodySnapshot(input.env.OPENCODE_E2E_OWNED_ROOT), before);
+        assert.deepEqual(custodySnapshot(input.projectPath), projectBefore);
+        if (process.platform !== 'win32') {
+          assert.equal(before.mode & 0o777, 0o700);
+          assert.equal(before.contents['.opencode-proof-owned.json'].mode & 0o777, 0o600);
+          assert.equal(projectBefore.mode & 0o777, 0o700);
+          assert.equal(projectBefore.contents['.opencode-proof-project.json'].mode & 0o777, 0o600);
+        }
+        assert.equal(fs.readFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, 'utf8'), original);
+        assert.deepEqual(fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('opencode-team-auth-handoff-')), handoffsBefore);
+        assert.doesNotMatch(logs.join('\n'), /synthetic|handoff|exported|valid|reusable|Rotated selected auth/i);
+        if (outcome === 'passed') {
+          assert.ok(logs.some((line) => line.includes(`owned OAuth state retained: ${input.env.OPENCODE_E2E_OWNED_ROOT}, project ${input.projectPath}`)));
+        } else assert.ok(logs.some((line) => line.startsWith('Smoke failed;')));
+        assert.equal(fs.readFileSync(path.join(root, TEST_PROJECT_MARKER), 'utf8'), TEST_PROJECT_MARKER_CONTENT);
+      } finally {
+        if (input) fs.rmSync(input.projectPath, { recursive: true, force: true });
+        cleanup(input); fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+}

--- a/test/scripts/proveOpenCodeFullTeam.test.mjs
+++ b/test/scripts/proveOpenCodeFullTeam.test.mjs
@@ -461,7 +461,6 @@ for (const raw of ['unchanged', 'unchanged-internal', 'rotated', 'missing', 'mal
       if (raw !== 'unchanged-internal') env.OPENCODE_E2E_PROJECT_PATH = root;
       let input, before, projectBefore, spawns = 0;
       const logs = [];
-      const handoffsBefore = fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('opencode-team-auth-handoff-'));
       const stage = (value) => {
         input = value;
         const runEnv = value.env;
@@ -517,7 +516,6 @@ for (const raw of ['unchanged', 'unchanged-internal', 'rotated', 'missing', 'mal
           assert.equal(projectBefore.contents['.opencode-proof-project.json'].mode & 0o777, 0o600);
         }
         assert.equal(fs.readFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, 'utf8'), original);
-        assert.deepEqual(fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('opencode-team-auth-handoff-')), handoffsBefore);
         assert.doesNotMatch(logs.join('\n'), /synthetic|handoff|exported|valid|reusable|Rotated selected auth/i);
         if (outcome === 'passed') {
           assert.ok(logs.some((line) => line.includes(`owned OAuth state retained: ${input.env.OPENCODE_E2E_OWNED_ROOT}, project ${input.projectPath}`)));

--- a/test/scripts/proveOpenCodeMixedTeam.test.mjs
+++ b/test/scripts/proveOpenCodeMixedTeam.test.mjs
@@ -9,7 +9,6 @@ import { test } from 'node:test';
 import { URL } from 'node:url';
 
 import {
-  preserveRotatedSelectedOAuth,
   runMixedTeamSmoke,
 } from '../../scripts/prove-opencode-mixed-team.mjs';
 
@@ -23,7 +22,6 @@ async function importOfflineHelper(relativePath) {
 }
 const evidenceHelpers = await importOfflineHelper('../main/services/team/openCodeMixedTeamEvidence.ts');
 const diagnosticsHelpers = await importOfflineHelper('../main/services/team/openCodeFullTeamProofDiagnostics.ts');
-
 
 function passingProof() {
   const names = ['zai-one', 'zai-two', 'grok-one', 'grok-two'];
@@ -120,8 +118,8 @@ test('isolates auth/home/config and retains cleanup-confirmed proof after succes
       },
     });
     assert.equal(status, 0);
-    assert.equal(fs.existsSync(input.projectPath), false);
-    assert.equal(fs.existsSync(input.env.HOME), false);
+    assert.equal(fs.existsSync(input.projectPath), true);
+    assert.equal(fs.existsSync(input.env.HOME), true);
     assert.ok(fs.existsSync(path.join(input.env.OPENCODE_E2E_PROOF_DIRECTORY, 'proof.json')));
   } finally {
     cleanup(input);
@@ -215,63 +213,6 @@ test('rejects external project and absent/non-OAuth SuperGrok before preflight',
   }
 });
 
-test('retains rotated OAuth only in a private selected-auth handoff', () => {
-  const { root, env } = fixture();
-  let handoff;
-  try {
-    const initial = fs.readFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, 'utf8');
-    assert.equal(preserveRotatedSelectedOAuth(initial, env.OPENCODE_E2E_TEST_AUTH_PATH), null);
-    const current = JSON.parse(initial);
-    delete current.unrelated;
-    current.xai.refresh = 'synthetic-rotated-refresh';
-    current.unexpected = { type: 'api', key: 'must-not-copy' };
-    fs.writeFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, JSON.stringify(current));
-    // The runner supplies only selected providers as initialJson.
-    const selected = JSON.stringify({
-      'zai-coding-plan': JSON.parse(initial)['zai-coding-plan'],
-      xai: JSON.parse(initial).xai,
-    });
-    handoff = preserveRotatedSelectedOAuth(selected, env.OPENCODE_E2E_TEST_AUTH_PATH);
-    assert.equal(fs.statSync(handoff).mode & 0o777, 0o600);
-    assert.equal(fs.statSync(path.dirname(handoff)).mode & 0o777, 0o700);
-    const saved = JSON.parse(fs.readFileSync(handoff, 'utf8'));
-    assert.deepEqual(Object.keys(saved).sort(), ['xai', 'zai-coding-plan']);
-    assert.equal(saved.xai.refresh, 'synthetic-rotated-refresh');
-  } finally {
-    if (handoff) fs.rmSync(path.dirname(handoff), { recursive: true, force: true });
-    fs.rmSync(root, { recursive: true, force: true });
-  }
-});
-
-test('fails successful inference cleanup if selected OAuth cannot be recovered', async () => {
-  const { root, env } = fixture();
-  let input;
-  try {
-    const status = await runMixedTeamSmoke({
-      vitestEntryPath: path.join(root, 'vitest.mjs'),
-      sourceEnv: env,
-      log() {},
-      preflight: async (value) => {
-        input = value;
-        return { ok: true };
-      },
-      spawn: (_command, _args, { env: runEnv }) => {
-        fs.writeFileSync(
-          path.join(runEnv.OPENCODE_E2E_PROOF_DIRECTORY, 'proof.json'),
-          JSON.stringify(passingProof())
-        );
-        fs.writeFileSync(path.join(runEnv.XDG_DATA_HOME, 'opencode/auth.json'), '{}');
-        return { status: 0 };
-      },
-    });
-    assert.equal(status, 1);
-    assert.ok(fs.existsSync(input.env.HOME));
-  } finally {
-    cleanup(input);
-    fs.rmSync(root, { recursive: true, force: true });
-  }
-});
-
 test('mixed wrapper requires both explicit opt-ins before credential access', async () => {
   const { root, env } = fixture();
   try {
@@ -311,31 +252,6 @@ test('mixed wrapper rejects wrong member/model/task/ACK and empty evidence despi
     }
   } finally { cleanup(input); fs.rmSync(root, { recursive: true, force: true }); }
 });
-
-test('OAuth handoff covers every selected provider and rejects lost refresh tokens', () => {
-  const { root, env } = fixture();
-  let handoff;
-  const initial = {
-    'zai-coding-plan': { type: 'oauth', access: 'synthetic-zai', refresh: 'synthetic-zai-refresh' },
-    xai: { type: 'oauth', access: 'synthetic-xai', refresh: 'synthetic-xai-refresh' },
-  };
-  try {
-    fs.writeFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, JSON.stringify({ ...initial,
-      'zai-coding-plan': { ...initial['zai-coding-plan'], refresh: 'synthetic-zai-rotated' },
-      unrelated: { type: 'api', key: 'synthetic-unrelated' },
-    }));
-    handoff = preserveRotatedSelectedOAuth(JSON.stringify(initial), env.OPENCODE_E2E_TEST_AUTH_PATH);
-    const saved = JSON.parse(fs.readFileSync(handoff, 'utf8'));
-    assert.equal(saved['zai-coding-plan'].refresh, 'synthetic-zai-rotated');
-    assert.equal(saved.unrelated, undefined);
-    fs.writeFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, JSON.stringify({ ...initial, xai: { type: 'oauth', access: 'synthetic-new' } }));
-    assert.throws(() => preserveRotatedSelectedOAuth(JSON.stringify(initial), env.OPENCODE_E2E_TEST_AUTH_PATH), /recovery unavailable/);
-  } finally {
-    if (handoff) fs.rmSync(path.dirname(handoff), { recursive: true, force: true });
-    fs.rmSync(root, { recursive: true, force: true });
-  }
-});
-
 
 function toolTranscript(name, input, output = '', overrides = {}) {
   return { data: { sessionId: 'session-1', messages: [{ role: 'assistant', providerId: 'selected',
@@ -464,3 +380,94 @@ test('failed proof persistence still resets process-wide Claude path isolation',
   await evidenceHelpers.finalizeProof(async () => {}, () => { resets++; });
   assert.equal(resets, 2);
 });
+
+// Opaque custody fixtures deliberately model no runtime authority or admission rules.
+function custodySnapshot(target) {
+  const stat = fs.lstatSync(target);
+  return { mode: stat.mode, ino: stat.ino, dev: stat.dev,
+    contents: stat.isDirectory()
+      ? Object.fromEntries(fs.readdirSync(target).sort().map((name) => [name, custodySnapshot(path.join(target, name))]))
+      : fs.readFileSync(target).toString('base64') };
+}
+
+for (const raw of ['unchanged', 'rotated', 'missing', 'malformed', 'empty']) {
+  for (const outcome of ['passed', 'preflight-failed', 'preflight-threw', 'child-failed', 'child-threw',
+    'terminated', 'missing-proof', 'cleanup-missing', 'stop-missing']) {
+    test(`Mixed OAuth custody: ${raw}, ${outcome}`, async () => {
+      const { root, env } = fixture();
+      const store = JSON.parse(fs.readFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, 'utf8'));
+      store.xai = { type: 'oauth', access: 'synthetic-C0', refresh: 'synthetic-refresh' };
+      const original = JSON.stringify(store);
+      fs.writeFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, original);
+
+      let input, before, projectBefore, spawns = 0;
+      const logs = [];
+      const handoffsBefore = fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('opencode-team-auth-handoff-'));
+      const stage = (value) => {
+        input = value;
+        const runEnv = value.env;
+        for (const [key, name] of [
+          ['XDG_DATA_HOME', 'sidecar'], ['XDG_STATE_HOME', 'receipt'], ['HOME', 'nativehistory'],
+          ['CLAUDE_MULTIMODEL_DATA_HOME', 'fence'], ['CLAUDE_MULTIMODEL_CACHE_HOME', 'ledger'],
+          ['TMPDIR', 'profiles'],
+        ]) fs.writeFileSync(path.join(runEnv[key], name), `opaque-synthetic-${name}\0`, { mode: 0o600 });
+        fs.writeFileSync(path.join(value.projectPath, 'identity'), 'synthetic-project', { mode: 0o600 });
+        const auth = path.join(runEnv.XDG_DATA_HOME, 'opencode/auth.json');
+        if (raw === 'missing') fs.unlinkSync(auth);
+        if (raw === 'malformed') fs.writeFileSync(auth, '{synthetic-invalid');
+        if (raw === 'empty') fs.writeFileSync(auth, '{}');
+        if (raw === 'rotated') {
+          const selected = JSON.parse(fs.readFileSync(auth, 'utf8'));
+          selected.xai.refresh = 'synthetic-rotated';
+          fs.writeFileSync(auth, JSON.stringify(selected));
+        }
+        before = custodySnapshot(runEnv.OPENCODE_E2E_OWNED_ROOT);
+        projectBefore = custodySnapshot(value.projectPath);
+      };
+      try {
+        const run = runMixedTeamSmoke({ sourceEnv: env, vitestEntryPath: path.join(root, 'vitest.mjs'),
+          log: (message) => logs.push(message),
+          preflight: async (value) => {
+            stage(value);
+            if (outcome === 'preflight-threw') throw new Error('synthetic-preflight-error');
+            return { ok: outcome !== 'preflight-failed' };
+          },
+          spawn: () => {
+            spawns++;
+            if (outcome === 'child-threw') throw new Error('synthetic-child-error');
+            if (outcome !== 'missing-proof') {
+              const proof = passingProof();
+              if (outcome === 'cleanup-missing') delete proof.cleanupConfirmed;
+              if (outcome === 'stop-missing') delete proof.finalStopConfirmed;
+              fs.writeFileSync(path.join(input.env.OPENCODE_E2E_PROOF_DIRECTORY, 'proof.json'), JSON.stringify(proof));
+            }
+            return { status: outcome === 'child-failed' ? 7 : outcome === 'terminated' ? null : 0,
+              stderr: 'synthetic-provider-error' };
+          },
+        });
+        if (['preflight-threw', 'child-threw', 'missing-proof', 'cleanup-missing', 'stop-missing'].includes(outcome))
+          await assert.rejects(run);
+        else assert.equal(await run, outcome === 'passed' ? 0 : outcome === 'child-failed' ? 7 : 1);
+        assert.equal(spawns, outcome.startsWith('preflight-') ? 0 : 1);
+        assert.deepEqual(custodySnapshot(input.env.OPENCODE_E2E_OWNED_ROOT), before);
+        assert.deepEqual(custodySnapshot(input.projectPath), projectBefore);
+        if (process.platform !== 'win32') {
+          assert.equal(before.mode & 0o777, 0o700);
+          assert.equal(before.contents['.opencode-proof-owned.json'].mode & 0o777, 0o600);
+          assert.equal(projectBefore.mode & 0o777, 0o700);
+          assert.equal(projectBefore.contents['.opencode-proof-project.json'].mode & 0o777, 0o600);
+        }
+        assert.equal(fs.readFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, 'utf8'), original);
+        assert.deepEqual(fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('opencode-team-auth-handoff-')), handoffsBefore);
+        assert.doesNotMatch(logs.join('\n'), /synthetic|handoff|exported|valid|reusable|Rotated selected auth/i);
+        if (outcome === 'passed') {
+          assert.ok(logs.some((line) => line.includes(`owned OAuth state retained: ${input.env.OPENCODE_E2E_OWNED_ROOT}, project ${input.projectPath}`)));
+        } else assert.ok(logs.some((line) => line.startsWith('Smoke failed;')));
+
+      } finally {
+        if (input) fs.rmSync(input.projectPath, { recursive: true, force: true });
+        cleanup(input); fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+}

--- a/test/scripts/proveOpenCodeMixedTeam.test.mjs
+++ b/test/scripts/proveOpenCodeMixedTeam.test.mjs
@@ -402,7 +402,6 @@ for (const raw of ['unchanged', 'rotated', 'missing', 'malformed', 'empty']) {
 
       let input, before, projectBefore, spawns = 0;
       const logs = [];
-      const handoffsBefore = fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('opencode-team-auth-handoff-'));
       const stage = (value) => {
         input = value;
         const runEnv = value.env;
@@ -458,7 +457,6 @@ for (const raw of ['unchanged', 'rotated', 'missing', 'malformed', 'empty']) {
           assert.equal(projectBefore.contents['.opencode-proof-project.json'].mode & 0o777, 0o600);
         }
         assert.equal(fs.readFileSync(env.OPENCODE_E2E_TEST_AUTH_PATH, 'utf8'), original);
-        assert.deepEqual(fs.readdirSync(os.tmpdir()).filter((name) => name.startsWith('opencode-team-auth-handoff-')), handoffsBefore);
         assert.doesNotMatch(logs.join('\n'), /synthetic|handoff|exported|valid|reusable|Rotated selected auth/i);
         if (outcome === 'passed') {
           assert.ok(logs.some((line) => line.includes(`owned OAuth state retained: ${input.env.OPENCODE_E2E_OWNED_ROOT}, project ${input.projectPath}`)));


### PR DESCRIPTION
Successful OAuth smoke runs could delete the only runtime-authorized successor because cleanup inspected unchanged raw auth inputs. Retain the entire private owned sandbox and project whenever selected credentials include OAuth. Successful exit still requires complete proof and confirmed process cleanup. Failed runs retain state and fail; API-only success still deletes its owned files.

Remove raw-token export helpers. Retention preserves evidence; it does not establish reusable credentials or bypass normal runtime admission. No runtime API or authority checks change.

Validation: independent hosted review approved the four changed files; all 128 offline script tests pass. The same tests against the original wrappers produce 76 failures and 52 passes. Cases cover unchanged, rotated, missing and malformed raw auth, opaque authority artifacts, external marked test projects and failed/incomplete proof. No real credentials or providers were used by these tests.

Based on merged #633 at 5c5fc0d46f2a1592b1c6700d0f5b38140f6cf7ee. Current head 3fe038377e9225b6ce5b6fe29efaacde75c78bba retains byte-identical custody source/test files from independently reviewed b674b0084e4a589d8ac461e88e7d651d099664f5. Final CI is running on the rebased head. No release publication.
