### PR TITLE
fix(opencode): allow slower provider summary responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,3 +264,6 @@ jobs:
 
       - name: Test OpenCode nvm-windows runtime resolution
         run: pnpm exec vitest run test/main/services/runtime/OpenCodeRuntimeNvmResolution.safe-e2e.test.ts
+
+      - name: Test delayed provider summaries through real subprocesses
+        run: pnpm exec vitest run --maxWorkers=1 test/main/services/runtime/ProviderSummaryTimeout.safe-e2e.test.ts

--- a/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
+++ b/src/main/services/runtime/ClaudeMultimodelBridgeService.ts
@@ -43,7 +43,6 @@ const logger = createLogger('ClaudeMultimodelBridgeService');
 
 const PROVIDER_STATUS_TIMEOUT_MS = 90_000;
 const PROVIDER_STATUS_SUMMARY_TIMEOUT_MS = 30_000;
-const LEGACY_FALLBACK_PROVIDER_STATUS_SUMMARY_TIMEOUT_MS = 5_000;
 const CODEX_PROVIDER_STATUS_SUMMARY_TIMEOUT_MS = 15_000;
 const SOURCE_PROVIDER_STATUS_SUMMARY_TIMEOUT_MS = 45_000;
 const LEGACY_PROVIDER_AUTH_TIMEOUT_MS = 15_000;
