### PR TITLE
test(opencode): qualify Windows settings with an unreleased runtime candidate

### DIFF
--- a/.github/workflows/opencode-packaged-e2e.yml
+++ b/.github/workflows/opencode-packaged-e2e.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - .github/workflows/opencode-packaged-e2e.yml
       - scripts/e2e/opencode-diagnostics/packaged*.mjs
+      - scripts/e2e/opencode-diagnostics/stage-candidate.mjs
       - scripts/e2e/opencode-diagnostics/run-packaged.mjs
       - scripts/e2e/opencode-diagnostics-desktop.mjs
       - scripts/e2e/opencode-diagnostics/platform.mjs

--- a/.github/workflows/opencode-packaged-e2e.yml
+++ b/.github/workflows/opencode-packaged-e2e.yml
@@ -66,6 +66,13 @@ jobs:
         run: node scripts/stage-opencode-console-wrapper.mjs --platform win32-x64 --require
       - name: Package without publishing
         run: pnpm pack:win:x64 --dir --publish never
+      - name: Verify packaged candidate identity
+        if: inputs.runtime_candidate_run != ''
+        shell: pwsh
+        run: |
+          $candidate = Get-Content runtime-candidate-evidence.json | ConvertFrom-Json
+          $packagedHash = (Get-FileHash 'release/win-unpacked/resources/runtime/claude-multimodel.exe' -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($packagedHash -ne $candidate.binarySha256) { throw 'Packaging replaced the verified runtime candidate' }
       - name: Validate bundle
         run: node scripts/electron-builder/verifyBundle.cjs release/win-unpacked win32 x64
       - name: Qualify cold and warm packaged starts

--- a/.github/workflows/opencode-packaged-e2e.yml
+++ b/.github/workflows/opencode-packaged-e2e.yml
@@ -2,6 +2,15 @@ name: OpenCode packaged Windows E2E
 
 on:
   workflow_dispatch:
+    inputs:
+      runtime_candidate_run:
+        description: 'Optional successful runtime CI run for test-only packaging'
+        type: string
+        default: ''
+      runtime_candidate_sha:
+        description: 'Exact runtime source SHA (required with candidate run)'
+        type: string
+        default: ''
   pull_request:
     paths:
       - .github/workflows/opencode-packaged-e2e.yml
@@ -38,6 +47,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RUNTIME_BUILD_DISPATCH_TOKEN }}
         run: node scripts/stage-runtime.mjs --platform win32-x64
+      - name: Stage verified test-only runtime candidate
+        if: inputs.runtime_candidate_run != '' || inputs.runtime_candidate_sha != ''
+        env:
+          GH_TOKEN: ${{ secrets.RUNTIME_BUILD_DISPATCH_TOKEN }}
+          RUNTIME_CANDIDATE_RUN: ${{ inputs.runtime_candidate_run }}
+          RUNTIME_CANDIDATE_SHA: ${{ inputs.runtime_candidate_sha }}
+        run: node scripts/e2e/opencode-diagnostics/stage-candidate.mjs
       - name: Stage pinned terminal runtime
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -71,7 +87,9 @@ jobs:
           @"
           Windows test build, not an installer or an updater release.
           Source commit: $env:GITHUB_SHA
-          Runtime version: $((Get-Content runtime.lock.json | ConvertFrom-Json).version)
+          Runtime payload version: $((Get-Content runtime.lock.json | ConvertFrom-Json).version)
+          Runtime candidate source (empty for published pin): ${{ inputs.runtime_candidate_sha }}
+          If a candidate source is present this is an unreleased test runtime. See runtime-candidate-evidence.json.
           Extract the ZIP. Do not launch AgentTeamsAI.exe directly with your everyday profile.
           Use the separate disposable-profile instructions supplied with this test build.
           Do not launch teams in real projects.
@@ -88,6 +106,7 @@ jobs:
             release/AgentTeamsAI-windows-test-*.zip
             release/test-build-SHA256SUMS.txt
             release/test-build-README.txt
+            runtime-candidate-evidence.json
       - name: Preserve qualification evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/opencode-packaged-e2e.yml
+++ b/.github/workflows/opencode-packaged-e2e.yml
@@ -15,7 +15,7 @@ on:
     paths:
       - .github/workflows/opencode-packaged-e2e.yml
       - scripts/e2e/opencode-diagnostics/packaged*.mjs
-      - scripts/e2e/opencode-diagnostics/stage-candidate.mjs
+      - scripts/e2e/opencode-diagnostics/stage-candidate*.mjs
       - scripts/e2e/opencode-diagnostics/run-packaged.mjs
       - scripts/e2e/opencode-diagnostics-desktop.mjs
       - scripts/e2e/opencode-diagnostics/platform.mjs
@@ -43,7 +43,7 @@ jobs:
           python-version: '3.11'
       - run: pnpm install --frozen-lockfile
       - name: Verify harness contracts
-        run: node --test scripts/e2e/opencode-diagnostics/platform.test.mjs scripts/e2e/opencode-diagnostics/packaged.test.mjs scripts/e2e/opencode-diagnostics/catalog.test.mjs
+        run: node --test scripts/e2e/opencode-diagnostics/platform.test.mjs scripts/e2e/opencode-diagnostics/packaged.test.mjs scripts/e2e/opencode-diagnostics/catalog.test.mjs scripts/e2e/opencode-diagnostics/stage-candidate.test.mjs
       - name: Stage pinned runtime
         env:
           GH_TOKEN: ${{ secrets.RUNTIME_BUILD_DISPATCH_TOKEN }}

--- a/.github/workflows/opencode-packaged-e2e.yml
+++ b/.github/workflows/opencode-packaged-e2e.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       runtime_candidate_run:
-        description: 'Optional successful runtime CI run for test-only packaging'
+        description: 'Optional runtime CI run with a successful Windows candidate job'
         type: string
         default: ''
       runtime_candidate_sha:

