### PR TITLE
fix(opencode): protect startup admission and cleanup process identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,5 +268,8 @@ jobs:
       - name: Test Windows cleanup probe diagnostics
         run: pnpm exec vitest run --maxWorkers=1 test/main/utils/processStartTime.test.ts test/main/utils/windowsProcessTable.test.ts test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
 
+      - name: Test startup cleanup admission and IPC recovery
+        run: pnpm exec vitest run --maxWorkers=1 src/main/services/team/contracts/__tests__/TeamProvisioningStartupCleanupBusy.test.ts src/main/services/team/contracts/__tests__/TeamProvisioningApis.test.ts test/main/ipc/teams.test.ts test/renderer/store/teamSlice.test.ts
+
       - name: Test delayed provider summaries through real subprocesses
         run: pnpm exec vitest run --maxWorkers=1 test/main/services/runtime/ProviderSummaryTimeout.safe-e2e.test.ts

--- a/src/main/services/team/contracts/TeamProvisioningApis.ts
+++ b/src/main/services/team/contracts/TeamProvisioningApis.ts
@@ -1,7 +1,10 @@
 import { createLogger } from '@shared/utils/logger';
 
 import { purgeStaleOpenCodeHostStartupLocksBeforeLaunch } from '../opencode/bridge/OpenCodeHostStartupLockCleanup';
-import { whenOpenCodeStartupRuntimeSweepSettled } from '../opencode/bridge/OpenCodeStartupSweepGate';
+import {
+  OpenCodeStartupCleanupBusyError,
+  whenOpenCodeStartupRuntimeSweepSettled,
+} from '../opencode/bridge/OpenCodeStartupSweepGate';
 
 import type { OpenCodeRuntimeControlAck, OpenCodeRuntimeControlApi } from '../runtime-control';
 import type { TeamProvisioningStatusApi as FeatureTeamProvisioningStatusApi } from '@features/team-provisioning/contracts';