@@ -837,7 +836,7 @@ export class ClaudeMultimodelBridgeService {
       const fallbackTimeout =
         providerId === 'codex'
           ? CODEX_PROVIDER_STATUS_SUMMARY_TIMEOUT_MS
-          : LEGACY_FALLBACK_PROVIDER_STATUS_SUMMARY_TIMEOUT_MS;
+          : PROVIDER_STATUS_SUMMARY_TIMEOUT_MS;
       return Math.min(options.timeoutMs ?? PROVIDER_STATUS_SUMMARY_TIMEOUT_MS, fallbackTimeout);
     }
     return (

--- a/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
+++ b/test/main/services/runtime/ClaudeMultimodelBridgeService.test.ts
@@ -1017,16 +1017,24 @@ describe('ClaudeMultimodelBridgeService', () => {
     expect(execCliMock.mock.calls.map((call) => call[1].join(' '))).toEqual([
       'runtime status --json --provider opencode --summary',
     ]);
-    expect(execCliMock.mock.calls[0][2]?.timeout).toBe(5_000);
+    expect(execCliMock.mock.calls[0][2]?.timeout).toBe(30_000);
     expect(vi.mocked(console.warn).mock.calls.map((call) => call.join(' '))).toEqual([
       expect.stringContaining('returning scoped degraded status without fallback'),
     ]);
     vi.mocked(console.warn).mockClear();
   });
 
-  it.each(['anthropic', 'codex', 'gemini', 'opencode'] as const)(
-    'allows the dev source runtime enough time to return %s summary status',
-    async (providerId) => {
+  it.each([
+    ['anthropic', '/mock/cli-source', 45_000],
+    ['codex', '/mock/cli-source', 45_000],
+    ['gemini', '/mock/cli-source', 45_000],
+    ['opencode', '/mock/cli-source', 45_000],
+    ['anthropic', '/mock/claude-multimodel', 30_000],
+    ['opencode', '/mock/claude-multimodel', 30_000],
+    ['codex', '/mock/claude-multimodel', 15_000],
+  ] as const)(
+    'gives %s summary through %s a %i ms budget',
+    async (providerId, binaryPath, timeoutMs) => {
       execCliMock.mockImplementation((_binaryPath, args) => {
         const normalizedArgs = Array.isArray(args) ? args.join(' ') : '';
         if (normalizedArgs === `runtime status --json --provider ${providerId} --summary`) {
@@ -1063,7 +1071,7 @@ describe('ClaudeMultimodelBridgeService', () => {
         await import('@main/services/runtime/ClaudeMultimodelBridgeService');
       const service = new ClaudeMultimodelBridgeService();
 
-      const provider = await service.getProviderStatus('/mock/cli-source', providerId);
+      const provider = await service.getProviderStatus(binaryPath, providerId);
 
       expect(provider).toMatchObject({
         providerId,
@@ -1072,7 +1080,7 @@ describe('ClaudeMultimodelBridgeService', () => {
         verificationState: 'verified',
         statusCheckOutcome: 'authoritative',
       });
-      expect(execCliMock.mock.calls[0][2]?.timeout).toBe(45_000);
+      expect(execCliMock.mock.calls[0][2]?.timeout).toBe(timeoutMs);
     }
   );
 
@@ -1273,8 +1281,8 @@ describe('ClaudeMultimodelBridgeService', () => {
         'OpenCode is taking longer than expected to load provider status. Your saved connections were not changed. Retry in a moment.',
     });
     expect(provider.detailMessage).not.toContain('/mock/runtime');
-    expect(provider.detailMessage).not.toContain('5000ms');
-    expect(execCliMock.mock.calls[0][2]?.timeout).toBe(5_000);
+    expect(provider.detailMessage).not.toContain('30000ms');
+    expect(execCliMock.mock.calls[0][2]?.timeout).toBe(30_000);
     vi.mocked(console.warn).mockClear();
   });
 
@@ -1515,7 +1523,7 @@ describe('ClaudeMultimodelBridgeService', () => {
     expect(execCliMock).toHaveBeenCalledTimes(8);
     expect(
       execCliMock.mock.calls.map((call) => call[2]?.timeout as number).sort((a, b) => a - b)
-    ).toEqual([5000, 5000, 15000, 15000, 15000, 25000, 25000, 25000]);
+    ).toEqual([15000, 15000, 15000, 25000, 25000, 25000, 30000, 30000]);
     expect(calls).toEqual(
       expect.arrayContaining([
         'runtime status --json --provider anthropic --summary',

--- a/test/main/services/runtime/ProviderSummaryTimeout.safe-e2e.test.ts
+++ b/test/main/services/runtime/ProviderSummaryTimeout.safe-e2e.test.ts
@@ -15,7 +15,7 @@ vi.mock('@main/services/runtime/providerAwareCliEnv', () => ({
 }));
 vi.mock('@main/services/runtime/ProviderConnectionService', () => ({
   providerConnectionService: {
-    applyPassiveProviderStatusConnectionEnv: async (env: NodeJS.ProcessEnv) => env,
+    applyPassiveProviderStatusConnectionEnv: (env: NodeJS.ProcessEnv) => Promise.resolve(env),
   },
 }));
 

--- a/test/main/services/runtime/ProviderSummaryTimeout.safe-e2e.test.ts
+++ b/test/main/services/runtime/ProviderSummaryTimeout.safe-e2e.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+/* eslint-disable security/detect-non-literal-fs-filename */
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ClaudeMultimodelBridgeService } from '@main/services/runtime/ClaudeMultimodelBridgeService';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const isolated = vi.hoisted(() => ({ env: {} as NodeJS.ProcessEnv }));
+
+// Only credential/environment ports are replaced; execution and parsing stay real.
+vi.mock('@main/services/runtime/providerAwareCliEnv', () => ({
+  buildPassiveProviderStatusCliEnv: () => ({ env: isolated.env, connectionIssues: {} }),
+}));
+vi.mock('@main/services/runtime/ProviderConnectionService', () => ({
+  providerConnectionService: {
+    applyPassiveProviderStatusConnectionEnv: async (env: NodeJS.ProcessEnv) => env,
+  },
+}));
+
+// This disposable program accepts only the passive summary, never launches a team,
+// and exits naturally after its single delayed response (also if the test fails).
+const summaryProgram = `
+const fs = require('node:fs');
+const path = require('node:path');
+const args = process.argv.slice(2);
+const providerId = args[4];
+if (!['opencode', 'anthropic'].includes(providerId) ||
+    JSON.stringify(args) !== JSON.stringify(['runtime', 'status', '--json', '--provider', providerId, '--summary'])) {
+  throw new Error('Sandbox fixture only accepts provider summary');
+}
+const startedAt = Date.now();
+const capture = {
+  args, pid: process.pid, home: process.env.HOME,
+  config: process.env.XDG_CONFIG_HOME, shim: process.env.SUMMARY_CMD_SHIM,
+};
+fs.appendFileSync(path.join(process.env.HOME, 'calls.jsonl'), JSON.stringify(capture) + '\\n');
+setTimeout(() => {
+  console.log(JSON.stringify({ providers: { [providerId]: {
+    providerId, supported: true, authenticated: false, authMethod: null,
+    verificationState: 'unknown', canLoginFromUi: false,
+    capabilities: { teamLaunch: false, oneShot: false, extensions: {} },
+    selectedBackendId: null, resolvedBackendId: null, availableBackends: [],
+    externalRuntimeDiagnostics: [], backend: null, models: [],
+    statusCheckOutcome: 'authoritative', statusMessage: 'Sandbox delayed summary',
+    detailMessage: String(Date.now() - startedAt),
+  } } }));
+}, 8000);
+`;
+
+function quoteSh(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+describe('Provider summary timeout subprocess integration', () => {
+  let sandbox: string | undefined;
+
+  afterEach(async () => {
+    if (sandbox) {
+      await rm(sandbox, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      sandbox = undefined;
+    }
+  });
+
+  it.each(['opencode', 'anthropic'] as const)(
+    'parses an authoritative %s summary after eight seconds',
+    async (providerId) => {
+      sandbox = await mkdtemp(path.join(os.tmpdir(), 'provider summary sandbox '));
+      const config = path.join(sandbox, 'fresh config');
+      await mkdir(config);
+      isolated.env = {
+        HOME: sandbox,
+        USERPROFILE: sandbox,
+        XDG_CONFIG_HOME: config,
+        CLAUDE_CONFIG_DIR: config,
+        APPDATA: config,
+        LOCALAPPDATA: config,
+        XDG_DATA_HOME: config,
+        XDG_CACHE_HOME: config,
+        TEMP: sandbox,
+        TMP: sandbox,
+        PATH: '',
+        ...(process.platform === 'win32' ? { SystemRoot: process.env.SystemRoot } : {}),
+      };
+      const program = path.join(sandbox, 'summary fixture.cjs');
+      const launcher = path.join(sandbox, process.platform === 'win32' ? 'summary.cmd' : 'summary');
+      await writeFile(program, summaryProgram);
+      // Deliberately not an npm/Bun shim: Windows must execute the actual .cmd
+      // fallback. Its environment marker proves the batch body was evaluated.
+      await writeFile(
+        launcher,
+        process.platform === 'win32'
+          ? `@echo off\r\nset "SUMMARY_CMD_SHIM=executed"\r\n"${process.execPath}" "${program}" %*\r\n`
+          : `#!/bin/sh\nexec ${quoteSh(process.execPath)} ${quoteSh(program)} "$@"\n`
+      );
+      await chmod(launcher, 0o755);
+
+      const status = await new ClaudeMultimodelBridgeService().getProviderStatus(
+        launcher,
+        providerId
+      );
+
+      expect(status).toMatchObject({
+        providerId,
+        supported: true,
+        authenticated: false,
+        statusCheckOutcome: 'authoritative',
+        statusMessage: 'Sandbox delayed summary',
+        capabilities: { teamLaunch: false },
+      });
+      expect(status.statusCheckErrorCode).toBeUndefined();
+      expect(Number(status.detailMessage)).toBeGreaterThanOrEqual(8000);
+      const calls = (await readFile(path.join(sandbox, 'calls.jsonl'), 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      expect(calls).toEqual([
+        expect.objectContaining({
+          args: ['runtime', 'status', '--json', '--provider', providerId, '--summary'],
+          home: sandbox,
+          config,
+          ...(process.platform === 'win32' ? { shim: 'executed' } : {}),
+        }),
+      ]);
+      expect(calls[0].pid).not.toBe(process.pid);
+    },
+    20_000
+  );
+});


### PR DESCRIPTION
OpenCode and Anthropic provider summaries were capped at 5 seconds, so a valid response taking 8 seconds could be reported as degraded. Use the existing 30-second summary budget for these providers while preserving the override cap, fallback behavior, Codex's 15-second budget, source runtime's 45-second budget, and full status's 90-second budget.

Adds a disposable real-subprocess regression for both providers with an 8-second response and a native Windows .cmd fixture, and includes it in the existing Windows CI job.

Validation: 179 focused bridge/store/catalog tests passed; both real subprocess tests passed on Linux; targeted formatting, fast lint and typecheck passed. Windows execution is covered by the added CI step and remains to be confirmed by this PR's checks.

This fixes the confirmed summary timeout. Catalog failure diagnostics and Windows cleanup behavior are separate follow-ups; this PR does not claim the reporter's complete OpenCode issue is resolved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Provider status checks for Anthropic and OpenCode now reliably handle delayed summaries.
  - Increased fallback wait times to reduce premature status-check failures during slower responses.

- **Tests**
  - Added coverage for delayed provider summaries across Unix and Windows environments.
  - Expanded validation using real subprocess execution, including response parsing and launch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->