--- a/scripts/e2e/opencode-diagnostics-desktop.mjs
+++ b/scripts/e2e/opencode-diagnostics-desktop.mjs
@@ -221,15 +221,26 @@ if (mode === 'seed-packaged') {
   const ordered = data.packaged
     ? packagedStopOrder(owned, data.artifact.app.path)
     : [...owned].reverse();
-  for (const entry of ordered) {
-    const current = processes().find((p) => p.pid === entry.pid);
-    if (!current) continue;
-    sameIdentity(entry, current);
-    try {
-      process.kill(entry.pid, 'SIGTERM');
-    } catch (error) {
-      if (error.code !== 'ESRCH') throw error;
+  const signals = [];
+  try {
+    for (const entry of ordered) {
+      const record = { expected: entry, at: new Date().toISOString(), outcome: 'checking' };
+      signals.push(record);
+      const current = processes().find((p) => p.pid === entry.pid);
+      record.current = current ?? null;
+      if (!current) { record.outcome = 'missing-from-identity-snapshot'; continue; }
+      sameIdentity(entry, current);
+      try {
+        process.kill(entry.pid, 'SIGTERM');
+        record.outcome = 'signal-returned';
+      } catch (error) {
+        record.outcome = error.code ?? String(error);
+        if (error.code !== 'ESRCH') throw error;
+      }
     }
+  } finally {
+    if (data.packaged)
+      await writeFile(path.join(root, 'cleanup-signals.json'), JSON.stringify(signals, null, 2));
   }
   console.log('Stopped owned test process tree');
 } else if (mode === 'start') {

--- a/scripts/e2e/opencode-diagnostics-desktop.mjs
+++ b/scripts/e2e/opencode-diagnostics-desktop.mjs
@@ -13,6 +13,7 @@ import {
   preparePackagedProfile,
   packagedTarget,
   packagedStopOrder,
+  closePackagedBrowser,
 } from './opencode-diagnostics/packaged.mjs';
 import { verifyPackaged } from './opencode-diagnostics/packaged-verify.mjs';
 import { catalogScenarios, verifyCatalog } from './opencode-diagnostics/catalog.mjs';
@@ -213,10 +214,36 @@ if (mode === 'seed-packaged') {
   await writeFile(path.join(dir, 'manifest.json'), JSON.stringify(data, null, 2));
   console.log(dir);
 } else if (mode === 'stop') {
-  const owned = await ownedProcesses();
+  let owned = await ownedProcesses();
   const data = await manifest();
   if (data.packaged)
     await writeFile(path.join(root, 'cleanup-identities.json'), JSON.stringify(owned, null, 2));
+  if (data.packaged) {
+    const graceful = { at: new Date().toISOString() };
+    try {
+      graceful.outcome = await closePackagedBrowser({
+        assertOwnership: assertOwnedDebugEndpoint,
+        readVersion: async () => (await fetch('http://127.0.0.1:9222/json/version', {
+          signal: AbortSignal.timeout(5000),
+        })).json(),
+        connect: endpoint => new WebSocket(endpoint),
+      });
+      const deadline = Date.now() + 5000;
+      while (Date.now() < deadline) {
+        const snapshot = processes();
+        if (!owned.some(entry => entry.pid !== data.launcher.pid && snapshot.some(current =>
+          entry.pid === current.pid && entry.birth === current.birth))) break;
+        await delay(100);
+      }
+    } catch (error) {
+      graceful.error = String(error); // Identity-checked signals remain the fallback.
+    }
+    await writeFile(path.join(root, 'cleanup-graceful.json'), JSON.stringify(graceful, null, 2));
+    const survivors = await ownedProcesses();
+    for (const entry of survivors)
+      if (!owned.some(prior => prior.pid === entry.pid && prior.birth === entry.birth)) owned.push(entry);
+    await writeFile(path.join(root, 'cleanup-identities.json'), JSON.stringify(owned, null, 2));
+  }
   // Capture identities before cleanup; never use taskkill /T or a process-group signal.
   const ordered = data.packaged
     ? packagedStopOrder(owned, data.artifact.app.path)

--- a/scripts/e2e/opencode-diagnostics-desktop.mjs
+++ b/scripts/e2e/opencode-diagnostics-desktop.mjs
@@ -12,6 +12,7 @@ import {
   packagedArtifact,
   preparePackagedProfile,
   packagedTarget,
+  packagedStopOrder,
 } from './opencode-diagnostics/packaged.mjs';
 import { verifyPackaged } from './opencode-diagnostics/packaged-verify.mjs';
 import { catalogScenarios, verifyCatalog } from './opencode-diagnostics/catalog.mjs';
@@ -213,10 +214,14 @@ if (mode === 'seed-packaged') {
   console.log(dir);
 } else if (mode === 'stop') {
   const owned = await ownedProcesses();
-  if ((await manifest()).packaged)
+  const data = await manifest();
+  if (data.packaged)
     await writeFile(path.join(root, 'cleanup-identities.json'), JSON.stringify(owned, null, 2));
   // Capture identities before cleanup; never use taskkill /T or a process-group signal.
-  for (const entry of owned.reverse()) {
+  const ordered = data.packaged
+    ? packagedStopOrder(owned, data.artifact.app.path)
+    : [...owned].reverse();
+  for (const entry of ordered) {
     const current = processes().find((p) => p.pid === entry.pid);
     if (!current) continue;
     sameIdentity(entry, current);

--- a/scripts/e2e/opencode-diagnostics/packaged-verify.mjs
+++ b/scripts/e2e/opencode-diagnostics/packaged-verify.mjs
@@ -412,6 +412,28 @@ export async function qualifyUIRefresh(records, completed) {
   return { sources, modelIds };
 }
 
+export function settingsRefreshSettled(observation, now, quietMs = 500) {
+  const records = observation.records;
+  return !observation.overflow && records.some(record =>
+    record.method === 'loadProviderDirectory' && record.input?.runtimeId === 'opencode'
+    && record.input.refresh === true && record.input.summary !== true)
+    && records.every(record => Number.isFinite(record.completedAt) && record.response
+      && !record.error && !record.response.error && now - record.completedAt >= quietMs
+      && record.response.schemaVersion === 1 && record.response.runtimeId === 'opencode'
+      && (record.method === 'loadProviderDirectory'
+        ? record.response.directory?.runtimeId === 'opencode'
+          && Array.isArray(record.response.directory.entries)
+          && record.response.directory.returnedCount === record.response.directory.entries.length
+          && Number.isInteger(record.response.directory.totalCount)
+          && record.response.directory.totalCount >= record.response.directory.returnedCount
+          && Array.isArray(record.response.directory.diagnostics)
+          && record.response.directory.diagnostics.length === 0
+        : record.method === 'loadModels'
+          && record.response.models?.catalogState === 'fresh'
+          && record.response.models?.runtimeId === 'opencode'
+          && Array.isArray(record.response.models.models)));
+}
+
 export function qualifySettings(response) {
   assert.equal(response?.schemaVersion, 1);
   assert.equal(response.runtimeId, 'opencode');
@@ -691,6 +713,24 @@ export async function verifyPackaged({
       settingsRendered = settingsRendered && !requests.overflow && requests.records.length > 0
         && requests.records.every(record => record.completedAt && record.response && !record.error && !record.response.error);
       if (settingsRendered) break;
+      await pause(250);
+    }
+    assert(settingsRendered, 'Provider settings initial load did not finish');
+    await observe('globalThis.__packagedCatalogObservation.records = []');
+    await clickControl(evaluate, send,
+      `document.querySelector('[role="dialog"] [data-testid="runtime-provider-refresh-catalog"]:not(:disabled)')`);
+    settingsRendered = false;
+    for (let attempt = 0; attempt < 360; attempt++) {
+      const requests = await observe('globalThis.__packagedCatalogObservation');
+      const now = await observe('Date.now()');
+      const ready = await evaluate(`Boolean(document.querySelector('[role="dialog"] [data-testid="runtime-provider-catalog-list"]'))
+        && Boolean(document.querySelector('[role="dialog"] [data-testid="runtime-provider-refresh-catalog"]:not(:disabled)'))
+        && !document.querySelector('[role="dialog"] [data-testid="runtime-provider-loading-skeleton"]')`);
+      if (ready && settingsRefreshSettled(requests, now)) {
+        settingsRendered = true;
+        evidence.settingsRefresh = requests.records;
+        break;
+      }
       await pause(250);
     }
     await shot('provider-settings');

--- a/scripts/e2e/opencode-diagnostics/packaged-verify.mjs
+++ b/scripts/e2e/opencode-diagnostics/packaged-verify.mjs
@@ -412,6 +412,18 @@ export async function qualifyUIRefresh(records, completed) {
   return { sources, modelIds };
 }
 
+export function qualifySettings(response) {
+  assert.equal(response?.schemaVersion, 1);
+  assert.equal(response.runtimeId, 'opencode');
+  assert(!response.error, 'Provider settings returned a runtime error');
+  const view = response.view;
+  assert.equal(view?.runtimeId, 'opencode');
+  assert(['ready', 'needs-auth'].includes(view.runtime?.state), 'Provider settings is incomplete');
+  assert(Array.isArray(view.providers) && Array.isArray(view.configuredModels));
+  assert(Array.isArray(view.diagnostics) && view.diagnostics.length === 0, 'Settings diagnostics present');
+  return { state: view.runtime.state, providers: view.providers.length, models: view.configuredModels.length };
+}
+
 export async function verifyPackaged({
   root,
   data,
@@ -658,6 +670,34 @@ export async function verifyPackaged({
       ''
     );
     await shot('dashboard');
+    // Native preload -> IPC -> compact runtime view, repeated in each cold/warm run.
+    // This supplements the UI catalog check; it does not claim settings UI coverage.
+    evidence.settings = [];
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const response = await probe(
+        `settings-${attempt + 1}`,
+        'window.electronAPI.runtimeProviderManagement.loadView({runtimeId:"opencode",projectPath:null})',
+        95000
+      );
+      evidence.settings.push(qualifySettings(response));
+    }
+    await observe('globalThis.__packagedCatalogObservation.records = []; globalThis.__packagedCatalogObservation.active = true');
+    await clickControl(evaluate, send, `document.querySelector('[data-testid="runtime-manage-opencode"]')`);
+    let settingsRendered = false;
+    for (let attempt = 0; attempt < 360; attempt++) {
+      settingsRendered = await evaluate(`Boolean(document.querySelector('[role="dialog"] [data-testid="runtime-provider-catalog-list"]'))
+        && !document.querySelector('[role="dialog"] [data-testid="runtime-provider-loading-skeleton"]')`);
+      const requests = await observe('globalThis.__packagedCatalogObservation');
+      settingsRendered = settingsRendered && !requests.overflow && requests.records.length > 0
+        && requests.records.every(record => record.completedAt && record.response && !record.error && !record.response.error);
+      if (settingsRendered) break;
+      await pause(250);
+    }
+    await shot('provider-settings');
+    assert(settingsRendered, 'Provider settings dialog did not finish loading');
+    assert(!await evaluate(`Boolean(document.querySelector('[role="dialog"] [data-testid="runtime-provider-directory-error"], [role="dialog"] [data-testid="runtime-provider-error"]'))`),
+      'Provider settings dialog displays an error');
+    evidence.settingsDialog = { rendered: true, completedAt: new Date().toISOString() };
     evidence.passed = true;
   } catch (error) {
     evidence.error = String(error);

--- a/scripts/e2e/opencode-diagnostics/packaged.mjs
+++ b/scripts/e2e/opencode-diagnostics/packaged.mjs
@@ -299,3 +299,48 @@ export function packagedDrainSnapshot(identities, snapshot, listenerPids) {
   return { ownedRemaining, listenerPids,
     drained: ownedRemaining.length === 0 && listenerPids.length === 0 };
 }
+
+// Acknowledgement is diagnostic only; the caller must still prove OS/socket drain.
+export async function closePackagedBrowser({ assertOwnership, readVersion, connect, timeoutMs = 5000 }) {
+  await assertOwnership();
+  const version = await readVersion();
+  const endpoint = new URL(version.webSocketDebuggerUrl);
+  assert(endpoint.protocol === 'ws:' && endpoint.port === '9222'
+    && ['127.0.0.1', 'localhost', '[::1]'].includes(endpoint.hostname)
+    && !endpoint.username && !endpoint.password && endpoint.pathname.startsWith('/devtools/browser/'),
+  'Unexpected packaged browser CDP endpoint');
+  await assertOwnership();
+  const ws = connect(endpoint);
+  try {
+    return await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => finish(new Error('Packaged Browser.close timed out')), timeoutMs);
+      let sent = false;
+      let finished = false;
+      const finish = (error, outcome) => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timer);
+        error ? reject(error) : resolve(outcome);
+      };
+      ws.once('error', error => finish(error));
+      ws.once('close', () => finish(sent ? null : new Error('CDP closed before Browser.close'), 'socket-closed'));
+      ws.on('message', raw => {
+        try {
+          const response = JSON.parse(String(raw));
+          if (response.id === 1) finish(response.error ? new Error(response.error.message) : null, 'acknowledged');
+        } catch (error) { finish(error); }
+      });
+      ws.once('open', async () => {
+        try {
+          await assertOwnership();
+          if (finished) return;
+          if (ws.readyState !== 1) throw new Error('CDP closed during ownership check');
+          ws.send(JSON.stringify({ id: 1, method: 'Browser.close' }));
+          sent = true;
+        } catch (error) { finish(error); }
+      });
+    });
+  } finally {
+    ws.terminate();
+  }
+}

--- a/scripts/e2e/opencode-diagnostics/packaged.mjs
+++ b/scripts/e2e/opencode-diagnostics/packaged.mjs
@@ -284,3 +284,18 @@ export function probeOrchestratorVersion(
     );
   });
 }
+
+// Ownership is established before ordering; executable names alone grant no authority.
+export function packagedStopOrder(owned, executable) {
+  const main = owned.filter(entry => entry.parent === owned[0]?.pid
+    && entry.executable?.toLowerCase() === executable.toLowerCase());
+  assert(main.length <= 1, 'Ambiguous packaged main identity');
+  return [...main, ...owned.filter(entry => entry !== main[0]).reverse()];
+}
+
+export function packagedDrainSnapshot(identities, snapshot, listenerPids) {
+  const ownedRemaining = identities.filter(entry => snapshot.some(current =>
+    current.pid === entry.pid && current.birth === entry.birth));
+  return { ownedRemaining, listenerPids,
+    drained: ownedRemaining.length === 0 && listenerPids.length === 0 };
+}

--- a/scripts/e2e/opencode-diagnostics/packaged.test.mjs
+++ b/scripts/e2e/opencode-diagnostics/packaged.test.mjs
@@ -6,6 +6,8 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   packagedArguments,
+  packagedStopOrder,
+  packagedDrainSnapshot,
   packagedEnvironment,
   packagedTarget,
   containedPath,
@@ -770,4 +772,17 @@ test('settings refresh waits for fresh explicit request and delayed settlement',
   delayed.response.error = 'late failure';
   assert.equal(settingsRefreshSettled(observation, 2400), false);
   assert.equal(settingsRefreshSettled({ records: [{ ...first, input: { refresh: false } }], overflow: false }, 3000), false);
+});
+
+test('packaged cleanup stops main before recovering helpers and drains sockets jointly', () => {
+  const launcher = { pid: 1, birth: 'one' };
+  const main = { pid: 2, parent: 1, birth: 'two', executable: exe };
+  const helper = { pid: 3, parent: 2, birth: 'three', executable: exe };
+  const owned = [launcher, main, helper];
+  assert.deepEqual(packagedStopOrder(owned, exe), [main, helper, launcher]);
+  assert.deepEqual(owned, [launcher, main, helper]);
+  assert.equal(packagedDrainSnapshot(owned, [], [2]).drained, false);
+  assert.equal(packagedDrainSnapshot(owned, [main], []).drained, false);
+  assert.equal(packagedDrainSnapshot(owned, [], []).drained, true);
+  assert.equal(packagedDrainSnapshot(owned, [{ ...main, birth: 'reused' }], [2]).drained, false);
 });

--- a/scripts/e2e/opencode-diagnostics/packaged.test.mjs
+++ b/scripts/e2e/opencode-diagnostics/packaged.test.mjs
@@ -20,6 +20,7 @@ import {
   refreshSettled,
   qualifySummary,
   qualifySettings,
+  settingsRefreshSettled,
   waitForAppVersion,
   qualifyModels,
   collectPages,
@@ -750,4 +751,23 @@ test('native settings qualification rejects degraded or failed reads', () => {
   }
   assert.throws(() => qualifySettings({ ...response, error: { message: 'timeout' } }));
   assert.throws(() => qualifySettings({ ...response, view: { ...response.view, diagnostics: ['HTTP timeout'] } }));
+});
+
+test('settings refresh waits for fresh explicit request and delayed settlement', () => {
+  const first = { method: 'loadProviderDirectory', input: { runtimeId: 'opencode', refresh: true }, response: { schemaVersion: 1, runtimeId: 'opencode', directory: { runtimeId: 'opencode', entries: [], returnedCount: 0, totalCount: 0, diagnostics: [] } }, completedAt: 1000 };
+  const observation = { records: [first], overflow: false };
+  assert.equal(settingsRefreshSettled(observation, 1499), false);
+  assert.equal(settingsRefreshSettled(observation, 1500), true);
+  first.response.directory.diagnostics.push({ message: 'inventory timed out' });
+  assert.equal(settingsRefreshSettled(observation, 1500), false);
+  first.response.directory.diagnostics = [];
+  const delayed = { method: 'loadModels', startedAt: 1400 };
+  observation.records.push(delayed);
+  assert.equal(settingsRefreshSettled(observation, 2000), false);
+  Object.assign(delayed, { response: { schemaVersion: 1, runtimeId: 'opencode', models: { runtimeId: 'opencode', catalogState: 'fresh', models: [] } }, completedAt: 1800 });
+  assert.equal(settingsRefreshSettled(observation, 2000), false);
+  assert.equal(settingsRefreshSettled(observation, 2300), true);
+  delayed.response.error = 'late failure';
+  assert.equal(settingsRefreshSettled(observation, 2400), false);
+  assert.equal(settingsRefreshSettled({ records: [{ ...first, input: { refresh: false } }], overflow: false }, 3000), false);
 });

--- a/scripts/e2e/opencode-diagnostics/packaged.test.mjs
+++ b/scripts/e2e/opencode-diagnostics/packaged.test.mjs
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { EventEmitter } from 'node:events';
 import { execFile } from 'node:child_process';
 import { mkdtemp, mkdir, writeFile, symlink, rm, stat, readdir } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import {
   packagedArguments,
+  closePackagedBrowser,
   packagedStopOrder,
   packagedDrainSnapshot,
   packagedEnvironment,
@@ -785,4 +787,55 @@ test('packaged cleanup stops main before recovering helpers and drains sockets j
   assert.equal(packagedDrainSnapshot(owned, [main], []).drained, false);
   assert.equal(packagedDrainSnapshot(owned, [], []).drained, true);
   assert.equal(packagedDrainSnapshot(owned, [{ ...main, birth: 'reused' }], [2]).drained, false);
+});
+
+function browserCloseFixture({ endpoint = 'ws://127.0.0.1:9222/devtools/browser/test', failCheck = 0, respond = true } = {}) {
+  const socket = new EventEmitter();
+  socket.readyState = 1;
+  const sent = [];
+  let checks = 0;
+  let connected = false;
+  let terminated = false;
+  socket.send = message => {
+    sent.push(JSON.parse(message));
+    if (respond) queueMicrotask(() => socket.emit('message', '{"id":1,"result":{}}'));
+  };
+  socket.terminate = () => { terminated = true; socket.readyState = 3; };
+  return {
+    options: {
+      assertOwnership: async () => { if (++checks === failCheck) throw new Error('PID reused'); },
+      readVersion: async () => ({ webSocketDebuggerUrl: endpoint }),
+      connect: () => { connected = true; queueMicrotask(() => socket.emit('open')); return socket; },
+      timeoutMs: 50,
+    },
+    state: () => ({ sent, checks, connected, terminated }),
+  };
+}
+
+test('graceful packaged cleanup checks ownership before discovery, connection and Browser.close', async () => {
+  const fixture = browserCloseFixture();
+  assert.equal(await closePackagedBrowser(fixture.options), 'acknowledged');
+  assert.deepEqual(fixture.state(), {
+    sent: [{ id: 1, method: 'Browser.close' }], checks: 3, connected: true, terminated: true,
+  });
+});
+
+test('graceful packaged cleanup rejects foreign endpoints and ownership changes', async () => {
+  for (const endpoint of ['ws://foreign:9222/devtools/browser/test', 'ws://127.0.0.1:9223/devtools/browser/test',
+    'ws://127.0.0.1:9222/devtools/page/test', 'ws://user@127.0.0.1:9222/devtools/browser/test']) {
+    const fixture = browserCloseFixture({ endpoint });
+    await assert.rejects(closePackagedBrowser(fixture.options), /Unexpected/);
+    assert.equal(fixture.state().connected, false);
+  }
+  for (const failCheck of [1, 2, 3]) {
+    const fixture = browserCloseFixture({ failCheck });
+    await assert.rejects(closePackagedBrowser(fixture.options), /PID reused/);
+    assert.deepEqual(fixture.state().sent, []);
+  }
+});
+
+test('graceful packaged cleanup bounds an unresponsive browser and closes its socket', async () => {
+  const fixture = browserCloseFixture({ respond: false });
+  await assert.rejects(closePackagedBrowser(fixture.options), /timed out/);
+  assert.equal(fixture.state().terminated, true);
 });

--- a/scripts/e2e/opencode-diagnostics/packaged.test.mjs
+++ b/scripts/e2e/opencode-diagnostics/packaged.test.mjs
@@ -19,6 +19,7 @@ import {
   matchesPackagedPreload,
   refreshSettled,
   qualifySummary,
+  qualifySettings,
   waitForAppVersion,
   qualifyModels,
   collectPages,
@@ -737,4 +738,16 @@ test('main readiness waits only for missing version handler and preserves real f
     }, 0),
     /No handler/
   );
+});
+
+test('native settings qualification rejects degraded or failed reads', () => {
+  const response = { schemaVersion: 1, runtimeId: 'opencode', view: {
+    runtimeId: 'opencode', runtime: { state: 'ready' }, providers: [], configuredModels: [], diagnostics: [],
+  } };
+  assert.equal(qualifySettings(response).state, 'ready');
+  for (const state of ['degraded', 'needs-setup', undefined]) {
+    assert.throws(() => qualifySettings({ ...response, view: { ...response.view, runtime: { state } } }));
+  }
+  assert.throws(() => qualifySettings({ ...response, error: { message: 'timeout' } }));
+  assert.throws(() => qualifySettings({ ...response, view: { ...response.view, diagnostics: ['HTTP timeout'] } }));
 });

