### PR TITLE
feat(opencode): expose copyable version failure diagnostics

### DIFF
--- a/docs/opencode-error-diagnostics.md
+++ b/docs/opencode-error-diagnostics.md
@@ -1,0 +1,24 @@
+# OpenCode error diagnostics
+
+When an OpenCode `--version` probe fails, the onboarding error exposes a compact stage label and a Copy diagnostics button. Details expand to show the selected binary/source, elapsed time and timeout, exit code or signal, bounded stdout/stderr, platform and a report ID. The same ID appears in `app-errors.ndjson`.
+
+The report is an opt-in support artifact. It retains binary paths (which can include a username), while removing credential-like values and URL credentials/query strings. It never intentionally collects environment variables, auth files, HTTP headers or response bodies. Clipboard failure exposes selectable text. A successful status retry removes the previous error.
+
+Provider-management diagnostics also accept optional stage/timing/HTTP metadata from a compatible runtime. Older runtime responses remain supported. This app change does not upgrade the bundled runtime or claim to diagnose every catalog failure. Runtime startup and catalog HTTP collection, aggregated status errors, and the separately reported five-second Windows summary timeout need their own changes.
+
+## Verification
+
+Focused suites cover the CLI boundary, installer, report normalization and clipboard failure/stale completion. The isolated Linux Electron fixture verified nonzero exit, the actual 30-second timeout, real clipboard copying, log correlation and successful recovery.
+
+The Unix-only desktop fixture can be run with:
+
+```sh
+node scripts/e2e/opencode-diagnostics-desktop.mjs seed
+node scripts/e2e/opencode-diagnostics-desktop.mjs start <printed-sandbox-path>
+node scripts/e2e/opencode-diagnostics-desktop.mjs verify <printed-sandbox-path>
+node scripts/e2e/opencode-diagnostics-desktop.mjs stop <printed-sandbox-path>
+```
+
+Use only disposable profiles/projects. The start command refuses an occupied dev CDP port. On a headless Linux host use Xvfb. The harness disables the Chromium sandbox for the test Electron process and must not load untrusted content. It does not launch teams or agents.
+
+Set the sandbox's `scenario` file to `version-exit`, `version-timeout` or `ready` before verification. The clipboard assertion uses the isolated test display. Windows and macOS desktop qualification and full production-runtime HTTP desktop E2E have not been completed.

