### PR TITLE
fix(opencode): preserve app MCP context across reopen

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2193,9 +2193,8 @@ async function initializeServices(): Promise<void> {
   // (did-finish-load handler) to avoid thread pool contention at startup.
   httpServer = new HttpServer();
   teamProvisioningService.setControlApiBaseUrlResolver(async () => {
-    if (!httpServer.isRunning()) {
-      await startHttpServer(handleModeSwitch);
-    }
+    // Listening alone does not prove that Host publication has committed.
+    await startHttpServer(handleModeSwitch);
 
     return getTeamControlApiBaseUrl();
   });
@@ -2605,9 +2604,7 @@ async function initializeServices(): Promise<void> {
     listLifecycleActiveTeamNames: listMemberWorkSyncLifecycleActiveTeamNames,
     ...createTeamProvisioningMemberWorkSyncBusySignals(teamProvisioningService),
     resolveControlUrl: async () => {
-      if (!httpServer.isRunning()) {
-        await startHttpServer(handleModeSwitch);
-      }
+      await startHttpServer(handleModeSwitch);
       return getTeamControlApiBaseUrl();
     },
     proofMissingRecoveryGuard: {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1862,6 +1862,8 @@ function reconfigureLocalContextForClaudeRoot(): void {
 const announcementsLifecycle = new AnnouncementsLifecycle();
 
 async function initializeServices(): Promise<void> {
+  // An inherited endpoint belongs to a previous process, not this Host's server.
+  await clearTeamControlApiState();
   void announcementsLifecycle
     .initialize({
       userDataPath: app.getPath('userData'),

--- a/src/main/services/runtime/agentTeamsMcpLaunchEnv.ts
+++ b/src/main/services/runtime/agentTeamsMcpLaunchEnv.ts
@@ -2,6 +2,7 @@ import {
   resolveAgentTeamsMcpLaunchSpec,
   resolvePackagedAgentTeamsMcpEntry,
 } from '@main/services/team/TeamMcpConfigBuilder';
+import { getClaudeBasePath } from '@main/utils/pathDecoder';
 import { createLogger } from '@shared/utils/logger';
 
 import type { McpLaunchSpec } from '@main/services/team/TeamMcpConfigBuilder';
@@ -15,6 +16,36 @@ const MCP_ENV_JSON_ENV = 'CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON';
 const ELECTRON_RUN_AS_NODE_ENV = 'ELECTRON_RUN_AS_NODE';
 
 export type AgentTeamsMcpLaunchEnv = Record<string, string | undefined>;
+
+/** Project existing app authority only; never resolve or start a server on a read. */
+export function applyAgentTeamsMcpAppContext(
+  env: AgentTeamsMcpLaunchEnv,
+  claudeBasePath: string = getClaudeBasePath(),
+  controlApiBaseUrl: string | null | undefined = process.env.CLAUDE_TEAM_CONTROL_URL
+): void {
+  const rawChildEnv = env[MCP_ENV_JSON_ENV]?.trim();
+  const parsed: unknown = rawChildEnv ? JSON.parse(rawChildEnv) : {};
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    Array.isArray(parsed) ||
+    Object.values(parsed).some((value) => typeof value !== 'string')
+  ) {
+    throw new Error('Agent Teams MCP child environment must be a JSON object of strings');
+  }
+  const childEnv = { ...parsed } as Record<string, string>;
+  env.AGENT_TEAMS_MCP_CLAUDE_DIR = claudeBasePath;
+  childEnv.AGENT_TEAMS_MCP_CLAUDE_DIR = claudeBasePath;
+  const controlUrl = controlApiBaseUrl?.trim();
+  if (controlUrl) {
+    env.CLAUDE_TEAM_CONTROL_URL = controlUrl;
+    childEnv.CLAUDE_TEAM_CONTROL_URL = controlUrl;
+  } else {
+    delete env.CLAUDE_TEAM_CONTROL_URL;
+    delete childEnv.CLAUDE_TEAM_CONTROL_URL;
+  }
+  env[MCP_ENV_JSON_ENV] = JSON.stringify(childEnv);
+}
 
 export function hasAgentTeamsMcpLocalLaunchEnv(env: AgentTeamsMcpLaunchEnv): boolean {
   return Boolean(

--- a/src/main/services/runtime/providerAwareCliEnv.ts
+++ b/src/main/services/runtime/providerAwareCliEnv.ts
@@ -11,7 +11,10 @@ import {
   resolveVerifiedOpenCodeRuntimeBinaryPath,
 } from '../infrastructure/OpenCodeRuntimeInstallerService';
 
-import { ensureAgentTeamsMcpLocalLaunchEnv } from './agentTeamsMcpLaunchEnv';
+import {
+  applyAgentTeamsMcpAppContext,
+  ensureAgentTeamsMcpLocalLaunchEnv,
+} from './agentTeamsMcpLaunchEnv';
 import { buildRuntimeBaseEnv } from './buildRuntimeBaseEnv';
 import {
   applyOpenCodeRuntimeBinaryEnv,
@@ -94,6 +97,7 @@ export function buildPassiveProviderStatusCliEnv(
       delete env[OPENCODE_LEGACY_BINARY_PATH_ENV];
     }
     applyOpenCodeRuntimeBinaryEnv(env, explicitOpenCodeBinary ?? knownOpenCodeBinary);
+    applyAgentTeamsMcpAppContext(env);
   }
   if (!options.providerId || options.providerId === 'codex') {
     const appManagedCodexBinary = resolveAppManagedCodexRuntimeBinaryPath();
@@ -176,6 +180,7 @@ export async function buildProviderAwareCliEnv(
   }
   if (!resolvedProviderId || resolvedProviderId === 'opencode') {
     await ensureAgentTeamsMcpLocalLaunchEnv(env);
+    applyAgentTeamsMcpAppContext(env);
   }
 
   if (options.providerId) {

--- a/src/main/services/team/TeamControlApiState.ts
+++ b/src/main/services/team/TeamControlApiState.ts
@@ -7,6 +7,15 @@ import path from 'path';
 const logger = createLogger('Service:TeamControlApiState');
 
 const TEAM_CONTROL_API_STATE_FILE = 'team-control-api.json';
+let publicationGeneration = 0;
+let publicationTail: Promise<void> = Promise.resolve();
+
+// Host start/stop/root-change callers must order disk publication as well as env updates.
+function enqueuePublication(operation: () => Promise<void>): Promise<void> {
+  const result = publicationTail.then(operation);
+  publicationTail = result.catch(() => undefined);
+  return result;
+}
 
 function normalizeBaseUrlHost(host: string): string {
   if (host === '0.0.0.0' || host === '::') {
@@ -25,23 +34,32 @@ function getTeamControlApiStatePath(): string {
 }
 
 export async function writeTeamControlApiState(baseUrl: string): Promise<void> {
+  const generation = ++publicationGeneration;
+  delete process.env.CLAUDE_TEAM_CONTROL_URL;
   const statePath = getTeamControlApiStatePath();
-  await atomicWriteAsync(
-    statePath,
-    JSON.stringify(
-      {
-        baseUrl,
-        pid: process.pid,
-        updatedAt: new Date().toISOString(),
-      },
-      null,
-      2
-    )
-  );
-  logger.info(`Published team control API endpoint: ${baseUrl}`);
+  await enqueuePublication(async () => {
+    await atomicWriteAsync(
+      statePath,
+      JSON.stringify(
+        {
+          baseUrl,
+          pid: process.pid,
+          updatedAt: new Date().toISOString(),
+        },
+        null,
+        2
+      )
+    );
+    // Publish only committed Host state, never a configured port or a late stopped endpoint.
+    if (generation !== publicationGeneration) return;
+    process.env.CLAUDE_TEAM_CONTROL_URL = baseUrl;
+    logger.info(`Published team control API endpoint: ${baseUrl}`);
+  });
 }
 
 export async function clearTeamControlApiState(): Promise<void> {
+  publicationGeneration++;
+  delete process.env.CLAUDE_TEAM_CONTROL_URL;
   const statePath = getTeamControlApiStatePath();
-  await rm(statePath, { force: true }).catch(() => undefined);
+  await enqueuePublication(() => rm(statePath, { force: true }).catch(() => undefined));
 }

--- a/src/main/services/team/provisioning/TeamProvisioningEnvBuilder.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningEnvBuilder.ts
@@ -1,4 +1,5 @@
 import { prepareAgentChildProcessWritableEnv } from '@main/services/runtime/agentChildProcessPreflight';
+import { applyAgentTeamsMcpAppContext } from '@main/services/runtime/agentTeamsMcpLaunchEnv';
 import { buildProviderAwareCliEnv } from '@main/services/runtime/providerAwareCliEnv';
 import { resolveTeamProviderId } from '@main/services/runtime/providerRuntimeEnv';
 import {
@@ -362,6 +363,9 @@ export async function buildProvisioningEnv({
   const controlApiBaseUrl = await ports.resolveControlApiBaseUrl();
   if (controlApiBaseUrl) {
     providerEnv.CLAUDE_TEAM_CONTROL_URL = controlApiBaseUrl;
+  }
+  if (resolvedProviderId === 'opencode') {
+    applyAgentTeamsMcpAppContext(providerEnv, resolvedClaudeBasePath, controlApiBaseUrl);
   }
 
   // SHELL is a Unix concept - only set it on non-Windows platforms.

--- a/src/main/services/team/provisioning/TeamProvisioningEnvRuntimePorts.ts
+++ b/src/main/services/team/provisioning/TeamProvisioningEnvRuntimePorts.ts
@@ -22,7 +22,6 @@ export interface TeamProvisioningEnvRuntimePortsDeps {
   getRuntimeTurnSettledEnvironmentProvider(): RuntimeTurnSettledEnvironmentProvider | null;
   getRuntimeTurnSettledHookSettingsProvider(): RuntimeTurnSettledHookSettingsProvider | null;
   logger: TeamProvisioningEnvBuilderPorts['logger'];
-  processEnv?: NodeJS.ProcessEnv;
 }
 
 export interface TeamProvisioningEnvRuntimePorts {
@@ -41,10 +40,7 @@ export interface TeamProvisioningEnvRuntimePorts {
 }
 
 export async function resolveControlApiBaseUrlForProvisioning(
-  deps: Pick<
-    TeamProvisioningEnvRuntimePortsDeps,
-    'getControlApiBaseUrlResolver' | 'logger' | 'processEnv'
-  >
+  deps: Pick<TeamProvisioningEnvRuntimePortsDeps, 'getControlApiBaseUrlResolver' | 'logger'>
 ): Promise<string | null> {
   const resolver = deps.getControlApiBaseUrlResolver();
   if (!resolver) {
@@ -56,7 +52,6 @@ export async function resolveControlApiBaseUrlForProvisioning(
     if (!baseUrl) {
       throw new Error('Team control API resolver returned no base URL after startup.');
     }
-    (deps.processEnv ?? process.env).CLAUDE_TEAM_CONTROL_URL = baseUrl;
     return baseUrl;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningEnvBuilder.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningEnvBuilder.test.ts
@@ -62,6 +62,29 @@ function createPorts(
 }
 
 describe('TeamProvisioningEnvBuilder', () => {
+  it('projects the late launch-resolved control URL and app root into MCP child env as well as outer env', async () => {
+    const ports = createPorts({
+      getClaudeBasePath: () => '/sandbox/private-claude',
+      resolveControlApiBaseUrl: vi.fn(async () => 'http://127.0.0.1:4588'),
+      buildProviderAwareCliEnv: vi.fn(async () => ({
+        env: {
+          CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON:
+            '{"ELECTRON_RUN_AS_NODE":"1","CLAUDE_TEAM_CONTROL_URL":"http://stale:9999"}',
+        },
+        connectionIssues: {},
+        providerArgs: [],
+      })),
+    });
+    const result = await buildProvisioningEnv({ providerId: 'opencode', ports });
+    expect(result.env.AGENT_TEAMS_MCP_CLAUDE_DIR).toBe('/sandbox/private-claude');
+    expect(result.env.CLAUDE_TEAM_CONTROL_URL).toBe('http://127.0.0.1:4588');
+    expect(JSON.parse(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON!)).toEqual({
+      ELECTRON_RUN_AS_NODE: '1',
+      AGENT_TEAMS_MCP_CLAUDE_DIR: '/sandbox/private-claude',
+      CLAUDE_TEAM_CONTROL_URL: 'http://127.0.0.1:4588',
+    });
+  });
+
   it('returns codex runtime auth source for Codex provider env', async () => {
     const ports = createPorts({
       buildRuntimeTurnSettledEnvironment: vi.fn(async () => ({

--- a/src/main/services/team/provisioning/__tests__/TeamProvisioningEnvRuntimePorts.test.ts
+++ b/src/main/services/team/provisioning/__tests__/TeamProvisioningEnvRuntimePorts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createTeamProvisioningEnvRuntimePorts,
@@ -25,24 +25,23 @@ function createDeps(
       warn: vi.fn(),
       error: vi.fn(),
     },
-    processEnv: {},
     ...overrides,
   };
 }
 
 describe('TeamProvisioningEnvRuntimePorts', () => {
-  it('publishes resolved control API base URL through injectable process env', async () => {
-    const processEnv = {};
+  afterEach(() => vi.unstubAllEnvs());
+  it('returns the control API base URL without taking publication ownership from the Host', async () => {
+    vi.stubEnv('CLAUDE_TEAM_CONTROL_URL', 'http://127.0.0.1:4568');
     const logger = { warn: vi.fn(), error: vi.fn() };
 
     const result = await resolveControlApiBaseUrlForProvisioning({
       getControlApiBaseUrlResolver: () => vi.fn(async () => 'http://127.0.0.1:4567'),
       logger,
-      processEnv,
     });
 
     expect(result).toBe('http://127.0.0.1:4567');
-    expect(processEnv).toEqual({ CLAUDE_TEAM_CONTROL_URL: 'http://127.0.0.1:4567' });
+    expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBe('http://127.0.0.1:4568');
     expect(logger.error).not.toHaveBeenCalled();
   });
 
@@ -53,7 +52,6 @@ describe('TeamProvisioningEnvRuntimePorts', () => {
       resolveControlApiBaseUrlForProvisioning({
         getControlApiBaseUrlResolver: () => vi.fn(async () => null),
         logger,
-        processEnv: {},
       })
     ).rejects.toThrow(
       'Team control API failed to start or publish its base URL. Team runtime commands require the desktop Control API. Team control API resolver returned no base URL after startup.'

--- a/test/main/services/runtime/providerAwareCliEnv.test.ts
+++ b/test/main/services/runtime/providerAwareCliEnv.test.ts
@@ -1,8 +1,21 @@
 // @vitest-environment node
 import * as fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execCliMock = vi.fn();
+vi.mock('@main/utils/childProcess', () => ({
+  execCli: (...args: unknown[]) => execCliMock(...args),
+  spawnCli: vi.fn(() => {
+    throw new Error('unexpected spawn');
+  }),
+  killProcessTree: vi.fn(),
+}));
+vi.mock('@main/services/team/ClaudeBinaryResolver', () => ({
+  ClaudeBinaryResolver: { resolve: vi.fn(() => Promise.resolve('/sandbox/agent-teams-cli')) },
+}));
 
 const buildEnrichedEnvMock = vi.fn();
 const getCachedShellEnvMock = vi.fn();
@@ -29,6 +42,7 @@ vi.mock('@main/utils/cliEnv', () => ({
 
 vi.mock('@main/utils/shellEnv', () => ({
   getCachedShellEnv: () => getCachedShellEnvMock(),
+  resolveInteractiveShellEnvBestEffort: () => Promise.resolve(getCachedShellEnvMock()),
   getShellPreferredHome: () => getShellPreferredHomeMock(),
 }));
 
@@ -95,6 +109,86 @@ vi.mock('@main/services/team/TeamMcpConfigBuilder', () => ({
 }));
 
 describe('buildProviderAwareCliEnv', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it.each(['active', 'passive'] as const)(
+    'projects current app root/control into %s outer and MCP child env without stale shell contamination',
+    async (mode) => {
+      const { setClaudeBasePathOverride } = await import('@main/utils/pathDecoder');
+      const { buildProviderAwareCliEnv, buildPassiveProviderStatusCliEnv } =
+        await import('@main/services/runtime/providerAwareCliEnv');
+      setClaudeBasePathOverride('/sandbox/private-claude');
+      vi.stubEnv('CLAUDE_TEAM_CONTROL_URL', 'http://127.0.0.1:4569');
+      const options = {
+        providerId: 'opencode' as const,
+        env: {
+          HOME: '/sandbox/home',
+          CLAUDE_CONFIG_DIR: '/sandbox/auth-namespace',
+          AGENT_TEAMS_MCP_CLAUDE_DIR: '/stale/root',
+          CLAUDE_TEAM_CONTROL_URL: 'http://127.0.0.1:9999',
+          CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND: '/sandbox/electron',
+          CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/sandbox/mcp.js',
+          CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ARGS_JSON: '["/sandbox/mcp.js"]',
+          CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON: JSON.stringify({
+            ELECTRON_RUN_AS_NODE: '1',
+            OWNER_FIXTURE: 'unchanged',
+            AGENT_TEAMS_MCP_CLAUDE_DIR: '/stale/child',
+            CLAUDE_TEAM_CONTROL_URL: 'http://127.0.0.1:9998',
+          }),
+        },
+      };
+      try {
+        const result =
+          mode === 'active'
+            ? await buildProviderAwareCliEnv(options)
+            : buildPassiveProviderStatusCliEnv(options);
+        expect(result.env.AGENT_TEAMS_MCP_CLAUDE_DIR).toBe('/sandbox/private-claude');
+        expect(result.env.CLAUDE_TEAM_CONTROL_URL).toBe('http://127.0.0.1:4569');
+        expect(JSON.parse(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON!)).toEqual({
+          ELECTRON_RUN_AS_NODE: '1',
+          OWNER_FIXTURE: 'unchanged',
+          AGENT_TEAMS_MCP_CLAUDE_DIR: '/sandbox/private-claude',
+          CLAUDE_TEAM_CONTROL_URL: 'http://127.0.0.1:4569',
+        });
+        expect(result.env.HOME).toBe('/sandbox/home');
+        expect(result.env.CLAUDE_CONFIG_DIR).toBe('/sandbox/auth-namespace');
+        expect(options.env.AGENT_TEAMS_MCP_CLAUDE_DIR).toBe('/stale/root');
+        expect(resolveAgentTeamsMcpLaunchSpecMock).not.toHaveBeenCalled();
+        if (mode === 'passive') {
+          expect(resolveVerifiedOpenCodeRuntimeBinaryPathMock).not.toHaveBeenCalled();
+          expect(resolveVerifiedAppManagedCodexRuntimeBinaryPathMock).not.toHaveBeenCalled();
+          expect(augmentConfiguredConnectionEnvMock).not.toHaveBeenCalled();
+          expect(applyConfiguredConnectionEnvMock).not.toHaveBeenCalled();
+        }
+      } finally {
+        setClaudeBasePathOverride(null);
+      }
+    }
+  );
+
+  it('keeps passive reads passive when no server or MCP launch metadata exists and strips dead endpoints', async () => {
+    vi.stubEnv('CLAUDE_TEAM_CONTROL_URL', undefined);
+    const { buildPassiveProviderStatusCliEnv } =
+      await import('@main/services/runtime/providerAwareCliEnv');
+    const result = buildPassiveProviderStatusCliEnv({
+      providerId: 'opencode',
+      shellEnv: {
+        CLAUDE_TEAM_CONTROL_URL: 'http://127.0.0.1:9999',
+        CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON:
+          '{"CLAUDE_TEAM_CONTROL_URL":"http://127.0.0.1:9998"}',
+      },
+    });
+    expect(result.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
+    expect(
+      JSON.parse(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON!).CLAUDE_TEAM_CONTROL_URL
+    ).toBeUndefined();
+    expect(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND).toBeUndefined();
+    expect(resolveAgentTeamsMcpLaunchSpecMock).not.toHaveBeenCalled();
+    expect(resolvePackagedAgentTeamsMcpEntryMock).not.toHaveBeenCalled();
+    expect(resolveVerifiedOpenCodeRuntimeBinaryPathMock).not.toHaveBeenCalled();
+    expect(augmentConfiguredConnectionEnvMock).not.toHaveBeenCalled();
+  });
+
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
@@ -131,6 +225,97 @@ describe('buildProviderAwareCliEnv', () => {
     });
     resolvePackagedAgentTeamsMcpEntryMock.mockResolvedValue(null);
   });
+
+  it('passes cold Host publication and changed-port reopen to direct provider catalog without provisioning', async () => {
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'app-catalog-context-'));
+    const { setClaudeBasePathOverride } = await import('@main/utils/pathDecoder');
+    const { writeTeamControlApiState, clearTeamControlApiState } =
+      await import('@main/services/team/TeamControlApiState');
+    const { AgentTeamsRuntimeProviderManagementCliClient } =
+      await import('@features/runtime-provider-management/main/infrastructure/AgentTeamsRuntimeProviderManagementCliClient');
+    vi.stubEnv('CLAUDE_TEAM_CONTROL_URL', 'http://127.0.0.1:9999');
+    setClaudeBasePathOverride(root);
+    getCachedShellEnvMock.mockReturnValue({
+      HOME: root,
+      CLAUDE_CONFIG_DIR: path.join(root, 'auth-namespace'),
+      AGENT_TEAMS_MCP_CLAUDE_DIR: '/stale/shell-root',
+      CLAUDE_TEAM_CONTROL_URL: 'http://127.0.0.1:9998',
+    });
+    resolveAgentTeamsMcpLaunchSpecMock.mockResolvedValue({
+      command: '/sandbox/electron',
+      args: ['/sandbox/mcp.js'],
+      env: { ELECTRON_RUN_AS_NODE: '1' },
+    });
+    const response = {
+      schemaVersion: 1,
+      runtimeId: 'opencode',
+      models: {
+        runtimeId: 'opencode',
+        providerId: 'xai',
+        models: [],
+        defaultModelId: null,
+        diagnostics: [],
+        catalogState: 'fresh',
+      },
+    };
+    execCliMock.mockResolvedValue({ stdout: JSON.stringify(response), stderr: '' });
+    try {
+      await clearTeamControlApiState();
+      for (const port of [4580, 4581]) {
+        await writeTeamControlApiState(`http://127.0.0.1:${port}`);
+        const client = new AgentTeamsRuntimeProviderManagementCliClient();
+        await expect(
+          client.loadModels({ runtimeId: 'opencode', providerId: 'xai' })
+        ).resolves.toEqual(response);
+        const [command, args, options] = execCliMock.mock.calls.at(-1)!;
+        expect(command).toBe('/sandbox/agent-teams-cli');
+        expect(args).toEqual([
+          'runtime',
+          'providers',
+          'models',
+          '--runtime',
+          'opencode',
+          '--provider',
+          'xai',
+          '--json',
+        ]);
+        expect(options.env).toMatchObject({
+          AGENT_TEAMS_MCP_CLAUDE_DIR: root,
+          CLAUDE_TEAM_CONTROL_URL: `http://127.0.0.1:${port}`,
+          HOME: root,
+          CLAUDE_CONFIG_DIR: path.join(root, 'auth-namespace'),
+        });
+        expect(JSON.parse(options.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON)).toEqual({
+          ELECTRON_RUN_AS_NODE: '1',
+          AGENT_TEAMS_MCP_CLAUDE_DIR: root,
+          CLAUDE_TEAM_CONTROL_URL: `http://127.0.0.1:${port}`,
+        });
+        await clearTeamControlApiState();
+        expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
+      }
+      expect(execCliMock).toHaveBeenCalledTimes(2);
+    } finally {
+      await clearTeamControlApiState();
+      setClaudeBasePathOverride(null);
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each(['null', '[]', '{"OWNER":42}', '{broken'])(
+    'rejects malformed existing MCP child env %s without repairing away owner fields',
+    async (raw) => {
+      const { buildPassiveProviderStatusCliEnv } =
+        await import('@main/services/runtime/providerAwareCliEnv');
+      expect(() =>
+        buildPassiveProviderStatusCliEnv({
+          providerId: 'opencode',
+          env: { CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON: raw },
+        })
+      ).toThrow();
+      expect(resolveAgentTeamsMcpLaunchSpecMock).not.toHaveBeenCalled();
+      expect(augmentConfiguredConnectionEnvMock).not.toHaveBeenCalled();
+    }
+  );
 
   it('returns narrow provider status stored credential allowlists', async () => {
     const {
@@ -535,9 +720,9 @@ describe('buildProviderAwareCliEnv', () => {
     });
 
     expect(result.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
-    expect(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON).toBe(
-      '{"ELECTRON_RUN_AS_NODE":"1"}'
-    );
+    expect(JSON.parse(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON!)).toMatchObject({
+      ELECTRON_RUN_AS_NODE: '1',
+    });
     expect(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND).toBe(
       '/opt/Agent Teams AI/agent-teams-ai'
     );
@@ -560,9 +745,9 @@ describe('buildProviderAwareCliEnv', () => {
     expect(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND).toBe('custom-node');
     expect(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY).toBe('/custom/mcp.js');
     expect(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ARGS_JSON).toBe('["/custom/mcp.js"]');
-    expect(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON).toBe(
-      '{"ELECTRON_RUN_AS_NODE":"1"}'
-    );
+    expect(JSON.parse(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON!)).toMatchObject({
+      ELECTRON_RUN_AS_NODE: '1',
+    });
     expect(result.env.ELECTRON_RUN_AS_NODE).toBeUndefined();
   });
 
@@ -705,10 +890,10 @@ describe('buildProviderAwareCliEnv', () => {
   });
 
   it('returns Codex custom provider launch args after API-key env application', async () => {
-    applyConfiguredConnectionEnvMock.mockImplementation(async (env: NodeJS.ProcessEnv) => {
+    applyConfiguredConnectionEnvMock.mockImplementation((env: NodeJS.ProcessEnv) => {
       env.OPENAI_API_KEY = 'stored-key';
       env.CODEX_API_KEY = 'stored-key';
-      return env;
+      return Promise.resolve(env);
     });
     const customSettings = JSON.stringify({
       codex: {
@@ -749,14 +934,14 @@ describe('buildProviderAwareCliEnv', () => {
 
   it('passes Codex env refreshed by strict credential application into launch args and issue checks', async () => {
     applyConfiguredConnectionEnvMock.mockImplementation(
-      async (env: NodeJS.ProcessEnv, providerId: string) => {
+      (env: NodeJS.ProcessEnv, providerId: string) => {
         expect(providerId).toBe('codex');
         env.CODEX_CLI_PATH = '/Users/tester/.local/bin/codex';
         env.CODEX_HOME = '/Users/tester/.codex-custom';
         env.CLAUDE_CODE_CODEX_FORCED_LOGIN_METHOD = 'chatgpt';
         delete env.OPENAI_API_KEY;
         delete env.CODEX_API_KEY;
-        return env;
+        return Promise.resolve(env);
       }
     );
     getConfiguredConnectionLaunchArgsMock.mockResolvedValue([

--- a/test/main/services/runtime/providerAwareCliEnv.test.ts
+++ b/test/main/services/runtime/providerAwareCliEnv.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import * as fs from 'node:fs';
-import path from 'node:path';
 import os from 'node:os';
+import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/test/main/services/team/TeamControlApiHostWiring.test.ts
+++ b/test/main/services/team/TeamControlApiHostWiring.test.ts
@@ -4,15 +4,14 @@ import os from 'node:os';
 import path from 'node:path';
 import { runInNewContext } from 'node:vm';
 
-import ts from 'typescript';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
 import {
   buildTeamControlApiBaseUrl,
   clearTeamControlApiState,
   writeTeamControlApiState,
 } from '@main/services/team/TeamControlApiState';
 import { setClaudeBasePathOverride } from '@main/utils/pathDecoder';
+import ts from 'typescript';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Exercise the existing private Host wiring with offline server doubles. Importing
 // main/index would boot Electron and all app services, outside this test's scope.
@@ -30,7 +29,43 @@ function functionSource(name: string): string {
   return declaration.getText(source);
 }
 
-function createHost() {
+type ResolverKind = 'provisioning' | 'memberWorkSync';
+
+function resolverSource(kind: ResolverKind): string {
+  const matches: ts.Expression[] = [];
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node)) {
+      if (
+        kind === 'provisioning' &&
+        node.expression.getText(source) === 'teamProvisioningService.setControlApiBaseUrlResolver'
+      ) {
+        matches.push(node.arguments[0]);
+      }
+      if (
+        kind === 'memberWorkSync' &&
+        node.expression.getText(source) === 'createMemberWorkSyncFeature'
+      ) {
+        const options = node.arguments[0];
+        if (ts.isObjectLiteralExpression(options)) {
+          for (const property of options.properties) {
+            if (
+              ts.isPropertyAssignment(property) &&
+              property.name.getText(source) === 'resolveControlUrl'
+            ) {
+              matches.push(property.initializer);
+            }
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(source);
+  if (matches.length !== 1) throw new Error(`Expected exactly one ${kind} Host resolver`);
+  return matches[0].getText(source);
+}
+
+function createHost(publish = writeTeamControlApiState) {
   let running = false;
   let shuttingDown = false;
   const server = {
@@ -46,19 +81,24 @@ function createHost() {
     }),
   };
   const code = ts.transpileModule(
-    ['getTeamControlApiBaseUrl', 'syncTeamControlApiState', 'startHttpServer']
-      .map(functionSource)
-      .join('\n'),
+    [
+      ...['getTeamControlApiBaseUrl', 'syncTeamControlApiState', 'startHttpServer'].map(
+        functionSource
+      ),
+      `const provisioning = ${resolverSource('provisioning')};`,
+      `const memberWorkSync = ${resolverSource('memberWorkSync')};`,
+    ].join('\n'),
     { compilerOptions: { target: ts.ScriptTarget.ES2022 } }
   ).outputText;
   // Only named functions from this repository are executed, with offline dependencies.
   // eslint-disable-next-line sonarjs/code-eval -- trusted local source, no user input
-  const host = runInNewContext(`${code}\n({ startHttpServer })`, {
+  const host = runInNewContext(`${code}\n({ startHttpServer, provisioning, memberWorkSync })`, {
     httpServer: server,
     isShutdownStarted: () => shuttingDown,
     buildTeamControlApiBaseUrl,
     clearTeamControlApiState,
-    writeTeamControlApiState,
+    writeTeamControlApiState: publish,
+    handleModeSwitch: () => Promise.resolve(),
     configManager: { getConfig: () => ({ httpServer: { port: 3456 } }) },
     contextRegistry: { getActive: () => ({}) },
     teamHttpHandlerApis: {},
@@ -72,10 +112,15 @@ function createHost() {
     updaterService: {},
     sshConnectionManager: {},
     logger: { info: vi.fn(), error: vi.fn() },
-  }) as { startHttpServer: (handler: () => Promise<void>) => Promise<void> };
+  }) as {
+    startHttpServer: (handler: () => Promise<void>) => Promise<void>;
+    provisioning: () => Promise<string | null>;
+    memberWorkSync: () => Promise<string | null>;
+  };
   return {
     server,
     start: () => host.startHttpServer(() => Promise.resolve()),
+    resolve: (kind: ResolverKind) => host[kind](),
     shutdown: () => {
       shuttingDown = true;
     },
@@ -127,6 +172,61 @@ describe('existing app Host endpoint wiring', () => {
       code: 'ENOENT',
     });
   });
+
+  it.each(['provisioning', 'memberWorkSync'] as const)(
+    '%s retries failed publication even when the server is already listening',
+    async (kind) => {
+      const publish = vi.fn(writeTeamControlApiState);
+      publish.mockRejectedValueOnce(new Error('disk unavailable'));
+      const host = createHost(publish);
+      await expect(host.start()).rejects.toThrow('disk unavailable');
+      expect(host.server.isRunning()).toBe(true);
+      expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
+
+      publish.mockRejectedValueOnce(new Error('disk still unavailable'));
+      await expect(host.resolve(kind)).rejects.toThrow('disk still unavailable');
+      expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
+      await expect(host.resolve(kind)).resolves.toBe('http://127.0.0.1:4591');
+      expect(host.server.start).toHaveBeenCalledOnce();
+      expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBe('http://127.0.0.1:4591');
+      expect(
+        JSON.parse(await readFile(path.join(root, 'team-control-api.json'), 'utf8')).baseUrl
+      ).toBe('http://127.0.0.1:4591');
+    }
+  );
+
+  it.each(['provisioning', 'memberWorkSync'] as const)(
+    '%s awaits publication when listening precedes disk completion',
+    async (kind) => {
+      await clearTeamControlApiState();
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const publish = vi.fn(async (baseUrl: string) => {
+        await gate;
+        await writeTeamControlApiState(baseUrl);
+      });
+      const host = createHost(publish);
+      const starting = host.start();
+      await vi.waitFor(() => expect(publish).toHaveBeenCalledOnce());
+      let resolved = false;
+      const resolving = host.resolve(kind).then((url) => {
+        resolved = true;
+        return url;
+      });
+      try {
+        // Drain promise continuations while the publication is explicitly blocked.
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(resolved).toBe(false);
+        expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
+      } finally {
+        release();
+        await Promise.all([starting, resolving]);
+      }
+      expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBe('http://127.0.0.1:4591');
+    }
+  );
 
   it('clears both publications when shutdown interrupts server startup', async () => {
     await writeTeamControlApiState('http://127.0.0.1:4590');

--- a/test/main/services/team/TeamControlApiHostWiring.test.ts
+++ b/test/main/services/team/TeamControlApiHostWiring.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment node
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+import ts from 'typescript';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildTeamControlApiBaseUrl,
+  clearTeamControlApiState,
+  writeTeamControlApiState,
+} from '@main/services/team/TeamControlApiState';
+import { setClaudeBasePathOverride } from '@main/utils/pathDecoder';
+
+// Exercise the existing private Host wiring with offline server doubles. Importing
+// main/index would boot Electron and all app services, outside this test's scope.
+const source = ts.createSourceFile(
+  'index.ts',
+  await readFile(path.resolve('src/main/index.ts'), 'utf8'),
+  ts.ScriptTarget.Latest,
+  true
+);
+function functionSource(name: string): string {
+  const declaration = source.statements.find(
+    (node) => ts.isFunctionDeclaration(node) && node.name?.text === name
+  );
+  if (!declaration) throw new Error(`Missing Host function ${name}`);
+  return declaration.getText(source);
+}
+
+function createHost() {
+  let running = false;
+  let shuttingDown = false;
+  const server = {
+    isRunning: () => running,
+    getPort: () => 4591,
+    start: vi.fn(() => {
+      running = true;
+      return Promise.resolve(4591);
+    }),
+    stop: vi.fn(() => {
+      running = false;
+      return Promise.resolve();
+    }),
+  };
+  const code = ts.transpileModule(
+    ['getTeamControlApiBaseUrl', 'syncTeamControlApiState', 'startHttpServer']
+      .map(functionSource)
+      .join('\n'),
+    { compilerOptions: { target: ts.ScriptTarget.ES2022 } }
+  ).outputText;
+  // Only named functions from this repository are executed, with offline dependencies.
+  // eslint-disable-next-line sonarjs/code-eval -- trusted local source, no user input
+  const host = runInNewContext(`${code}\n({ startHttpServer })`, {
+    httpServer: server,
+    isShutdownStarted: () => shuttingDown,
+    buildTeamControlApiBaseUrl,
+    clearTeamControlApiState,
+    writeTeamControlApiState,
+    configManager: { getConfig: () => ({ httpServer: { port: 3456 } }) },
+    contextRegistry: { getActive: () => ({}) },
+    teamHttpHandlerApis: {},
+    bindTeamHttpDataApi: () => ({}),
+    teamDataService: {},
+    recentProjectsFeature: {},
+    organizationsFeature: {},
+    workspaceTrustStatus: {},
+    tokenUsageFeature: null,
+    memberWorkSyncFeature: null,
+    updaterService: {},
+    sshConnectionManager: {},
+    logger: { info: vi.fn(), error: vi.fn() },
+  }) as { startHttpServer: (handler: () => Promise<void>) => Promise<void> };
+  return {
+    server,
+    start: () => host.startHttpServer(() => Promise.resolve()),
+    shutdown: () => {
+      shuttingDown = true;
+    },
+  };
+}
+
+describe('existing app Host endpoint wiring', () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(os.tmpdir(), 'app-control-host-'));
+    setClaudeBasePathOverride(root);
+    vi.stubEnv('CLAUDE_TEAM_CONTROL_URL', 'http://127.0.0.1:9999');
+  });
+  afterEach(async () => {
+    await clearTeamControlApiState();
+    setClaudeBasePathOverride(null);
+    vi.unstubAllEnvs();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('revokes inherited endpoint before initializing services or exposing provider handlers', () => {
+    const init = source.statements.find(
+      (node): node is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(node) && node.name?.text === 'initializeServices'
+    );
+    expect(init?.body?.statements[0]?.getText(source)).toBe('await clearTeamControlApiState();');
+  });
+
+  it('publishes the listening fallback port on cold start and already-running start', async () => {
+    const host = createHost();
+    await host.start();
+    expect(host.server.start).toHaveBeenCalledWith(expect.any(Object), expect.any(Function), 3456);
+    expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBe('http://127.0.0.1:4591');
+    expect(
+      JSON.parse(await readFile(path.join(root, 'team-control-api.json'), 'utf8')).baseUrl
+    ).toBe('http://127.0.0.1:4591');
+    await host.start();
+    expect(host.server.start).toHaveBeenCalledOnce();
+    expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBe('http://127.0.0.1:4591');
+  });
+
+  it('clears both publications when server startup fails', async () => {
+    await writeTeamControlApiState('http://127.0.0.1:4590');
+    const host = createHost();
+    host.server.start.mockRejectedValueOnce(new Error('all ports occupied'));
+    await expect(host.start()).rejects.toThrow('all ports occupied');
+    expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
+    await expect(readFile(path.join(root, 'team-control-api.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('clears both publications when shutdown interrupts server startup', async () => {
+    await writeTeamControlApiState('http://127.0.0.1:4590');
+    const host = createHost();
+    host.server.start.mockImplementationOnce(() => {
+      host.shutdown();
+      return Promise.resolve(4591);
+    });
+    await host.start();
+    expect(host.server.stop).toHaveBeenCalledOnce();
+    expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
+    await expect(readFile(path.join(root, 'team-control-api.json'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+});

--- a/test/main/services/team/TeamControlApiState.test.ts
+++ b/test/main/services/team/TeamControlApiState.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+import { mkdtemp, readFile, rm as removeDirectory } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { writeGate, removeGate, context } = vi.hoisted(() => ({
+  writeGate: vi.fn(),
+  removeGate: vi.fn(),
+  context: { root: '' },
+}));
+vi.mock('@main/utils/atomicWrite', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@main/utils/atomicWrite')>();
+  return {
+    ...original,
+    atomicWriteAsync: async (...args: Parameters<typeof original.atomicWriteAsync>) => {
+      await writeGate();
+      return original.atomicWriteAsync(...args);
+    },
+  };
+});
+vi.mock('fs/promises', async (importOriginal) => {
+  const original = await importOriginal<typeof import('fs/promises')>();
+  return {
+    ...original,
+    rm: async (...args: Parameters<typeof original.rm>) => {
+      await removeGate();
+      return original.rm(...args);
+    },
+  };
+});
+vi.mock('@main/utils/pathDecoder', () => ({ getClaudeBasePath: () => context.root }));
+
+import {
+  buildTeamControlApiBaseUrl,
+  clearTeamControlApiState,
+  writeTeamControlApiState,
+} from '@main/services/team/TeamControlApiState';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function statePath() {
+  return path.join(context.root, 'team-control-api.json');
+}
+
+async function expectPublished(baseUrl: string) {
+  expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBe(baseUrl);
+  expect(JSON.parse(await readFile(statePath(), 'utf8'))).toMatchObject({
+    baseUrl,
+    pid: process.pid,
+  });
+}
+
+async function expectCleared() {
+  expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
+  await expect(readFile(statePath(), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+}
+
+describe('Host control endpoint publication', () => {
+  beforeEach(async () => {
+    context.root = await mkdtemp(path.join(os.tmpdir(), 'app-control-publication-'));
+    writeGate.mockReset().mockResolvedValue(undefined);
+    removeGate.mockReset().mockResolvedValue(undefined);
+    vi.stubEnv('CLAUDE_TEAM_CONTROL_URL', 'http://127.0.0.1:9999');
+  });
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await removeDirectory(context.root, { recursive: true, force: true });
+  });
+
+  it('publishes the actual listening endpoint only after disk publication succeeds', async () => {
+    const gate = deferred();
+    writeGate.mockReturnValueOnce(gate.promise);
+    const pending = writeTeamControlApiState(buildTeamControlApiBaseUrl(4569));
+    expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
+    gate.resolve();
+    await pending;
+    await expectPublished('http://127.0.0.1:4569');
+  });
+
+  it('revokes stale publication on failure and can subsequently restart on another port', async () => {
+    writeGate.mockRejectedValueOnce(new Error('disk unavailable'));
+    await expect(writeTeamControlApiState('http://127.0.0.1:4570')).rejects.toThrow(
+      'disk unavailable'
+    );
+    await expectCleared();
+    await writeTeamControlApiState('http://127.0.0.1:4571');
+    await expectPublished('http://127.0.0.1:4571');
+  });
+
+  it('revokes synchronously on stop, tolerates cleanup failure and repeated stop, and republishes on reopen', async () => {
+    await writeTeamControlApiState('http://127.0.0.1:4572');
+    removeGate.mockRejectedValueOnce(new Error('file inaccessible'));
+    const stopping = clearTeamControlApiState();
+    expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
+    await stopping;
+    await clearTeamControlApiState();
+    await expectCleared();
+    await writeTeamControlApiState('http://127.0.0.1:4573');
+    await expectPublished('http://127.0.0.1:4573');
+  });
+
+  it('orders write then clear so a late atomic write cannot restore the stopped file or env', async () => {
+    const gate = deferred();
+    writeGate.mockReturnValueOnce(gate.promise);
+    const pending = writeTeamControlApiState('http://127.0.0.1:4574');
+    await vi.waitFor(() => expect(writeGate).toHaveBeenCalledOnce());
+    const stopping = clearTeamControlApiState();
+    // Give an incorrectly unqueued remove time to finish before releasing the write.
+    await vi.waitFor(() => expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined());
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    gate.resolve();
+    await Promise.all([pending, stopping]);
+    await expectCleared();
+  });
+
+  it('orders clear then write so a late remove cannot delete the restarted endpoint file', async () => {
+    await writeTeamControlApiState('http://127.0.0.1:4575');
+    const gate = deferred();
+    removeGate.mockReturnValueOnce(gate.promise);
+    const stopping = clearTeamControlApiState();
+    await vi.waitFor(() => expect(removeGate).toHaveBeenCalledOnce());
+    const restarting = writeTeamControlApiState('http://127.0.0.1:4576');
+    await new Promise<void>((resolve) => setTimeout(resolve, 20));
+    gate.resolve();
+    await Promise.all([stopping, restarting]);
+    await expectPublished('http://127.0.0.1:4576');
+  });
+});

--- a/test/main/services/team/TeamControlApiState.test.ts
+++ b/test/main/services/team/TeamControlApiState.test.ts
@@ -101,6 +101,8 @@ describe('Host control endpoint publication', () => {
     const stopping = clearTeamControlApiState();
     expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
     await stopping;
+    // Best-effort cleanup cannot promise disk removal when the filesystem rejects it.
+    expect(JSON.parse(await readFile(statePath(), 'utf8')).baseUrl).toBe('http://127.0.0.1:4572');
     await clearTeamControlApiState();
     await expectCleared();
     await writeTeamControlApiState('http://127.0.0.1:4573');
@@ -132,5 +134,31 @@ describe('Host control endpoint publication', () => {
     gate.resolve();
     await Promise.all([stopping, restarting]);
     await expectPublished('http://127.0.0.1:4576');
+  });
+
+  it('captures each root before queued writes and clears run across a root change', async () => {
+    const originalRoot = context.root;
+    const oldPath = statePath();
+    const gate = deferred();
+    writeGate.mockReturnValueOnce(gate.promise);
+    const pending = writeTeamControlApiState('http://127.0.0.1:4577');
+    await vi.waitFor(() => expect(writeGate).toHaveBeenCalledOnce());
+    const clearingOldRoot = clearTeamControlApiState();
+    context.root = path.join(originalRoot, 'alternate-root');
+    const publishingNewRoot = writeTeamControlApiState('http://127.0.0.1:4578');
+    try {
+      expect(process.env.CLAUDE_TEAM_CONTROL_URL).toBeUndefined();
+    } finally {
+      gate.resolve();
+      await Promise.all([pending, clearingOldRoot, publishingNewRoot]);
+    }
+    try {
+      await expectPublished('http://127.0.0.1:4578');
+      await expect(readFile(oldPath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' });
+      await clearTeamControlApiState();
+      await expectCleared();
+    } finally {
+      context.root = originalRoot;
+    }
   });
 });


### PR DESCRIPTION
After a real mixed OpenCode team completed tasks, stopped and reopened the desktop, SuperGrok model discovery rejected the retained OAuth context. Provider-management CLI calls inherited a different MCP Claude root and no current Control API endpoint, while team provisioning supplied the app-owned values.

Project the app's actual Claude root and existing Control API endpoint into both outer and MCP child environments. Publish the endpoint from the Host lifecycle after successful state publication, revoke it on startup/stop failure, and serialize disk writes and clears so late operations cannot restore or delete a newer endpoint. Runtime resolvers also await publication when the HTTP server is already listening, recovering from earlier failed writes. Passive status reads remain passive. Runtime OAuth ownership checks are unchanged.

Validation: independent hosted review accepted the final source tree 4364fb80cd9720a3e20ab97d7131c6462d49a8e2, exactly matching commit a4efe509b6d1893a26a86607797f5327cdced249. All 82 focused tests pass across provider catalog transport, provisioning, Host publication and HTTP IPC. The original 75 tests produce 19 failures on base production; the four added resolver regressions fail before the review correction. A separate generation-only negative control proves both disk races are rejected. Fast lint, syntactic checks and existing source-size/provisioning architecture guards pass. Final CI 34421281723 passes on a4efe509b6d1893a26a86607797f5327cdced249, including both complete test shards, validation and all lint shards; installer checks and CodeQL also pass. The hosted independent review covers the accepted exact source tree. The separate ReviewRouter check failed before review with provider_authentication_unavailable.

The packaged same-team relaunch remains required after this fix. Existing mixed tasks/messages and confirmed Stop evidence does not prove this new path. No public release or updater publication.