--- a/scripts/e2e/opencode-diagnostics/platform.mjs
+++ b/scripts/e2e/opencode-diagnostics/platform.mjs
@@ -235,3 +235,25 @@ export function assertLauncherCommand(launcher) {
     'Launcher command changed; refusing access/cleanup'
   );
 }
+
+// Read-only failure evidence. Missing identity never grants signal authority.
+export function windowsCleanupEvidence(pids) {
+  assert(pids.every(pid => Number.isInteger(pid) && pid > 0));
+  assert(pids.length <= 500, 'Cleanup evidence PID bound exceeded');
+  if (!windows) return null;
+  const ids = [...new Set(pids)].join(',');
+  return JSON.parse(powershell(`
+    $targets = @(${ids});
+    $cim = @(Get-CimInstance Win32_Process | Where-Object { $targets -contains [int]$_.ProcessId } | ForEach-Object {
+      [pscustomobject]@{ pid=[int]$_.ProcessId; parent=[int]$_.ParentProcessId; creationDate=$_.CreationDate; executable=$_.ExecutablePath }
+    });
+    $native = @($targets | ForEach-Object {
+      $targetPid = $_;
+      try { $proc = Get-Process -Id $targetPid -ErrorAction Stop;
+        [pscustomobject]@{ pid=$targetPid; startTime=$proc.StartTime.ToUniversalTime().ToString('o'); hasExited=$proc.HasExited }
+      } catch { [pscustomobject]@{ pid=$targetPid; error=$_.Exception.Message } }
+    });
+    $tcp = @(Get-NetTCPConnection | Where-Object { $_.LocalPort -eq 9222 } | Select-Object LocalAddress,LocalPort,State,OwningProcess);
+    @{ cim=$cim; native=$native; tcp=$tcp } | ConvertTo-Json -Depth 5 -Compress
+  `).replace(/^\uFEFF/, '').trim());
+}