--- a/docs/opencode-error-diagnostics.md
+++ b/docs/opencode-error-diagnostics.md
@@ -19,6 +19,6 @@ node scripts/e2e/opencode-diagnostics-desktop.mjs verify <printed-sandbox-path>
 node scripts/e2e/opencode-diagnostics-desktop.mjs stop <printed-sandbox-path>
 ```
 
-Use only disposable profiles/projects. The start command refuses an occupied dev CDP port. On a headless Linux host use Xvfb. The harness disables the Chromium sandbox for the test Electron process and must not load untrusted content. It does not launch teams or agents.
+Use only disposable profiles/projects. The start command refuses an occupied dev CDP port. The Unix harness requires `ps` and `lsof` and verifies the CDP listener belongs to the recorded launcher process tree before interacting with it. On a headless Linux host use Xvfb. The harness disables the Chromium sandbox for the test Electron process and must not load untrusted content. It does not launch teams or agents.
 
 Set the sandbox's `scenario` file to `version-exit`, `version-timeout` or `ready` before verification. The clipboard assertion uses the isolated test display. Windows and macOS desktop qualification and full production-runtime HTTP desktop E2E have not been completed.

--- a/docs/opencode-user-diagnostic-prompt.md
+++ b/docs/opencode-user-diagnostic-prompt.md
@@ -1,0 +1,50 @@
+# OpenCode integration diagnostic prompt
+
+Help diagnose an OpenCode integration failure in Agent Teams on my machine.
+
+## Symptoms
+
+- The installed app sometimes times out running OpenCode `--version`.
+- Other times it reports:
+  ```text
+  opencode: OpenCode catalog request failed.
+  cursor-acp: OpenCode catalog request failed.
+  kiro: OpenCode catalog request failed.
+  ollama: OpenCode catalog request failed.
+  ```
+- OpenCode works independently in my terminal and in its desktop app.
+- Running Agent Teams as administrator did not resolve the issue.
+
+Repository: 777genius/agent-teams-ai
+
+## Investigation
+
+Investigate first, without changing code or reinstalling anything:
+
+1. Record my OS, installed Agent Teams version, OpenCode version and installation method. Locate all OpenCode executables resolved by my shell.
+
+2. Locate Agent Teams diagnostics and `app-errors.ndjson`, if available. Inspect entries around a fresh reproduction. Ask me to reproduce the failure if necessary. Do not assume missing logs mean nothing failed.
+
+3. Determine the exact OpenCode executable selected by Agent Teams, including whether it is app-managed or resolved from PATH. Compare it with the working terminal executable. Distinguish confirmed observations from information inferred from code.
+
+4. Run that exact executable with `--version` from a new disposable test directory. Capture elapsed time, stdout, stderr and exit status. Compare relevant environment differences with the app where observable: PATH, working directory, home/config directories and elevation. Never dump the full environment or authentication files.
+
+5. Trace catalog loading in the source matching the installed release. Identify whether the failure occurs during executable discovery, version probing, server startup or a catalog HTTP request. Preserve the underlying error, including connection cause or HTTP status. Do not treat the repeated provider errors as independent failures without evidence.
+
+6. If installed-app evidence is insufficient, clone into a new test directory and follow the repository setup instructions. Use the desktop Electron app via `pnpm dev` and capture terminal output. If automating UI inspection, follow the repository's `pnpm dev:mcp` instructions. Compare the matching release first; label any tests against a newer version separately.
+
+## Constraints
+
+Do not launch teams or agents, open runtimes in real projects, modify credentials, disable security software or kill unrelated processes.
+
+Redact tokens, passwords, authorization headers and private data from anything you ask me to share.
+
+## Report
+
+Return a concise report:
+
+- Confirmed failing stage and evidence.
+- Exact executable and version used.
+- Relevant sanitized log excerpts.
+- Whether the installed and development apps behave differently.
+- Most likely cause, confidence and the smallest next diagnostic step.

--- a/scripts/e2e/opencode-diagnostics-desktop.mjs
+++ b/scripts/e2e/opencode-diagnostics-desktop.mjs
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+// Disposable Electron profile and CLI only. No agent/team launch commands.
+import assert from 'node:assert/strict';
+import { execFileSync, spawn } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import WebSocket from 'ws';
+
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const mode = process.argv[2];
+const root = process.argv[3];
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function manifest() {
+  assert(
+    root && path.basename(root).startsWith('opencode-diagnostics-e2e-'),
+    'Owned sandbox required'
+  );
+  const data = JSON.parse(await readFile(path.join(root, 'manifest.json'), 'utf8'));
+  assert.equal(data.root, path.resolve(root));
+  return data;
+}
+
+if (mode === 'seed') {
+  assert(
+    process.platform !== 'win32',
+    'This shell fixture runner supports Unix; Windows requires native shim fixtures'
+  );
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'opencode-diagnostics-e2e-'));
+  const data = {
+    root: dir,
+    home: path.join(dir, 'home'),
+    userData: path.join(dir, 'user-data'),
+    bin: path.join(dir, 'bin'),
+  };
+  for (const value of [data.home, data.userData, data.bin]) await mkdir(value, { recursive: true });
+  await writeFile(path.join(dir, 'manifest.json'), JSON.stringify(data));
+  await writeFile(path.join(dir, 'scenario'), 'version-exit');
+  const fixture = `#!${process.execPath}
+const fs = require('node:fs');
+const root = ${JSON.stringify(dir)};
+const scenario = fs.readFileSync(root + '/scenario', 'utf8').trim();
+const args = process.argv.slice(2);
+fs.appendFileSync(root + '/calls.ndjson', JSON.stringify({binary: process.argv[1], args})+'\\n');
+if (process.argv[1].endsWith('/opencode')) {
+  if (scenario === 'version-timeout') { process.stderr.write('waiting for fixture\\n'); setTimeout(()=>{}, 60000); }
+  else if (scenario === 'version-exit') { process.stderr.write('fixture failed api_key=DO_NOT_COPY_THIS_SECRET\\n'); process.exitCode=9; }
+  else console.log('1.14.24');
+} else if (args.includes('--version')) console.log('2.1.114 (Claude Code)');
+else if (args[0] === 'auth') console.log(JSON.stringify({loggedIn:true,authMethod:'oauth'}));
+else if (args[0] === 'runtime' && args[1] === 'status') console.log(JSON.stringify({providers:Object.fromEntries(['anthropic','codex','gemini','opencode'].map(providerId=>[providerId,{providerId,supported:true,authenticated:true,verificationState:'verified',statusCheckOutcome:'authoritative',statusMessage:'Sandbox fixture',models:[],capabilities:{teamLaunch:false,oneShot:false}}]))}));
+else if (args[0] === 'runtime' && args[1] === 'providers') console.log(JSON.stringify({runtimeId:'opencode',ok:false,error:{code:'runtime-unhealthy',message:'Sandbox provider settings unavailable',recoverable:true}}));
+else console.log('{}');
+`;
+  for (const name of ['opencode', 'fixture-runtime'])
+    await writeFile(path.join(data.bin, name), fixture, { mode: 0o755 });
+  console.log(dir);
+} else if (mode === 'stop') {
+  await manifest();
+  const launcher = Number(await readFile(path.join(root, 'launcher.pid'), 'utf8'));
+  const lines = execFileSync('ps', ['-eo', 'pid=,ppid=,args='], { encoding: 'utf8' })
+    .trim()
+    .split('\n');
+  const processes = lines
+    .map((line) => {
+      const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
+      return match ? { pid: Number(match[1]), parent: Number(match[2]), command: match[3] } : null;
+    })
+    .filter(Boolean);
+  assert(
+    processes.find((entry) => entry.pid === launcher)?.command.includes('pnpm dev:mcp'),
+    'Launcher identity changed; refusing cleanup'
+  );
+  const owned = [launcher];
+  for (let index = 0; index < owned.length; index++)
+    for (const entry of processes) if (entry.parent === owned[index]) owned.push(entry.pid);
+  for (const pid of owned.reverse()) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch (error) {
+      if (error.code !== 'ESRCH') throw error;
+    }
+  }
+  console.log('Stopped owned test process tree');
+} else if (mode === 'start') {
+  const data = await manifest();
+  // Refuse to attach to a pre-existing app or replace its CDP endpoint.
+  let occupied = false;
+  try {
+    occupied = (await fetch('http://127.0.0.1:9222/json/version')).ok;
+  } catch {
+    /* vacant */
+  }
+  assert(!occupied, 'Port 9222 belongs to another process');
+  const child = spawn('pnpm', ['dev:mcp', '--noSandbox'], {
+    cwd: repo,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      HOME: data.home,
+      USERPROFILE: data.home,
+      PATH: `${data.bin}${path.delimiter}${process.env.PATH}`,
+      SHELL: '/bin/sh',
+      AGENT_TEAMS_ELECTRON_USER_DATA_DIR: data.userData,
+      AGENT_TEAMS_ELECTRON_CLAUDE_ROOT: path.join(data.home, '.claude'),
+      CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH: path.join(data.bin, 'fixture-runtime'),
+      CLAUDE_CLI_PATH: path.join(data.bin, 'fixture-runtime'),
+      CLAUDE_TEAM_OPENCODE_MCP_HTTP: '0',
+      NODE_BINARY: process.execPath,
+      XDG_CONFIG_HOME: path.join(data.home, '.config'),
+      XDG_DATA_HOME: path.join(data.home, '.local/share'),
+    },
+  });
+  await writeFile(path.join(root, 'launcher.pid'), String(child.pid));
+  child.on('exit', (code) => {
+    process.exitCode = code ?? 1;
+  });
+  process.on('SIGTERM', () => child.kill('SIGTERM'));
+} else if (mode === 'inspect' || mode === 'verify') {
+  await manifest();
+  const targets = await (await fetch('http://127.0.0.1:9222/json/list')).json();
+  const target = targets.find(
+    (entry) => entry.type === 'page' && /^http:\/\/(localhost|127\.0\.0\.1):/.test(entry.url)
+  );
+  assert(target, 'No dev renderer');
+  const ws = new WebSocket(target.webSocketDebuggerUrl);
+  await new Promise((resolve, reject) => {
+    ws.once('open', resolve);
+    ws.once('error', reject);
+  });
+  let id = 0;
+  const pending = new Map();
+  ws.on('message', (raw) => {
+    const response = JSON.parse(String(raw));
+    if (response.method === 'Log.entryAdded' || response.method === 'Runtime.exceptionThrown')
+      console.log(JSON.stringify(response.params));
+    const item = pending.get(response.id);
+    if (item) {
+      pending.delete(response.id);
+      clearTimeout(item.timer);
+      response.error
+        ? item.reject(new Error(response.error.message))
+        : item.resolve(response.result);
+    }
+  });
+  const send = (method, params = {}) =>
+    new Promise((resolve, reject) => {
+      const key = ++id;
+      const timer = setTimeout(() => {
+        pending.delete(key);
+        reject(new Error(`CDP timeout: ${method} ${params.expression?.slice(0, 80) ?? ''}`));
+      }, 15000);
+      pending.set(key, { resolve, reject, timer });
+      ws.send(JSON.stringify({ id: key, method, params }));
+    });
+  const evaluate = async (expression) => {
+    const result = await send('Runtime.evaluate', {
+      expression,
+      returnByValue: true,
+      awaitPromise: true,
+      userGesture: true,
+    });
+    if (result.exceptionDetails) throw new Error(JSON.stringify(result.exceptionDetails));
+    return result.result?.value;
+  };
+  try {
+    await send('Runtime.enable');
+    await send('Log.enable');
+    await send('Page.bringToFront');
+    if (mode === 'verify')
+      await send('Browser.grantPermissions', {
+        origin: new URL(target.url).origin,
+        permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite'],
+      });
+    if (mode === 'inspect') {
+      console.log(await evaluate('document.body.innerText'));
+      console.log(
+        await evaluate(
+          'JSON.stringify({ready:document.readyState,resources:performance.getEntriesByType("resource").slice(-6).map(r=>({name:r.name,duration:r.duration})),scripts:[...document.scripts].map(s=>s.src)})'
+        )
+      );
+    } else {
+      const scenario = (await readFile(path.join(root, 'scenario'), 'utf8')).trim();
+      let found;
+      for (let attempt = 0; attempt < 90; attempt++) {
+        if (attempt === 0) {
+          const refresh = await evaluate(
+            `(() => { const button = [...document.querySelectorAll('button')].find(b => b.textContent.trim() === 'Refresh status' && !b.disabled); if (!button) return null; button.scrollIntoView({block:'center'}); const r = button.getBoundingClientRect(); return {x:r.x+r.width/2,y:r.y+r.height/2}; })()`
+          );
+          if (refresh) {
+            await send('Input.dispatchMouseEvent', {
+              type: 'mousePressed',
+              button: 'left',
+              clickCount: 1,
+              ...refresh,
+            });
+            await send('Input.dispatchMouseEvent', {
+              type: 'mouseReleased',
+              button: 'left',
+              clickCount: 1,
+              ...refresh,
+            });
+          }
+        }
+        found = await evaluate(
+          `document.querySelector('[data-testid="opencode-version-diagnostics"]')?.innerText`
+        );
+        if (
+          scenario === 'ready'
+            ? !found && attempt >= 5
+            : found && (scenario !== 'version-timeout' || found.includes('timed out'))
+        )
+          break;
+        await delay(1000);
+      }
+      if (scenario === 'ready') {
+        assert(!found, 'Successful retry retained stale diagnostics');
+        console.log(JSON.stringify({ passed: true, scenario, platform: process.platform }));
+        const screenshot = await send('Page.captureScreenshot');
+        await writeFile(path.join(root, 'ready.png'), Buffer.from(screenshot.data, 'base64'));
+        ws.close();
+        process.exit(0);
+      }
+      assert(found, 'Version diagnostic alert not visible');
+      assert.match(found, /version_probe/);
+      await evaluate(
+        `document.querySelector('[data-testid="opencode-version-diagnostics"] button').scrollIntoView({block:'center'})`
+      );
+      const point = await evaluate(
+        `(() => { const r = document.querySelector('[data-testid="opencode-version-diagnostics"] button').getBoundingClientRect(); return {x:r.x+r.width/2,y:r.y+r.height/2}; })()`
+      );
+      await send('Input.dispatchMouseEvent', {
+        type: 'mousePressed',
+        button: 'left',
+        clickCount: 1,
+        ...point,
+      });
+      await send('Input.dispatchMouseEvent', {
+        type: 'mouseReleased',
+        button: 'left',
+        clickCount: 1,
+        ...point,
+      });
+      for (let attempt = 0; attempt < 30; attempt++) {
+        if (
+          (
+            await evaluate(
+              `document.querySelector('[data-testid="opencode-version-diagnostics"] button').innerText`
+            )
+          ).includes('Copied')
+        )
+          break;
+        await delay(100);
+      }
+      const copied = await evaluate('navigator.clipboard.readText()');
+      assert.match(copied, /version_probe/);
+      assert.match(copied, /reportId: oc-[a-f0-9]{32}/);
+      assert.match(copied, /timeoutMs: 30000/);
+      assert.match(copied, scenario === 'version-timeout' ? /timedOut: true/ : /Exit code: 9/);
+      assert(!copied.includes('DO_NOT_COPY_THIS_SECRET'));
+      const logs = await readFile(path.join(root, 'user-data/logs/app-errors.ndjson'), 'utf8');
+      assert(!logs.includes('DO_NOT_COPY_THIS_SECRET'));
+      const reportId = copied.match(/reportId: (oc-[a-f0-9]{32})/)[1];
+      assert(logs.includes(reportId), 'Log lost the report correlation ID');
+      await writeFile(path.join(root, `copied-report-${scenario}.txt`), copied);
+      await writeFile(path.join(root, 'copied-report.txt'), copied);
+      console.log(
+        JSON.stringify({
+          passed: true,
+          platform: process.platform,
+          reportPath: path.join(root, 'copied-report.txt'),
+        })
+      );
+    }
+    const screenshot = await send('Page.captureScreenshot');
+    await writeFile(path.join(root, `${mode}.png`), Buffer.from(screenshot.data, 'base64'));
+  } finally {
+    ws.close();
+  }
+} else throw new Error('Usage: seed | start <sandbox> | inspect <sandbox> | verify <sandbox>');

--- a/scripts/e2e/opencode-diagnostics-desktop.mjs
+++ b/scripts/e2e/opencode-diagnostics-desktop.mjs
@@ -23,6 +23,53 @@ async function manifest() {
   return data;
 }
 
+function processBirth(pid) {
+  return execFileSync('ps', ['-p', String(pid), '-o', 'lstart='], {
+    encoding: 'utf8',
+    env: { ...process.env, LC_ALL: 'C' },
+  }).trim();
+}
+
+async function ownedProcessIds() {
+  const launcher = Number(await readFile(path.join(root, 'launcher.pid'), 'utf8'));
+  const expectedBirth = (await readFile(path.join(root, 'launcher.birth'), 'utf8')).trim();
+  assert(
+    expectedBirth && processBirth(launcher) === expectedBirth,
+    'Launcher PID was reused; refusing access'
+  );
+  const lines = execFileSync('ps', ['-eo', 'pid=,ppid=,args='], { encoding: 'utf8' })
+    .trim()
+    .split('\n');
+  const processes = lines
+    .map((line) => {
+      const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
+      return match ? { pid: Number(match[1]), parent: Number(match[2]), command: match[3] } : null;
+    })
+    .filter(Boolean);
+  assert(
+    processes.find((entry) => entry.pid === launcher)?.command.includes('pnpm dev:mcp'),
+    'Launcher identity changed; refusing cleanup'
+  );
+  const owned = [launcher];
+  for (let index = 0; index < owned.length; index++)
+    for (const entry of processes) if (entry.parent === owned[index]) owned.push(entry.pid);
+  return owned;
+}
+
+async function assertOwnedDebugEndpoint() {
+  const owned = await ownedProcessIds();
+  const listeners = execFileSync('lsof', ['-nP', '-t', '-iTCP:9222', '-sTCP:LISTEN'], {
+    encoding: 'utf8',
+  })
+    .trim()
+    .split(/\s+/)
+    .map(Number);
+  assert(
+    listeners.length && listeners.every((pid) => owned.includes(pid)),
+    'CDP listener is not owned by this sandbox; refusing access'
+  );
+}
+
 if (mode === 'seed') {
   assert(
     process.platform !== 'win32',
@@ -59,23 +106,7 @@ else console.log('{}');
   console.log(dir);
 } else if (mode === 'stop') {
   await manifest();
-  const launcher = Number(await readFile(path.join(root, 'launcher.pid'), 'utf8'));
-  const lines = execFileSync('ps', ['-eo', 'pid=,ppid=,args='], { encoding: 'utf8' })
-    .trim()
-    .split('\n');
-  const processes = lines
-    .map((line) => {
-      const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
-      return match ? { pid: Number(match[1]), parent: Number(match[2]), command: match[3] } : null;
-    })
-    .filter(Boolean);
-  assert(
-    processes.find((entry) => entry.pid === launcher)?.command.includes('pnpm dev:mcp'),
-    'Launcher identity changed; refusing cleanup'
-  );
-  const owned = [launcher];
-  for (let index = 0; index < owned.length; index++)
-    for (const entry of processes) if (entry.parent === owned[index]) owned.push(entry.pid);
+  const owned = await ownedProcessIds();
   for (const pid of owned.reverse()) {
     try {
       process.kill(pid, 'SIGTERM');
@@ -114,12 +145,14 @@ else console.log('{}');
     },
   });
   await writeFile(path.join(root, 'launcher.pid'), String(child.pid));
+  await writeFile(path.join(root, 'launcher.birth'), processBirth(child.pid));
   child.on('exit', (code) => {
     process.exitCode = code ?? 1;
   });
   process.on('SIGTERM', () => child.kill('SIGTERM'));
 } else if (mode === 'inspect' || mode === 'verify') {
   await manifest();
+  await assertOwnedDebugEndpoint();
   const targets = await (await fetch('http://127.0.0.1:9222/json/list')).json();
   const target = targets.find(
     (entry) => entry.type === 'page' && /^http:\/\/(localhost|127\.0\.0\.1):/.test(entry.url)

--- a/src/features/runtime-provider-management/contracts/errorDiagnostics.ts
+++ b/src/features/runtime-provider-management/contracts/errorDiagnostics.ts
@@ -1,0 +1,118 @@
+export const RUNTIME_ERROR_STAGES = [
+  'binary_lookup',
+  'version_probe',
+  'profile_setup',
+  'catalog_identity',
+  'server_startup',
+  'catalog_http',
+  'runtime_command',
+  'unknown',
+] as const;
+
+export interface RuntimeErrorDetails {
+  schemaVersion?: 1;
+  reportId?: string;
+  timestamp?: string;
+  appVersion?: string;
+  platform?: string;
+  arch?: string;
+  stage?: (typeof RUNTIME_ERROR_STAGES)[number];
+  binaryRole?: 'opencode' | 'orchestrator';
+  binarySource?: 'path' | 'app-managed' | 'unknown';
+  durationMs?: number;
+  timeoutMs?: number;
+  timedOut?: boolean;
+  signal?: string;
+  systemErrorCode?: string;
+  httpMethod?: string;
+  endpoint?: string;
+  httpStatus?: number;
+  cause?: string;
+}
+
+/** Sanitize before clipping, so a truncated credential cannot evade redaction. */
+export function cleanRuntimeDiagnosticText(value: unknown, limit = 4096): string | null {
+  if (typeof value !== 'string') return null;
+  // Telemetry redaction hides binary paths and report IDs needed for this opt-in report.
+  const cleaned = value
+    .replace(/\b(?:sk|pk|rk|ghp|gho|github_pat|xoxb|xoxp|ya29)[A-Za-z0-9_-]{12,}\b/g, '[redacted]')
+    .replace(/\b(?:Bearer|Basic)\s+[^\s,"']+/gi, '[redacted]')
+    .replace(
+      /((?:authorization|cookie|password|secret|api[-_]?key|[\w-]*token)["']?\s*[=:]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
+      '$1[redacted]'
+    )
+    .replace(/https?:\/\/[^\s<>"']+/gi, (url) => safeRuntimeEndpoint(url) ?? '[url redacted]');
+  return cleaned.length > limit ? `${cleaned.slice(0, limit - 15)}...[truncated]` : cleaned;
+}
+
+/** Only catalog routes are safe to retain; other path segments can contain credentials. */
+export function safeRuntimeEndpoint(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return undefined;
+    const route = ['/provider', '/config/providers', '/config', '/doc', '/global/health'].includes(
+      url.pathname
+    )
+      ? url.pathname
+      : '/[path redacted]';
+    return `${url.protocol}//${url.host}${route}`;
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeRuntimeErrorDetails(value: unknown): RuntimeErrorDetails {
+  if (!value || typeof value !== 'object') return {};
+  const input = value as Record<string, unknown>;
+  const output: RuntimeErrorDetails = {};
+  if (input.schemaVersion === 1) output.schemaVersion = 1;
+  for (const key of [
+    'reportId',
+    'timestamp',
+    'appVersion',
+    'platform',
+    'arch',
+    'signal',
+    'systemErrorCode',
+    'cause',
+  ] as const) {
+    const text = cleanRuntimeDiagnosticText(input[key], key === 'cause' ? 1024 : 256);
+    if (text) output[key] = text;
+  }
+  if (RUNTIME_ERROR_STAGES.includes(input.stage as RuntimeErrorDetails['stage'] & string)) {
+    output.stage = input.stage as RuntimeErrorDetails['stage'];
+  }
+  if (input.binaryRole === 'opencode' || input.binaryRole === 'orchestrator')
+    output.binaryRole = input.binaryRole;
+  if (
+    input.binarySource === 'path' ||
+    input.binarySource === 'app-managed' ||
+    input.binarySource === 'unknown'
+  )
+    output.binarySource = input.binarySource;
+  for (const key of ['durationMs', 'timeoutMs'] as const) {
+    if (typeof input[key] === 'number' && Number.isFinite(input[key]) && input[key] >= 0)
+      output[key] = Math.round(input[key]);
+  }
+  if (typeof input.timedOut === 'boolean') output.timedOut = input.timedOut;
+  if (
+    Number.isInteger(input.httpStatus) &&
+    Number(input.httpStatus) >= 100 &&
+    Number(input.httpStatus) <= 599
+  )
+    output.httpStatus = Number(input.httpStatus);
+  if (
+    typeof input.httpMethod === 'string' &&
+    /^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)$/.test(input.httpMethod)
+  )
+    output.httpMethod = input.httpMethod;
+  const endpoint = safeRuntimeEndpoint(input.endpoint);
+  if (endpoint) output.endpoint = endpoint;
+  return output;
+}
+
+export function runtimeErrorDetailRows(value: RuntimeErrorDetails): [string, string][] {
+  const details = normalizeRuntimeErrorDetails(value);
+  return Object.entries(details).map(([key, entry]) => [key, String(entry)]);
+}

