### PR TITLE
fix(opencode): use current Host MCP transport for catalogs

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -117,7 +117,10 @@ import {
   type TokenUsageFeatureFacade,
 } from '@features/token-usage/main';
 import * as workspaceTrustFeature from '@features/workspace-trust/main';
-import { ensureAgentTeamsMcpLocalLaunchEnv } from '@main/services/runtime/agentTeamsMcpLaunchEnv';
+import {
+  applyAgentTeamsMcpAppContext,
+  ensureAgentTeamsMcpLocalLaunchEnv,
+} from '@main/services/runtime/agentTeamsMcpLaunchEnv';
 import { ensureOpenCodeBridgeRuntimeBinaryEnv } from '@main/services/runtime/openCodeBridgeRuntimeEnv';
 import { ClaudeMultimodelBridgeService } from '@main/services/runtime/ClaudeMultimodelBridgeService';
 import { applyOpenCodeAutoUpdatePolicy } from '@main/services/runtime/openCodeAutoUpdatePolicy';
@@ -149,7 +152,6 @@ import {
   hasOpenCodeLocalMcpLaunchEnv,
   isOpenCodeMcpHttpBridgeEnabled,
   mergeOpenCodeLocalMcpChildEnvironment,
-  retainOpenCodeHttpMcpBridgeEnv,
   shouldEnsureOpenCodeLocalMcpLaunchEnv,
   snapshotOpenCodeLocalMcpLaunchEnv,
 } from '@main/services/team/opencode/bridge/OpenCodeMcpBridgeEnv';
@@ -510,6 +512,8 @@ async function createOpenCodeRuntimeAdapterRegistry(
   });
   bridgeEnv.AGENT_TEAMS_MCP_CLAUDE_DIR = getClaudeBasePath();
   const useHttpMcpBridge = isOpenCodeMcpHttpBridgeEnabled(bridgeEnv);