--- a/scripts/e2e/opencode-diagnostics/platform.test.mjs
+++ b/scripts/e2e/opencode-diagnostics/platform.test.mjs
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   parseWindowsProcesses,
+  windowsCleanupEvidence,
   parseUnixProcesses,
   parseListeners,
   ownedTree,
@@ -160,4 +161,11 @@ test('timeout fixture stays live until its owning test terminates it', async () 
     if (child && child.exitCode === null) child.kill();
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test('Windows cleanup evidence retains current PID through independent read-only queries', { skip: process.platform !== 'win32' }, () => {
+  const evidence = windowsCleanupEvidence([process.pid]);
+  assert(evidence.cim.some(entry => entry.pid === process.pid && entry.creationDate));
+  assert(evidence.native.some(entry => entry.pid === process.pid && entry.startTime && entry.hasExited === false));
+  assert(Array.isArray(evidence.tcp));
 });

--- a/scripts/e2e/opencode-diagnostics/run-packaged.mjs
+++ b/scripts/e2e/opencode-diagnostics/run-packaged.mjs
@@ -6,7 +6,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { open, readFile, writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { packagedArguments } from './packaged.mjs';
+import { packagedArguments, packagedDrainSnapshot } from './packaged.mjs';
 import { processes, listeners, sameIdentity } from './platform.mjs';
 
 const args = process.argv.slice(2);
@@ -98,30 +98,24 @@ for (const run of ['cold', 'warm-1', 'warm-2']) {
         JSON.stringify(identities, null, 2)
       );
       const deadline = Date.now() + 15000;
-      let alive;
+      let drain;
       do {
-        const snapshot = processes();
-        alive = identities.filter((entry) =>
-          snapshot.some((now) => now.pid === entry.pid && now.birth === entry.birth)
-        );
-        if (!alive.length) break;
+        drain = packagedDrainSnapshot(identities, processes(), listeners());
+        if (drain.drained) break;
         await new Promise((resolve) => setTimeout(resolve, 250));
       } while (Date.now() < deadline);
-      assert.equal(alive.length, 0, 'Owned processes survived cleanup; refusing warm restart');
-      const listenerPids = listeners();
       await writeFile(
         path.join(runDir, 'cleanup.json'),
         JSON.stringify(
           {
             at: new Date().toISOString(),
-            ownedRemaining: alive,
-            listenerPids,
+            ...drain,
           },
           null,
           2
         )
       );
-      assert.equal(listenerPids.length, 0, 'Port occupied after cleanup; refusing warm restart');
+      assert(drain.drained, 'Owned processes or CDP listener survived cleanup; refusing warm restart');
       const current = JSON.parse(await readFile(manifestPath, 'utf8'));
       sameIdentity(ownedManifest.launcher, current.launcher);
       delete current.launcher;

--- a/scripts/e2e/opencode-diagnostics/run-packaged.mjs
+++ b/scripts/e2e/opencode-diagnostics/run-packaged.mjs
@@ -7,7 +7,7 @@ import { open, readFile, writeFile, mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { packagedArguments, packagedDrainSnapshot } from './packaged.mjs';
-import { processes, listeners, sameIdentity } from './platform.mjs';
+import { processes, listeners, sameIdentity, windowsCleanupEvidence } from './platform.mjs';
 
 const args = process.argv.slice(2);
 packagedArguments(args); // Validate before creating a profile or launching anything.
@@ -115,6 +115,12 @@ for (const run of ['cold', 'warm-1', 'warm-2']) {
           2
         )
       );
+      if (!drain.drained) {
+        let diagnostic;
+        try { diagnostic = windowsCleanupEvidence([...new Set([...identities.map(p => p.pid), ...drain.listenerPids])]); }
+        catch (error) { diagnostic = { collectionError: String(error) }; }
+        await writeFile(path.join(runDir, 'cleanup-os.json'), JSON.stringify(diagnostic, null, 2));
+      }
       assert(drain.drained, 'Owned processes or CDP listener survived cleanup; refusing warm restart');
       const current = JSON.parse(await readFile(manifestPath, 'utf8'));
       sameIdentity(ownedManifest.launcher, current.launcher);

--- a/scripts/e2e/opencode-diagnostics/stage-candidate.mjs
+++ b/scripts/e2e/opencode-diagnostics/stage-candidate.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdtemp, readFile, writeFile, copyFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+// Explicit CI-only test packaging. Never edits runtime.lock or publishes a release.
+const repo = '777genius/agent_teams_orchestrator';
+const runId = process.env.RUNTIME_CANDIDATE_RUN;
+const sha = process.env.RUNTIME_CANDIDATE_SHA;
+assert(process.env.GITHUB_ACTIONS === 'true' && process.platform === 'win32');
+assert(/^\d+$/.test(runId ?? ''), 'Expected numeric candidate CI run');
+assert(/^[a-f0-9]{40}$/.test(sha ?? ''), 'Expected exact candidate source SHA');
+const gh = (...args) => execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] });
+const api = (endpoint) => JSON.parse(gh('api', endpoint));
+const run = api(`repos/${repo}/actions/runs/${runId}`);
+assert.equal(run.head_sha, sha, 'Candidate source mismatch');
+assert.equal(run.head_repository.full_name, repo, 'Foreign candidate repository');
+assert.equal(run.path, '.github/workflows/ci.yml', 'Not the runtime CI workflow');
+assert.equal(run.status, 'completed', 'Runtime CI is not complete');
+assert.equal(run.conclusion, 'success', 'Runtime CI did not pass');
+const pkg = api(`repos/${repo}/contents/package.json?ref=${sha}`);
+const sourceVersion = JSON.parse(Buffer.from(pkg.content, 'base64').toString('utf8')).version;
+const lock = JSON.parse(await readFile('runtime.lock.json', 'utf8'));
+assert.equal(sourceVersion, lock.version, 'Candidate packaging requires the same payload version');
+const name = `opencode-windows-runtime-candidate-${sha}`;
+const listing = api(`repos/${repo}/actions/runs/${runId}/artifacts?per_page=100`);
+const matches = listing.artifacts.filter(item => item.name === name && !item.expired);
+assert.equal(matches.length, 1, 'Missing or ambiguous candidate artifact');
+const artifact = matches[0];
+assert(/^sha256:[a-f0-9]{64}$/.test(artifact.digest ?? ''), 'Missing artifact integrity digest');
+const temp = await mkdtemp(path.join(os.tmpdir(), 'opencode-candidate-'));
+try {
+  // Verify the archive itself against GitHub's immutable artifact digest before extraction.
+  const archive = execFileSync('gh', ['api', `repos/${repo}/actions/artifacts/${artifact.id}/zip`], {
+    maxBuffer: 256 * 1024 * 1024,
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  assert.equal(`sha256:${createHash('sha256').update(archive).digest('hex')}`, artifact.digest);
+  const archivePath = path.join(temp, 'candidate.zip');
+  await writeFile(archivePath, archive);
+  const extract = path.join(temp, 'payload');
+  execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command',
+    'Expand-Archive -LiteralPath $env:OC_CANDIDATE_ARCHIVE -DestinationPath $env:OC_CANDIDATE_EXTRACT'], {
+    env: { ...process.env, OC_CANDIDATE_ARCHIVE: archivePath, OC_CANDIDATE_EXTRACT: extract },
+    stdio: 'inherit',
+  });
+  const binary = path.join(extract, 'cli.exe');
+  const bytes = await readFile(binary);
+  assert(bytes.length > 1024 && bytes.subarray(0, 2).toString() === 'MZ', 'Not a Windows executable');
+  const binarySha256 = createHash('sha256').update(bytes).digest('hex');
+  await copyFile(binary, 'resources/runtime/claude-multimodel.exe');
+  const provenance = { schemaVersion: 1, testOnly: true, repository: repo, runId, sourceSha: sha,
+    sourceVersion, artifactId: artifact.id, artifactDigest: artifact.digest, binarySha256 };
+  await writeFile('resources/runtime/TEST-CANDIDATE.json', JSON.stringify(provenance, null, 2));
+  await writeFile('runtime-candidate-evidence.json', JSON.stringify(provenance, null, 2));
+  console.log(JSON.stringify(provenance));
+} finally {
+  await rm(temp, { recursive: true, force: true });
+}

