### PR TITLE
feat(opencode): expose cleanup process probe diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,3 +264,6 @@ jobs:
 
       - name: Test OpenCode nvm-windows runtime resolution
         run: pnpm exec vitest run test/main/services/runtime/OpenCodeRuntimeNvmResolution.safe-e2e.test.ts
+
+      - name: Test Windows cleanup probe diagnostics
+        run: pnpm exec vitest run --maxWorkers=1 test/main/utils/processStartTime.test.ts test/main/utils/windowsProcessTable.test.ts test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts

--- a/src/main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup.ts
@@ -128,7 +128,11 @@ export async function cleanupManagedOpenCodeServeProcesses(
     options.readProcessDetails ??
     (platform === 'win32' ? async () => null : readNativeProcessCommandWithEnv);
   const readStartTimeMs =
-    options.readProcessStartTimeMs ?? ((pid: number) => readProcessStartTimeMs(pid, platform));
+    options.readProcessStartTimeMs ??
+    ((pid: number) =>
+      readProcessStartTimeMs(pid, platform, undefined, (diagnostic) => {
+        result.diagnostics.push(`pid=${pid}; ${diagnostic}`);
+      }));
   const disposeServeHost = options.disposeServeHost ?? disposeOpenCodeServeHost;
   const readServeHostConfig = options.readServeHostConfig ?? readOpenCodeServeHostConfig;
   const killProcess = options.killProcess;

--- a/src/main/utils/processProbeDiagnostics.ts
+++ b/src/main/utils/processProbeDiagnostics.ts
@@ -1,0 +1,49 @@
+import { boundedDiagnosticString } from '@shared/utils/diagnosticsRedaction';
+import { redactSentryEvent } from '@shared/utils/sentryConfig';
+
+/** Only copy outcome metadata: exec errors can embed commands and stdout in their message. */
+export function processProbeDiagnostic(
+  operation: string,
+  startedAt: number,
+  timeoutMs: number,
+  reason: string,
+  error?: unknown,
+  stderr?: string
+): string {
+  const outcome = (error && typeof error === 'object' ? error : {}) as Record<string, unknown>;
+  const fields = [
+    `${operation}: ${reason}`,
+    `durationMs=${Math.max(0, Math.round(performance.now() - startedAt))}`,
+    `timeoutMs=${timeoutMs}`,
+  ];
+  for (const key of ['code', 'errno', 'signal', 'killed'] as const) {
+    const value = outcome[key];
+    if (
+      (typeof value === 'number' && Number.isFinite(value)) ||
+      (key === 'killed' && typeof value === 'boolean') ||
+      ((key === 'code' || key === 'signal') &&
+        typeof value === 'string' &&
+        /^[A-Z][A-Z0-9_]{0,63}$/.test(value))
+    ) {
+      fields.push(`${key}=${value}`);
+    }
+  }
+  // Node's killed/signal fields do not establish why a child was terminated.
+  fields.push(`timedOut=${outcome.code === 'ETIMEDOUT' ? 'true' : 'unknown'}`);
+  const preview = boundedDiagnosticString(String(redactSentryEvent(stderr ?? '')));
+  fields.push(`stderr=${JSON.stringify(preview ?? '')}`);
+  return fields.join('; ');
+}
+
+export type ProcessProbeObserver = (diagnostic: string) => void | Promise<void>;
+
+export function observeProcessProbe(
+  observer: ProcessProbeObserver | undefined,
+  diagnostic: string
+): void {
+  try {
+    void Promise.resolve(observer?.(diagnostic)).catch(() => undefined);
+  } catch {
+    // Observation must never change the probe's result.
+  }
+}

--- a/src/main/utils/processStartTime.ts
+++ b/src/main/utils/processStartTime.ts
@@ -1,3 +1,8 @@
+import {
+  observeProcessProbe,
+  processProbeDiagnostic,
+  type ProcessProbeObserver,
+} from '@main/utils/processProbeDiagnostics';
 import { execFile, type ExecFileException } from 'child_process';
 
 const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
@@ -22,11 +27,12 @@ const PROBE_MAX_BUFFER_BYTES = 64 * 1024;
 export async function readProcessStartTimeMs(
   pid: number,
   platform: NodeJS.Platform = process.platform,
-  timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS
+  timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS,
+  onDiagnostic?: ProcessProbeObserver
 ): Promise<number | null> {
   return platform === 'win32'
-    ? readWindowsProcessStartTimeMs(pid, timeoutMs)
-    : readNativeProcessStartTimeMs(pid, timeoutMs);
+    ? readWindowsProcessStartTimeMs(pid, timeoutMs, onDiagnostic)
+    : readNativeProcessStartTimeMs(pid, timeoutMs, onDiagnostic);
 }
 
 /**
@@ -79,24 +85,30 @@ async function readStartTimeOrNull(
 
 async function readNativeProcessStartTimeMs(
   pid: number,
-  timeoutMs: number
+  timeoutMs: number,
+  onDiagnostic?: ProcessProbeObserver
 ): Promise<number | null> {
-  const output = await execProcessProbeText('ps', ['-p', String(pid), '-o', 'lstart='], timeoutMs);
-  if (!output) {
-    return null;
-  }
-  const parsed = Date.parse(output.trim());
-  return Number.isFinite(parsed) ? parsed : null;
+  return execProcessProbeText('ps', ['-p', String(pid), '-o', 'lstart='], timeoutMs, onDiagnostic);
 }
 
 async function readWindowsProcessStartTimeMs(
   pid: number,
-  timeoutMs: number
+  timeoutMs: number,
+  onDiagnostic?: ProcessProbeObserver
 ): Promise<number | null> {
   const normalizedPid = Math.trunc(pid);
   // The pid is interpolated into a PowerShell script, so anything that is not a
   // plain positive integer is refused here rather than quoted downstream.
   if (!Number.isFinite(normalizedPid) || normalizedPid <= 0) {
+    observeProcessProbe(
+      onDiagnostic,
+      processProbeDiagnostic(
+        'process_start_time:powershell.exe',
+        performance.now(),
+        timeoutMs,
+        'invalid pid'
+      )
+    );
     return null;
   }
 
@@ -105,23 +117,21 @@ async function readWindowsProcessStartTimeMs(
     `$process = Get-Process -Id ${normalizedPid} -ErrorAction Stop`,
     '$process.StartTime.ToUniversalTime().ToString("o")',
   ].join('; ');
-  const output = await execProcessProbeText(
+  return execProcessProbeText(
     'powershell.exe',
     ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
-    timeoutMs
+    timeoutMs,
+    onDiagnostic
   );
-  if (!output) {
-    return null;
-  }
-  const parsed = Date.parse(output.trim());
-  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function execProcessProbeText(
   command: string,
   args: string[],
-  timeout: number
-): Promise<string | null> {
+  timeout: number,
+  onDiagnostic?: ProcessProbeObserver
+): Promise<number | null> {
+  const startedAt = performance.now();
   return new Promise((resolve) => {
     execFile(
       command,
@@ -139,8 +149,23 @@ function execProcessProbeText(
         // break the `ps` lookup on some hosts.
         env: { ...process.env, LC_ALL: 'C' },
       },
-      (error: ExecFileException | null, stdout: string | Buffer) => {
-        resolve(error ? null : String(stdout));
+      (error: ExecFileException | null, stdout: string | Buffer, stderr: string | Buffer) => {
+        const output = String(stdout);
+        const parsed = error ? Number.NaN : Date.parse(output.trim());
+        if (!Number.isFinite(parsed)) {
+          observeProcessProbe(
+            onDiagnostic,
+            processProbeDiagnostic(
+              `process_start_time:${command}`,
+              startedAt,
+              timeout,
+              error ? 'probe failed' : output.trim() ? 'invalid start time' : 'empty start time',
+              error,
+              stderr === undefined ? undefined : String(stderr)
+            )
+          );
+        }
+        resolve(Number.isFinite(parsed) ? parsed : null);
       }
     );
   });

--- a/src/main/utils/windowsProcessTable.ts
+++ b/src/main/utils/windowsProcessTable.ts
@@ -1,5 +1,7 @@
 import { execFile, execFileSync } from 'node:child_process';
 
+import { processProbeDiagnostic } from '@main/utils/processProbeDiagnostics';
+
 export interface WindowsProcessTableRow {
   pid: number;
   ppid: number;
@@ -75,6 +77,7 @@ export function parseWindowsProcessTableJson(stdout: string): WindowsProcessTabl
 }
 
 function readWindowsProcessTableUncached(timeoutMs: number): Promise<WindowsProcessTableRow[]> {
+  const startedAt = performance.now();
   return new Promise((resolve, reject) => {
     execFile(
       'powershell.exe',
@@ -86,12 +89,19 @@ function readWindowsProcessTableUncached(timeoutMs: number): Promise<WindowsProc
         maxBuffer: 8 * 1024 * 1024,
       },
       (error, stdout, stderr) => {
-        if (error) {
-          reject(error);
-          return;
-        }
-        if (stderr?.trim()) {
-          reject(new Error(stderr.trim()));
+        if (error || stderr?.trim()) {
+          reject(
+            new Error(
+              processProbeDiagnostic(
+                'windows_process_enumeration',
+                startedAt,
+                timeoutMs,
+                error ? 'probe failed' : 'stderr received',
+                error,
+                stderr
+              )
+            )
+          );
           return;
         }
         resolve(parseWindowsProcessTableJson(String(stdout)));

--- a/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
+++ b/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import {
   cleanupManagedOpenCodeServeProcesses,
   getOpenCodeServeLoopbackBaseUrl,
@@ -8,7 +9,13 @@ import {
   isOrchestratorServeCommand,
 } from '@main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup';
 import { listWindowsProcessTable } from '@main/utils/windowsProcessTable';
+import * as childProcess from 'child_process';
 import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, execFile: vi.fn(actual.execFile) };
+});
 
 vi.mock('@main/utils/windowsProcessTable', () => ({
   listWindowsProcessTable: vi.fn(async () => []),
@@ -49,6 +56,43 @@ function resolved<T>(value: T): Promise<T> {
 }
 
 describe('OpenCodeManagedHostProcessCleanup', () => {
+  it('records default identity probe diagnostics and never kills an unreadable Windows identity', async () => {
+    const exec = vi.mocked(childProcess.execFile).mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as (error: Error, stdout: string, stderr: string) => void;
+      callback(
+        Object.assign(new Error('private command'), { code: 5, killed: true }),
+        'private stdout',
+        'denied API_KEY=mock-secret'
+      );
+      return {} as ReturnType<typeof childProcess.execFile>;
+    });
+    const killProcess = vi.fn();
+    const disposeServeHost = vi.fn();
+    try {
+      const result = await cleanupManagedOpenCodeServeProcesses({
+        mode: 'force',
+        platform: 'win32',
+        listProcessRows: async () => [{ pid: 42, ppid: 1, command: 'opencode serve' }],
+        readProcessDetails: async () => MANAGED_DETAILS,
+        killProcess,
+        disposeServeHost,
+        isProcessAlive: () => true,
+      });
+      expect(result.diagnostics.join(' ')).toContain(
+        'pid=42; process_start_time:powershell.exe: probe failed'
+      );
+      expect(result.diagnostics.join(' ')).toContain(
+        'timeoutMs=2000; code=5; killed=true; timedOut=unknown'
+      );
+      expect(result.diagnostics.join(' ')).not.toMatch(/private|mock-secret/);
+      expect(result.killed).toBe(0);
+      expect(killProcess).not.toHaveBeenCalled();
+      expect(disposeServeHost).not.toHaveBeenCalled();
+    } finally {
+      exec.mockRestore();
+    }
+  });
+
   it.each(['darwin', 'linux', 'win32'] as const)(
     'startup cleans only old orphaned hosts in the same profile on %s',
     async (platform) => {
@@ -1263,8 +1307,7 @@ describe('whose orchestrator serve host is it', () => {
       platform: 'win32',
       listProcessRows: () => Promise.resolve([{ pid: 10, ppid: 1, command: ORCHESTRATOR }]),
       readProcessDetails: async () => null,
-      readServeHostConfig: async () =>
-        '{"description":"claude-multimodel runtime orchestration"}',
+      readServeHostConfig: async () => '{"description":"claude-multimodel runtime orchestration"}',
       disposeServeHost: async () => undefined,
       killProcess: vi.fn(),
       // The host is gone by the time the signal would have been sent, so the

--- a/test/main/utils/processStartTime.test.ts
+++ b/test/main/utils/processStartTime.test.ts
@@ -17,17 +17,21 @@ interface RecordedProbe {
   options: { env?: NodeJS.ProcessEnv; timeout?: number; maxBuffer?: number };
 }
 
-function recordProbes(result: { stdout?: string; error?: Error }): RecordedProbe[] {
+function recordProbes(result: {
+  stdout?: string;
+  stderr?: string;
+  error?: Error;
+}): RecordedProbe[] {
   const probes: RecordedProbe[] = [];
   (childProcess.execFile as unknown as Mock).mockImplementation(
     (
       command: string,
       args: string[],
       options: RecordedProbe['options'],
-      callback: (error: Error | null, stdout: string) => void
+      callback: (error: Error | null, stdout: string, stderr: string) => void
     ) => {
       probes.push({ command, args, options });
-      callback(result.error ?? null, result.stdout ?? '');
+      callback(result.error ?? null, result.stdout ?? '', result.stderr ?? '');
       return {};
     }
   );
@@ -38,6 +42,63 @@ describe('processStartTime', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
+  });
+
+  it.each(['linux', 'win32'] as const)(
+    'optionally observes failed identity on %s without changing null',
+    async (platform) => {
+      recordProbes({
+        error: Object.assign(new Error('private command'), {
+          code: 9,
+          signal: 'SIGTERM',
+          killed: true,
+          errno: -2,
+        }),
+        stderr: 'denied TOKEN=mock-secret Authorization: Bearer mockbearersecret',
+      });
+      const observe = vi.fn();
+      await expect(readProcessStartTimeMs(4321, platform, undefined, observe)).resolves.toBeNull();
+      const message = observe.mock.calls[0][0];
+      expect(message).toContain('process_start_time:');
+      expect(message).toMatch(/durationMs=\d+; timeoutMs=2000/);
+      expect(message).toContain('code=9; errno=-2; signal=SIGTERM; killed=true; timedOut=unknown');
+      expect(message).not.toMatch(/mock-secret|mockbearersecret|private command/);
+      await expect(readProcessStartTimeMs(4321, platform)).resolves.toBeNull();
+      expect(observe).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it.each(['', 'not a date'])(
+    'reports unavailable parsed identity without exposing stdout: %j',
+    async (stdout) => {
+      recordProbes({ stdout });
+      const observe = vi.fn();
+      await expect(readProcessStartTimeMs(4321, 'win32', 250, observe)).resolves.toBeNull();
+      expect(observe.mock.calls[0][0]).toContain(
+        stdout ? 'invalid start time' : 'empty start time'
+      );
+      expect(observe.mock.calls[0][0]).not.toMatch(/not a date|code=0/);
+    }
+  );
+
+  it.each([false, true])('observer failure is isolated (async=%s)', async (asyncFailure) => {
+    recordProbes({ error: new Error('probe failed') });
+    const observe = () => {
+      if (asyncFailure) return Promise.reject(new Error('observer failed'));
+      throw new Error('observer failed');
+    };
+    await expect(readProcessStartTimeMs(4321, 'win32', 2_000, observe)).resolves.toBeNull();
+  });
+
+  it('does not observe successful probes even with stderr, and observes invalid Windows pid', async () => {
+    recordProbes({ stdout: '2025-08-27T08:12:33Z', stderr: 'warning' });
+    const observe = vi.fn();
+    expect(await readProcessStartTimeMs(4321, 'win32', undefined, observe)).toBe(
+      Date.parse('2025-08-27T08:12:33Z')
+    );
+    expect(observe).not.toHaveBeenCalled();
+    await expect(readProcessStartTimeMs(0, 'win32', undefined, observe)).resolves.toBeNull();
+    expect(observe.mock.calls[0][0]).toContain('invalid pid');
   });
 
   it('forces the C locale so POSIX lstart= stays parseable on a non-English desktop', async () => {

--- a/test/main/utils/windowsProcessTable.test.ts
+++ b/test/main/utils/windowsProcessTable.test.ts
@@ -31,6 +31,68 @@ describe('windowsProcessTable', () => {
     windowsProcessTable = await import('../../../src/main/utils/windowsProcessTable');
   });
 
+  it.each([
+    [{ code: 7, signal: 'SIGTERM', killed: true, errno: -1 }, 'unknown'],
+    [{ code: 'ETIMEDOUT', signal: 'SIGTERM', killed: true }, 'true'],
+    [{ killed: true }, 'unknown'],
+    [{}, 'unknown'],
+  ])('reports only available outcome metadata for %j', async (metadata, timedOut) => {
+    const clock = vi.spyOn(performance, 'now').mockReturnValueOnce(100).mockReturnValueOnce(137);
+    const callbacks = captureExecFileCallbacks();
+    const request = windowsProcessTable.listWindowsProcessTable(123, { bypassCache: true });
+    callbacks[0](
+      Object.assign(new Error('foreign command --private-data'), metadata),
+      'foreign process table stdout',
+      'access denied API_KEY="mock-secret" --token mock-token'
+    );
+    const error = await request.catch((error: Error) => error);
+    expect(error).toBeInstanceOf(Error);
+    const message = String(error);
+    expect(message).toContain('windows_process_enumeration: probe failed');
+    expect(message).toContain('durationMs=37; timeoutMs=123');
+    expect(message).toContain(`timedOut=${timedOut}`);
+    for (const [key, value] of Object.entries(metadata))
+      expect(message).toContain(`${key}=${value}`);
+    expect(message).toContain('access denied');
+    expect(message).not.toMatch(/foreign|mock-secret|mock-token|code=0/);
+    clock.mockRestore();
+  });
+
+  it('keeps empty stderr and missing outcome unknown, including stderr-only rejection', async () => {
+    for (const [error, stderr] of [
+      [new Error('ignored'), ''],
+      [null, 'warning'],
+    ] as const) {
+      const callbacks = captureExecFileCallbacks();
+      const request = windowsProcessTable.listWindowsProcessTable();
+      callbacks[0](error, 'private stdout', stderr);
+      await expect(request).rejects.toThrow(`stderr=${JSON.stringify(stderr)}`);
+      await expect(request).rejects.not.toThrow(/code=|signal=|killed=|private/);
+    }
+  });
+
+  it('sanitizes before bounding stderr and leaves successful parse and sync behavior unchanged', async () => {
+    const callbacks = captureExecFileCallbacks();
+    const failed = windowsProcessTable.listWindowsProcessTable();
+    callbacks[0](
+      new Error('ignored'),
+      '',
+      '--password "' + 'private'.repeat(200) + '" end ' + 'x'.repeat(600)
+    );
+    const message = String(await failed.catch((error: Error) => error));
+    expect(message).toContain('--password [redacted] end');
+    expect(message).not.toContain('private');
+    expect(message.length).toBeLessThan(750);
+    const success = windowsProcessTable.listWindowsProcessTable();
+    callbacks[1](null, 'malformed private stdout', '');
+    await expect(success).resolves.toEqual([]);
+    childProcessMock.execFileSync.mockReturnValue(makeProcessTableJson(5));
+    expect(windowsProcessTable.listWindowsProcessTableSync()).toEqual([
+      expect.objectContaining({ pid: 5 }),
+    ]);
+    expect(childProcessMock.execFileSync.mock.calls[0][2].timeout).toBe(4_000);
+  });
+
   it('parses PowerShell process table JSON objects and arrays', () => {
     expect(
       windowsProcessTable.parseWindowsProcessTableJson(


### PR DESCRIPTION
Windows cleanup failures currently lose the process probe context, and failed PID start-time reads quietly become an unknown identity. Add bounded, redacted diagnostics with the operation, elapsed time, actual timeout and available process outcome fields. Cleanup records identity failures while other start-time consumers keep their existing quiet null result.

Keeps current probe budgets, process ownership checks, launch gating and termination behavior. This is the diagnostic checkpoint; the Windows cleanup behavior fix remains separate.

Validation: 75 focused cleanup/process-probe tests passed; typecheck, targeted formatting/lint and source-size/provisioning guards passed. Adds these focused suites to the existing Windows CI job. No tests launch agents or operate on user projects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics when process identity and Windows process probes fail.
  * Added safe error metadata and sanitized output while preventing sensitive command details from appearing in diagnostics.
  * Ensured diagnostic observation failures do not affect process cleanup results.
  * Improved reporting for unavailable, invalid, timed-out, and unparseable process information.
* **Tests**
  * Expanded coverage for failed, invalid, timed-out, and unparseable process probes across supported platforms.
  * Added end-to-end coverage for delayed provider summaries and diagnostic privacy safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->