+  if (isShutdownStarted()) throw new Error('Host MCP composition cancelled during shutdown');
+  revokeMcpAppContext = agentTeamsMcpHttpServer.appContext.bind(bridgeEnv, useHttpMcpBridge);
   const explicitLocalMcpLaunchEnv = snapshotOpenCodeLocalMcpLaunchEnv(bridgeEnv);
   delete bridgeEnv.ELECTRON_RUN_AS_NODE;
   if (explicitLocalMcpLaunchEnv) {
@@ -620,6 +624,7 @@ async function createOpenCodeRuntimeAdapterRegistry(
     const nextEnv = { ...bridgeEnv };
     await ensureOpenCodeRuntimeBinaryEnv(nextEnv, { includeShellEnv: true });
     if (!useHttpMcpBridge) {
+      applyAgentTeamsMcpAppContext(nextEnv);
       return nextEnv;
     }
     try {
@@ -635,17 +640,16 @@ async function createOpenCodeRuntimeAdapterRegistry(
       nextEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH = mcpHttpServer.urlHash;
       await ensureOpenCodeLocalMcpLaunchEnv(nextEnv);
     } catch (error) {
-      if (!retainOpenCodeHttpMcpBridgeEnv(bridgeEnv, nextEnv)) {
-        delete nextEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL;
-        delete nextEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH;
-        await ensureOpenCodeLocalMcpLaunchEnv(nextEnv);
-      }
+      delete bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL;
+      delete bridgeEnv.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH;
+      await ensureOpenCodeLocalMcpLaunchEnv(nextEnv);
       logger.warn(
         `[OpenCode] Runtime adapter bridge MCP HTTP server refresh failed: ${
           error instanceof Error ? error.message : String(error)
         }`
       );
     }
+    applyAgentTeamsMcpAppContext(nextEnv);
     return nextEnv;
   };
   const bridgeControlDir = join(app.getPath('userData'), 'opencode-bridge');
@@ -1024,6 +1028,7 @@ let appStartupHandlersRegistered = false;
 let fileChangeCleanup: (() => void) | null = null;
 let todoChangeCleanup: (() => void) | null = null;
 let teamChangeCleanup: (() => void) | null = null;
+let revokeMcpAppContext: (() => void) | null = null;
 let shutdownPromise: Promise<void> | null = null;
 let shutdownComplete = false;
 const startupTimers = new Set<ReturnType<typeof setTimeout>>();
@@ -3021,6 +3026,8 @@ async function shutdownServices(): Promise<void> {
     return shutdownPromise;
   }
 
+  revokeMcpAppContext?.();
+  revokeMcpAppContext = null;
   shutdownPromise = (async () => {
     logger.info('Shutting down services...');
     await runShutdownStep('announcements cleanup', () => announcementsLifecycle.dispose());

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3026,8 +3026,6 @@ async function shutdownServices(): Promise<void> {
     return shutdownPromise;
   }
 
-  revokeMcpAppContext?.();
-  revokeMcpAppContext = null;
   shutdownPromise = (async () => {
     logger.info('Shutting down services...');
     await runShutdownStep('announcements cleanup', () => announcementsLifecycle.dispose());
@@ -3057,9 +3055,11 @@ async function shutdownServices(): Promise<void> {
       () => cleanupOpenCodeHostsForLifecycle('shutdown'),
       10_000
     );
-    await runShutdownStep('Agent Teams MCP HTTP server cleanup', () =>
-      agentTeamsMcpHttpServer.stop({ preventRestart: true })
-    );
+    await runShutdownStep('Agent Teams MCP HTTP server cleanup', () => {
+      revokeMcpAppContext?.(); // Cleanup Stop needs live authority until transport teardown.
+      revokeMcpAppContext = null;
+      return agentTeamsMcpHttpServer.stop({ preventRestart: true });
+    });
     await runShutdownStep('tracked CLI subprocess cleanup', () =>
       killTrackedCliProcesses('SIGKILL')
     );

--- a/src/main/services/runtime/agentTeamsMcpLaunchEnv.ts
+++ b/src/main/services/runtime/agentTeamsMcpLaunchEnv.ts
@@ -1,3 +1,4 @@
+import { agentTeamsMcpHttpServer } from '@main/services/team/AgentTeamsMcpHttpServer';
 import {
   resolveAgentTeamsMcpLaunchSpec,
   resolvePackagedAgentTeamsMcpEntry,
@@ -23,6 +24,15 @@ export function applyAgentTeamsMcpAppContext(
   claudeBasePath: string = getClaudeBasePath(),
   controlApiBaseUrl: string | null | undefined = process.env.CLAUDE_TEAM_CONTROL_URL
 ): void {
+  const current = agentTeamsMcpHttpServer.appContext.read(claudeBasePath);
+  // Only the current Host can select a remote endpoint; never retain shell hints.
+  delete env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL;
+  delete env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH;
+  delete env.CLAUDE_TEAM_APP_INSTANCE_ID;
+  delete env.CLAUDE_TEAM_APP_PROFILE_SCOPE;
+  if (current) {
+    Object.assign(env, current);
+  }
   const rawChildEnv = env[MCP_ENV_JSON_ENV]?.trim();
   const parsed: unknown = rawChildEnv ? JSON.parse(rawChildEnv) : {};
   if (
@@ -34,6 +44,24 @@ export function applyAgentTeamsMcpAppContext(
     throw new Error('Agent Teams MCP child environment must be a JSON object of strings');
   }
   const childEnv = { ...parsed } as Record<string, string>;
+  if (current) {
+    for (const key of ['CLAUDE_TEAM_APP_INSTANCE_ID', 'CLAUDE_TEAM_APP_PROFILE_SCOPE']) {
+      if (childEnv[key] !== undefined && childEnv[key] !== current[key]) {
+        throw new Error('Foreign Host MCP child context');
+      }
+    }
+    if (
+      childEnv.AGENT_TEAMS_MCP_CLAUDE_DIR !== undefined &&
+      childEnv.AGENT_TEAMS_MCP_CLAUDE_DIR !== claudeBasePath
+    ) {
+      throw new Error('Foreign Host MCP child root');
+    }
+    childEnv.CLAUDE_TEAM_APP_INSTANCE_ID = current.CLAUDE_TEAM_APP_INSTANCE_ID!;
+    childEnv.CLAUDE_TEAM_APP_PROFILE_SCOPE = current.CLAUDE_TEAM_APP_PROFILE_SCOPE!;
+  } else {
+    delete childEnv.CLAUDE_TEAM_APP_INSTANCE_ID;
+    delete childEnv.CLAUDE_TEAM_APP_PROFILE_SCOPE;
+  }
   env.AGENT_TEAMS_MCP_CLAUDE_DIR = claudeBasePath;
   childEnv.AGENT_TEAMS_MCP_CLAUDE_DIR = claudeBasePath;
   const controlUrl = controlApiBaseUrl?.trim();

--- a/src/main/services/team/AgentTeamsMcpHttpServer.ts
+++ b/src/main/services/team/AgentTeamsMcpHttpServer.ts
@@ -14,6 +14,7 @@ import { getAppDataPath, getClaudeBasePath } from '@main/utils/pathDecoder';
 import { forceKillProcessByPidNoWait, killProcessByPid } from '@main/utils/processKill';
 import { createLogger } from '@shared/utils/logger';
 
+import { createOpenCodeMcpAppContext } from './opencode/bridge/OpenCodeMcpBridgeEnv';
 import { type FileLockOptions, withFileLock } from './fileLock';
 import { type McpLaunchSpec, resolveAgentTeamsMcpLaunchSpec } from './TeamMcpConfigBuilder';
 
@@ -682,6 +683,9 @@ function execFileText(
 }
 
 export class AgentTeamsMcpHttpServer {
+  readonly appContext = createOpenCodeMcpAppContext(() =>
+    this.preventFutureStarts ? null : this.getCurrentHandle()
+  );
   private startPromise: Promise<AgentTeamsMcpHttpServerHandle> | null = null;
   private child: ChildProcess | null = null;
   private handle: AgentTeamsMcpHttpServerHandle | null = null;
@@ -690,15 +694,12 @@ export class AgentTeamsMcpHttpServer {
   private readonly ownerInstanceId = randomUUID();
   private readonly startedAtMs = Date.now();
   private preventFutureStarts = false;
-
   constructor(private readonly deps: AgentTeamsMcpHttpServerDeps = {}) {}
-
   async ensureStarted(): Promise<AgentTeamsMcpHttpServerHandle> {
     this.throwIfStartsPrevented();
     if (this.startPromise) {
       return this.startPromise;
     }
-
     this.startPromise = (
       this.handle ? this.reuseOrRestartExistingHandle(this.handle) : this.startOnce()
     ).finally(() => {
@@ -735,7 +736,6 @@ export class AgentTeamsMcpHttpServer {
   getCurrentHandle(): AgentTeamsMcpHttpServerHandle | null {
     return this.handle;
   }
-
   private resolveStatePath(): string | null {
     if (this.deps.statePath === null) {
       return null;

--- a/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeBridgeCommandClient.ts
@@ -186,8 +186,6 @@ export class OpenCodeBridgeCommandClient {
   private readonly clock: () => Date;
   private readonly env: NodeJS.ProcessEnv;
   private readonly envProvider: (() => NodeJS.ProcessEnv | Promise<NodeJS.ProcessEnv>) | null;
-  private lastKnownMcpUrl: string | null;
-  private lastKnownMcpUrlHash: string | null;
   private readonly keepInputFile: boolean;
   private readonly ensureWindowsNodeModulesJunction: (
     profileId: string,
@@ -205,8 +203,6 @@ export class OpenCodeBridgeCommandClient {
     this.clock = options.clock ?? (() => new Date());
     this.env = applyOpenCodeAutoUpdatePolicy(options.env ?? process.env);
     this.envProvider = options.envProvider ?? null;
-    this.lastKnownMcpUrl = this.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL?.trim() || null;
-    this.lastKnownMcpUrlHash = this.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH?.trim() || null;
     this.keepInputFile = options.keepInputFile ?? false;
     this.ensureWindowsNodeModulesJunction =
       options.ensureWindowsNodeModulesJunction ?? ensureOpenCodeProfileNodeModulesJunction;
@@ -471,23 +467,9 @@ export class OpenCodeBridgeCommandClient {
     if (!this.envProvider) {
       return this.env;
     }
-    const resolved = applyOpenCodeAutoUpdatePolicy(await this.envProvider());
-    const resolvedMcpUrl = resolved.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL?.trim();
-    if (resolvedMcpUrl) {
-      this.lastKnownMcpUrl = resolvedMcpUrl;
-      this.lastKnownMcpUrlHash =
-        resolved.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH?.trim() || null;
-    } else if (this.lastKnownMcpUrl) {
-      // A transient HTTP MCP refresh failure must not silently switch an active
-      // OpenCode launch from its sealed remote transport to the local fallback.
-      // The next command can recover the endpoint, while changing transport
-      // here would invalidate every already-running selected session.
-      resolved.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL = this.lastKnownMcpUrl;
-      if (this.lastKnownMcpUrlHash) {
-        resolved.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH = this.lastKnownMcpUrlHash;
-      }
-    }
-    return resolved;
+    // Host publication is authoritative, including removal. A cached URL can name
+    // a retired server and must never override the current transport selection.
+    return applyOpenCodeAutoUpdatePolicy(await this.envProvider());
   }
 
   private async writeInputFile<TBody>(

--- a/src/main/services/team/opencode/bridge/OpenCodeMcpBridgeEnv.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeMcpBridgeEnv.ts
@@ -196,3 +196,51 @@ export function clearOpenCodeLocalMcpLaunchEnv(env: OpenCodeMcpBridgeEnv): void 
     delete env[key];
   }
 }
+
+/** A projection owned by the existing Host transport, with identity-checked revocation. */
+export function createOpenCodeMcpAppContext(
+  getCurrentHandle: () => { url: string; port: number; urlHash: string } | null
+): {
+  bind: (env: OpenCodeMcpBridgeEnv, httpEnabled: boolean) => () => void;
+  read: (claudeRoot: string) => OpenCodeMcpBridgeEnv | null;
+} {
+  let current: { env: OpenCodeMcpBridgeEnv; httpEnabled: boolean } | null = null;
+  return {
+    bind(env, httpEnabled) {
+      const owner = { env, httpEnabled };
+      current = owner;
+      return () => {
+        if (current === owner) current = null;
+      };
+    },
+    read(claudeRoot) {
+      if (!current) return null;
+      const { env, httpEnabled } = current;
+      const instance = env.CLAUDE_TEAM_APP_INSTANCE_ID;
+      const profile = env.CLAUDE_TEAM_APP_PROFILE_SCOPE;
+      if (
+        env.AGENT_TEAMS_MCP_CLAUDE_DIR !== claudeRoot ||
+        !instance?.trim() ||
+        !/^[a-f0-9]{64}$/.test(profile ?? '')
+      ) {
+        throw new Error('Invalid current Host MCP app context');
+      }
+      const result: OpenCodeMcpBridgeEnv = {
+        CLAUDE_TEAM_APP_INSTANCE_ID: instance,
+        CLAUDE_TEAM_APP_PROFILE_SCOPE: profile,
+      };
+      for (const key of [...LOCAL_MCP_LAUNCH_ENV_KEYS, ...OPTIONAL_LOCAL_MCP_LAUNCH_ENV_KEYS]) {
+        if (env[key] !== undefined) result[key] = env[key];
+      }
+      const handle = getCurrentHandle();
+      if (httpEnabled && handle) {
+        if (handle.url !== `http://127.0.0.1:${handle.port}/mcp`) {
+          throw new Error('Invalid current Host MCP transport');
+        }
+        result[HTTP_MCP_URL_ENV] = buildOpenCodeAppScopedMcpUrl(handle.url, instance, profile);
+        result[HTTP_MCP_URL_HASH_ENV] = handle.urlHash;
+      }
+      return result;
+    },
+  };
+}

--- a/test/main/services/runtime/providerAwareCliEnv.test.ts
+++ b/test/main/services/runtime/providerAwareCliEnv.test.ts
@@ -301,6 +301,180 @@ describe('buildProviderAwareCliEnv', () => {
     }
   });
 
+  it.each([undefined, 'http://foreign.invalid/mcp#stale'])(
+    'projects current Host remote transport into the actual provider-management command (%s)',
+    async (staleUrl) => {
+      const { agentTeamsMcpHttpServer: server } =
+        await import('@main/services/team/AgentTeamsMcpHttpServer');
+      const { getClaudeBasePath } = await import('@main/utils/pathDecoder');
+      const { AgentTeamsRuntimeProviderManagementCliClient } =
+        await import('@features/runtime-provider-management/main/infrastructure/AgentTeamsRuntimeProviderManagementCliClient');
+      const { buildPassiveProviderStatusCliEnv } =
+        await import('@main/services/runtime/providerAwareCliEnv');
+      const profile = 'a'.repeat(64);
+      const hostEnv = {
+        AGENT_TEAMS_MCP_CLAUDE_DIR: getClaudeBasePath(),
+        CLAUDE_TEAM_APP_INSTANCE_ID: 'sandbox-host',
+        CLAUDE_TEAM_APP_PROFILE_SCOPE: profile,
+        CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND: '/sandbox/host-node',
+        CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/sandbox/host-mcp.js',
+        CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ARGS_JSON: '["/sandbox/host-mcp.js"]',
+        CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON: '{"OWNER":"host"}',
+      };
+      // Optional only so this behavior oracle also runs against the unpatched base.
+      const revoke = server.appContext?.bind(hostEnv, true) ?? (() => undefined);
+      const handle = vi.spyOn(server, 'getCurrentHandle');
+      const start = vi
+        .spyOn(server, 'ensureStarted')
+        .mockRejectedValue(new Error('passive startup forbidden'));
+      const response = {
+        schemaVersion: 1,
+        runtimeId: 'opencode',
+        models: {
+          runtimeId: 'opencode',
+          providerId: 'xai',
+          models: [],
+          defaultModelId: null,
+          diagnostics: [],
+          catalogState: 'fresh',
+        },
+      };
+      execCliMock.mockResolvedValue({ stdout: JSON.stringify(response), stderr: '' });
+      getCachedShellEnvMock.mockReturnValue({
+        CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL: staleUrl,
+        CLAUDE_CONFIG_DIR: '/sandbox/selected-auth',
+      });
+      try {
+        for (const port of [41001, 41002]) {
+          handle.mockReturnValue({
+            url: `http://127.0.0.1:${port}/mcp`,
+            port,
+            urlHash: 'hash',
+            pid: 123,
+            generation: 1,
+            diagnostics: [],
+            transportEvidence: {},
+          } as ReturnType<typeof server.getCurrentHandle>);
+          await new AgentTeamsRuntimeProviderManagementCliClient().loadModels({
+            runtimeId: 'opencode',
+            providerId: 'xai',
+          });
+          const env = execCliMock.mock.calls.at(-1)![2].env;
+          // Independent literal oracle: do not compute expected values with the production mapper.
+          expect(env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBe(
+            `http://127.0.0.1:${port}/mcp#agent-teams-app-instance=sandbox-host&agent-teams-app-profile=${profile}`
+          );
+          expect(env.CLAUDE_CONFIG_DIR).toBe('/sandbox/selected-auth');
+          expect(env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND).toBe('/sandbox/host-node');
+          expect(JSON.parse(env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON)).toMatchObject({
+            OWNER: 'host',
+            CLAUDE_TEAM_APP_INSTANCE_ID: 'sandbox-host',
+            CLAUDE_TEAM_APP_PROFILE_SCOPE: profile,
+          });
+          expect(
+            buildPassiveProviderStatusCliEnv({ providerId: 'opencode' }).env
+              .CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL
+          ).toBe(env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL);
+        }
+        handle.mockReturnValue(null);
+        expect(
+          buildPassiveProviderStatusCliEnv({ providerId: 'opencode' }).env
+            .CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL
+        ).toBeUndefined();
+        const revokeLocal = server.appContext.bind(hostEnv, false);
+        revoke(); // delayed old teardown cannot clear the newer local selection
+        expect(
+          buildPassiveProviderStatusCliEnv({ providerId: 'opencode' }).env
+            .CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND
+        ).toBe('/sandbox/host-node');
+        revokeLocal();
+        const revoked = buildPassiveProviderStatusCliEnv({
+          providerId: 'opencode',
+          env: {
+            ...hostEnv,
+            CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL: 'http://127.0.0.1:41001/mcp',
+          },
+        }).env;
+        expect(revoked.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBeUndefined();
+        expect(revoked.CLAUDE_TEAM_APP_INSTANCE_ID).toBeUndefined();
+        expect(revoked.CLAUDE_TEAM_APP_PROFILE_SCOPE).toBeUndefined();
+        expect(start).not.toHaveBeenCalled();
+      } finally {
+        revoke();
+        handle.mockRestore();
+        start.mockRestore();
+      }
+    }
+  );
+
+  it('finishes delayed catalog environment preparation with the newer Host context', async () => {
+    const { agentTeamsMcpHttpServer: server } =
+      await import('@main/services/team/AgentTeamsMcpHttpServer');
+    const { getClaudeBasePath } = await import('@main/utils/pathDecoder');
+    const { buildProviderAwareCliEnv } = await import('@main/services/runtime/providerAwareCliEnv');
+    const env = {
+      AGENT_TEAMS_MCP_CLAUDE_DIR: getClaudeBasePath(),
+      CLAUDE_TEAM_APP_INSTANCE_ID: 'old',
+      CLAUDE_TEAM_APP_PROFILE_SCOPE: 'a'.repeat(64),
+    };
+    const revokeOld = server.appContext.bind(env, true);
+    let finish!: (value: { command: string; args: string[] }) => void;
+    resolveAgentTeamsMcpLaunchSpecMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    const pending = buildProviderAwareCliEnv({ providerId: 'opencode', connectionMode: 'augment' });
+    await vi.waitFor(() => expect(finish).toBeTypeOf('function'));
+    const revokeNew = server.appContext.bind({ ...env, CLAUDE_TEAM_APP_INSTANCE_ID: 'new' }, false);
+    try {
+      revokeOld();
+      finish({ command: '/sandbox/node', args: ['/sandbox/mcp.js'] });
+      const result = await pending;
+      expect(result.env.CLAUDE_TEAM_APP_INSTANCE_ID).toBe('new');
+      expect(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBeUndefined();
+      expect(result.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND).toBe('/sandbox/node');
+    } finally {
+      revokeNew();
+    }
+  });
+
+  it.each([
+    '{broken',
+    '{"CLAUDE_TEAM_APP_INSTANCE_ID":"foreign"}',
+    '{"AGENT_TEAMS_MCP_CLAUDE_DIR":"/foreign/root"}',
+  ])(
+    'rejects malformed or foreign Host child context %s before a provider command',
+    async (childEnv) => {
+      const { agentTeamsMcpHttpServer: server } =
+        await import('@main/services/team/AgentTeamsMcpHttpServer');
+      const { getClaudeBasePath } = await import('@main/utils/pathDecoder');
+      const { AgentTeamsRuntimeProviderManagementCliClient } =
+        await import('@features/runtime-provider-management/main/infrastructure/AgentTeamsRuntimeProviderManagementCliClient');
+      const revoke = server.appContext.bind(
+        {
+          AGENT_TEAMS_MCP_CLAUDE_DIR: getClaudeBasePath(),
+          CLAUDE_TEAM_APP_INSTANCE_ID: 'host',
+          CLAUDE_TEAM_APP_PROFILE_SCOPE: 'a'.repeat(64),
+          CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON: childEnv,
+        },
+        true
+      );
+      try {
+        await expect(
+          new AgentTeamsRuntimeProviderManagementCliClient().loadModels({
+            runtimeId: 'opencode',
+            providerId: 'xai',
+          })
+        ).rejects.toThrow();
+        expect(execCliMock).not.toHaveBeenCalled();
+      } finally {
+        revoke();
+      }
+    }
+  );
+
   it.each(['null', '[]', '{"OWNER":42}', '{broken'])(
     'rejects malformed existing MCP child env %s without repairing away owner fields',
     async (raw) => {

--- a/test/main/services/runtime/providerAwareCliEnv.test.ts
+++ b/test/main/services/runtime/providerAwareCliEnv.test.ts
@@ -353,8 +353,18 @@ describe('buildProviderAwareCliEnv', () => {
             pid: 123,
             generation: 1,
             diagnostics: [],
-            transportEvidence: {},
-          } as ReturnType<typeof server.getCurrentHandle>);
+            transportEvidence: {
+              schemaVersion: 1,
+              transport: 'httpStream',
+              host: '127.0.0.1',
+              port,
+              endpoint: '/mcp',
+              url: `http://127.0.0.1:${port}/mcp`,
+              urlHash: 'hash',
+              generation: 1,
+              observedAt: '2026-09-10T00:00:00.000Z',
+            },
+          });
           await new AgentTeamsRuntimeProviderManagementCliClient().loadModels({
             runtimeId: 'opencode',
             providerId: 'xai',

--- a/test/main/services/team/AgentTeamsMcpHttpServer.test.ts
+++ b/test/main/services/team/AgentTeamsMcpHttpServer.test.ts
@@ -132,6 +132,96 @@ describe('AgentTeamsMcpHttpServer', () => {
     hoisted.untrackCliProcessMock.mockReset();
   });
 
+  it('publishes only live Host readiness across exit, restart, failure and quit', async () => {
+    const children: FakeChildProcess[] = [];
+    let ready: (() => void) | undefined;
+    const waitForPort = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          ready = resolve;
+        })
+    );
+    let port = 41001;
+    const server = new AgentTeamsMcpHttpServer({
+      statePath: null,
+      resolveLaunchSpec: async () => ({ command: 'node', args: ['/sandbox/mcp.js'] }),
+      allocatePort: async () => port++,
+      spawnProcess: () => {
+        const child = new FakeChildProcess();
+        children.push(child);
+        return child as unknown as ChildProcess;
+      },
+      waitForPort,
+    });
+    const env = {
+      AGENT_TEAMS_MCP_CLAUDE_DIR: getClaudeBasePath(),
+      CLAUDE_TEAM_APP_INSTANCE_ID: 'first',
+      CLAUDE_TEAM_APP_PROFILE_SCOPE: 'a'.repeat(64),
+    };
+    const revokeOld = server.appContext.bind(env, true);
+    const read = () => server.appContext.read(getClaudeBasePath());
+    expect(read()?.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBeUndefined();
+    expect(waitForPort).not.toHaveBeenCalled();
+    const starting = server.ensureStarted();
+    await vi.waitFor(() => expect(ready).toBeTypeOf('function'));
+    expect(read()?.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBeUndefined();
+    ready!();
+    await starting;
+    expect(read()?.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toContain('http://127.0.0.1:41001/mcp#');
+    children[0].emit('exit', 1, null);
+    expect(read()?.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBeUndefined();
+    ready = undefined;
+    const restarting = server.ensureStarted();
+    await vi.waitFor(() => expect(ready).toBeTypeOf('function'));
+    const revokeNew = server.appContext.bind(
+      { ...env, CLAUDE_TEAM_APP_INSTANCE_ID: 'reopen' },
+      true
+    );
+    revokeOld();
+    ready!();
+    await restarting;
+    expect(read()?.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toContain(
+      '41002/mcp#agent-teams-app-instance=reopen'
+    );
+    children[1].emit('exit', 1, null);
+    ready = undefined;
+    const failing = server.ensureStarted();
+    const failed = expect(failing).rejects.toThrow();
+    await vi.waitFor(() => expect(ready).toBeTypeOf('function'));
+    children[2].emit('exit', 1, null);
+    await failed;
+    expect(read()?.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBeUndefined();
+    revokeNew();
+    await server.stop({ preventRestart: true });
+    ready!(); // a delayed readiness completion cannot republish after quit
+    expect(read()).toBeNull();
+    await expect(server.ensureStarted()).rejects.toThrow('shutdown');
+    const reopenedChild = new FakeChildProcess();
+    const reopened = new AgentTeamsMcpHttpServer({
+      statePath: null,
+      resolveLaunchSpec: async () => ({ command: 'node', args: ['/sandbox/mcp.js'] }),
+      allocatePort: async () => 41004,
+      spawnProcess: () => reopenedChild as unknown as ChildProcess,
+      waitForPort: async () => undefined,
+    });
+    const revokeReopened = reopened.appContext.bind(
+      { ...env, CLAUDE_TEAM_APP_INSTANCE_ID: 'after-quit' }, true
+    );
+    expect(reopened.appContext.read(getClaudeBasePath())?.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL)
+      .toBeUndefined();
+    await reopened.ensureStarted();
+    revokeOld();
+    revokeNew();
+    expect(reopened.appContext.read(getClaudeBasePath())?.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL)
+      .toContain('41004/mcp#agent-teams-app-instance=after-quit');
+    expect(read()).toBeNull();
+    revokeReopened();
+    reopenedChild.emit('exit', 1, null);
+    await reopened.stop({ preventRestart: true });
+    expect(vi.mocked(console.warn).mock.calls).toHaveLength(4);
+    vi.mocked(console.warn).mockClear();
+  });
+
   it('starts the MCP server over HTTP with hidden app-owned process env', async () => {
     const child = new FakeChildProcess();
     const spawnProcess = vi.fn(() => child as unknown as ChildProcess);

--- a/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
+++ b/test/main/services/team/OpenCodeBridgeCommandClient.test.ts
@@ -1,5 +1,5 @@
-import { OpenCodeBackfillRetry } from '@main/services/team/opencode/OpenCodeBackfillRetry';
 import { OpenCodeReadinessBridge } from '@main/services/team/opencode/bridge/OpenCodeReadinessBridge';
+import { OpenCodeBackfillRetry } from '@main/services/team/opencode/OpenCodeBackfillRetry';
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -745,7 +745,7 @@ describe('OpenCodeBridgeCommandClient', () => {
     });
   });
 
-  it('keeps the sealed HTTP MCP transport when a later env refresh falls back locally', async () => {
+  it('does not revive an initial HTTP MCP endpoint after Host selects local fallback', async () => {
     runner.nextResult = {
       stdout: `${JSON.stringify(bridgeSuccess({ data: { runId: 'run-1' } }))}\n`,
       stderr: '',
@@ -775,14 +775,14 @@ describe('OpenCodeBridgeCommandClient', () => {
       }
     );
 
+    expect(runner.calls[0].env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBeUndefined();
+    expect(runner.calls[0].env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH).toBeUndefined();
     expect(runner.calls[0].env).toMatchObject({
-      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL: 'http://127.0.0.1:5001/mcp',
-      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH: 'url-hash-1',
       CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/tmp/mcp.js',
     });
   });
 
-  it('retains an HTTP MCP transport first discovered by the lazy env provider', async () => {
+  it('does not revive an HTTP MCP endpoint retired by the lazy Host env provider', async () => {
     runner.nextResult = {
       stdout: `${JSON.stringify(bridgeSuccess({ data: { runId: 'run-1' } }))}\n`,
       stderr: '',
@@ -819,9 +819,12 @@ describe('OpenCodeBridgeCommandClient', () => {
       );
     }
 
+    expect(runner.calls[0].env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBe(
+      'http://127.0.0.1:5001/mcp'
+    );
+    expect(runner.calls[1].env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBeUndefined();
+    expect(runner.calls[1].env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH).toBeUndefined();
     expect(runner.calls[1].env).toMatchObject({
-      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL: 'http://127.0.0.1:5001/mcp',
-      CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH: 'url-hash-1',
       CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/tmp/mcp.js',
     });
   });

--- a/test/main/services/team/OpenCodeMcpBridgeEnv.test.ts
+++ b/test/main/services/team/OpenCodeMcpBridgeEnv.test.ts
@@ -1,10 +1,11 @@
 import {
-  buildOpenCodeAppProfileScope,
   buildOpenCodeAppProcessOwnershipMarkers,
+  buildOpenCodeAppProfileScope,
   buildOpenCodeAppScopedMcpOwnershipMarker,
   buildOpenCodeAppScopedMcpUrl,
   clearOpenCodeLocalMcpLaunchEnv,
   copyOpenCodeLocalMcpLaunchEnv,
+  createOpenCodeMcpAppContext,
   hasOpenCodeLocalMcpLaunchEnv,
   isOpenCodeMcpHttpBridgeEnabled,
   mergeOpenCodeLocalMcpChildEnvironment,
@@ -15,6 +16,69 @@ import {
 import { describe, expect, it } from 'vitest';
 
 describe('OpenCodeMcpBridgeEnv', () => {
+  it('reads the current handle after delayed work and fences old revocation', async () => {
+    let handle: { url: string; port: number; urlHash: string } | null = null;
+    const projection = createOpenCodeMcpAppContext(() => handle);
+    const env = {
+      AGENT_TEAMS_MCP_CLAUDE_DIR: '/sandbox/root',
+      CLAUDE_TEAM_APP_INSTANCE_ID: 'old',
+      CLAUDE_TEAM_APP_PROFILE_SCOPE: 'a'.repeat(64),
+    };
+    const revokeOld = projection.bind(env, true);
+    let finish!: () => void;
+    const delayed = new Promise<void>((resolve) => {
+      finish = resolve;
+    }).then(() => {
+      revokeOld();
+      return projection.read('/sandbox/root');
+    });
+    const revokeNew = projection.bind({ ...env, CLAUDE_TEAM_APP_INSTANCE_ID: 'new' }, true);
+    handle = { url: 'http://127.0.0.1:41002/mcp', port: 41002, urlHash: 'new-hash' };
+    finish();
+    expect((await delayed)?.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toContain(
+      '41002/mcp#agent-teams-app-instance=new'
+    );
+    revokeNew();
+    expect(projection.read('/sandbox/root')).toBeNull();
+    projection.bind(env, false);
+    expect(projection.read('/sandbox/root')?.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBeUndefined();
+  });
+
+  it.each([
+    { AGENT_TEAMS_MCP_CLAUDE_DIR: '/foreign/root' },
+    { CLAUDE_TEAM_APP_INSTANCE_ID: '' },
+    { CLAUDE_TEAM_APP_PROFILE_SCOPE: 'malformed' },
+  ])('rejects invalid Host context %j', (override) => {
+    const projection = createOpenCodeMcpAppContext(() => null);
+    projection.bind(
+      {
+        AGENT_TEAMS_MCP_CLAUDE_DIR: '/sandbox/root',
+        CLAUDE_TEAM_APP_INSTANCE_ID: 'host',
+        CLAUDE_TEAM_APP_PROFILE_SCOPE: 'a'.repeat(64),
+        ...override,
+      },
+      true
+    );
+    expect(() => projection.read('/sandbox/root')).toThrow('Invalid current Host');
+  });
+
+  it('rejects foreign or malformed live transport without rewriting it', () => {
+    const projection = createOpenCodeMcpAppContext(() => ({
+      url: 'https://foreign.invalid/mcp#foreign',
+      port: 41001,
+      urlHash: 'hash',
+    }));
+    projection.bind(
+      {
+        AGENT_TEAMS_MCP_CLAUDE_DIR: '/sandbox/root',
+        CLAUDE_TEAM_APP_INSTANCE_ID: 'host',
+        CLAUDE_TEAM_APP_PROFILE_SCOPE: 'a'.repeat(64),
+      },
+      true
+    );
+    expect(() => projection.read('/sandbox/root')).toThrow('Invalid current Host MCP transport');
+  });
+
   it('preserves exact profile ownership across app restarts and separates full authority roots', () => {
     const profile = buildOpenCodeAppProfileScope('/tmp/desktop/profile', '/tmp/desktop/.claude');
     expect(buildOpenCodeAppProfileScope('/tmp/desktop/profile', '/tmp/desktop/.claude')).toBe(

--- a/test/main/services/team/ShutdownMcpTransport.test.ts
+++ b/test/main/services/team/ShutdownMcpTransport.test.ts
@@ -1,0 +1,233 @@
+// @vitest-environment node
+import { EventEmitter } from 'node:events';
+import { readFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { applyAgentTeamsMcpAppContext } from '@main/services/runtime/agentTeamsMcpLaunchEnv';
+import {
+  AgentTeamsMcpHttpServer,
+  agentTeamsMcpHttpServer as server,
+} from '@main/services/team/AgentTeamsMcpHttpServer';
+import { OpenCodeBridgeCommandClient } from '@main/services/team/opencode/bridge/OpenCodeBridgeCommandClient';
+import { buildOpenCodeAppScopedMcpUrl } from '@main/services/team/opencode/bridge/OpenCodeMcpBridgeEnv';
+import { getClaudeBasePath } from '@main/utils/pathDecoder';
+import ts from 'typescript';
+import { describe, expect, it, vi } from 'vitest';
+
+// Execute exact source boundaries without booting Electron, discovering binaries,
+// or contacting providers. Extract AST nodes, not a rewritten algorithm.
+const mainSource = ts.createSourceFile(
+  'main.ts',
+  readFileSync('src/main/index.ts', 'utf8'),
+  ts.ScriptTarget.Latest,
+  true
+);
+function sourceNode(name: string): ts.Node {
+  let found: ts.Node | undefined;
+  function visit(node: ts.Node) {
+    if (
+      (ts.isFunctionDeclaration(node) || ts.isVariableDeclaration(node)) &&
+      node.name?.getText(mainSource) === name
+    )
+      found = node;
+    ts.forEachChild(node, visit);
+  }
+  visit(mainSource);
+  if (!found) throw new Error(`Source boundary missing: ${name}`);
+  return found;
+}
+function compileExpression(expression: string, ports: Record<string, unknown>): unknown {
+  const js = ts.transpileModule(`const boundary = ${expression};`, {
+    compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.None },
+  }).outputText;
+  return Function(...Object.keys(ports), `${js}; return boundary;`)(...Object.values(ports));
+}
+const profile = 'a'.repeat(64);
+const hostEnv = () => ({
+  AGENT_TEAMS_MCP_CLAUDE_DIR: getClaudeBasePath(),
+  CLAUDE_TEAM_APP_INSTANCE_ID: 'review-host',
+  CLAUDE_TEAM_APP_PROFILE_SCOPE: profile,
+  CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_COMMAND: '/sandbox/node',
+  CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENTRY: '/sandbox/mcp.js',
+  CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ARGS_JSON: '["/sandbox/mcp.js"]',
+  CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON: JSON.stringify({
+    CLAUDE_TEAM_APP_INSTANCE_ID: 'review-host',
+    CLAUDE_TEAM_APP_PROFILE_SCOPE: profile,
+  }),
+});
+const handle: NonNullable<ReturnType<typeof server.getCurrentHandle>> = {
+  url: 'http://127.0.0.1:41001/mcp',
+  port: 41001,
+  urlHash: 'review-hash',
+  pid: 123,
+  generation: 1,
+  diagnostics: [],
+  transportEvidence: {
+    schemaVersion: 1,
+    transport: 'httpStream',
+    host: '127.0.0.1',
+    port: 41001,
+    endpoint: '/mcp',
+    url: 'http://127.0.0.1:41001/mcp',
+    urlHash: 'review-hash',
+    generation: 1,
+    observedAt: '2026-09-10T00:00:00.000Z',
+  },
+};
+function bridgeResolver(env: Record<string, string>, overrides: Record<string, unknown> = {}) {
+  const node = sourceNode('resolveBridgeCommandEnv') as ts.VariableDeclaration;
+  return compileExpression(node.initializer!.getText(mainSource), {
+    bridgeEnv: env,
+    useHttpMcpBridge: true,
+    agentTeamsMcpHttpServer: server,
+    ensureOpenCodeRuntimeBinaryEnv: async () => {},
+    ensureOpenCodeLocalMcpLaunchEnv: async () => {},
+    buildOpenCodeAppScopedMcpUrl,
+    openCodeManagedHostInstanceId: 'review-host',
+    profileScope: profile,
+    applyAgentTeamsMcpAppContext,
+    logger: { warn() {} },
+    ...overrides,
+  });
+}
+
+describe('shutdown MCP transport authority', () => {
+  it('retains matching Stop authority through both cleanup phases and revokes at teardown', async () => {
+    const env = hostEnv();
+    const revoke = server.appContext.bind(env, true);
+    const directory = await mkdtemp(join(tmpdir(), 'shutdown-mcp-'));
+    const live = vi.spyOn(server, 'getCurrentHandle').mockReturnValue(handle);
+    const start = vi.spyOn(server, 'ensureStarted').mockResolvedValue(handle);
+    const resolveEnv = bridgeResolver(env) as () => Promise<NodeJS.ProcessEnv>;
+    const accepted = new Error('authorized Stop intercepted; no subprocess');
+    let acceptedStops = 0;
+    const expectedUrl = `http://127.0.0.1:41001/mcp#agent-teams-app-instance=review-host&agent-teams-app-profile=${profile}`;
+    const client = new OpenCodeBridgeCommandClient({
+      binaryPath: '/sandbox/cli',
+      tempDirectory: directory,
+      env,
+      envProvider: resolveEnv,
+      processRunner: {
+        async run(input) {
+          const child = JSON.parse(input.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON!);
+          // Reject mismatched current transport/authority, as a retaining non-Cursor
+          // Stop probe does. Never manufacture a successful bridge response.
+          if (
+            server.getCurrentHandle() !== handle ||
+            input.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL !== expectedUrl ||
+            input.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH !== handle.urlHash ||
+            input.env.CLAUDE_TEAM_APP_INSTANCE_ID !== 'review-host' ||
+            input.env.CLAUDE_TEAM_APP_PROFILE_SCOPE !== profile ||
+            child.CLAUDE_TEAM_APP_INSTANCE_ID !== 'review-host' ||
+            child.CLAUDE_TEAM_APP_PROFILE_SCOPE !== profile ||
+            child.AGENT_TEAMS_MCP_CLAUDE_DIR !== getClaudeBasePath()
+          ) {
+            throw new Error('retaining Stop rejected: current MCP transport/authority mismatch');
+          }
+          acceptedStops += 1;
+          throw accepted;
+        },
+      },
+    });
+    const stop = async () => {
+      await expect(
+        client.execute(
+          'opencode.stopTeam',
+          {
+            teamId: 'sandbox-team',
+            laneId: 'primary',
+            runId: 'sandbox-run',
+          },
+          { cwd: directory, timeoutMs: 1000 }
+        )
+      ).rejects.toBe(accepted);
+    };
+    const finished = new Error('bounded shutdown completed MCP teardown');
+    const noOp = () => {};
+    const teardown = vi.spyOn(server, 'stop').mockImplementation(async () => {
+      // Revocation must already hold on entry, even when server.stop is slow.
+      expect(server.appContext.read(getClaudeBasePath())).toBeNull();
+      live.mockReturnValue(null);
+      start.mockRejectedValue(new Error('startup disabled during shutdown'));
+    });
+    const shutdown = compileExpression(sourceNode('shutdownServices').getText(mainSource), {
+      shutdownPromise: null,
+      revokeMcpAppContext: revoke,
+      logger: { info: noOp },
+      announcementsLifecycle: { dispose: noOp },
+      runShutdownStep: async (_name: string, step: () => unknown) => step(),
+      clearStartupTimers: noOp,
+      clearInboxNotifyTimers: noOp,
+      stopPeriodicOpenCodeHostStartupLockPurge: null,
+      teamRuntimeRecoveryFeature: null,
+      teamProvisioningService: { setRuntimeRecoveryFailureObserver: noOp, stopAllTeams: stop },
+      cleanupOpenCodeHostsForLifecycle: stop,
+      agentTeamsMcpHttpServer: server,
+      killTrackedCliProcesses: () => {
+        throw finished;
+      },
+    }) as () => Promise<void>;
+    try {
+      expect((await resolveEnv()).CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBe(expectedUrl);
+      let resume!: (value: typeof handle) => void;
+      start.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resume = resolve;
+          })
+      );
+      const late = resolveEnv();
+      await vi.waitFor(() => expect(resume).toBeTypeOf('function'));
+      await expect(shutdown()).rejects.toBe(finished);
+      expect(acceptedStops).toBe(2);
+      expect(teardown).toHaveBeenCalledExactlyOnceWith({ preventRestart: true });
+      const after = await resolveEnv();
+      expect(after.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBeUndefined();
+      expect(after.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL_HASH).toBeUndefined();
+      expect(after.CLAUDE_TEAM_APP_INSTANCE_ID).toBeUndefined();
+      expect(after.CLAUDE_TEAM_APP_PROFILE_SCOPE).toBeUndefined();
+      expect(JSON.parse(after.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON!)).not.toHaveProperty(
+        'CLAUDE_TEAM_APP_INSTANCE_ID'
+      );
+      // A resolver suspended before teardown must also project revocation when resumed.
+      resume(handle);
+      expect((await late).CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL).toBeUndefined();
+      expect(server.appContext.read(getClaudeBasePath())).toBeNull();
+    } finally {
+      revoke();
+      start.mockRestore();
+      live.mockRestore();
+      teardown.mockRestore();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('does not publish a stopped in-flight child when readiness completes late', async () => {
+    const child = Object.assign(new EventEmitter(), { stderr: new EventEmitter(), pid: undefined });
+    let ready!: () => void;
+    const owned = new AgentTeamsMcpHttpServer({
+      statePath: null,
+      resolveLaunchSpec: async () => ({ command: '/sandbox/node', args: ['/sandbox/mcp.js'] }),
+      allocatePort: async () => 41002,
+      spawnProcess: () => child as never,
+      waitForPort: () =>
+        new Promise<void>((resolve) => {
+          ready = resolve;
+        }),
+    });
+    const revoke = owned.appContext.bind(hostEnv(), true);
+    const pending = owned.ensureStarted();
+    const rejected = expect(pending).rejects.toThrow('exited before startup completed');
+    await vi.waitFor(() => expect(ready).toBeTypeOf('function'));
+    await owned.stop({ preventRestart: true });
+    ready();
+    await rejected;
+    expect(owned.getCurrentHandle()).toBeNull();
+    expect(
+      owned.appContext.read(getClaudeBasePath())?.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_URL
+    ).toBeUndefined();
+    revoke();
+  });
+});

--- a/test/main/services/team/ShutdownMcpTransport.test.ts
+++ b/test/main/services/team/ShutdownMcpTransport.test.ts
@@ -42,6 +42,8 @@ function compileExpression(expression: string, ports: Record<string, unknown>): 
   const js = ts.transpileModule(`const boundary = ${expression};`, {
     compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.None },
   }).outputText;
+  // Execute only checked-in source AST with test-owned ports, never user input.
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, sonarjs/code-eval
   return Function(...Object.keys(ports), `${js}; return boundary;`)(...Object.values(ports));
 }
 const profile = 'a'.repeat(64);
@@ -82,13 +84,13 @@ function bridgeResolver(env: Record<string, string>, overrides: Record<string, u
     bridgeEnv: env,
     useHttpMcpBridge: true,
     agentTeamsMcpHttpServer: server,
-    ensureOpenCodeRuntimeBinaryEnv: async () => {},
-    ensureOpenCodeLocalMcpLaunchEnv: async () => {},
+    ensureOpenCodeRuntimeBinaryEnv: vi.fn().mockResolvedValue(undefined),
+    ensureOpenCodeLocalMcpLaunchEnv: vi.fn().mockResolvedValue(undefined),
     buildOpenCodeAppScopedMcpUrl,
     openCodeManagedHostInstanceId: 'review-host',
     profileScope: profile,
     applyAgentTeamsMcpAppContext,
-    logger: { warn() {} },
+    logger: { warn: vi.fn() },
     ...overrides,
   });
 }
@@ -110,7 +112,7 @@ describe('shutdown MCP transport authority', () => {
       env,
       envProvider: resolveEnv,
       processRunner: {
-        async run(input) {
+        run(input) {
           const child = JSON.parse(input.env.CLAUDE_MULTIMODEL_AGENT_TEAMS_MCP_ENV_JSON!);
           // Reject mismatched current transport/authority, as a retaining non-Cursor
           // Stop probe does. Never manufacture a successful bridge response.
@@ -127,7 +129,7 @@ describe('shutdown MCP transport authority', () => {
             throw new Error('retaining Stop rejected: current MCP transport/authority mismatch');
           }
           acceptedStops += 1;
-          throw accepted;
+          return Promise.reject(accepted);
         },
       },
     });
@@ -145,19 +147,20 @@ describe('shutdown MCP transport authority', () => {
       ).rejects.toBe(accepted);
     };
     const finished = new Error('bounded shutdown completed MCP teardown');
-    const noOp = () => {};
-    const teardown = vi.spyOn(server, 'stop').mockImplementation(async () => {
+    const noOp = vi.fn();
+    const teardown = vi.spyOn(server, 'stop').mockImplementation(() => {
       // Revocation must already hold on entry, even when server.stop is slow.
       expect(server.appContext.read(getClaudeBasePath())).toBeNull();
       live.mockReturnValue(null);
       start.mockRejectedValue(new Error('startup disabled during shutdown'));
+      return Promise.resolve();
     });
     const shutdown = compileExpression(sourceNode('shutdownServices').getText(mainSource), {
       shutdownPromise: null,
       revokeMcpAppContext: revoke,
       logger: { info: noOp },
       announcementsLifecycle: { dispose: noOp },
-      runShutdownStep: async (_name: string, step: () => unknown) => step(),
+      runShutdownStep: async (_name: string, step: () => unknown) => await step(),
       clearStartupTimers: noOp,
       clearInboxNotifyTimers: noOp,
       stopPeriodicOpenCodeHostStartupLockPurge: null,
@@ -209,8 +212,9 @@ describe('shutdown MCP transport authority', () => {
     let ready!: () => void;
     const owned = new AgentTeamsMcpHttpServer({
       statePath: null,
-      resolveLaunchSpec: async () => ({ command: '/sandbox/node', args: ['/sandbox/mcp.js'] }),
-      allocatePort: async () => 41002,
+      resolveLaunchSpec: () =>
+        Promise.resolve({ command: '/sandbox/node', args: ['/sandbox/mcp.js'] }),
+      allocatePort: () => Promise.resolve(41002),
       spawnProcess: () => child as never,
       waitForPort: () =>
         new Promise<void>((resolve) => {


### PR DESCRIPTION
Cold provider model loading can reject a valid retained SuperGrok login after a team session refreshes OAuth: the team bridge uses the Host's HTTP MCP transport while provider management reconstructs local MCP context. The runtime correctly rejects the mismatched scope before contacting the provider.

Project the existing Host-owned current MCP handle into provider-management and bridge environments. Preserve its full app-scoped URL and exact local fallback metadata. During shutdown, retain that authority through both cleanup Stop phases and revoke it at MCP transport teardown. Respect endpoint removal instead of restoring a cached URL. OAuth admission and host identity checks remain unchanged.

Validation of the production correction: 250 focused tests across 10 files passed, including the actual loopback health endpoint and shutdown/late-readiness regressions. Pinned native TypeScript check and focused lint passed on the hosted verification workspace, with changed-file hashes verified against the commit. Four behavior assertions reject the prior catalog/client implementation. Independent review caught the early shutdown revocation regression, now corrected; final exact-commit delta review accepted the correction with 109 independently passing tests and two behavioral negatives against the old shutdown order. Final head 4318a94f489e85564431f7b8ce4aefaa05555f41 also has accepted independent test-delta review, full typed test lint, and passing CI [34437307664](https://github.com/777genius/agent-teams-ai/actions/runs/34437307664). CI tested the merge with current main af72eafba4de76828b93c5cda39533d143eacbc5. The separate ReviewRouter job failed because its CI OAuth refresh token was already used; it is not counted as completed review. Hosted independent review is complete.

Windows packaged backfill passed at 1493bfa with runtime 0.0.92; all 14 relevant source/dependency/workflow files are byte-identical on final 4318a94: nine native calls across ASCII, spaces and Unicode paths, one event imported and no duplicates on replay. Archive, executable and nine application source-file hashes were independently verified. [Qualification run](https://github.com/777genius/agent-teams-ai/actions/runs/34436250448). This uses a controlled OpenCode fixture and does not prove Windows mixed-provider or OneDrive lifecycle.

Supporting actual macOS evidence: unchanged runtime 0.0.92 admits the retained owner with the current remote context and returns 12 fresh xAI models, exit 0 and empty stderr, without reauthentication or changing authority bytes. This is CLI evidence, not completed packaged-app lifecycle E2E. Remote port drift remains fail-closed. No release is published.

Related: https://github.com/777genius/agent-teams-ai/pull/636
