### PR TITLE
fix(dashboard): allow opening project from empty state

### DIFF
--- a/src/features/recent-projects/renderer/ui/RecentProjectsSection.tsx
+++ b/src/features/recent-projects/renderer/ui/RecentProjectsSection.tsx
@@ -142,7 +142,13 @@ export const RecentProjectsSection = ({
           <FolderGit2 className="size-6 text-text-muted" />
         </div>
         <p className="mb-1 text-sm text-text-secondary">{t('recentProjects.noRecentProjects')}</p>
-        <p className="text-xs text-text-muted">{t('recentProjects.emptyDescription')}</p>
+        <p className="mb-4 text-xs text-text-muted">{t('recentProjects.emptyDescription')}</p>
+        {isElectron && (
+          <Button size="sm" onClick={() => void selectProjectFolder()}>
+            <FolderOpen className="size-4" />
+            {t('recentProjects.selectFolder')}
+          </Button>
+        )}
       </div>
     );
   }

--- a/test/features/recent-projects/renderer/ui/RecentProjectsSection.test.tsx
+++ b/test/features/recent-projects/renderer/ui/RecentProjectsSection.test.tsx
@@ -44,6 +44,8 @@ import { RecentProjectsSection } from '@features/recent-projects/renderer/ui/Rec
 describe('RecentProjectsSection', () => {
   beforeEach(() => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    hookState.cards = [{ id: 'repo:alpha' }];
+    hookState.isElectron = true;
     hookState.selectProjectFolder.mockClear();
   });
 
@@ -83,6 +85,27 @@ describe('RecentProjectsSection', () => {
       false
     );
 
+    act(() => selectFolder?.click());
+    expect(hookState.selectProjectFolder).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+  });
+
+  it('offers project selection when there are no recent projects', () => {
+    hookState.cards = [];
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    act(() => {
+      root.render(<RecentProjectsSection searchQuery="" />);
+    });
+
+    const selectFolder = [...host.querySelectorAll<HTMLButtonElement>('button')].find((button) =>
+      button.textContent?.includes('Select Folder')
+    );
+
+    expect(selectFolder).toBeDefined();
     act(() => selectFolder?.click());
     expect(hookState.selectProjectFolder).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## Summary

- show the shared project folder button when recent projects are empty
- reuse the existing project selection and navigation flow
- cover the empty-state action with a focused renderer test

## Verification

- pnpm vitest run test/features/recent-projects/renderer/ui/RecentProjectsSection.test.tsx
- pnpm lint:fast:files -- src/features/recent-projects/renderer/ui/RecentProjectsSection.tsx test/features/recent-projects/renderer/ui/RecentProjectsSection.test.tsx
- pnpm typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Select Folder” button to the empty Recent Projects view in Electron, allowing users to choose a project folder.

- **Style**
  - Improved spacing beneath the empty-state description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->