### PR TITLE
fix(opencode): pin qualified Windows startup runtime 0.0.94

### DIFF
--- a/.github/workflows/opencode-packaged-e2e.yml
+++ b/.github/workflows/opencode-packaged-e2e.yml
@@ -10,6 +10,7 @@ on:
       - scripts/e2e/opencode-diagnostics-desktop.mjs
       - scripts/e2e/opencode-diagnostics/platform.mjs
       - scripts/e2e/opencode-diagnostics/catalog.mjs
+      - runtime.lock.json
 
 permissions:
   contents: read
@@ -60,6 +61,33 @@ jobs:
           $executable = (Resolve-Path 'release/win-unpacked/AgentTeamsAI.exe').Path
           node scripts/e2e/opencode-diagnostics/run-packaged.mjs --packaged-executable $executable --runtime-setup app-install
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Archive qualified Windows test build
+        shell: pwsh
+        run: |
+          $archive = "AgentTeamsAI-windows-test-$env:GITHUB_SHA.zip"
+          Compress-Archive -Path release/win-unpacked -DestinationPath "release/$archive"
+          $digest = (Get-FileHash "release/$archive" -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$digest  $archive" | Set-Content release/test-build-SHA256SUMS.txt
+          @"
+          Windows test build, not an installer or an updater release.
+          Source commit: $env:GITHUB_SHA
+          Runtime version: $((Get-Content runtime.lock.json | ConvertFrom-Json).version)
+          Extract the ZIP. Do not launch AgentTeamsAI.exe directly with your everyday profile.
+          Use the separate disposable-profile instructions supplied with this test build.
+          Do not launch teams in real projects.
+          Qualification reports and screenshots are in opencode-packaged-windows-$env:GITHUB_SHA.
+          "@ | Set-Content release/test-build-README.txt
+      - name: Preserve qualified Windows test build
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencode-windows-test-build-${{ github.sha }}
+          retention-days: 14
+          if-no-files-found: error
+          compression-level: 0
+          path: |
+            release/AgentTeamsAI-windows-test-*.zip
+            release/test-build-SHA256SUMS.txt
+            release/test-build-README.txt
       - name: Preserve qualification evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/runtime.lock.json
+++ b/runtime.lock.json
@@ -1,40 +1,40 @@
 {
-  "version": "0.0.87",
+  "version": "0.0.94",
   "cliVersion": "2.1.251",
-  "sourceRef": "v0.0.87",
+  "sourceRef": "v0.0.94",
   "sourceRepository": "777genius/agent_teams_orchestrator",
   "releaseRepository": "777genius/agent_teams_orchestrator_binaries",
-  "releaseTag": "runtime-v0.0.87",
+  "releaseTag": "runtime-v0.0.94",
   "assets": {
     "darwin-arm64": {
-      "file": "agent-teams-runtime-darwin-arm64-v0.0.87.tar.gz",
+      "file": "agent-teams-runtime-darwin-arm64-v0.0.94.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "3ce02d517a19685eeacde08e51f6c1b1b1fbd239b08cf96cd82f9bd8a12ad41d"
+      "sha256": "e683b7dfb0bd34c3bb9c794544cf61060f64aab9a49f101e219941e4121ead14"
     },
     "darwin-x64": {
-      "file": "agent-teams-runtime-darwin-x64-v0.0.87.tar.gz",
+      "file": "agent-teams-runtime-darwin-x64-v0.0.94.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "5483b3e1f157c5b28ab3a59a8e7617e3f614a2f564f5ba77f1f7589bf646e3cd"
+      "sha256": "aa762f0caaff00fe27e6ee5b978dec8b22a9cda1775e3f90cf8ab90115c73ee2"
     },
     "linux-x64": {
-      "file": "agent-teams-runtime-linux-x64-v0.0.87.tar.gz",
+      "file": "agent-teams-runtime-linux-x64-v0.0.94.tar.gz",
       "archiveKind": "tar.gz",
       "binaryName": "claude-multimodel",
-      "sha256": "7d335c727cc13d47bd280f8dc719eca3584a761954c050dcc354ea16f6de4175"
+      "sha256": "fd1d40c35d572aaaa052c08b93a767c97d4758db00456b9c30ee4bf68d0e29c1"
     },
     "win32-arm64": {
-      "file": "agent-teams-runtime-win32-arm64-v0.0.87.zip",
+      "file": "agent-teams-runtime-win32-arm64-v0.0.94.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "0d63d4704e018fb5c64e29213a5fc46e2099e4bc6f02e7496337f63e4356c12c"
+      "sha256": "4870012fec3b71d9ae1ec7ae98f47a2c7199ae9b3bd0427e329b1fec97868100"
     },
     "win32-x64": {
-      "file": "agent-teams-runtime-win32-x64-v0.0.87.zip",
+      "file": "agent-teams-runtime-win32-x64-v0.0.94.zip",
       "archiveKind": "zip",
       "binaryName": "claude-multimodel.exe",
-      "sha256": "f4f36d3f3697fcb3208e7bfc784829a447d8c7faf65570479fa0b4a92ed1ef5d"
+      "sha256": "2c965232fd9de629e36d5e0241609b6693bad04506cffa657a0a3c0ebea66da2"
     }
   }
 }


### PR DESCRIPTION
Pins runtime 0.0.94 with the verified Windows startup cleanup contract. The packaged workflow retains the qualified Windows test build and SHA-256 checksum only after cold and two warm catalog checks pass. No frontend release or updater publication is included.

Validation at head 46d4b786847be3f1c2fd99166e6c8e57324455fe:
- Full CI [34460656748](https://github.com/777genius/agent-teams-ai/actions/runs/34460656748) passed.
- Packaged Windows E2E and handoff archive [34460656760](https://github.com/777genius/agent-teams-ai/actions/runs/34460656760) passed. The tested merge commit 2eeca3db26665562920542bfaa3afdc8049b23a7 has the same Git tree as this head (d0d997a07716b629af9a1e7690677143e5b23347).
- All three starts used the same app-managed OpenCode 1.18.30 and returned nine models from three sources through fresh UI requests. Independent evidence review confirmed the matching payloads and rendered inventory.
- Downloaded archive SHA-256 e7b7842970aeccece7e570c553e4a4ea12687453a57d3337b37080ec9602e12b matches its checksum; app, app.asar, orchestrator and renderer fingerprints match the qualified artifacts.
- Runtime v0.0.94 source and binary releases were published with explicit owner authorization. Anonymous bootstrap [34460656828](https://github.com/777genius/agent-teams-ai/actions/runs/34460656828) passed on Linux, Windows and both macOS architectures after publication. Published asset digests are unchanged from the qualified draft.
- Independent workflow review completed; handoff README requires separate disposable-profile instructions. ReviewRouter failed authentication and supplied no code findings.

PR #646 is merged; this PR now targets main and changes only runtime.lock.json and the packaged workflow. Passive summary does not prove authentication, generation or agent launch readiness; original reporter verification remains separate.

Runtime source: https://github.com/777genius/agent_teams_orchestrator/pull/85 and https://github.com/777genius/agent_teams_orchestrator/pull/86.