--- a/src/features/runtime-provider-management/contracts/errorDiagnostics.ts
+++ b/src/features/runtime-provider-management/contracts/errorDiagnostics.ts
@@ -34,19 +34,49 @@ export interface RuntimeErrorDetails {
 export function cleanRuntimeDiagnosticText(value: unknown, limit = 4096): string | null {
   if (typeof value !== 'string') return null;
   // Telemetry redaction hides binary paths and report IDs needed for this opt-in report.
-  const cleaned = value
+  const withoutTokens = value
     .replace(/\b(?:sk|pk|rk|ghp|gho|github_pat|xoxb|xoxp|ya29)[A-Za-z0-9_-]{12,}\b/g, '[redacted]')
     .replace(/\b(?:or-[A-Za-z0-9_-]{12,}|AIza[A-Za-z0-9_-]{20,})\b/g, '[redacted]')
-    .replace(/\b(?:Bearer|Basic)\s+[^\s,"']+/gi, '[redacted]')
-    .replace(
-      /(\b([\w-]+)["']?\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s,;]+)/g,
-      (field: string, prefix: string, name: string) =>
-        /(?:authorization|cookie|password|secret|key|token)$/i.test(name)
-          ? `${prefix}[redacted]`
-          : field
-    )
-    .replace(/https?:\/\/[^\s<>"']+/gi, (url) => safeRuntimeEndpoint(url) ?? '[url redacted]');
+    .replace(/\b(?:Bearer|Basic)\s+[^\s,"']+/gi, '[redacted]');
+  const cleaned = redactCredentialFields(withoutTokens).replace(
+    /https?:\/\/[^\s<>"']+/gi,
+    (url) => safeRuntimeEndpoint(url) ?? '[url redacted]'
+  );
   return cleaned.length > limit ? `${cleaned.slice(0, limit - 15)}...[truncated]` : cleaned;
+}
+
+/** Consume a value only for a secret field, so enclosing messages/JSON cannot hide it. */
+function redactCredentialFields(value: string): string {
+  const pieces: string[] = [];
+  let consumed = 0;
+  for (const match of value.matchAll(/\b([\w-]+)["']?\s*[=:]\s*/g)) {
+    if (
+      match.index < consumed ||
+      !/(?:authorization|cookie|password|secret|key|token)$/i.test(match[1] ?? '')
+    )
+      continue;
+    const start = match.index + match[0].length;
+    let end = start;
+    const quote = value.charAt(start);
+    if (quote === '"' || quote === "'") {
+      end += 1;
+      while (end < value.length) {
+        if (value[end] === '\\') {
+          end = Math.min(end + 2, value.length);
+          continue;
+        }
+        if (value[end++] === quote) break;
+      }
+    } else if (/cookie$/i.test(match[1] ?? '')) {
+      while (end < value.length && !/[\r\n]/.test(value.charAt(end))) end += 1;
+    } else {
+      while (end < value.length && !/[\s,;}]/.test(value.charAt(end))) end += 1;
+    }
+    pieces.push(value.slice(consumed, start), '[redacted]');
+    consumed = end;
+  }
+  pieces.push(value.slice(consumed));
+  return pieces.join('');
 }
 
 /** Only catalog routes are safe to retain; other path segments can contain credentials. */

--- a/src/features/runtime-provider-management/contracts/errorDiagnostics.ts
+++ b/src/features/runtime-provider-management/contracts/errorDiagnostics.ts
@@ -36,10 +36,14 @@ export function cleanRuntimeDiagnosticText(value: unknown, limit = 4096): string
   // Telemetry redaction hides binary paths and report IDs needed for this opt-in report.
   const cleaned = value
     .replace(/\b(?:sk|pk|rk|ghp|gho|github_pat|xoxb|xoxp|ya29)[A-Za-z0-9_-]{12,}\b/g, '[redacted]')
+    .replace(/\b(?:or-[A-Za-z0-9_-]{12,}|AIza[A-Za-z0-9_-]{20,})\b/g, '[redacted]')
     .replace(/\b(?:Bearer|Basic)\s+[^\s,"']+/gi, '[redacted]')
     .replace(
-      /((?:authorization|cookie|password|secret|api[-_]?key|[\w-]*token)["']?\s*[=:]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
-      '$1[redacted]'
+      /(\b([\w-]+)["']?\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s,;]+)/g,
+      (field: string, prefix: string, name: string) =>
+        /(?:authorization|cookie|password|secret|key|token)$/i.test(name)
+          ? `${prefix}[redacted]`
+          : field
     )
     .replace(/https?:\/\/[^\s<>"']+/gi, (url) => safeRuntimeEndpoint(url) ?? '[url redacted]');
   return cleaned.length > limit ? `${cleaned.slice(0, limit - 15)}...[truncated]` : cleaned;

--- a/src/features/runtime-provider-management/contracts/index.ts
+++ b/src/features/runtime-provider-management/contracts/index.ts
@@ -1,5 +1,11 @@
 export type * from './api';
 export * from './channels';
+export type { RuntimeErrorDetails } from './errorDiagnostics';
+export {
+  cleanRuntimeDiagnosticText,
+  normalizeRuntimeErrorDetails,
+  runtimeErrorDetailRows,
+} from './errorDiagnostics';
 export type * from './types';
 export {
   isRuntimeProviderCompanionAction,

--- a/src/features/runtime-provider-management/contracts/types.ts
+++ b/src/features/runtime-provider-management/contracts/types.ts
@@ -1,3 +1,5 @@
+import type { RuntimeErrorDetails } from './errorDiagnostics';
+
 export type RuntimeProviderManagementRuntimeId = 'opencode';
 
 export const RUNTIME_PROVIDER_COMPANION_IDS = ['kiro-cli', 'cursor-agent'] as const;
@@ -337,7 +339,7 @@ export type RuntimeProviderManagementErrorCodeDto =
   | 'model-test-failed'
   | 'unsupported-auth-method';
 
-export interface RuntimeProviderManagementErrorDiagnosticsDto {
+export interface RuntimeProviderManagementErrorDiagnosticsDto extends RuntimeErrorDetails {
   errorCode?: RuntimeProviderManagementErrorCodeDto | null;
   summary: string | null;
   likelyCause: string | null;

--- a/src/features/runtime-provider-management/main/index.ts
+++ b/src/features/runtime-provider-management/main/index.ts
@@ -13,3 +13,8 @@ export {
   RECOMMENDED_AGENT_TEAMS_LOCAL_CONTEXT_TOKENS,
 } from './infrastructure/OpenCodeLocalModelRuntimeInspector';
 export { OpenCodeLocalProviderConnector } from './infrastructure/OpenCodeLocalProviderConnector';
+export {
+  type OpenCodeBinaryCandidateFailure,
+  type OpenCodeBinaryVersionProbe,
+  probeOpenCodeBinaryVersion,
+} from './infrastructure/openCodeVersionDiagnostics';

--- a/src/features/runtime-provider-management/main/infrastructure/AgentTeamsRuntimeProviderManagementCliClient.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/AgentTeamsRuntimeProviderManagementCliClient.ts
@@ -33,6 +33,7 @@ import {
   truncateCommandErrorDetail,
 } from './runtimeProviderCommandPresentation';
 import { normalizeRuntimeProviderDirectoryResponse } from './runtimeProviderDirectoryResponse';
+import { sanitizeRuntimeProviderDiagnostics } from './runtimeProviderErrorBoundary';
 import { RuntimeProviderModelRequestTracker } from './runtimeProviderModelRequestTracker';
 import {
   RUNTIME_PROVIDER_MODEL_PROBE_COMMAND_TIMEOUT_MS,
@@ -215,7 +216,10 @@ function sanitizeRuntimeProviderError(error: unknown): RuntimeProviderManagement
     RUNTIME_PROVIDER_ERROR_CODES.has(rawCode as RuntimeProviderManagementErrorDto['code'])
       ? (rawCode as RuntimeProviderManagementErrorDto['code'])
       : 'runtime-unhealthy';
-  const diagnostics = sanitizeRuntimeProviderDiagnostics(error.diagnostics);
+  const diagnostics = sanitizeRuntimeProviderDiagnostics(
+    error.diagnostics,
+    RUNTIME_PROVIDER_ERROR_CODES
+  );
   const message =
     sanitizeNullableRuntimeProviderText(error.message) ??
     'Runtime provider management command failed';
@@ -250,36 +254,6 @@ function sanitizeRuntimeProviderOutputValue(value: unknown): unknown {
   return Object.fromEntries(
     Object.entries(value).map(([key, entry]) => [key, sanitizeRuntimeProviderOutputValue(entry)])
   );
-}
-
-function sanitizeRuntimeProviderDiagnostics(
-  diagnostics: unknown
-): RuntimeProviderManagementErrorDto['diagnostics'] {
-  if (!isRecord(diagnostics)) {
-    return null;
-  }
-  return {
-    errorCode:
-      typeof diagnostics.errorCode === 'string' &&
-      RUNTIME_PROVIDER_ERROR_CODES.has(
-        diagnostics.errorCode as RuntimeProviderManagementErrorDto['code']
-      )
-        ? (diagnostics.errorCode as RuntimeProviderManagementErrorDto['code'])
-        : null,
-    summary: sanitizeNullableRuntimeProviderText(diagnostics.summary),
-    likelyCause: sanitizeNullableRuntimeProviderText(diagnostics.likelyCause),
-    binaryPath: sanitizeNullableRuntimeProviderText(diagnostics.binaryPath),
-    command: sanitizeNullableRuntimeProviderText(diagnostics.command),
-    projectPath: sanitizeNullableRuntimeProviderText(diagnostics.projectPath),
-    exitCode: typeof diagnostics.exitCode === 'number' ? diagnostics.exitCode : null,
-    stderrPreview: sanitizeNullableRuntimeProviderText(diagnostics.stderrPreview),
-    stdoutPreview: sanitizeNullableRuntimeProviderText(diagnostics.stdoutPreview),
-    hints: Array.isArray(diagnostics.hints)
-      ? diagnostics.hints
-          .filter((hint): hint is string => typeof hint === 'string')
-          .map(sanitizeRuntimeProviderText)
-      : [],
-  };
 }
 
 function sanitizeNullableRuntimeProviderText(value: unknown): string | null {

--- a/src/features/runtime-provider-management/main/infrastructure/openCodeVersionDiagnostics.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/openCodeVersionDiagnostics.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from 'node:crypto';
+
+import { execCli } from '@main/utils/childProcess';
+import { APP_VERSION } from '@shared/utils/buildMetadata';
+import { createLogger } from '@shared/utils/logger';
+
+import { cleanRuntimeDiagnosticText } from '../../contracts';
+
+import type { RuntimeProviderManagementErrorDiagnosticsDto } from '../../contracts';
+
+const logger = createLogger('OpenCodeVersionDiagnostics');
+const VERSION_TIMEOUT_MS = 30_000;
+
+export type OpenCodeBinaryVersionProbe =
+  | { ok: true; version: string | null }
+  | { ok: false; error: string; diagnostics: RuntimeProviderManagementErrorDiagnosticsDto };
+
+export interface OpenCodeBinaryCandidateFailure {
+  binaryPath: string;
+  error: string;
+  diagnostics?: RuntimeProviderManagementErrorDiagnosticsDto;
+}
+
+export async function probeOpenCodeBinaryVersion(
+  binaryPath: string
+): Promise<OpenCodeBinaryVersionProbe> {
+  const started = performance.now();
+  try {
+    const { stdout } = await execCli(binaryPath, ['--version'], {
+      timeout: VERSION_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    return { ok: true, version: stdout.trim() || null };
+  } catch (error) {
+    const raw = error && typeof error === 'object' ? (error as Record<string, unknown>) : {};
+    const message =
+      cleanRuntimeDiagnosticText(error instanceof Error ? error.message : String(error)) ??
+      'OpenCode version check failed';
+    const diagnostics: RuntimeProviderManagementErrorDiagnosticsDto = {
+      schemaVersion: 1,
+      reportId: `oc-${randomUUID().replaceAll('-', '')}`,
+      timestamp: new Date().toISOString(),
+      appVersion: APP_VERSION,
+      platform: process.platform,
+      arch: process.arch,
+      stage: 'version_probe',
+      binaryRole: 'opencode',
+      durationMs: Math.round(performance.now() - started),
+      timeoutMs: VERSION_TIMEOUT_MS,
+      timedOut:
+        error instanceof Error &&
+        error.message.startsWith(`Command timed out after ${VERSION_TIMEOUT_MS}ms:`),
+      ...(typeof raw.signal === 'string' ? { signal: raw.signal } : {}),
+      ...(typeof raw.code === 'string' ? { systemErrorCode: raw.code } : {}),
+      summary: message,
+      likelyCause: null,
+      binaryPath: cleanRuntimeDiagnosticText(binaryPath),
+      command: '--version',
+      projectPath: null,
+      exitCode: typeof raw.code === 'number' && Number.isInteger(raw.code) ? raw.code : null,
+      stderrPreview: cleanRuntimeDiagnosticText(raw.stderr),
+      stdoutPreview: cleanRuntimeDiagnosticText(raw.stdout),
+      hints: [],
+    };
+    logger.warn(`OpenCode version probe failed, report ${diagnostics.reportId}`, diagnostics);
+    return { ok: false, error: message, diagnostics };
+  }
+}

--- a/src/features/runtime-provider-management/main/infrastructure/runtimeProviderErrorBoundary.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/runtimeProviderErrorBoundary.ts
@@ -1,0 +1,46 @@
+import { normalizeRuntimeErrorDetails } from '../../contracts';
+
+import { sanitizeRuntimeProviderText } from './runtimeProviderModelTestBoundary';
+
+import type { RuntimeProviderManagementErrorDto } from '../../contracts';
+
+function cleanRuntimeDiagnosticText(value: unknown, limit = 4096): string | null {
+  if (typeof value !== 'string') return null;
+  const cleaned = sanitizeRuntimeProviderText(value);
+  return cleaned.length > limit ? `${cleaned.slice(0, limit - 15)}...[truncated]` : cleaned;
+}
+
+export function sanitizeRuntimeProviderDiagnostics(
+  diagnostics: unknown,
+  errorCodes: ReadonlySet<RuntimeProviderManagementErrorDto['code']>
+): RuntimeProviderManagementErrorDto['diagnostics'] {
+  if (!diagnostics || typeof diagnostics !== 'object' || Array.isArray(diagnostics)) {
+    return null;
+  }
+  const input = diagnostics as Record<string, unknown>;
+  return {
+    ...normalizeRuntimeErrorDetails(diagnostics),
+    errorCode:
+      typeof input.errorCode === 'string' &&
+      errorCodes.has(input.errorCode as RuntimeProviderManagementErrorDto['code'])
+        ? (input.errorCode as RuntimeProviderManagementErrorDto['code'])
+        : null,
+    summary: cleanRuntimeDiagnosticText(input.summary),
+    likelyCause: cleanRuntimeDiagnosticText(input.likelyCause),
+    binaryPath: cleanRuntimeDiagnosticText(input.binaryPath),
+    command: cleanRuntimeDiagnosticText(input.command),
+    projectPath: cleanRuntimeDiagnosticText(input.projectPath),
+    exitCode:
+      typeof input.exitCode === 'number' && Number.isInteger(input.exitCode)
+        ? input.exitCode
+        : null,
+    stderrPreview: cleanRuntimeDiagnosticText(input.stderrPreview),
+    stdoutPreview: cleanRuntimeDiagnosticText(input.stdoutPreview),
+    hints: Array.isArray(input.hints)
+      ? input.hints
+          .filter((hint): hint is string => typeof hint === 'string')
+          .slice(0, 8)
+          .map((hint) => cleanRuntimeDiagnosticText(hint, 256) ?? '')
+      : [],
+  };
+}

--- a/src/features/runtime-provider-management/renderer/index.ts
+++ b/src/features/runtime-provider-management/renderer/index.ts
@@ -42,3 +42,4 @@ export { RuntimeProviderOnboardingDialog } from './RuntimeProviderOnboardingDial
 export { RuntimeProviderQuickConnect } from './RuntimeProviderQuickConnect';
 export { LocalProviderPrivateNetworkApprovalControl } from './ui/LocalProviderPrivateNetworkApprovalControl';
 export { ProviderBrandIcon } from './ui/providerBrandIcons';
+export { RuntimeProviderErrorAlert } from './ui/RuntimeProviderErrorAlert';

--- a/src/features/runtime-provider-management/renderer/ui/RuntimeProviderErrorAlert.tsx
+++ b/src/features/runtime-provider-management/renderer/ui/RuntimeProviderErrorAlert.tsx
@@ -1,0 +1,344 @@
+import { type JSX, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useAppTranslation } from '@features/localization/renderer';
+import { Button } from '@renderer/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@renderer/components/ui/collapsible';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@renderer/components/ui/tooltip';
+import { cn } from '@renderer/lib/utils';
+import { isOpenCodeWindowsNodeModulesSymlinkPermissionDiagnostic } from '@shared/utils/openCodeWindowsAccessDenied';
+import { AlertTriangle, Check, ClipboardList } from 'lucide-react';
+
+import { cleanRuntimeDiagnosticText, runtimeErrorDetailRows } from '../../contracts';
+
+import type { RuntimeProviderManagementErrorDiagnosticsDto } from '../../contracts';
+
+interface RuntimeProviderErrorAlertProps {
+  readonly message: string;
+  readonly diagnostics?: RuntimeProviderManagementErrorDiagnosticsDto | null;
+  readonly testId: string;
+  readonly compact?: boolean;
+}
+
+export function formatRuntimeProviderDiagnosticsCopyText(
+  message: string,
+  diagnostics: RuntimeProviderManagementErrorDiagnosticsDto | null | undefined
+): string {
+  const lines = [
+    'OpenCode provider settings diagnostics',
+    '',
+    'Message:',
+    cleanRuntimeDiagnosticText(message) ?? '',
+  ];
+  if (!diagnostics) {
+    return lines.join('\n');
+  }
+  const hints = diagnostics.hints ?? [];
+
+  const fields: [string, string | number | null][] = [
+    ['Error code', diagnostics.errorCode ?? null],
+    ['Summary', diagnostics.summary],
+    ['Likely cause', diagnostics.likelyCause],
+    ['Resolved runtime binary', diagnostics.binaryPath],
+    ['Command', diagnostics.command],
+    ['Project path', diagnostics.projectPath],
+    ['Exit code', diagnostics.exitCode],
+  ];
+
+  fields.push(...runtimeErrorDetailRows(diagnostics));
+  lines.push('', 'Structured diagnostics:');
+  for (const [label, value] of fields) {
+    if (value !== null && value !== '') {
+      lines.push(`${label}: ${String(value)}`);
+    }
+  }
+
+  if (hints.length > 0) {
+    lines.push('', 'Hints:', ...hints.map((hint) => `- ${hint}`));
+  }
+  if (diagnostics.stderrPreview) {
+    lines.push('', 'stderr preview:', diagnostics.stderrPreview);
+  }
+  if (diagnostics.stdoutPreview) {
+    lines.push('', 'stdout preview:', diagnostics.stdoutPreview);
+  }
+
+  return cleanRuntimeDiagnosticText(lines.join('\n'), 16384) ?? '';
+}
+
+function getRuntimeProviderDiagnosticRows(
+  diagnostics: RuntimeProviderManagementErrorDiagnosticsDto
+): [string, string][] {
+  const rows: [string, string | number | null][] = [
+    ['Code', diagnostics.errorCode ?? null],
+    ['Binary', diagnostics.binaryPath],
+    ['Command', diagnostics.command],
+    ['Project', diagnostics.projectPath],
+    ['Exit', diagnostics.exitCode],
+  ];
+  rows.push(...runtimeErrorDetailRows(diagnostics));
+  return rows
+    .filter(([, value]) => value !== null && value !== '')
+    .map(([label, value]) => [label, String(value)]);
+}
+
+function isOpenCodeWindowsNodeModulesSymlinkPermissionError(
+  message: string,
+  diagnostics: RuntimeProviderManagementErrorDiagnosticsDto | null | undefined
+): boolean {
+  const value = [
+    message,
+    diagnostics?.stderrPreview ?? '',
+    diagnostics?.stdoutPreview ?? '',
+    diagnostics?.likelyCause ?? '',
+    ...(diagnostics?.hints ?? []),
+  ].join('\n');
+  return isOpenCodeWindowsNodeModulesSymlinkPermissionDiagnostic(value);
+}
+
+async function writeRuntimeProviderDiagnosticsToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall back to the selection API below.
+    }
+  }
+
+  return copyRuntimeProviderDiagnosticsWithSelection(text);
+}
+
+function copyRuntimeProviderDiagnosticsWithSelection(text: string): boolean {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', 'true');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+  }
+}
+
+export const RuntimeProviderErrorAlert = ({
+  message,
+  diagnostics = null,
+  testId,
+  compact = false,
+}: RuntimeProviderErrorAlertProps): JSX.Element => {
+  const { t } = useAppTranslation('settings');
+  const [copied, setCopied] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [copyFailed, setCopyFailed] = useState(false);
+  const { t: commonT } = useAppTranslation('common');
+  const [headline = message, ...detailLines] = message.trim().split(/\r?\n/);
+  const fallbackDetails = detailLines.join('\n').trim();
+  const hints = diagnostics?.hints ?? [];
+  const showWindowsSymlinkPermissionHint = isOpenCodeWindowsNodeModulesSymlinkPermissionError(
+    message,
+    diagnostics
+  );
+  const copyText = useMemo(
+    () => formatRuntimeProviderDiagnosticsCopyText(message, diagnostics),
+    [diagnostics, message]
+  );
+  const copyGeneration = useRef(0);
+  const diagnosticRows = diagnostics ? getRuntimeProviderDiagnosticRows(diagnostics) : [];
+  const copyDiagnostics = useCallback(async (): Promise<void> => {
+    const generation = copyGeneration.current;
+    const success = await writeRuntimeProviderDiagnosticsToClipboard(copyText);
+    if (copyGeneration.current !== generation) return;
+    setCopied(success);
+    setCopyFailed(!success);
+  }, [copyText]);
+
+  useEffect(() => {
+    if (!copied) {
+      return;
+    }
+    const timeout = window.setTimeout(() => setCopied(false), 1_500);
+    return () => window.clearTimeout(timeout);
+  }, [copied]);
+
+  useEffect(() => {
+    setCopied(false);
+    setCopyFailed(false);
+    return () => {
+      copyGeneration.current += 1;
+    };
+  }, [copyText]);
+
+  return (
+    <div
+      data-testid={testId}
+      role="alert"
+      className="flex min-w-0 items-start gap-2 rounded-md border px-3 py-2 text-xs"
+      style={{
+        borderColor: 'rgba(248, 113, 113, 0.25)',
+        backgroundColor: 'rgba(248, 113, 113, 0.06)',
+        color: '#fca5a5',
+      }}
+    >
+      <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 flex-wrap items-start justify-between gap-2">
+          <div className="min-w-0 whitespace-pre-wrap break-words font-medium leading-5">
+            {headline || message}
+            {showWindowsSymlinkPermissionHint ? (
+              <span className="ml-2 inline-flex rounded border border-red-200/30 bg-red-500/10 px-1.5 py-0.5 text-[11px] font-semibold leading-4 text-red-50">
+                {t('runtimeProvider.diagnostics.windowsSymlinkAdminHint')}
+              </span>
+            ) : null}
+          </div>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className={cn(
+                    'h-6 shrink-0 px-2 text-[11px]',
+                    !copied && 'member-launch-diagnostics-pulse'
+                  )}
+                  aria-label={
+                    copied
+                      ? t('runtimeProvider.diagnostics.copied')
+                      : t('runtimeProvider.diagnostics.copy')
+                  }
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void copyDiagnostics();
+                  }}
+                >
+                  {copied ? (
+                    <Check className="mr-1 size-3" />
+                  ) : (
+                    <ClipboardList className="mr-1 size-3" />
+                  )}
+                  {copied
+                    ? t('runtimeProvider.diagnostics.copiedShort')
+                    : t('runtimeProvider.diagnostics.copy')}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('runtimeProvider.diagnostics.copy')}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+        {copyFailed ? (
+          <div role="status">
+            {commonT('codexLogin.copyFailed')}
+            <pre tabIndex={0} className="max-h-48 select-text overflow-auto whitespace-pre-wrap">
+              {copyText}
+            </pre>
+          </div>
+        ) : null}
+        {compact && diagnostics?.stage ? (
+          <div className="mt-1 font-mono">{diagnostics.stage}</div>
+        ) : null}
+        <Collapsible open={!compact || expanded} onOpenChange={setExpanded}>
+          {compact ? (
+            <CollapsibleTrigger asChild>
+              <Button type="button" variant="ghost" size="sm">
+                {commonT(expanded ? 'tmuxInstaller.details.hide' : 'tmuxInstaller.details.show')}
+              </Button>
+            </CollapsibleTrigger>
+          ) : null}
+          <CollapsibleContent>
+            {diagnostics ? (
+              <div className="mt-2 space-y-2">
+                {diagnostics.likelyCause ? (
+                  <div className="whitespace-pre-wrap break-words leading-5 text-red-100">
+                    <span className="font-medium text-red-100">
+                      {t('runtimeProvider.diagnostics.likelyCause')}{' '}
+                    </span>
+                    {diagnostics.likelyCause}
+                  </div>
+                ) : null}
+                {diagnosticRows.length > 0 ? (
+                  <dl className="grid gap-1 rounded border px-2 py-1.5 text-[11px] leading-4 sm:grid-cols-[92px_minmax(0,1fr)]">
+                    {diagnosticRows.map(([label, value]) => (
+                      <div key={label} className="contents">
+                        <dt className="text-red-200/75">{label}</dt>
+                        <dd className="min-w-0 break-words font-mono text-red-100">{value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                ) : null}
+                {hints.length > 0 ? (
+                  <div>
+                    <div className="mb-1 font-medium text-red-100">
+                      {t('runtimeProvider.diagnostics.hints')}
+                    </div>
+                    <ul className="space-y-1 pl-4">
+                      {hints.map((hint, index) => (
+                        <li
+                          key={`${hint}-${index}`}
+                          className="list-disc whitespace-pre-wrap break-words"
+                        >
+                          {hint}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+                {diagnostics.stderrPreview ? (
+                  <pre
+                    data-testid={`${testId}-stderr-preview`}
+                    className="m-0 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border px-2 py-1.5 font-mono text-[11px] leading-4"
+                    style={{
+                      borderColor: 'rgba(248, 113, 113, 0.2)',
+                      backgroundColor: 'rgba(15, 23, 42, 0.38)',
+                      color: '#fecaca',
+                    }}
+                  >
+                    {`stderr preview:\n${diagnostics.stderrPreview}`}
+                  </pre>
+                ) : null}
+                {diagnostics.stdoutPreview ? (
+                  <pre
+                    data-testid={`${testId}-stdout-preview`}
+                    className="m-0 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border px-2 py-1.5 font-mono text-[11px] leading-4"
+                    style={{
+                      borderColor: 'rgba(248, 113, 113, 0.2)',
+                      backgroundColor: 'rgba(15, 23, 42, 0.38)',
+                      color: '#fecaca',
+                    }}
+                  >
+                    {`stdout preview:\n${diagnostics.stdoutPreview}`}
+                  </pre>
+                ) : null}
+              </div>
+            ) : fallbackDetails ? (
+              <pre
+                className="m-0 mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded border px-2 py-1.5 font-mono text-[11px] leading-4"
+                style={{
+                  borderColor: 'rgba(248, 113, 113, 0.2)',
+                  backgroundColor: 'rgba(15, 23, 42, 0.38)',
+                  color: '#fecaca',
+                }}
+              >
+                {fallbackDetails}
+              </pre>
+            ) : null}
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+    </div>
+  );
+};

--- a/src/features/runtime-provider-management/renderer/ui/RuntimeProviderManagementPanelView.tsx
+++ b/src/features/runtime-provider-management/renderer/ui/RuntimeProviderManagementPanelView.tsx
@@ -26,13 +26,11 @@ import {
   isOpenCodeLocalProviderId,
   isOpenCodeModelExplicitlyFree,
 } from '@shared/utils/opencodeModelRoute';
-import { isOpenCodeWindowsNodeModulesSymlinkPermissionDiagnostic } from '@shared/utils/openCodeWindowsAccessDenied';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   AlertTriangle,
   Check,
   CheckCircle2,
-  ClipboardList,
   ExternalLink,
   Eye,
   EyeOff,
@@ -59,6 +57,7 @@ import {
   OpenCodeDefaultTargetBanner,
 } from './OpenCodeDefaultModelInheritanceCard';
 import { ProviderBrandIcon } from './providerBrandIcons';
+import { RuntimeProviderErrorAlert } from './RuntimeProviderErrorAlert';
 import {
   canAttemptOpenCodeDefaultSelection,
   getOpenCodeRouteUnavailableTitle,
@@ -78,7 +77,6 @@ import type {
   RuntimeProviderConnectionDto,
   RuntimeProviderDefaultScopeDto,
   RuntimeProviderDirectoryEntryDto,
-  RuntimeProviderManagementErrorDiagnosticsDto,
   RuntimeProviderModelDto,
   RuntimeProviderModelTestResultDto,
   RuntimeProviderSetupAuthOptionDto,
@@ -121,12 +119,6 @@ interface ProviderRowProps {
   readonly intendedProjectPath: string | null;
   readonly onDefaultSaved: () => void;
   readonly actions: RuntimeProviderManagementActions;
-}
-
-interface RuntimeProviderErrorAlertProps {
-  readonly message: string;
-  readonly diagnostics?: RuntimeProviderManagementErrorDiagnosticsDto | null;
-  readonly testId: string;
 }
 
 type OpenCodeSettingsSection = 'models' | 'providers';
@@ -919,269 +911,6 @@ const RuntimeProviderLoadingPlaceholder = (): JSX.Element => {
             }}
           />
         </div>
-      </div>
-    </div>
-  );
-};
-
-function formatRuntimeProviderDiagnosticsCopyText(
-  message: string,
-  diagnostics: RuntimeProviderManagementErrorDiagnosticsDto | null | undefined
-): string {
-  const lines = ['OpenCode provider settings diagnostics', '', 'Message:', message.trim()];
-  if (!diagnostics) {
-    return lines.join('\n');
-  }
-  const hints = diagnostics.hints ?? [];
-
-  const fields: [string, string | number | null][] = [
-    ['Error code', diagnostics.errorCode ?? null],
-    ['Summary', diagnostics.summary],
-    ['Likely cause', diagnostics.likelyCause],
-    ['Resolved runtime binary', diagnostics.binaryPath],
-    ['Command', diagnostics.command],
-    ['Project path', diagnostics.projectPath],
-    ['Exit code', diagnostics.exitCode],
-  ];
-
-  lines.push('', 'Structured diagnostics:');
-  for (const [label, value] of fields) {
-    if (value !== null && value !== '') {
-      lines.push(`${label}: ${String(value)}`);
-    }
-  }
-
-  if (hints.length > 0) {
-    lines.push('', 'Hints:', ...hints.map((hint) => `- ${hint}`));
-  }
-  if (diagnostics.stderrPreview) {
-    lines.push('', 'stderr preview:', diagnostics.stderrPreview);
-  }
-  if (diagnostics.stdoutPreview) {
-    lines.push('', 'stdout preview:', diagnostics.stdoutPreview);
-  }
-
-  return lines.join('\n');
-}
-
-function getRuntimeProviderDiagnosticRows(
-  diagnostics: RuntimeProviderManagementErrorDiagnosticsDto
-): [string, string][] {
-  const rows: [string, string | number | null][] = [
-    ['Code', diagnostics.errorCode ?? null],
-    ['Binary', diagnostics.binaryPath],
-    ['Command', diagnostics.command],
-    ['Project', diagnostics.projectPath],
-    ['Exit', diagnostics.exitCode],
-  ];
-  return rows
-    .filter(([, value]) => value !== null && value !== '')
-    .map(([label, value]) => [label, String(value)]);
-}
-
-function isOpenCodeWindowsNodeModulesSymlinkPermissionError(
-  message: string,
-  diagnostics: RuntimeProviderManagementErrorDiagnosticsDto | null | undefined
-): boolean {
-  const value = [
-    message,
-    diagnostics?.stderrPreview ?? '',
-    diagnostics?.stdoutPreview ?? '',
-    diagnostics?.likelyCause ?? '',
-    ...(diagnostics?.hints ?? []),
-  ].join('\n');
-  return isOpenCodeWindowsNodeModulesSymlinkPermissionDiagnostic(value);
-}
-
-async function writeRuntimeProviderDiagnosticsToClipboard(text: string): Promise<boolean> {
-  if (navigator.clipboard?.writeText) {
-    try {
-      await navigator.clipboard.writeText(text);
-      return true;
-    } catch {
-      // Fall back to the selection API below.
-    }
-  }
-
-  return copyRuntimeProviderDiagnosticsWithSelection(text);
-}
-
-function copyRuntimeProviderDiagnosticsWithSelection(text: string): boolean {
-  const textarea = document.createElement('textarea');
-  textarea.value = text;
-  textarea.setAttribute('readonly', 'true');
-  textarea.style.position = 'fixed';
-  textarea.style.top = '-9999px';
-  textarea.style.opacity = '0';
-  document.body.appendChild(textarea);
-  textarea.select();
-  try {
-    return document.execCommand('copy');
-  } catch {
-    return false;
-  } finally {
-    textarea.remove();
-  }
-}
-
-const RuntimeProviderErrorAlert = ({
-  message,
-  diagnostics = null,
-  testId,
-}: RuntimeProviderErrorAlertProps): JSX.Element => {
-  const { t } = useAppTranslation('settings');
-  const [copied, setCopied] = useState(false);
-  const [headline = message, ...detailLines] = message.trim().split(/\r?\n/);
-  const fallbackDetails = detailLines.join('\n').trim();
-  const hints = diagnostics?.hints ?? [];
-  const showWindowsSymlinkPermissionHint = isOpenCodeWindowsNodeModulesSymlinkPermissionError(
-    message,
-    diagnostics
-  );
-  const copyText = useMemo(
-    () => formatRuntimeProviderDiagnosticsCopyText(message, diagnostics),
-    [diagnostics, message]
-  );
-  const diagnosticRows = diagnostics ? getRuntimeProviderDiagnosticRows(diagnostics) : [];
-  const copyDiagnostics = useCallback(async (): Promise<void> => {
-    setCopied(await writeRuntimeProviderDiagnosticsToClipboard(copyText));
-  }, [copyText]);
-
-  useEffect(() => {
-    if (!copied) {
-      return;
-    }
-    const timeout = window.setTimeout(() => setCopied(false), 1_500);
-    return () => window.clearTimeout(timeout);
-  }, [copied]);
-
-  return (
-    <div
-      data-testid={testId}
-      role="alert"
-      className="flex min-w-0 items-start gap-2 rounded-md border px-3 py-2 text-xs"
-      style={{
-        borderColor: 'rgba(248, 113, 113, 0.25)',
-        backgroundColor: 'rgba(248, 113, 113, 0.06)',
-        color: '#fca5a5',
-      }}
-    >
-      <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
-      <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 flex-wrap items-start justify-between gap-2">
-          <div className="min-w-0 whitespace-pre-wrap break-words font-medium leading-5">
-            {headline || message}
-            {showWindowsSymlinkPermissionHint ? (
-              <span className="ml-2 inline-flex rounded border border-red-200/30 bg-red-500/10 px-1.5 py-0.5 text-[11px] font-semibold leading-4 text-red-50">
-                {t('runtimeProvider.diagnostics.windowsSymlinkAdminHint')}
-              </span>
-            ) : null}
-          </div>
-          <Button
-            type="button"
-            size="sm"
-            variant="ghost"
-            className={cn(
-              'h-6 shrink-0 px-2 text-[11px]',
-              !copied && 'member-launch-diagnostics-pulse'
-            )}
-            title={
-              copied
-                ? t('runtimeProvider.diagnostics.copied')
-                : t('runtimeProvider.diagnostics.copy')
-            }
-            aria-label={
-              copied
-                ? t('runtimeProvider.diagnostics.copied')
-                : t('runtimeProvider.diagnostics.copy')
-            }
-            onClick={(event) => {
-              event.stopPropagation();
-              void copyDiagnostics();
-            }}
-          >
-            {copied ? <Check className="mr-1 size-3" /> : <ClipboardList className="mr-1 size-3" />}
-            {copied
-              ? t('runtimeProvider.diagnostics.copiedShort')
-              : t('runtimeProvider.diagnostics.copy')}
-          </Button>
-        </div>
-        {diagnostics ? (
-          <div className="mt-2 space-y-2">
-            {diagnostics.likelyCause ? (
-              <div className="whitespace-pre-wrap break-words leading-5 text-red-100">
-                <span className="font-medium text-red-100">
-                  {t('runtimeProvider.diagnostics.likelyCause')}{' '}
-                </span>
-                {diagnostics.likelyCause}
-              </div>
-            ) : null}
-            {diagnosticRows.length > 0 ? (
-              <dl className="grid gap-1 rounded border px-2 py-1.5 text-[11px] leading-4 sm:grid-cols-[92px_minmax(0,1fr)]">
-                {diagnosticRows.map(([label, value]) => (
-                  <div key={label} className="contents">
-                    <dt className="text-red-200/75">{label}</dt>
-                    <dd className="min-w-0 break-words font-mono text-red-100">{value}</dd>
-                  </div>
-                ))}
-              </dl>
-            ) : null}
-            {hints.length > 0 ? (
-              <div>
-                <div className="mb-1 font-medium text-red-100">
-                  {t('runtimeProvider.diagnostics.hints')}
-                </div>
-                <ul className="space-y-1 pl-4">
-                  {hints.map((hint, index) => (
-                    <li
-                      key={`${hint}-${index}`}
-                      className="list-disc whitespace-pre-wrap break-words"
-                    >
-                      {hint}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-            {diagnostics.stderrPreview ? (
-              <pre
-                data-testid={`${testId}-stderr-preview`}
-                className="m-0 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border px-2 py-1.5 font-mono text-[11px] leading-4"
-                style={{
-                  borderColor: 'rgba(248, 113, 113, 0.2)',
-                  backgroundColor: 'rgba(15, 23, 42, 0.38)',
-                  color: '#fecaca',
-                }}
-              >
-                {`stderr preview:\n${diagnostics.stderrPreview}`}
-              </pre>
-            ) : null}
-            {diagnostics.stdoutPreview ? (
-              <pre
-                data-testid={`${testId}-stdout-preview`}
-                className="m-0 max-h-40 overflow-auto whitespace-pre-wrap break-words rounded border px-2 py-1.5 font-mono text-[11px] leading-4"
-                style={{
-                  borderColor: 'rgba(248, 113, 113, 0.2)',
-                  backgroundColor: 'rgba(15, 23, 42, 0.38)',
-                  color: '#fecaca',
-                }}
-              >
-                {`stdout preview:\n${diagnostics.stdoutPreview}`}
-              </pre>
-            ) : null}
-          </div>
-        ) : fallbackDetails ? (
-          <pre
-            className="m-0 mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded border px-2 py-1.5 font-mono text-[11px] leading-4"
-            style={{
-              borderColor: 'rgba(248, 113, 113, 0.2)',
-              backgroundColor: 'rgba(15, 23, 42, 0.38)',
-              color: '#fecaca',
-            }}
-          >
-            {fallbackDetails}
-          </pre>
-        ) : null}
       </div>
     </div>
   );

--- a/src/main/services/infrastructure/OpenCodeRuntimeInstallerService.ts
+++ b/src/main/services/infrastructure/OpenCodeRuntimeInstallerService.ts
@@ -1,3 +1,8 @@
+import {
+  type OpenCodeBinaryCandidateFailure,
+  type OpenCodeBinaryVersionProbe,
+  probeOpenCodeBinaryVersion,
+} from '@features/runtime-provider-management/main';
 import { atomicWriteAsync, renamePathWithRetry } from '@main/utils/atomicWrite';
 import { execCli } from '@main/utils/childProcess';
 import { getAppDataPath } from '@main/utils/pathDecoder';
@@ -36,10 +41,7 @@ import {
   versionProbeInFlight,
 } from './openCodeRuntimeResolverCache';
 
-import type {
-  OpenCodeBinaryVersionProbe,
-  VerifiedOpenCodeBinaryProbe,
-} from './openCodeRuntimeResolverCache';
+import type { VerifiedOpenCodeBinaryProbe } from './openCodeRuntimeResolverCache';
 import type { OpenCodeRuntimeInstallProgress, OpenCodeRuntimeStatus } from '@shared/types';
 import type { BrowserWindow } from 'electron';
 export {
@@ -244,18 +246,6 @@ function collectVersionedOpenCodeBinaryCandidates(rootPath: string, binSegment =
     });
 }
 
-async function probeOpenCodeBinaryVersion(binaryPath: string): Promise<OpenCodeBinaryVersionProbe> {
-  try {
-    const { stdout } = await execCli(binaryPath, ['--version'], {
-      timeout: VERSION_TIMEOUT_MS,
-      windowsHide: true,
-    });
-    return { ok: true, version: stdout.trim() || null };
-  } catch (error) {
-    return { ok: false, error: getErrorMessage(error) };
-  }
-}
-
 function normalizeBinaryCandidateForCompare(binaryPath: string): string {
   const normalized = path.resolve(binaryPath);
   return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
@@ -303,7 +293,7 @@ async function probeOpenCodeBinaryVersionCached(
 async function probeFirstWorkingOpenCodeBinaryCandidate(
   candidates: string[],
   seen: Set<string>,
-  firstFailure: { binaryPath: string; error: string } | null
+  firstFailure: OpenCodeBinaryCandidateFailure | null
 ): Promise<VerifiedOpenCodeBinaryProbe> {
   let nextFirstFailure = firstFailure;
   for (const binaryPath of candidates) {
@@ -322,6 +312,9 @@ async function probeFirstWorkingOpenCodeBinaryCandidate(
         };
       }
       nextFirstFailure ??= {
+        ...(!version.ok
+          ? { diagnostics: { ...version.diagnostics, binarySource: 'path' as const } }
+          : {}),
         binaryPath: launchBinaryPath,
         error: version.ok
           ? getUnsupportedAgentTeamsOpenCodeVersionMessage(version.version)
@@ -358,7 +351,7 @@ async function probeFirstWorkingPathOpenCodeBinary(
   options: OpenCodeRuntimeBinaryResolveOptions = {}
 ): Promise<VerifiedOpenCodeBinaryProbe> {
   const seenCandidates = new Set<string>();
-  let firstFailure: { binaryPath: string; error: string } | null = null;
+  let firstFailure: OpenCodeBinaryCandidateFailure | null = null;
 
   const cachedProbe = await probeFirstWorkingOpenCodeBinaryCandidate(
     collectPathOpenCodeBinaryCandidates([], {
@@ -840,6 +833,9 @@ export class OpenCodeRuntimeInstallerService {
       version: manifest.version,
       source: 'app-managed',
       state: 'failed',
+      ...(!version.ok
+        ? { diagnostics: { ...version.diagnostics, binarySource: 'app-managed' as const } }
+        : {}),
       error: version.ok
         ? getUnsupportedAgentTeamsOpenCodeVersionMessage(version.version)
         : version.error,
@@ -866,6 +862,7 @@ export class OpenCodeRuntimeInstallerService {
       source: 'path',
       state: 'failed',
       error: result.firstFailure.error,
+      diagnostics: result.firstFailure.diagnostics,
     };
   }
 

--- a/src/main/services/infrastructure/openCodeRuntimeResolverCache.ts
+++ b/src/main/services/infrastructure/openCodeRuntimeResolverCache.ts
@@ -1,12 +1,14 @@
 import { isAbsoluteExistingFile } from '@main/utils/runtimePathBinaryResolver';
 
-export type OpenCodeBinaryVersionProbe =
-  | { ok: true; version: string | null }
-  | { ok: false; error: string };
+import type {
+  OpenCodeBinaryVersionProbe,
+  OpenCodeBinaryCandidateFailure,
+} from '@features/runtime-provider-management/main';
+export type { OpenCodeBinaryVersionProbe } from '@features/runtime-provider-management/main';
 
 export type VerifiedOpenCodeBinaryProbe =
   | { ok: true; binaryPath: string; version: string | null }
-  | { ok: false; firstFailure: { binaryPath: string; error: string } | null };
+  | { ok: false; firstFailure: OpenCodeBinaryCandidateFailure | null };
 
 interface CachedResult<T> {
   result: T;

--- a/src/main/services/infrastructure/openCodeRuntimeResolverCache.ts
+++ b/src/main/services/infrastructure/openCodeRuntimeResolverCache.ts
@@ -1,8 +1,8 @@
 import { isAbsoluteExistingFile } from '@main/utils/runtimePathBinaryResolver';
 
 import type {
-  OpenCodeBinaryVersionProbe,
   OpenCodeBinaryCandidateFailure,
+  OpenCodeBinaryVersionProbe,
 } from '@features/runtime-provider-management/main';
 export type { OpenCodeBinaryVersionProbe } from '@features/runtime-provider-management/main';
 

--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -22,6 +22,7 @@ import {
   isOpenCodeProviderOAuthBridgeOutdated,
   isOpenCodeRuntimeUsable,
   resolveOpenCodeQuickConnectGate,
+  RuntimeProviderErrorAlert,
   RuntimeProviderOnboardingDialog,
   RuntimeProviderQuickConnect,
   useOpenCodeConnectedModelCatalog,
@@ -1080,6 +1081,14 @@ const InstalledBanner = ({
       )}
       {cliStatus.flavor === 'agent_teams_orchestrator' ? (
         <div className={showExpandedContent ? undefined : 'hidden'}>
+          {openCodeRuntimeStatus?.diagnostics ? (
+            <RuntimeProviderErrorAlert
+              compact
+              message={openCodeRuntimeStatus.error ?? ''}
+              diagnostics={openCodeRuntimeStatus.diagnostics}
+              testId="opencode-version-diagnostics"
+            />
+          ) : null}
           <RuntimeProviderQuickConnect
             enabled
             cliStatusLoading={cliStatusLoading}

--- a/src/renderer/components/ui/collapsible.tsx
+++ b/src/renderer/components/ui/collapsible.tsx
@@ -1,0 +1,5 @@
+import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
+
+export const Collapsible = CollapsiblePrimitive.Root;
+export const CollapsibleTrigger = CollapsiblePrimitive.Trigger;
+export const CollapsibleContent = CollapsiblePrimitive.Content;

--- a/src/shared/types/cliInstaller.ts
+++ b/src/shared/types/cliInstaller.ts
@@ -13,6 +13,7 @@ import type {
   CodexManagedAccountDto,
   CodexRateLimitSnapshotDto,
 } from '@features/codex-account/contracts';
+import type { RuntimeProviderManagementErrorDiagnosticsDto } from '@features/runtime-provider-management/contracts';
 
 // =============================================================================
 // Platform Detection
@@ -456,6 +457,7 @@ export interface OpenCodeRuntimeStatus {
   state: OpenCodeRuntimeInstallerState;
   progress?: OpenCodeRuntimeInstallProgress;
   error?: string;
+  diagnostics?: RuntimeProviderManagementErrorDiagnosticsDto;
 }
 
 export interface OpenCodeRuntimeAPI {

--- a/test/main/features/runtime-provider-management/runtimeErrorDiagnostics.test.ts
+++ b/test/main/features/runtime-provider-management/runtimeErrorDiagnostics.test.ts
@@ -90,6 +90,22 @@ describe('OpenCode diagnostic transport', () => {
     expect(cleanRuntimeDiagnosticText('x'.repeat(8000))).toContain('[truncated]');
   });
 
+  it.each(['AIza' + 'a'.repeat(35), 'or-' + 'b'.repeat(32), 'custom-private-key-value'])(
+    'redacts provider keys from version diagnostics: %s',
+    async (secret) => {
+      execCli.mockRejectedValueOnce(
+        Object.assign(new Error('version failed'), {
+          stderr: JSON.stringify({ key: secret }),
+          stdout: secret.startsWith('custom') ? `key=${secret}` : secret,
+        })
+      );
+      const result = await probeOpenCodeBinaryVersion('/test/opencode');
+      expect(result.ok).toBe(false);
+      expect(JSON.stringify(result)).not.toContain(secret);
+      expect(JSON.stringify(result)).toContain('[redacted]');
+    }
+  );
+
   it.each([
     [
       'timeout',

--- a/test/main/features/runtime-provider-management/runtimeErrorDiagnostics.test.ts
+++ b/test/main/features/runtime-provider-management/runtimeErrorDiagnostics.test.ts
@@ -1,0 +1,139 @@
+vi.mock('@shared/utils/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shared/utils/logger')>();
+  return {
+    ...actual,
+    createLogger: (name: string) => {
+      const logger = actual.createLogger(name);
+      return name === 'OpenCodeVersionDiagnostics' ? { ...logger, warn: vi.fn() } : logger;
+    },
+  };
+});
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  cleanRuntimeDiagnosticText,
+  normalizeRuntimeErrorDetails,
+} from '../../../../src/features/runtime-provider-management/contracts/errorDiagnostics';
+import { sanitizeRuntimeProviderDiagnostics } from '../../../../src/features/runtime-provider-management/main/infrastructure/runtimeProviderErrorBoundary';
+
+const execCli = vi.hoisted(() => vi.fn());
+vi.mock('@main/utils/childProcess', () => ({ execCli }));
+import { probeOpenCodeBinaryVersion } from '../../../../src/features/runtime-provider-management/main/infrastructure/openCodeVersionDiagnostics';
+
+describe('OpenCode diagnostic transport', () => {
+  it('preserves useful platform paths and correlation IDs in opt-in support reports', () => {
+    for (const value of [
+      '/Users/alice/bin/opencode',
+      '/home/alice/opencode',
+      String.raw`C:\Users\alice\opencode.cmd`,
+      'oc-1234567890abcdef1234567890abcdef',
+    ]) {
+      expect(cleanRuntimeDiagnosticText(value)).toBe(value);
+    }
+  });
+  it('retains factual HTTP data while dropping credentials and arbitrary fields', () => {
+    const result = sanitizeRuntimeProviderDiagnostics(
+      {
+        schemaVersion: 1,
+        stage: 'catalog_http',
+        httpStatus: 503,
+        httpMethod: 'GET',
+        endpoint: 'http://user:password@127.0.0.1:9876/provider?token=private',
+        durationMs: 12.5,
+        timeoutMs: 15000,
+        timedOut: false,
+        cause: 'connect ECONNREFUSED',
+        headers: { authorization: 'secret' },
+        stderrPreview: 'Authorization: Bearer private-value',
+      },
+      new Set()
+    );
+    expect(result).toMatchObject({
+      stage: 'catalog_http',
+      httpStatus: 503,
+      endpoint: 'http://127.0.0.1:9876/provider',
+      durationMs: 13,
+      timeoutMs: 15000,
+      timedOut: false,
+      cause: 'connect ECONNREFUSED',
+    });
+    expect(JSON.stringify(result)).not.toMatch(/private|password|headers|secret/);
+  });
+
+  it('accepts legacy errors without inventing stages or status', () => {
+    expect(sanitizeRuntimeProviderDiagnostics(null, new Set())).toBeNull();
+    const result = sanitizeRuntimeProviderDiagnostics({ summary: 'old runtime' }, new Set());
+    expect(result?.summary).toBe('old runtime');
+    expect(result?.stage).toBeUndefined();
+    expect(result?.httpStatus).toBeUndefined();
+    expect(result?.exitCode).toBeNull();
+  });
+
+  it('rejects invalid measurements and cyclic cause without serializing the input', () => {
+    const input: Record<string, unknown> = {
+      durationMs: -1,
+      timeoutMs: Infinity,
+      httpStatus: 0,
+      stage: 'invented',
+    };
+    input.cause = input;
+    expect(normalizeRuntimeErrorDetails(input)).toEqual({});
+  });
+
+  it('redacts before limiting output, including secret URLs and quoted keys', () => {
+    const input = `api_key=${'s'.repeat(8000)}\nhttps://user:password@localhost/private-secret?token=hidden`;
+    const text = cleanRuntimeDiagnosticText(input)!;
+    expect(text.length).toBeLessThanOrEqual(4096);
+    expect(text).not.toContain('ssss');
+    expect(text).not.toMatch(/password|private-secret|hidden/);
+    expect(cleanRuntimeDiagnosticText('x'.repeat(8000))).toContain('[truncated]');
+  });
+
+  it.each([
+    [
+      'timeout',
+      Object.assign(new Error('Command timed out after 30000ms: /tmp/opencode --version'), {
+        killed: true,
+        signal: 'SIGTERM',
+        stderr: 'waiting',
+      }),
+      true,
+      null,
+    ],
+    [
+      'abort',
+      Object.assign(new Error('Command aborted: /tmp/opencode --version'), {
+        killed: true,
+        signal: 'SIGTERM',
+      }),
+      false,
+      null,
+    ],
+    [
+      'exit',
+      Object.assign(new Error('Command failed'), { code: 9, stderr: 'api_key=private-value' }),
+      false,
+      9,
+    ],
+    ['missing', Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }), false, null],
+  ])(
+    'preserves the %s outcome without conflating kills with timeouts',
+    async (_name, error, timedOut, exitCode) => {
+      execCli.mockRejectedValueOnce(error);
+      const result = await probeOpenCodeBinaryVersion('/tmp/opencode');
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('Expected failure');
+      expect(result.diagnostics).toMatchObject({
+        stage: 'version_probe',
+        binaryRole: 'opencode',
+        timedOut,
+        exitCode,
+        timeoutMs: 30000,
+      });
+      expect(result.diagnostics.reportId).toBeTruthy();
+      expect(result.diagnostics.durationMs).toBeGreaterThanOrEqual(0);
+      expect(JSON.stringify(result)).not.toContain('private-value');
+    }
+  );
+});

--- a/test/main/features/runtime-provider-management/runtimeErrorDiagnostics.test.ts
+++ b/test/main/features/runtime-provider-management/runtimeErrorDiagnostics.test.ts
@@ -107,6 +107,18 @@ describe('OpenCode diagnostic transport', () => {
   );
 
   it.each([
+    'Error: api_key=custom-private-key-value',
+    'Authorization: Bearer custom-private-key-value',
+    'Cookie: a=public; session=custom-private-key-value',
+    '{"auth":{"key":"custom-private-key-value"}}',
+  ])('redacts credentials nested in diagnostic text: %s', async (stderr) => {
+    execCli.mockRejectedValueOnce(Object.assign(new Error('version failed'), { stderr }));
+    const result = await probeOpenCodeBinaryVersion('/test/opencode');
+    expect(JSON.stringify(result)).not.toContain('custom-private-key-value');
+    expect(JSON.stringify(result)).toContain('[redacted]');
+  });
+
+  it.each([
     [
       'timeout',
       Object.assign(new Error('Command timed out after 30000ms: /tmp/opencode --version'), {

--- a/test/main/services/infrastructure/OpenCodeRuntimeInstallerService.test.ts
+++ b/test/main/services/infrastructure/OpenCodeRuntimeInstallerService.test.ts
@@ -1,3 +1,14 @@
+vi.mock('@shared/utils/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shared/utils/logger')>();
+  return {
+    ...actual,
+    createLogger: (name: string) => {
+      const logger = actual.createLogger(name);
+      return name === 'OpenCodeVersionDiagnostics' ? { ...logger, warn: vi.fn() } : logger;
+    },
+  };
+});
+
 import { createHash } from 'crypto';
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'fs/promises';
 import os from 'os';

--- a/test/main/services/runtime/OpenCodeRuntimeNvmResolution.safe-e2e.test.ts
+++ b/test/main/services/runtime/OpenCodeRuntimeNvmResolution.safe-e2e.test.ts
@@ -4,7 +4,7 @@ import { chmod, copyFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises
 import os from 'node:os';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   clearOpenCodeRuntimeBinaryResolverCache,
@@ -15,6 +15,18 @@ import { ensureOpenCodeBridgeRuntimeBinaryEnv } from '../../../../src/main/servi
 import { execCli } from '../../../../src/main/utils/childProcess';
 import { setAppDataBasePath } from '../../../../src/main/utils/pathDecoder';
 import { clearShellEnvCache } from '../../../../src/main/utils/shellEnv';
+
+const versionWarnings = vi.hoisted(() => vi.fn());
+vi.mock('@shared/utils/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shared/utils/logger')>();
+  return {
+    ...actual,
+    createLogger: (name: string) => {
+      const logger = actual.createLogger(name);
+      return name === 'OpenCodeVersionDiagnostics' ? { ...logger, warn: versionWarnings } : logger;
+    },
+  };
+});
 
 const describePosix = process.platform === 'win32' ? describe.skip : describe;
 const describeWindows = process.platform === 'win32' ? describe : describe.skip;
@@ -53,7 +65,8 @@ describePosix('OpenCode nvm runtime resolution safe e2e', () => {
   });
 
   it('reports and launches an npm global OpenCode binary installed under nvm when GUI PATH is empty', async () => {
-    await createFakeNvmOpenCodeBinary('v23.0.0', { broken: true });
+    versionWarnings.mockClear();
+    const brokenBinaryPath = await createFakeNvmOpenCodeBinary('v23.0.0', { broken: true });
     const binaryPath = await createFakeNvmOpenCodeBinary('v22.22.1');
     const binDir = path.dirname(binaryPath);
 
@@ -86,6 +99,17 @@ describePosix('OpenCode nvm runtime resolution safe e2e', () => {
       windowsHide: true,
     });
     expect(version.stdout.trim()).toBe('opencode 1.18.3');
+    expect(versionWarnings).toHaveBeenCalledTimes(1);
+    expect(versionWarnings).toHaveBeenCalledWith(
+      expect.stringContaining('OpenCode version probe failed, report oc-'),
+      expect.objectContaining({
+        stage: 'version_probe',
+        binaryPath: brokenBinaryPath,
+        exitCode: 2,
+        timedOut: false,
+        stderrPreview: expect.stringContaining('broken opencode'),
+      })
+    );
   });
 
   async function createFakeNvmOpenCodeBinary(

--- a/test/renderer/features/runtime-provider-management/RuntimeProviderErrorAlert.test.ts
+++ b/test/renderer/features/runtime-provider-management/RuntimeProviderErrorAlert.test.ts
@@ -1,0 +1,68 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { RuntimeProviderErrorAlert } from '../../../../src/features/runtime-provider-management/renderer/ui/RuntimeProviderErrorAlert';
+
+beforeEach(() => vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true));
+const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+afterEach(() => {
+  if (clipboardDescriptor) Object.defineProperty(navigator, 'clipboard', clipboardDescriptor);
+  else Reflect.deleteProperty(navigator, 'clipboard');
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  document.body.innerHTML = '';
+});
+
+it('offers the complete selectable report when both clipboard methods fail', async () => {
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+  });
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  await act(async () =>
+    root.render(
+      React.createElement(RuntimeProviderErrorAlert, {
+        message: 'OpenCode failed',
+        testId: 'error',
+        compact: true,
+      })
+    )
+  );
+  await act(async () => host.querySelector('button')!.click());
+  expect(host.textContent).not.toContain('Copied');
+  expect(host.querySelector('pre')?.textContent).toContain('OpenCode failed');
+  await act(async () => root.unmount());
+});
+
+it('ignores a clipboard completion belonging to the previous error', async () => {
+  let resolve!: () => void;
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: {
+      writeText: () =>
+        new Promise<void>((done) => {
+          resolve = done;
+        }),
+    },
+  });
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  const root = createRoot(host);
+  await act(async () =>
+    root.render(
+      React.createElement(RuntimeProviderErrorAlert, { message: 'First error', testId: 'error' })
+    )
+  );
+  await act(async () => host.querySelector('button')!.click());
+  await act(async () =>
+    root.render(
+      React.createElement(RuntimeProviderErrorAlert, { message: 'Second error', testId: 'error' })
+    )
+  );
+  await act(async () => resolve());
+  expect(host.textContent).toContain('Second error');
+  expect(host.textContent).not.toContain('Copied');
+  await act(async () => root.unmount());
+});

--- a/test/renderer/features/runtime-provider-management/RuntimeProviderErrorAlert.test.ts
+++ b/test/renderer/features/runtime-provider-management/RuntimeProviderErrorAlert.test.ts
@@ -1,7 +1,10 @@
 import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
-import { RuntimeProviderErrorAlert } from '../../../../src/features/runtime-provider-management/renderer/ui/RuntimeProviderErrorAlert';
+import {
+  RuntimeProviderErrorAlert,
+  formatRuntimeProviderDiagnosticsCopyText,
+} from '../../../../src/features/runtime-provider-management/renderer/ui/RuntimeProviderErrorAlert';
 
 beforeEach(() => vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true));
 const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
@@ -65,4 +68,14 @@ it('ignores a clipboard completion belonging to the previous error', async () =>
   expect(host.textContent).toContain('Second error');
   expect(host.textContent).not.toContain('Copied');
   await act(async () => root.unmount());
+});
+
+it('removes bare and named provider keys from clipboard report text', () => {
+  for (const secret of [
+    'AIza' + 'a'.repeat(35),
+    'or-' + 'b'.repeat(32),
+    'custom-private-key-value',
+  ]) {
+    expect(formatRuntimeProviderDiagnosticsCopyText(`key="${secret}"`, null)).not.toContain(secret);
+  }
 });

--- a/test/renderer/features/runtime-provider-management/RuntimeProviderErrorAlert.test.ts
+++ b/test/renderer/features/runtime-provider-management/RuntimeProviderErrorAlert.test.ts
@@ -79,3 +79,12 @@ it('removes bare and named provider keys from clipboard report text', () => {
     expect(formatRuntimeProviderDiagnosticsCopyText(`key="${secret}"`, null)).not.toContain(secret);
   }
 });
+
+it.each(['Error: api_key=custom-private-key-value', '{"auth":{"key":"custom-private-key-value"}}'])(
+  'redacts nested secrets from copy text: %s',
+  (message) => {
+    expect(formatRuntimeProviderDiagnosticsCopyText(message, null)).not.toContain(
+      'custom-private-key-value'
+    );
+  }
+);

--- a/test/scripts/opencodeDiagnosticsOwnership.test.ts
+++ b/test/scripts/opencodeDiagnosticsOwnership.test.ts
@@ -1,0 +1,42 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const sandboxes: string[] = [];
+afterEach(() =>
+  sandboxes.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true }))
+);
+const script = path.resolve('scripts/e2e/opencode-diagnostics-desktop.mjs');
+function sandbox() {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'opencode-diagnostics-e2e-'));
+  sandboxes.push(root);
+  writeFileSync(path.join(root, 'manifest.json'), JSON.stringify({ root }));
+  return root;
+}
+function refusal(root: string): string {
+  try {
+    execFileSync(process.execPath, [script, 'verify', root], { encoding: 'utf8', stdio: 'pipe' });
+  } catch (error) {
+    return String((error as { stderr: string }).stderr);
+  }
+  throw new Error('An unowned profile was accepted');
+}
+describe.skipIf(process.platform === 'win32')('OpenCode desktop fixture ownership', () => {
+  it('refuses seed-only verification before connecting to CDP', () => {
+    expect(refusal(sandbox())).toContain('launcher.pid');
+  });
+  it('refuses an unrelated live process even with a matching birth timestamp', () => {
+    const root = sandbox();
+    writeFileSync(path.join(root, 'launcher.pid'), String(process.pid));
+    writeFileSync(
+      path.join(root, 'launcher.birth'),
+      execFileSync('ps', ['-p', String(process.pid), '-o', 'lstart='], {
+        encoding: 'utf8',
+        env: { ...process.env, LC_ALL: 'C' },
+      })
+    );
+    expect(refusal(root)).toContain('Launcher identity changed');
+  });
+});


### PR DESCRIPTION
OpenCode version failures currently lose process details and leave users with an error that is difficult to report. This adds a compact error card with expandable diagnostics and Copy diagnostics, including the binary source/path, duration and timeout, exit/signal, sanitized output and a report ID shared with the app log.

The existing provider error UI is reused and accepts optional stage/HTTP fields from compatible runtimes. Clipboard denial exposes selectable text, and a late copy completion cannot mark a newer error as copied. The current resolver cache behavior is preserved.

Validation: 179 focused app tests and Linux Electron process/clipboard/timeout/recovery E2E passed before rebasing onto current main. Independent read-only review passed after fixing credential redaction and sandbox ownership findings. The final regression run passed 23 tests; final CI passed for 29a5b1b4e (both test shards, workspace validation, all lint shards and Windows smoke). ReviewRouter is unavailable due to a control-plane protocol mismatch, documented in the review comment. The bundled runtime is not upgraded here; the Windows five-second summary timeout, full catalog HTTP propagation and Windows/macOS desktop qualification remain separate follow-ups.