@@ -324,8 +327,8 @@ export function bindTeamProvisioningStartApi(
   options: {
     /**
      * Runs immediately before every create and every launch. It is a
-     * preparation step, never a precondition: a failure is swallowed here so
-     * that nothing it does can be the reason a team fails to start.
+     * best-effort preparation step except for typed startup cleanup busy,
+     * which refuses admission and requires an explicit retry.
      */
     beforeStart?: (input: TeamProvisioningStartHookInput) => Promise<void>;
   } = {}
@@ -341,6 +344,9 @@ export function bindTeamProvisioningStartApi(
     try {
       await beforeStart(input);
     } catch (error) {
+      if (error instanceof OpenCodeStartupCleanupBusyError) {
+        throw error;
+      }
       // Durable, not a warning: the start is going ahead regardless, so there
       // is nothing for a developer to act on in the moment - but the line has
       // to survive for whoever asks later why a launch was slow.
@@ -368,8 +374,8 @@ export function bindTeamProvisioningStartApi(
  * produce one has nothing to lose to it and must never pay the wait. A start
  * whose provider is not stated is resolved later from the saved config and can
  * still be OpenCode, so it keeps the wait. A launch request carries no roster:
- * a mixed team whose lead is not OpenCode relies on the sweep's own start-time
- * fence rather than on this gate.
+ * on Windows its unknown saved members must gate even for a non-OpenCode lead.
+ * Unix retains its existing wait policy.
  */
 function startRequestMayRaceOpenCodeStartupSweep(
   request: TeamCreateRequest | TeamLaunchRequest
@@ -378,7 +384,10 @@ function startRequestMayRaceOpenCodeStartupSweep(
     return true;
   }
   const members = 'members' in request ? request.members : undefined;
-  return members?.some((member) => member.providerId === 'opencode') === true;
+  return (
+    (process.platform === 'win32' && members === undefined) ||
+    members?.some((member) => member.providerId === 'opencode') === true
+  );
 }
 
 function buildStartupSweepWaitProgress(teamName: string): TeamProvisioningProgress {

--- a/src/main/services/team/contracts/__tests__/TeamProvisioningApis.test.ts
+++ b/src/main/services/team/contracts/__tests__/TeamProvisioningApis.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { beginOpenCodeStartupRuntimeSweep } from '../../opencode/bridge/OpenCodeStartupSweepGate';
 import {
@@ -1181,6 +1181,11 @@ describe('TeamProvisioning API binders', () => {
 });
 
 describe('the OpenCode start preparation both entry points install', () => {
+  beforeEach(() => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' });
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
   function startApiFor(
     request: TeamCreateRequest,
     onProgress: (progress: TeamProvisioningProgress) => void

--- a/src/main/services/team/contracts/__tests__/TeamProvisioningStartupCleanupBusy.test.ts
+++ b/src/main/services/team/contracts/__tests__/TeamProvisioningStartupCleanupBusy.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  beginOpenCodeStartupRuntimeSweep,
+  OpenCodeStartupCleanupBusyError,
+  whenOpenCodeStartupRuntimeSweepSettled,
+} from '../../opencode/bridge/OpenCodeStartupSweepGate';
+import {
+  bindTeamHttpHandlerApis,
+  bindTeamIpcHandlerApis,
+  bindTeamProvisioningStartApi,
+} from '../TeamProvisioningApis';
+
+import type { TeamCreateRequest, TeamLaunchRequest } from '@shared/types/team';
+
+vi.mock('../../opencode/bridge/OpenCodeHostStartupLockCleanup', () => ({
+  purgeStaleOpenCodeHostStartupLocksBeforeLaunch: vi.fn().mockResolvedValue(undefined),
+}));
+
+const createRequest: TeamCreateRequest = {
+  teamName: 'cleanup-gate-fixture',
+  cwd: '/sandbox/cleanup-gate-fixture',
+  providerId: 'claude',
+  members: [{ name: 'worker', role: 'Worker', providerId: 'opencode' }],
+};
+const launchRequest: TeamLaunchRequest = {
+  teamName: createRequest.teamName,
+  cwd: createRequest.cwd,
+  providerId: 'claude',
+};
+
+function fixture(transport: 'ipc' | 'http') {
+  const createTeam = vi.fn().mockResolvedValue({ runId: 'created' });
+  const launchTeam = vi.fn().mockResolvedValue({ runId: 'launched' });
+  const declared: Record<string, unknown> = {
+    createTeam,
+    launchTeam,
+    getAliveTeams: () => [],
+  };
+  const source = new Proxy(declared, {
+    get: (target, key: string) => target[key] ?? vi.fn(),
+  }) as unknown as Parameters<typeof bindTeamIpcHandlerApis>[0] &
+    Parameters<typeof bindTeamHttpHandlerApis>[0];
+  const api = (transport === 'ipc' ? bindTeamIpcHandlerApis : bindTeamHttpHandlerApis)(
+    source
+  ).provisioningStart;
+  return { api, createTeam, launchTeam };
+}
+
+describe('Windows startup cleanup admission', () => {
+  let release: () => void;
+  beforeEach(() => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' });
+    vi.useFakeTimers();
+    release = beginOpenCodeStartupRuntimeSweep();
+  });
+  afterEach(() => {
+    release();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it.each(['ipc', 'http'] as const)(
+    '%s refuses mixed create and unknown saved launch without delayed forwarding; manual retry works',
+    async (transport) => {
+      const { api, createTeam, launchTeam } = fixture(transport);
+      const onProgress = vi.fn();
+      await expect(api.createTeam(createRequest, onProgress)).rejects.toBeInstanceOf(
+        OpenCodeStartupCleanupBusyError
+      );
+      await expect(api.launchTeam(launchRequest, onProgress)).rejects.toThrow(/retry/);
+      await vi.advanceTimersByTimeAsync(120_000);
+      await expect(api.launchTeam(launchRequest, onProgress)).rejects.toBeInstanceOf(
+        OpenCodeStartupCleanupBusyError
+      );
+      expect(createTeam).not.toHaveBeenCalled();
+      expect(launchTeam).not.toHaveBeenCalled();
+      expect(onProgress).not.toHaveBeenCalled();
+      release();
+      await vi.runAllTimersAsync();
+      expect(createTeam).not.toHaveBeenCalled();
+      expect(launchTeam).not.toHaveBeenCalled();
+      await expect(api.createTeam(createRequest, onProgress)).resolves.toEqual({
+        runId: 'created',
+      });
+      await expect(api.launchTeam(launchRequest, onProgress)).resolves.toEqual({
+        runId: 'launched',
+      });
+      expect(createTeam).toHaveBeenCalledTimes(1);
+      expect(launchTeam).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('admits a known non-OpenCode create roster while cleanup is pending', async () => {
+    const { api, createTeam } = fixture('ipc');
+    await api.createTeam({ ...createRequest, members: [] }, vi.fn());
+    await api.createTeam(
+      { ...createRequest, members: [{ name: 'worker', role: 'Worker', providerId: 'codex' }] },
+      vi.fn()
+    );
+    expect(createTeam).toHaveBeenCalledTimes(2);
+    await expect(whenOpenCodeStartupRuntimeSweepSettled()).rejects.toBeInstanceOf(
+      OpenCodeStartupCleanupBusyError
+    );
+  });
+
+  it.each(['opencode', undefined] as const)('gates create provider %s', async (providerId) => {
+    const { api, createTeam } = fixture('ipc');
+    await expect(
+      api.createTeam({ ...createRequest, providerId, members: [] }, vi.fn())
+    ).rejects.toBeInstanceOf(OpenCodeStartupCleanupBusyError);
+    expect(createTeam).not.toHaveBeenCalled();
+  });
+
+  it('does not install a timeout or progress callback for a rejected waiter', async () => {
+    const onWaitStart = vi.fn();
+    await expect(
+      whenOpenCodeStartupRuntimeSweepSettled({ timeoutMs: 0, onWaitStart })
+    ).rejects.toBeInstanceOf(OpenCodeStartupCleanupBusyError);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(onWaitStart).not.toHaveBeenCalled();
+    await expect(whenOpenCodeStartupRuntimeSweepSettled()).rejects.toBeInstanceOf(
+      OpenCodeStartupCleanupBusyError
+    );
+  });
+
+  it('swallows ordinary preparation errors for both operations, even with the busy error name', async () => {
+    const { createTeam, launchTeam } = fixture('ipc');
+    const error = new Error('ordinary preparation failure');
+    error.name = 'OpenCodeStartupCleanupBusyError';
+    const api = bindTeamProvisioningStartApi(
+      { createTeam, launchTeam },
+      { beforeStart: () => Promise.reject(error) }
+    );
+    await api.createTeam(createRequest, vi.fn());
+    await api.launchTeam(launchRequest, vi.fn());
+    expect(createTeam).toHaveBeenCalledTimes(1);
+    expect(launchTeam).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe.each(['linux', 'darwin'])('%s startup sweep compatibility', (platform) => {
+  let release: () => void;
+  beforeEach(() => {
+    vi.stubGlobal('process', { ...process, platform });
+    vi.useFakeTimers();
+    release = beginOpenCodeStartupRuntimeSweep();
+  });
+  afterEach(() => {
+    release();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('waits before forwarding a mixed create and forwards once after release', async () => {
+    const { api, createTeam } = fixture('ipc');
+    const onProgress = vi.fn();
+    const started = api.createTeam(createRequest, onProgress);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(createTeam).not.toHaveBeenCalled();
+    expect(onProgress).toHaveBeenCalledTimes(1);
+    release();
+    await started;
+    expect(createTeam).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains the bounded waiter timeout and non-OpenCode saved lead bypass', async () => {
+    const { api, launchTeam } = fixture('ipc');
+    await api.launchTeam(launchRequest, vi.fn());
+    expect(launchTeam).toHaveBeenCalledTimes(1);
+    const logWaited = vi.fn();
+    const waiting = whenOpenCodeStartupRuntimeSweepSettled({ timeoutMs: 10, logWaited });
+    await vi.advanceTimersByTimeAsync(10);
+    await waiting;
+    expect(logWaited).toHaveBeenCalledWith(expect.stringContaining('settled=false'));
+    const onWaitStart = vi.fn();
+    await whenOpenCodeStartupRuntimeSweepSettled({ onWaitStart });
+    expect(onWaitStart).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/services/team/contracts/__tests__/TeamProvisioningStartupCleanupBusy.test.ts
+++ b/src/main/services/team/contracts/__tests__/TeamProvisioningStartupCleanupBusy.test.ts
@@ -20,13 +20,13 @@ vi.mock('../../opencode/bridge/OpenCodeHostStartupLockCleanup', () => ({
 const createRequest: TeamCreateRequest = {
   teamName: 'cleanup-gate-fixture',
   cwd: '/sandbox/cleanup-gate-fixture',
-  providerId: 'claude',
+  providerId: 'anthropic',
   members: [{ name: 'worker', role: 'Worker', providerId: 'opencode' }],
 };
 const launchRequest: TeamLaunchRequest = {
   teamName: createRequest.teamName,
   cwd: createRequest.cwd,
-  providerId: 'claude',
+  providerId: 'anthropic',
 };
 
 function fixture(transport: 'ipc' | 'http') {

--- a/src/main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeManagedHostProcessCleanup.ts
@@ -136,15 +136,6 @@ export async function cleanupManagedOpenCodeServeProcesses(
   const disposeServeHost = options.disposeServeHost ?? disposeOpenCodeServeHost;
   const readServeHostConfig = options.readServeHostConfig ?? readOpenCodeServeHostConfig;
   const killProcess = options.killProcess;
-  // The escalation after a survived kill must not be weaker than the kill it
-  // follows: on Windows process.kill() terminates that process alone, so the
-  // host's children (cmd.exe for the bash tool, cursor-agent trees) outlive the
-  // sweep as orphans. taskkill /T takes the tree, and the caller has just
-  // re-confirmed this pid's identity. On POSIX the first attempt already sent
-  // SIGTERM, so the escalation must use SIGKILL.
-  const forceKillProcess =
-    options.forceKillProcess ??
-    ((pid: number) => killProcessByPidAndWait(pid, { platform, signal: 'SIGKILL' }));
   const isProcessAlive = options.isProcessAlive ?? isNativeProcessAlive;
   const sleepMs = options.sleepMs ?? sleep;
 
@@ -298,13 +289,6 @@ export async function cleanupManagedOpenCodeServeProcesses(
       ): Promise<'confirmed' | 'gone' | 'changed'> => {
         let startTimeMatches = false;
         let ownershipMarkerMatches = false;
-        if (Number.isFinite(startedAtMs) && startedAtMs !== null) {
-          const currentStartedAtMs = await readStartTimeMs(row.pid);
-          if (currentStartedAtMs !== startedAtMs) {
-            return isProcessAlive(row.pid) ? 'changed' : 'gone';
-          }
-          startTimeMatches = true;
-        }
         if (requiredDetailsMarkers.length > 0) {
           const currentDetails = await readDetails(row.pid);
           if (currentDetails) {
@@ -347,6 +331,14 @@ export async function cleanupManagedOpenCodeServeProcesses(
             return isProcessAlive(row.pid) ? 'changed' : 'gone';
           }
         }
+        // Ownership probes may await I/O; check PID birth after all of them.
+        if (Number.isFinite(startedAtMs) && startedAtMs !== null) {
+          const currentStartedAtMs = await readStartTimeMs(row.pid);
+          if (currentStartedAtMs !== startedAtMs) {
+            return isProcessAlive(row.pid) ? 'changed' : 'gone';
+          }
+          startTimeMatches = true;
+        }
         if (startTimeMatches) {
           return 'confirmed';
         }
@@ -362,6 +354,11 @@ export async function cleanupManagedOpenCodeServeProcesses(
         }
         return isProcessAlive(row.pid) ? 'changed' : 'gone';
       };
+
+      const confirmTargetIdentity = async (): Promise<boolean> =>
+        Number.isFinite(startedAtMs) &&
+        startedAtMs !== null &&
+        (await readStartTimeMs(row.pid)) === startedAtMs;
 
       const identityBeforeDispose = await confirmCandidateIdentity();
       if (identityBeforeDispose === 'gone') {
@@ -416,10 +413,7 @@ export async function cleanupManagedOpenCodeServeProcesses(
         } else if (platform === 'win32') {
           await killProcessByPidAndWait(row.pid, {
             platform,
-            confirmTargetIdentity: async () =>
-              Number.isFinite(startedAtMs) &&
-              startedAtMs !== null &&
-              (await readStartTimeMs(row.pid)) === startedAtMs,
+            confirmTargetIdentity,
           });
         } else {
           killProcessByPid(row.pid);
@@ -435,7 +429,16 @@ export async function cleanupManagedOpenCodeServeProcesses(
           const identityBeforeForceKill = await confirmCandidateIdentity(true);
           if (identityBeforeForceKill === 'confirmed') {
             try {
-              await forceKillProcess(row.pid);
+              if (options.forceKillProcess) {
+                await options.forceKillProcess(row.pid);
+              } else {
+                // Windows taskkill awaits before its direct termination fallback.
+                await killProcessByPidAndWait(row.pid, {
+                  platform,
+                  signal: 'SIGKILL',
+                  ...(platform === 'win32' ? { confirmTargetIdentity } : {}),
+                });
+              }
             } catch (error) {
               if (isProcessAlive(row.pid)) {
                 throw error;

--- a/src/main/services/team/opencode/bridge/OpenCodeStartupSweepGate.ts
+++ b/src/main/services/team/opencode/bridge/OpenCodeStartupSweepGate.ts
@@ -6,13 +6,24 @@
  * bridge command ran, and the user saw a launch fail for no reason they could
  * see.
  *
- * This gate lets such a launch serialise behind the sweep instead of racing
- * it. It is belt and braces on top of the start-time fence the sweep itself
+ * Windows rejects such launches for manual retry; Unix waits behind the sweep.
+ * This protects admission only while the startup owner marks cleanup pending.
+ * Its finally callback does not prove externally dispatched cleanup has drained.
+ * It is belt and braces on top of the start-time fence the sweep itself
  * applies, because the sweep is reachable from more than one lifecycle path
  * and a fence can only protect processes that already exist when it is read.
  */
 
-/** A stuck sweep must never park launches forever. */
+export class OpenCodeStartupCleanupBusyError extends Error {
+  constructor() {
+    super(
+      'OpenCode startup cleanup is still running. Wait for cleanup to finish, then retry starting the team.'
+    );
+    this.name = 'OpenCodeStartupCleanupBusyError';
+  }
+}
+
+/** A stuck Unix sweep must never park launches forever. */
 export const OPEN_CODE_STARTUP_SWEEP_WAIT_TIMEOUT_MS = 60_000;
 
 interface PendingStartupSweep {
@@ -58,7 +69,8 @@ export interface WhenOpenCodeStartupRuntimeSweepSettledOptions {
 
 /**
  * Resolves immediately when no startup sweep is pending. Otherwise waits for
- * it and records the observed wait, so a launch that was slow because it
+ * it on Unix; Windows rejects with a busy error for manual retry. Records the
+ * observed Unix wait, so a launch that was slow because it
  * queued behind the sweep says so instead of leaving it to be inferred from
  * timestamps.
  */
@@ -68,6 +80,11 @@ export async function whenOpenCodeStartupRuntimeSweepSettled(
   const current = pendingStartupSweep;
   if (!current) {
     return;
+  }
+  if (process.platform === 'win32') {
+    // No waiter, progress run, or deferred launch survives this refusal.
+    // Only the startup completion owner may release the Windows gate.
+    throw new OpenCodeStartupCleanupBusyError();
   }
   options.onWaitStart?.();
   const nowMs = options.nowMs ?? (() => Date.now());

--- a/test/main/ipc/teams.test.ts
+++ b/test/main/ipc/teams.test.ts
@@ -1,3 +1,10 @@
+import { bindTeamProvisioningStartApi } from '@main/services/team/contracts/TeamProvisioningApis';
+import {
+  beginOpenCodeStartupRuntimeSweep,
+  OpenCodeStartupCleanupBusyError,
+  whenOpenCodeStartupRuntimeSweepSettled,
+} from '@main/services/team/opencode/bridge/OpenCodeStartupSweepGate';
+import type { ElectronAPI } from '@shared/types/api';
 import { setClaudeBasePathOverride } from '@main/utils/pathDecoder';
 import { MAX_TEXT_LENGTH } from '@shared/constants/teamLimits';
 import * as fs from 'fs';
@@ -27,7 +34,17 @@ vi.mock('@features/team-provisioning/main/composition/persistNodeMemberSettingsR
   persistNodeMemberSettingsRelaunch: modelRelaunchPersistence,
 }));
 
+const cleanupPreload = vi.hoisted(() => ({
+  exposeInMainWorld: vi.fn(),
+  invoke: vi.fn(),
+}));
+vi.mock('@preload/installRendererLogForwarding', () => ({
+  installRendererLogForwarding: vi.fn(),
+}));
 vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: cleanupPreload.exposeInMainWorld },
+  ipcRenderer: { invoke: cleanupPreload.invoke, send: vi.fn(), on: vi.fn() },
+  webUtils: { getPathForFile: vi.fn() },
   app: { getLocale: vi.fn(() => 'en'), getPath: vi.fn(() => '/tmp'), isPackaged: false },
   Notification: Object.assign(vi.fn(), { isSupported: vi.fn(() => false) }),
   BrowserWindow: { fromWebContents: vi.fn(() => null), getAllWindows: vi.fn(() => []) },
@@ -2457,6 +2474,69 @@ describe('ipc teams handlers', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Delegate mode is only supported when messaging the team lead');
+  });
+
+  it('propagates cleanup busy through main IPC and preload without deferred starts; explicit retry works', async () => {
+    vi.useFakeTimers();
+    const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cleanup-ipc-'));
+    setClaudeBasePathOverride(fixtureRoot);
+    const originalStart = { ...teamHandlerApis.provisioningStart };
+    const release = beginOpenCodeStartupRuntimeSweep();
+    // Stub only the platform observed by admission; all source actions remain mocks.
+    vi.stubGlobal('process', { ...process, platform: 'win32' });
+    Object.assign(
+      teamHandlerApis.provisioningStart,
+      bindTeamProvisioningStartApi(originalStart, {
+        beforeStart: () => whenOpenCodeStartupRuntimeSweepSettled(),
+      })
+    );
+    try {
+      await import('../../../src/preload/index');
+      const api = cleanupPreload.exposeInMainWorld.mock.calls.find(
+        ([name]) => name === 'electronAPI'
+      )![1] as ElectronAPI;
+      cleanupPreload.invoke.mockImplementation(async (channel: string, request: unknown) => {
+        const result = await handlers.get(channel)!({ sender: {} } as never, request);
+        // Electron transports a plain result, not the original Error instance.
+        return JSON.parse(JSON.stringify(result)) as unknown;
+      });
+      const request = { teamName: 'cleanup-fixture', cwd: fixtureRoot, members: [] };
+      const message = new OpenCodeStartupCleanupBusyError().message;
+      for (const operation of ['createTeam', 'launchTeam'] as const) {
+        await expect(api.teams[operation](request)).rejects.toThrow(message);
+        expect(await cleanupPreload.invoke.mock.results.at(-1)!.value).toEqual({
+          success: false,
+          error: message,
+        });
+      }
+      await vi.advanceTimersByTimeAsync(120_000);
+      // Passing the Unix timeout must not admit a Windows launch while cleanup is active.
+      await expect(api.teams.createTeam(request)).rejects.toThrow(message);
+      await expect(api.teams.launchTeam(request)).rejects.toThrow(message);
+      expect(originalStart.createTeam).not.toHaveBeenCalled();
+      expect(originalStart.launchTeam).not.toHaveBeenCalled();
+      release();
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(originalStart.createTeam).not.toHaveBeenCalled();
+      expect(originalStart.launchTeam).not.toHaveBeenCalled();
+      await expect(api.teams.createTeam(request)).resolves.toEqual({ runId: 'run-1' });
+      await expect(api.teams.launchTeam(request)).resolves.toEqual({ runId: 'run-2' });
+      expect(originalStart.createTeam).toHaveBeenCalledTimes(1);
+      expect(originalStart.launchTeam).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(console.error).mock.calls).toEqual([
+        ['[IPC:teams]', '[teams:create] ' + message],
+        ['[IPC:teams]', '[teams:launch] ' + message],
+        ['[IPC:teams]', '[teams:create] ' + message],
+        ['[IPC:teams]', '[teams:launch] ' + message],
+      ]);
+      vi.mocked(console.error).mockClear();
+    } finally {
+      release();
+      Object.assign(teamHandlerApis.provisioningStart, originalStart);
+      vi.unstubAllGlobals();
+      vi.clearAllTimers();
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    }
   });
 
   it('calls service and returns success on happy paths', async () => {
@@ -5662,28 +5742,47 @@ describe('ipc teams handlers', () => {
   });
 
   describe('replaceMembers', () => {
-    it.each([false, true])('routes guarded model relaunch persistence without unguarded fallback (conflict=%s)', async (conflict) => {
-      teamHandlerMocks.isTeamAlive.mockReturnValue(false);
-      modelRelaunchPersistence.mockReset();
-      if (conflict) modelRelaunchPersistence.mockRejectedValueOnce(new Error('target conflict'));
-      else modelRelaunchPersistence.mockResolvedValueOnce(undefined);
-      const intent = { memberName: 'alice', targetKind: 'member', expectedFingerprint: 'original',
-        baseline: [{ memberName: 'alice', expectedFingerprint: 'original' }], model: 'glm-5.3-flash', effort: null };
-      const result = await handlers.get(TEAM_REPLACE_MEMBERS)!({} as never, 'draft-team', {
-        members: [{ name: 'alice', model: 'glm-5.3-flash' }], memberSettingsRelaunch: intent,
-      }) as { success: boolean; error?: string };
-      expect(result.success).toBe(!conflict);
-      if (conflict) {
-        expect(result.error).toContain('target conflict');
-        expect(console.error).toHaveBeenCalledWith('[IPC:teams]', expect.stringContaining('target conflict'));
-        vi.mocked(console.error).mockClear();
+    it.each([false, true])(
+      'routes guarded model relaunch persistence without unguarded fallback (conflict=%s)',
+      async (conflict) => {
+        teamHandlerMocks.isTeamAlive.mockReturnValue(false);
+        modelRelaunchPersistence.mockReset();
+        if (conflict) modelRelaunchPersistence.mockRejectedValueOnce(new Error('target conflict'));
+        else modelRelaunchPersistence.mockResolvedValueOnce(undefined);
+        const intent = {
+          memberName: 'alice',
+          targetKind: 'member',
+          expectedFingerprint: 'original',
+          baseline: [{ memberName: 'alice', expectedFingerprint: 'original' }],
+          model: 'glm-5.3-flash',
+          effort: null,
+        };
+        const result = (await handlers.get(TEAM_REPLACE_MEMBERS)!({} as never, 'draft-team', {
+          members: [{ name: 'alice', model: 'glm-5.3-flash' }],
+          memberSettingsRelaunch: intent,
+        })) as { success: boolean; error?: string };
+        expect(result.success).toBe(!conflict);
+        if (conflict) {
+          expect(result.error).toContain('target conflict');
+          expect(console.error).toHaveBeenCalledWith(
+            '[IPC:teams]',
+            expect.stringContaining('target conflict')
+          );
+          vi.mocked(console.error).mockClear();
+        }
+        expect(modelRelaunchPersistence).toHaveBeenCalledWith(
+          'draft-team',
+          [expect.objectContaining({ name: 'alice', model: 'glm-5.3-flash' })],
+          intent,
+          expect.objectContaining({
+            isTeamAlive: expect.any(Function),
+            invalidateWorkerCache: expect.any(Function),
+          })
+        );
+        expect(service.replaceMembers).not.toHaveBeenCalled();
+        expect(teamHandlerMocks.attachLiveRosterMember).not.toHaveBeenCalled();
       }
-      expect(modelRelaunchPersistence).toHaveBeenCalledWith('draft-team',
-        [expect.objectContaining({ name: 'alice', model: 'glm-5.3-flash' })], intent,
-        expect.objectContaining({ isTeamAlive: expect.any(Function), invalidateWorkerCache: expect.any(Function) }));
-      expect(service.replaceMembers).not.toHaveBeenCalled();
-      expect(teamHandlerMocks.attachLiveRosterMember).not.toHaveBeenCalled();
-    });
+    );
 
     it('updates non-live draft members without requiring a full team snapshot', async () => {
       teamHandlerMocks.isTeamAlive.mockReturnValue(false);

--- a/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
+++ b/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
@@ -83,12 +83,12 @@ describe('OpenCodeManagedHostProcessCleanup', () => {
         const result = await cleanupManagedOpenCodeServeProcesses({
           mode: 'force',
           platform: 'win32',
-          listProcessRows: async () => [{ pid: 42, ppid: 1, command: 'opencode serve' }],
-          readProcessDetails: async () => MANAGED_DETAILS,
-          readProcessStartTimeMs: async () => birth,
+          listProcessRows: () => resolved([{ pid: 42, ppid: 1, command: 'opencode serve' }]),
+          readProcessDetails: () => resolved(MANAGED_DETAILS),
+          readProcessStartTimeMs: () => resolved(birth),
           killProcess,
           isProcessAlive: () => alive,
-          sleepMs: async () => undefined,
+          sleepMs: () => resolved(undefined),
         });
         expect(killProcess).toHaveBeenCalledWith(42);
         expect(exec).toHaveBeenCalledTimes(1);
@@ -118,13 +118,14 @@ describe('OpenCodeManagedHostProcessCleanup', () => {
         // Admission is the first probe, followed by dispose, kill, and force checks.
         if (++probes === phase + 1) birth = 20_000;
       };
-      const disposeServeHost = vi.fn(async () => undefined);
+      const disposeServeHost = vi.fn(() => resolved(undefined));
       const killProcess = vi.fn();
       const forceKillProcess = vi.fn();
       const result = await cleanupManagedOpenCodeServeProcesses({
         mode: 'force',
         platform: 'win32',
-        listProcessRows: async () => [{ pid: 42, ppid: 1, command: 'opencode serve --port 5001' }],
+        listProcessRows: () =>
+          resolved([{ pid: 42, ppid: 1, command: 'opencode serve --port 5001' }]),
         requiredDetailsMarkers: proof === 'details' ? ['OPENCODE_CONFIG_CONTENT='] : [],
         requiredServeConfigMarkersAny: proof === 'config' ? ['fixture-marker'] : [],
         requiredProfileScope: proof === 'profile' ? 'own' : undefined,
@@ -139,12 +140,12 @@ describe('OpenCodeManagedHostProcessCleanup', () => {
             mcp: { 'agent-teams': { environment: { CLAUDE_TEAM_APP_PROFILE_SCOPE: 'own' } } },
           });
         },
-        readProcessStartTimeMs: async () => birth,
+        readProcessStartTimeMs: () => resolved(birth),
         disposeServeHost,
         killProcess,
         forceKillProcess,
         isProcessAlive: () => true,
-        sleepMs: async () => undefined,
+        sleepMs: () => resolved(undefined),
       });
       expect(disposeServeHost).toHaveBeenCalledTimes(phase > 1 ? 1 : 0);
       expect(killProcess).toHaveBeenCalledTimes(phase > 2 ? 1 : 0);

--- a/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
+++ b/test/main/services/team/OpenCodeManagedHostProcessCleanup.test.ts
@@ -56,6 +56,111 @@ function resolved<T>(value: T): Promise<T> {
 }
 
 describe('OpenCodeManagedHostProcessCleanup', () => {
+  it.each([10_000, 20_000, null])(
+    'rechecks Windows birth after force taskkill before direct fallback (%s)',
+    async (birthAfterTaskkill) => {
+      let birth: number | null = 10_000;
+      let alive = true;
+      const nativeKill = vi.spyOn(process, 'kill').mockImplementation((_pid, signal) => {
+        if (signal === 0) {
+          if (!alive) throw Object.assign(new Error('gone'), { code: 'ESRCH' });
+        } else {
+          alive = false;
+        }
+        return true;
+      });
+      const exec = vi.mocked(childProcess.execFile).mockImplementation((...args: unknown[]) => {
+        const callback = args[3] as (error: Error | null) => void;
+        // Complete the external tree attempt asynchronously, with possible PID reuse.
+        void Promise.resolve().then(() => {
+          birth = birthAfterTaskkill;
+          callback(new Error('fixture taskkill failed'));
+        });
+        return {} as ReturnType<typeof childProcess.execFile>;
+      });
+      const killProcess = vi.fn();
+      try {
+        const result = await cleanupManagedOpenCodeServeProcesses({
+          mode: 'force',
+          platform: 'win32',
+          listProcessRows: async () => [{ pid: 42, ppid: 1, command: 'opencode serve' }],
+          readProcessDetails: async () => MANAGED_DETAILS,
+          readProcessStartTimeMs: async () => birth,
+          killProcess,
+          isProcessAlive: () => alive,
+          sleepMs: async () => undefined,
+        });
+        expect(killProcess).toHaveBeenCalledWith(42);
+        expect(exec).toHaveBeenCalledTimes(1);
+        expect(nativeKill.mock.calls.filter(([, signal]) => signal !== 0)).toEqual(
+          birthAfterTaskkill === 10_000 ? [[42, 'SIGKILL']] : []
+        );
+        expect(result.killed).toBe(birthAfterTaskkill === 10_000 ? 1 : 0);
+        if (birthAfterTaskkill !== 10_000) {
+          expect(result.candidates[0]).toMatchObject({
+            action: 'failed',
+            reason: expect.stringContaining('refusing unsafe direct termination'),
+          });
+        }
+      } finally {
+        nativeKill.mockRestore();
+        exec.mockRestore();
+      }
+    }
+  );
+
+  describe.each(['details', 'config', 'profile'] as const)('%s ownership probe', (proof) => {
+    it.each([1, 2, 3])('rejects PID reuse during confirmation phase %s', async (phase) => {
+      let birth = 10_000;
+      let probes = 0;
+      const changeBirthDuringProbe = async () => {
+        await Promise.resolve();
+        // Admission is the first probe, followed by dispose, kill, and force checks.
+        if (++probes === phase + 1) birth = 20_000;
+      };
+      const disposeServeHost = vi.fn(async () => undefined);
+      const killProcess = vi.fn();
+      const forceKillProcess = vi.fn();
+      const result = await cleanupManagedOpenCodeServeProcesses({
+        mode: 'force',
+        platform: 'win32',
+        listProcessRows: async () => [{ pid: 42, ppid: 1, command: 'opencode serve --port 5001' }],
+        requiredDetailsMarkers: proof === 'details' ? ['OPENCODE_CONFIG_CONTENT='] : [],
+        requiredServeConfigMarkersAny: proof === 'config' ? ['fixture-marker'] : [],
+        requiredProfileScope: proof === 'profile' ? 'own' : undefined,
+        readProcessDetails: async () => {
+          if (proof === 'details') await changeBirthDuringProbe();
+          return MANAGED_DETAILS;
+        },
+        readServeHostConfig: async () => {
+          await changeBirthDuringProbe();
+          return JSON.stringify({
+            marker: 'fixture-marker',
+            mcp: { 'agent-teams': { environment: { CLAUDE_TEAM_APP_PROFILE_SCOPE: 'own' } } },
+          });
+        },
+        readProcessStartTimeMs: async () => birth,
+        disposeServeHost,
+        killProcess,
+        forceKillProcess,
+        isProcessAlive: () => true,
+        sleepMs: async () => undefined,
+      });
+      expect(disposeServeHost).toHaveBeenCalledTimes(phase > 1 ? 1 : 0);
+      expect(killProcess).toHaveBeenCalledTimes(phase > 2 ? 1 : 0);
+      expect(forceKillProcess).not.toHaveBeenCalled();
+      expect(result.killed).toBe(0);
+      expect(result.candidates[0]).toMatchObject({
+        action: 'kept_unmanaged',
+        reason: [
+          'pid identity changed before graceful dispose',
+          'pid identity changed before cleanup signal',
+          'pid identity changed before force kill',
+        ][phase - 1],
+      });
+    });
+  });
+
   it('records default identity probe diagnostics and never kills an unreadable Windows identity', async () => {
     const exec = vi.mocked(childProcess.execFile).mockImplementation((...args: unknown[]) => {
       const callback = args[3] as (error: Error, stdout: string, stderr: string) => void;

--- a/test/renderer/store/teamSlice.test.ts
+++ b/test/renderer/store/teamSlice.test.ts
@@ -6414,9 +6414,7 @@ describe('teamSlice actions', () => {
       expect(store.getState().provisioningRuns['run-real']).toBeUndefined();
       expect(store.getState().ignoredProvisioningRunIds['run-real']).toBe('my-team');
       expect(store.getState().ignoredRuntimeRunIds['run-real']).toBe('my-team');
-      expect(store.getState().provisioningErrorByTeam['my-team']).toBe(
-        'MCP initialize timed out'
-      );
+      expect(store.getState().provisioningErrorByTeam['my-team']).toBe('MCP initialize timed out');
 
       store.getState().onProvisioningProgress({
         runId: 'run-late',
@@ -6483,6 +6481,64 @@ describe('teamSlice actions', () => {
       await newRejection;
       vi.useRealTimers();
     });
+
+    it.each(['createTeam', 'launchTeam'] as const)(
+      '%s clears cleanup busy pending state and waits for an explicit retry',
+      async (operation) => {
+        vi.useFakeTimers();
+        const store = createSliceStore();
+        store.setState({ selectedTeamName: 'my-team', selectedTeamLoading: true });
+        const response = createDeferredPromise<{ runId: string }>();
+        const message =
+          'OpenCode startup cleanup is still running. Wait for cleanup to finish, then retry starting the team.';
+        hoisted[operation].mockImplementationOnce(() => response.promise);
+        const request = { teamName: 'my-team', cwd: '/tmp/cleanup-store-fixture', members: [] };
+        const attempt = store.getState()[operation](request);
+        const rejection = expect(attempt).rejects.toMatchObject({
+          name: 'IpcError',
+          message,
+        });
+        const pendingRunId = store.getState().currentProvisioningRunIdByTeam['my-team'];
+        expect(pendingRunId).toMatch(/^pending:/);
+        // Admission has not emitted canonical progress; pending run state is enough.
+        // Preload reconstructs a plain Error from the main IpcResult.
+        response.reject(new Error(message));
+        await rejection;
+        expect(store.getState().provisioningErrorByTeam['my-team']).toBe(message);
+        expect(store.getState().currentProvisioningRunIdByTeam['my-team']).toBeUndefined();
+        expect(store.getState().currentRuntimeRunIdByTeam['my-team']).toBeUndefined();
+        expect(store.getState().provisioningRuns).toEqual({});
+        expect(store.getState().provisioningSnapshotByTeam['my-team']).toBeUndefined();
+        expect(store.getState().selectedTeamLoading).toBe(false);
+        expect(store.getState().teamsLoading).toBe(false);
+        expect(store.getState().launchParamsByTeam['my-team']).toBeUndefined();
+        await vi.advanceTimersByTimeAsync(120_000);
+        expect(hoisted[operation]).toHaveBeenCalledTimes(1);
+        expect(
+          hoisted.getProvisioningStatus.mock.calls.some(([runId]) => runId === pendingRunId)
+        ).toBe(false);
+        expect(
+          hoisted[operation === 'createTeam' ? 'launchTeam' : 'createTeam']
+        ).not.toHaveBeenCalled();
+
+        // Admission has become available; changing the response alone must not retry.
+        hoisted[operation].mockResolvedValue({ runId: 'retry-run' });
+        await vi.advanceTimersByTimeAsync(120_000);
+        expect(hoisted[operation]).toHaveBeenCalledTimes(1);
+        hoisted.getProvisioningStatus.mockResolvedValue({
+          runId: 'retry-run',
+          teamName: 'my-team',
+          state: 'ready',
+          message: 'Ready',
+          startedAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        });
+        await expect(store.getState()[operation](request)).resolves.toBe('retry-run');
+        expect(hoisted[operation]).toHaveBeenCalledTimes(2);
+        expect(store.getState().provisioningErrorByTeam['my-team']).toBeUndefined();
+        expect(store.getState().currentProvisioningRunIdByTeam['my-team']).toBe('retry-run');
+      }
+    );
 
     it('rolls back optimistic pending run on early createTeam failure', async () => {
       const store = createSliceStore();


### PR DESCRIPTION
Windows team starts could pass the startup cleanup gate after 60 seconds while cleanup was still running. Preparation errors were swallowed, and forced process termination lacked the fresh PID identity check used by the initial termination path.

Reject Windows starts while startup cleanup is pending and require manual retry. Preserve the busy error through IPC/preload and clear temporary renderer state. Keep known non-OpenCode teams unblocked and protect saved launches with unknown members. Recheck process birth after awaited ownership probes and before Windows direct-termination fallback. Unix signal behavior is preserved.

Validation: 442 tests across gate/API/IPC/store suites passed, and 61 process-cleanup tests passed separately, including PID replacement during ownership checks and unavailable/replaced identity before termination. These suites are included in Windows CI. The integrated head is awaiting CI and independent review.

This checkpoint does not increase probe budgets or prove that externally dispatched cleanup operations have drained. The remaining cleanup timing and packaged-runtime qualification are still open in the Windows report fix plan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows team creation and launch handling while startup cleanup is in progress. Requests now report a temporary busy state rather than proceeding unsafely.
  - Users can retry team creation or launch explicitly after cleanup finishes.
  - Improved protection against terminating the wrong process when identifiers are reused or ownership changes during cleanup.
- **Reliability**
  - Team provisioning errors now consistently clear loading and pending states without triggering unintended automatic retries.
  - Improved cross-platform handling while startup cleanup is pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->