--- a/scripts/e2e/opencode-diagnostics/stage-candidate.mjs
+++ b/scripts/e2e/opencode-diagnostics/stage-candidate.mjs
@@ -4,61 +4,96 @@ import { createHash } from 'node:crypto';
 import { mkdtemp, readFile, writeFile, copyFile, rm } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-// Explicit CI-only test packaging. Never edits runtime.lock or publishes a release.
-const repo = '777genius/agent_teams_orchestrator';
-const runId = process.env.RUNTIME_CANDIDATE_RUN;
-const sha = process.env.RUNTIME_CANDIDATE_SHA;
-assert(process.env.GITHUB_ACTIONS === 'true' && process.platform === 'win32');
-assert(/^\d+$/.test(runId ?? ''), 'Expected numeric candidate CI run');
-assert(/^[a-f0-9]{40}$/.test(sha ?? ''), 'Expected exact candidate source SHA');
-const gh = (...args) => execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] });
-const api = (endpoint) => JSON.parse(gh('api', endpoint));
-const run = api(`repos/${repo}/actions/runs/${runId}`);
-assert.equal(run.head_sha, sha, 'Candidate source mismatch');
-assert.equal(run.head_repository.full_name, repo, 'Foreign candidate repository');
-assert.equal(run.path, '.github/workflows/ci.yml', 'Not the runtime CI workflow');
-// Qualification can run alongside the remaining CI suites. Delivery still requires full CI.
-const jobs = api(`repos/${repo}/actions/runs/${runId}/jobs?per_page=100`);
-const producers = jobs.jobs.filter(job => job.name === 'Windows packaged backfill (candidate)');
-assert.equal(producers.length, 1, 'Missing or ambiguous candidate producer');
-assert.equal(producers[0].conclusion, 'success', 'Windows candidate producer did not pass');
-const pkg = api(`repos/${repo}/contents/package.json?ref=${sha}`);
-const sourceVersion = JSON.parse(Buffer.from(pkg.content, 'base64').toString('utf8')).version;
-const lock = JSON.parse(await readFile('runtime.lock.json', 'utf8'));
-assert.equal(sourceVersion, lock.version, 'Candidate packaging requires the same payload version');
-const name = `opencode-windows-runtime-candidate-${sha}`;
-const listing = api(`repos/${repo}/actions/runs/${runId}/artifacts?per_page=100`);
-const matches = listing.artifacts.filter(item => item.name === name && !item.expired);
-assert.equal(matches.length, 1, 'Missing or ambiguous candidate artifact');
-const artifact = matches[0];
-assert(/^sha256:[a-f0-9]{64}$/.test(artifact.digest ?? ''), 'Missing artifact integrity digest');
-const temp = await mkdtemp(path.join(os.tmpdir(), 'opencode-candidate-'));
-try {
-  // Verify the archive itself against GitHub's immutable artifact digest before extraction.
-  const archive = execFileSync('gh', ['api', `repos/${repo}/actions/artifacts/${artifact.id}/zip`], {
-    maxBuffer: 256 * 1024 * 1024,
-    stdio: ['ignore', 'pipe', 'inherit'],
-  });
-  assert.equal(`sha256:${createHash('sha256').update(archive).digest('hex')}`, artifact.digest);
-  const archivePath = path.join(temp, 'candidate.zip');
-  await writeFile(archivePath, archive);
-  const extract = path.join(temp, 'payload');
-  execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command',
-    'Expand-Archive -LiteralPath $env:OC_CANDIDATE_ARCHIVE -DestinationPath $env:OC_CANDIDATE_EXTRACT'], {
-    env: { ...process.env, OC_CANDIDATE_ARCHIVE: archivePath, OC_CANDIDATE_EXTRACT: extract },
-    stdio: 'inherit',
-  });
-  const binary = path.join(extract, 'cli.exe');
-  const bytes = await readFile(binary);
-  assert(bytes.length > 1024 && bytes.subarray(0, 2).toString() === 'MZ', 'Not a Windows executable');
-  const binarySha256 = createHash('sha256').update(bytes).digest('hex');
-  await copyFile(binary, 'resources/runtime/claude-multimodel.exe');
-  const provenance = { schemaVersion: 1, testOnly: true, repository: repo, runId, sourceSha: sha,
-    sourceVersion, producerJobId: producers[0].id, artifactId: artifact.id, artifactDigest: artifact.digest, binarySha256 };
-  await writeFile('resources/runtime/TEST-CANDIDATE.json', JSON.stringify(provenance, null, 2));
-  await writeFile('runtime-candidate-evidence.json', JSON.stringify(provenance, null, 2));
-  console.log(JSON.stringify(provenance));
-} finally {
-  await rm(temp, { recursive: true, force: true });
+// Bound API work and reject partial/changing listings before selecting a producer or artifact.
+export function candidatePages(api, endpoint, key) {
+  const perPage = 100;
+  const maxPages = 100;
+  const items = [];
+  const ids = new Set();
+  let total;
+  for (let page = 1; page <= maxPages; page++) {
+    const result = api(`${endpoint}?per_page=${perPage}&page=${page}`);
+    assert(Number.isSafeInteger(result.total_count) && result.total_count >= 0,
+      'Invalid candidate listing total');
+    assert(result.total_count <= perPage * maxPages, 'Candidate listing exceeds pagination cap');
+    total ??= result.total_count;
+    assert.equal(result.total_count, total, 'Candidate listing changed during pagination');
+    assert(Array.isArray(result[key]), 'Invalid candidate listing page');
+    assert.equal(result[key].length, Math.min(perPage, total - items.length),
+      'Incomplete candidate listing page');
+    for (const item of result[key]) {
+      assert(Number.isSafeInteger(item.id) && item.id > 0 && !ids.has(item.id),
+        'Invalid or repeated candidate listing identity');
+      ids.add(item.id);
+      items.push(item);
+    }
+    if (items.length === total) return items;
+  }
+  assert.fail('Candidate pagination cap reached');
+}
+
+async function stageCandidate() {
+  // Explicit CI-only test packaging. Never edits runtime.lock or publishes a release.
+  const repo = '777genius/agent_teams_orchestrator';
+  const runId = process.env.RUNTIME_CANDIDATE_RUN;
+  const sha = process.env.RUNTIME_CANDIDATE_SHA;
+  assert(process.env.GITHUB_ACTIONS === 'true' && process.platform === 'win32');
+  assert(/^\d+$/.test(runId ?? ''), 'Expected numeric candidate CI run');
+  assert(/^[a-f0-9]{40}$/.test(sha ?? ''), 'Expected exact candidate source SHA');
+  const gh = (...args) => execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] });
+  const api = (endpoint) => JSON.parse(gh('api', endpoint));
+  const run = api(`repos/${repo}/actions/runs/${runId}`);
+  assert.equal(run.head_sha, sha, 'Candidate source mismatch');
+  assert.equal(run.head_repository.full_name, repo, 'Foreign candidate repository');
+  assert.equal(run.path, '.github/workflows/ci.yml', 'Not the runtime CI workflow');
+  // Qualification can run alongside the remaining CI suites. Delivery still requires full CI.
+  const jobs = candidatePages(api, `repos/${repo}/actions/runs/${runId}/jobs`, 'jobs');
+  const producers = jobs.filter(job => job.name === 'Windows packaged backfill (candidate)');
+  assert.equal(producers.length, 1, 'Missing or ambiguous candidate producer');
+  assert.equal(producers[0].conclusion, 'success', 'Windows candidate producer did not pass');
+  const pkg = api(`repos/${repo}/contents/package.json?ref=${sha}`);
+  const sourceVersion = JSON.parse(Buffer.from(pkg.content, 'base64').toString('utf8')).version;
+  const lock = JSON.parse(await readFile('runtime.lock.json', 'utf8'));
+  assert.equal(sourceVersion, lock.version, 'Candidate packaging requires the same payload version');
+  const name = `opencode-windows-runtime-candidate-${sha}`;
+  const listing = candidatePages(api, `repos/${repo}/actions/runs/${runId}/artifacts`, 'artifacts');
+  const matches = listing.filter(item => item.name === name && !item.expired);
+  assert.equal(matches.length, 1, 'Missing or ambiguous candidate artifact');
+  const artifact = matches[0];
+  assert(/^sha256:[a-f0-9]{64}$/.test(artifact.digest ?? ''), 'Missing artifact integrity digest');
+  const temp = await mkdtemp(path.join(os.tmpdir(), 'opencode-candidate-'));
+  try {
+    // Verify the archive itself against GitHub's immutable artifact digest before extraction.
+    const archive = execFileSync('gh', ['api', `repos/${repo}/actions/artifacts/${artifact.id}/zip`], {
+      maxBuffer: 256 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+    assert.equal(`sha256:${createHash('sha256').update(archive).digest('hex')}`, artifact.digest);
+    const archivePath = path.join(temp, 'candidate.zip');
+    await writeFile(archivePath, archive);
+    const extract = path.join(temp, 'payload');
+    execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command',
+      'Expand-Archive -LiteralPath $env:OC_CANDIDATE_ARCHIVE -DestinationPath $env:OC_CANDIDATE_EXTRACT'], {
+      env: { ...process.env, OC_CANDIDATE_ARCHIVE: archivePath, OC_CANDIDATE_EXTRACT: extract },
+      stdio: 'inherit',
+    });
+    const binary = path.join(extract, 'cli.exe');
+    const bytes = await readFile(binary);
+    assert(bytes.length > 1024 && bytes.subarray(0, 2).toString() === 'MZ', 'Not a Windows executable');
+    const binarySha256 = createHash('sha256').update(bytes).digest('hex');
+    await copyFile(binary, 'resources/runtime/claude-multimodel.exe');
+    const provenance = { schemaVersion: 1, testOnly: true, repository: repo, runId, sourceSha: sha,
+      sourceVersion, producerJobId: producers[0].id, artifactId: artifact.id, artifactDigest: artifact.digest, binarySha256 };
+    await writeFile('resources/runtime/TEST-CANDIDATE.json', JSON.stringify(provenance, null, 2));
+    await writeFile('runtime-candidate-evidence.json', JSON.stringify(provenance, null, 2));
+    console.log(JSON.stringify(provenance));
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  await stageCandidate();
 }

