### PR TITLE
fix(models): require release date for new badge

### DIFF
--- a/src/features/codex-model-catalog/core/domain/__tests__/normalizeCodexAppServerModel.test.ts
+++ b/src/features/codex-model-catalog/core/domain/__tests__/normalizeCodexAppServerModel.test.ts
@@ -39,7 +39,7 @@ describe('normalizeCodexAppServerModels', () => {
     ]);
   });
 
-  it('maps the authoritative availability NUX to a new-model hint and status message', () => {
+  it('maps the availability NUX to a status message without an unbounded freshness hint', () => {
     const result = normalizeCodexAppServerModels([
       {
         id: 'gpt-6-astra',
@@ -50,7 +50,7 @@ describe('normalizeCodexAppServerModels', () => {
     expect(result.models[0]).toMatchObject({
       id: 'gpt-6-astra',
       statusMessage: 'A new generation of intelligence.',
-      metadata: { recentlyReleased: true },
+      metadata: null,
     });
   });
 

--- a/src/features/codex-model-catalog/core/domain/normalizeCodexAppServerModel.ts
+++ b/src/features/codex-model-catalog/core/domain/normalizeCodexAppServerModel.ts
@@ -211,7 +211,7 @@ export function normalizeCodexAppServerModels(
       source: 'app-server',
       badgeLabel: asBadgeLabel(id),
       statusMessage: availabilityNuxMessage,
-      metadata: availabilityNuxMessage ? { recentlyReleased: true } : null,
+      metadata: null,
     });
   }
 

--- a/src/renderer/components/runtime/ProviderModelBadges.tsx
+++ b/src/renderer/components/runtime/ProviderModelBadges.tsx
@@ -210,11 +210,7 @@ export const ProviderModelBadges = ({
     const modelLabel =
       getRuntimeAwareTeamModelBadgeLabel(providerId, model, providerStatus) ??
       formatModelBadgeLabel(providerId, model);
-    const recentlyReleased =
-      (providerId === 'codex' &&
-        model === 'gpt-6-astra' &&
-        !catalogModel?.metadata?.releaseDate?.trim()) ||
-      isRecentlyReleasedModel(catalogModel);
+    const recentlyReleased = isRecentlyReleasedModel(catalogModel);
     const catalogModelIsFree = isCatalogModelFree(model, providerStatus);
     const hasFollowingModel = index < displayedModels.length - 1;
     const title = [

--- a/src/renderer/utils/__tests__/modelReleaseFreshness.test.ts
+++ b/src/renderer/utils/__tests__/modelReleaseFreshness.test.ts
@@ -74,24 +74,24 @@ describe('model release freshness', () => {
     ).toBe(false);
   });
 
-  it('honors the runtime hint only when the release date is absent or blank', () => {
+  it('does not show an unbounded New badge when the release date is absent or blank', () => {
     expect(
       isRecentlyReleasedModel(buildModel({ id: 'astra', recentlyReleased: true }), NOW_MS)
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isRecentlyReleasedModel(
         buildModel({ id: 'blank-date', releaseDate: '   ', recentlyReleased: true }),
         NOW_MS
       )
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it('sorts recent runtime hints first, then known release dates newest-first', () => {
+  it('sorts known release dates newest-first without promoting undated runtime hints', () => {
     const hinted = buildModel({ id: 'hinted', recentlyReleased: true });
     const newer = buildModel({ id: 'newer', releaseDate: '2026-08-01T00:00:00.000Z' });
     const older = buildModel({ id: 'older', releaseDate: '2026-07-01T00:00:00.000Z' });
 
-    expect(compareModelReleaseFreshness(hinted, newer, NOW_MS)).toBeLessThan(0);
+    expect(compareModelReleaseFreshness(hinted, newer, NOW_MS)).toBeGreaterThan(0);
     expect(compareModelReleaseFreshness(newer, older, NOW_MS)).toBeLessThan(0);
   });
 });

--- a/src/renderer/utils/modelReleaseFreshness.ts
+++ b/src/renderer/utils/modelReleaseFreshness.ts
@@ -16,8 +16,6 @@ export function isRecentlyReleasedModel(
   catalogModel: CliProviderModelCatalogItem | null | undefined,
   nowMs = Date.now()
 ): boolean {
-  const releaseDate = catalogModel?.metadata?.releaseDate?.trim();
-  if (!releaseDate) return catalogModel?.metadata?.recentlyReleased === true;
   const releasedAt = getModelReleaseTimestamp(catalogModel, nowMs);
   return releasedAt !== null && nowMs - releasedAt < NEW_MODEL_BADGE_WINDOW_MS;
 }

--- a/test/renderer/components/runtime/ProviderModelBadgesFreshness.test.tsx
+++ b/test/renderer/components/runtime/ProviderModelBadgesFreshness.test.tsx
@@ -135,12 +135,12 @@ describe('ProviderModelBadges release freshness', () => {
     }
   );
 
-  it('keeps the Codex runtime hint when no release date is supplied', () => {
+  it('does not render a Codex New badge when no release date is supplied', () => {
     const host = renderModel(
       'codex',
       buildCatalogModel('gpt-6-astra', 'GPT-6 Astra', { recentlyReleased: true })
     );
 
-    expect(getNewBadges(host)).toHaveLength(1);
+    expect(getNewBadges(host)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

- require a valid release date before rendering a New model badge
- keep Codex availability NUX as status text without treating it as permanent freshness metadata
- remove the undated Astra badge exception

## Verification

- pnpm vitest run src/renderer/utils/__tests__/modelReleaseFreshness.test.ts test/renderer/components/runtime/ProviderModelBadgesFreshness.test.tsx src/features/codex-model-catalog/core/domain/__tests__/normalizeCodexAppServerModel.test.ts
- pnpm lint:fast:files -- src/renderer/utils/modelReleaseFreshness.ts src/renderer/components/runtime/ProviderModelBadges.tsx src/renderer/utils/__tests__/modelReleaseFreshness.test.ts test/renderer/components/runtime/ProviderModelBadgesFreshness.test.tsx src/features/codex-model-catalog/core/domain/normalizeCodexAppServerModel.ts src/features/codex-model-catalog/core/domain/__tests__/normalizeCodexAppServerModel.test.ts
- pnpm typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The **New** badge is now shown only for models with a valid, recent release date.
  - Models without a release date no longer receive freshness treatment or appear ahead of dated models solely because of an availability message.
  - Removed an exceptional badge case for an undated Codex model.
- **Tests**
  - Updated coverage to verify correct badge display, sorting, and status messaging for models without release dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->