--- a/scripts/e2e/opencode-diagnostics/stage-candidate.mjs
+++ b/scripts/e2e/opencode-diagnostics/stage-candidate.mjs
@@ -18,8 +18,11 @@ const run = api(`repos/${repo}/actions/runs/${runId}`);
 assert.equal(run.head_sha, sha, 'Candidate source mismatch');
 assert.equal(run.head_repository.full_name, repo, 'Foreign candidate repository');
 assert.equal(run.path, '.github/workflows/ci.yml', 'Not the runtime CI workflow');
-assert.equal(run.status, 'completed', 'Runtime CI is not complete');
-assert.equal(run.conclusion, 'success', 'Runtime CI did not pass');
+// Qualification can run alongside the remaining CI suites. Delivery still requires full CI.
+const jobs = api(`repos/${repo}/actions/runs/${runId}/jobs?per_page=100`);
+const producers = jobs.jobs.filter(job => job.name === 'Windows packaged backfill (candidate)');
+assert.equal(producers.length, 1, 'Missing or ambiguous candidate producer');
+assert.equal(producers[0].conclusion, 'success', 'Windows candidate producer did not pass');
 const pkg = api(`repos/${repo}/contents/package.json?ref=${sha}`);
 const sourceVersion = JSON.parse(Buffer.from(pkg.content, 'base64').toString('utf8')).version;
 const lock = JSON.parse(await readFile('runtime.lock.json', 'utf8'));
@@ -52,7 +55,7 @@ try {
   const binarySha256 = createHash('sha256').update(bytes).digest('hex');
   await copyFile(binary, 'resources/runtime/claude-multimodel.exe');
   const provenance = { schemaVersion: 1, testOnly: true, repository: repo, runId, sourceSha: sha,
-    sourceVersion, artifactId: artifact.id, artifactDigest: artifact.digest, binarySha256 };
+    sourceVersion, producerJobId: producers[0].id, artifactId: artifact.id, artifactDigest: artifact.digest, binarySha256 };
   await writeFile('resources/runtime/TEST-CANDIDATE.json', JSON.stringify(provenance, null, 2));
   await writeFile('runtime-candidate-evidence.json', JSON.stringify(provenance, null, 2));
   console.log(JSON.stringify(provenance));

--- a/scripts/e2e/opencode-diagnostics/stage-candidate.test.mjs
+++ b/scripts/e2e/opencode-diagnostics/stage-candidate.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { candidatePages } from './stage-candidate.mjs';
+
+for (const key of ['jobs', 'artifacts']) {
+  test(`${key}: collects candidates and ambiguity beyond the first 100 entries`, () => {
+    const entries = Array.from({ length: 201 }, (_, i) => ({ id: i + 1, name: 'other' }));
+    entries[150].name = 'candidate';
+    entries[200].name = 'candidate';
+    const calls = [];
+    const actual = candidatePages(endpoint => {
+      calls.push(endpoint);
+      const page = Number(new URL(`https://example.test/${endpoint}`).searchParams.get('page'));
+      return { total_count: entries.length, [key]: entries.slice((page - 1) * 100, page * 100) };
+    }, `runs/42/${key}`, key);
+    assert.deepEqual(actual, entries);
+    assert.equal(actual.filter(item => item.name === 'candidate').length, 2);
+    assert.deepEqual(calls, [1, 2, 3].map(page => `runs/42/${key}?per_page=100&page=${page}`));
+  });
+}
+
+test('empty and exact full-page listings finish without unnecessary requests', () => {
+  for (const count of [0, 100]) {
+    let calls = 0;
+    const entries = Array.from({ length: count }, (_, i) => ({ id: i + 1 }));
+    assert.deepEqual(candidatePages(() => {
+      calls++;
+      return { total_count: count, jobs: entries };
+    }, 'jobs', 'jobs'), entries);
+    assert.equal(calls, 1);
+  }
+});
+
+test('invalid totals, excessive listings and incomplete pages fail closed', () => {
+  for (const result of [
+    { jobs: [] }, { total_count: -1, jobs: [] }, { total_count: 0.5, jobs: [] },
+    { total_count: 10001, jobs: [] }, { total_count: 1, jobs: [] },
+    { total_count: 0, jobs: [{ id: 1 }] }, { total_count: 0 },
+    { total_count: 1, jobs: [{ id: '1' }] },
+  ]) assert.throws(() => candidatePages(() => result, 'jobs', 'jobs'));
+});
+
+test('changed totals and overlapping identities fail closed on subsequent pages', () => {
+  for (const second of [
+    { total_count: 102, jobs: [{ id: 101 }, { id: 102 }] },
+    { total_count: 101, jobs: [{ id: 100 }] },
+    { total_count: 101, jobs: [] },
+  ]) {
+    let calls = 0;
+    assert.throws(() => candidatePages(() => ++calls === 1
+      ? { total_count: 101, jobs: Array.from({ length: 100 }, (_, i) => ({ id: i + 1 })) }
+      : second, 'jobs', 'jobs'));
+    assert.equal(calls, 2);
+  }
+});
+
+test('the maximum listing completes within the explicit request cap', () => {
+  let calls = 0;
+  const items = candidatePages(() => {
+    const offset = calls++ * 100;
+    return { total_count: 10000, jobs: Array.from({ length: 100 }, (_, i) => ({ id: offset + i + 1 })) };
+  }, 'jobs', 'jobs');
+  assert.equal(items.length, 10000);
+  assert.equal(calls, 100);
+});

--- a/src/features/runtime-provider-management/renderer/ui/RuntimeProviderManagementPanelView.tsx
+++ b/src/features/runtime-provider-management/renderer/ui/RuntimeProviderManagementPanelView.tsx
@@ -2511,6 +2511,7 @@ export const RuntimeProviderManagementPanelView = ({
                     state.directorySummary ? 'Load the full OpenCode provider catalog' : undefined
                   }
                   disabled={disabled || state.directoryLoading || state.directoryRefreshing}
+                  data-testid="runtime-provider-refresh-catalog"
                   onClick={() => void actions.refreshDirectory()}
                 >
                   {state.directoryRefreshing ? (

--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -1207,7 +1207,6 @@ const InstalledBanner = ({
               modelCatalogLoading ||
               provider.modelCatalog?.diagnostics.message
             );
-
             return (
               <div
                 key={provider.providerId}

--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -1421,6 +1421,7 @@ const InstalledBanner = ({
                       </button>
                     ) : null}
                     <button
+                      data-testid={`runtime-manage-${provider.providerId}`}
                       onClick={() => onProviderManage(provider.providerId)}
                       disabled={actionDisabled}
                       className="flex items-center gap-1 rounded-md border px-2 py-[3px] text-[10px] font-medium transition-colors hover:bg-white/5 disabled:opacity-50"


### PR DESCRIPTION
Extend the Windows packaged harness with repeated native provider-settings requests and the actual provider-management dialog. Qualification rejects degraded responses and settings errors, waits for observed directory/model requests to settle, captures the dialog screenshot for each cold/warm run, and proves owned processes plus the CDP listener are drained before restart.

An explicit workflow-dispatch option packages an unreleased runtime candidate only after validating the successful producer job across paginated workflow evidence. It verifies the exact source SHA, repository, workflow, source payload version, artifact digest, and packaged executable hash. The workflow records provenance alongside the test archive, preserves runtime.lock, and uses --publish never.

Validation on exact head c881b014be9b2a022bfa14c9da9ac2c43b13d3ea:
- 36 focused harness tests passed locally, with one Windows-only skip
- Linux and Windows desktop CI, lint, test shards, CodeQL, CodeRabbit, and fixture diagnostics passed
- Native Windows packaged run 34564629535 passed cold, warm-1, and warm-2 against runtime candidate 773c99189a9df445f423fc0510e596f39619e1eb and OpenCode 1.18.30
- Every run qualified provider settings and explicit catalog refresh, then drained owned processes and the port 9222 listener
- The archived ZIP checksum and packaged runtime executable hash match their recorded provenance

Related: https://github.com/777genius/agent_teams_orchestrator/pull/88

This produces test artifacts only. It does not publish a frontend or runtime release. Direct IPC settings checks and UI directory rendering are distinct evidence; the dialog does not automatically invoke loadView.
