### PR TITLE
fix(opencode): keep local models visible after catalog refresh

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -28,6 +28,71 @@ Before publishing:
 - Confirm version numbers, runtime gates, asset names, and download links.
 - Keep the body in this document identical to the GitHub release body.
 
+## Draft: v2.14.3 (2026-09-11)
+
+Target branch: `main`.
+
+Runtime gate:
+
+- Agent Teams runtime: `v0.0.95`.
+- Terminal Platform runtime: `v0.3.3`.
+
+Release body source for GitHub release:
+
+<!-- RELEASE_BODY_START v2.14.3 -->
+Keeps local OpenCode models such as Ollama visible after a catalog refresh, and shows them as ready instead of missing.
+
+### Fixes
+
+- Keep Ollama, LM Studio, and llama.cpp models visible after refresh.
+- Show configured local providers as ready instead of asking to connect.
+- Keep available local OpenCode sources in the dashboard catalog.
+
+### Downloads
+
+<table>
+<tr>
+<td align="center">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.3/Agent.Teams.AI-2.14.3-arm64.dmg">
+    <img src="https://img.shields.io/badge/macOS_Apple_Silicon-.dmg-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Apple Silicon" />
+  </a>
+  <br />
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.3/Agent.Teams.AI-2.14.3-x64.dmg">
+    <img src="https://img.shields.io/badge/macOS_Intel-.dmg-434343?style=for-the-badge&logo=apple&logoColor=white" alt="macOS Intel" />
+  </a>
+</td>
+<td align="center">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.3/Agent.Teams.AI.Setup.2.14.3.exe">
+    <img src="https://img.shields.io/badge/Windows_x64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows x64" />
+  </a>
+  <br />
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.3/Agent.Teams.AI.Setup.2.14.3-arm64.exe">
+    <img src="https://img.shields.io/badge/Windows_ARM64-Download_.exe-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows ARM64" />
+  </a>
+  <br />
+  <sub>May trigger SmartScreen - click "More info" then "Run anyway"</sub>
+  <br />
+  <sub>Run normally. Administrator mode may be needed only if the app reports a specific OpenCode symlink or permission error.</sub>
+</td>
+<td align="center">
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.3/Agent.Teams.AI-2.14.3.AppImage">
+    <img src="https://img.shields.io/badge/Linux-Download_.AppImage-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux AppImage" />
+  </a>
+  <br />
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.3/agent-teams-ai_2.14.3_amd64.deb">
+    <img src="https://img.shields.io/badge/.deb-E95420?style=flat-square&logo=ubuntu" alt=".deb" />
+  </a>&nbsp;
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.3/agent-teams-ai-2.14.3.x86_64.rpm">
+    <img src="https://img.shields.io/badge/.rpm-294172?style=flat-square&logo=redhat" alt=".rpm" />
+  </a>&nbsp;
+  <a href="https://github.com/777genius/agent-teams-ai/releases/download/v2.14.3/agent-teams-ai-2.14.3.pacman">
+    <img src="https://img.shields.io/badge/.pacman-1793D1?style=flat-square&logo=archlinux" alt=".pacman" />
+  </a>
+</td>
+</tr>
+</table>
+<!-- RELEASE_BODY_END v2.14.3 -->
+
 ## Published: v2.14.2 (2026-09-11)
 
 GitHub release: [v2.14.2](https://github.com/777genius/agent-teams-ai/releases/tag/v2.14.2).

--- a/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderConnector.ollama-live.test.ts
+++ b/src/features/runtime-provider-management/main/infrastructure/OpenCodeLocalProviderConnector.ollama-live.test.ts
@@ -1,0 +1,139 @@
+/* eslint-disable sonarjs/no-clear-text-protocols -- live Ollama uses the documented local HTTP API */
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  isAppManagedOpenCodeLocalModel,
+  shouldRetainOpenCodeLocalCatalogModel,
+} from '@renderer/components/team/dialogs/openCodeLocalCatalogVisibility';
+import {
+  countConfiguredLocalOpenCodeCatalogModels,
+  isKnownConfiguredLocalOpenCodeCatalogModel,
+} from '@shared/utils/opencodeModelRoute';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { OpenCodeLocalProviderConnector } from './OpenCodeLocalProviderConnector';
+
+const LIVE_ENABLED = process.env.LIVE_OLLAMA === '1';
+const OLLAMA_BASE_URL = 'http://127.0.0.1:11434/v1';
+const liveDescribe = LIVE_ENABLED ? describe : describe.skip;
+
+async function generateOnce(modelId: string): Promise<string> {
+  const response = await fetch('http://127.0.0.1:11434/api/generate', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      model: modelId,
+      prompt: 'Reply with the single word ok.',
+      stream: false,
+      options: { num_predict: 8, temperature: 0 },
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Ollama generate failed: ${response.status} ${await response.text()}`);
+  }
+  const payload = (await response.json()) as { response?: unknown };
+  return typeof payload.response === 'string' ? payload.response : '';
+}
+
+liveDescribe('OpenCodeLocalProviderConnector live Ollama', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'agent-teams-ollama-live-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it(
+    'probes, configures into a sandbox, and keeps the catalog model after an empty overlay',
+    { timeout: 90_000 },
+    async () => {
+      const homePath = path.join(tempDir, 'home');
+      const projectPath = path.join(tempDir, 'sandbox-project');
+      await fs.mkdir(projectPath, { recursive: true });
+      const connector = new OpenCodeLocalProviderConnector({
+        homePath,
+        environment: {},
+      });
+
+      const probe = await connector.probeLocalProvider({
+        runtimeId: 'opencode',
+        presetId: 'ollama',
+      });
+      expect(probe.error).toBeUndefined();
+      expect(probe.probe).toMatchObject({
+        state: 'available',
+        providerId: 'ollama',
+        baseUrl: OLLAMA_BASE_URL,
+      });
+      const liveModelId = probe.probe?.models[0]?.id;
+      if (!liveModelId) {
+        throw new Error('Live Ollama probe did not return a model id.');
+      }
+
+      const generated = await generateOnce(liveModelId);
+      expect(generated.trim().length).toBeGreaterThan(0);
+
+      const configured = await connector.configureLocalProvider({
+        runtimeId: 'opencode',
+        scope: 'project',
+        projectPath,
+        presetId: 'ollama',
+        defaultModelId: liveModelId,
+        setAsDefault: true,
+      });
+      expect(configured.error).toBeUndefined();
+      expect(configured.configuration).toMatchObject({
+        providerId: 'ollama',
+        defaultModelId: liveModelId,
+        modelRoute: `ollama/${liveModelId}`,
+        scope: 'project',
+        setAsDefault: true,
+      });
+
+      const listed = await connector.listLocalProviders({
+        runtimeId: 'opencode',
+        scope: 'project',
+        projectPath,
+      });
+      expect(listed.error).toBeUndefined();
+      expect(listed.providers).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            providerId: 'ollama',
+            state: 'available',
+            defaultModelId: liveModelId,
+          }),
+        ])
+      );
+
+      const catalogModel = {
+        id: `ollama/${liveModelId}`,
+        launchModel: `ollama/${liveModelId}`,
+        metadata: {
+          opencode: {
+            providerId: 'ollama',
+            routeKind: 'configured_local' as const,
+            accessKind: 'configured_authless' as const,
+          },
+        },
+      };
+      const emptyOverlay = new Set<string>();
+      const v2141KeptCatalogLocal =
+        emptyOverlay.has(catalogModel.id) ||
+        !isAppManagedOpenCodeLocalModel(catalogModel.id, catalogModel);
+
+      expect(countConfiguredLocalOpenCodeCatalogModels([catalogModel])).toBe(1);
+      expect(isKnownConfiguredLocalOpenCodeCatalogModel(catalogModel.id, catalogModel)).toBe(true);
+      expect(v2141KeptCatalogLocal).toBe(false);
+      expect(
+        shouldRetainOpenCodeLocalCatalogModel(catalogModel.id, catalogModel, emptyOverlay)
+      ).toBe(true);
+    }
+  );
+});
+/* eslint-enable sonarjs/no-clear-text-protocols -- re-enable after the live Ollama HTTP calls */

--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.test.tsx
@@ -407,6 +407,17 @@ describe('connected OpenCode dashboard catalog', () => {
     ).toEqual(['opencode', 'openrouter', 'xai']);
   });
 
+  it('keeps available local OpenCode sources in the dashboard catalog inventory', () => {
+    expect(
+      connectedCatalogSourceIds([
+        { providerId: 'opencode', state: 'connected', metadata: {} },
+        { providerId: 'ollama', state: 'available', metadata: {} },
+        { providerId: 'lmstudio', state: 'available', metadata: { configuredAuthless: true } },
+        { providerId: 'openrouter', state: 'not-connected', metadata: {} },
+      ] as RuntimeProviderDirectoryEntryDto[])
+    ).toEqual(['opencode', 'lmstudio', 'ollama']);
+  });
+
   it('recovers an initial failure on the periodic tick and reloads changed connected sources', async () => {
     vi.useFakeTimers();
     try {

--- a/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.ts
+++ b/src/features/runtime-provider-management/renderer/hooks/useOpenCodeConnectedModelCatalog.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { api, isElectronMode } from '@renderer/api';
+import type { CliProviderStatus } from '@shared/types';
+import { isOpenCodeLocalProviderId } from '@shared/utils/opencodeModelRoute';
 
 import {
   catalogFailure,
@@ -12,7 +14,6 @@ import { loadOpenCodeScopedCatalog } from './loadOpenCodeScopedCatalog';
 import { mapCatalogModel } from './useOpenCodeProviderModelCatalog';
 
 import type { RuntimeProviderDirectoryEntryDto, RuntimeProviderModelDto } from '../../contracts';
-import type { CliProviderStatus } from '@shared/types';
 
 const CONCURRENT_SOURCE_LOADS = 1;
 let nextRequest = 0;
@@ -23,12 +24,23 @@ export function connectedCatalogSourceIds(
   return [
     ...new Set(
       entries
-        .filter(
-          (entry) =>
-            entry.providerId.trim().toLowerCase() === 'opencode' ||
-            (entry.state !== 'ignored' &&
-              (entry.state === 'connected' || entry.metadata.configuredAuthless))
-        )
+        .filter((entry) => {
+          const providerId = entry.providerId.trim().toLowerCase();
+          if (!providerId) {
+            return false;
+          }
+          if (providerId === 'opencode') {
+            return true;
+          }
+          if (entry.state === 'ignored') {
+            return false;
+          }
+          return (
+            entry.state === 'connected' ||
+            entry.metadata.configuredAuthless ||
+            (entry.state === 'available' && isOpenCodeLocalProviderId(providerId))
+          );
+        })
         .map((entry) => entry.providerId.trim().toLowerCase())
         .filter(Boolean)
     ),

--- a/src/renderer/components/dashboard/CliStatusBanner.tsx
+++ b/src/renderer/components/dashboard/CliStatusBanner.tsx
@@ -82,7 +82,7 @@ import { refreshCliStatusForCurrentMode } from '@renderer/utils/refreshCliStatus
 import { getRuntimeDisplayName as getHumanRuntimeDisplayName } from '@renderer/utils/runtimeDisplayName';
 import { getVisibleTeamProviderModels } from '@renderer/utils/teamModelCatalog';
 import { CLI_PROVIDER_STATUS_DEFERRED_MESSAGE } from '@shared/types/cliInstaller';
-import { getOpenCodeModelRoutePresentationStatus } from '@shared/utils/opencodeModelRoute';
+import { countConfiguredLocalOpenCodeCatalogModels } from '@shared/utils/opencodeModelRoute';
 import {
   AlertTriangle,
   CheckCircle,
@@ -568,6 +568,7 @@ function formatRuntimeAuthSummary(
   cliStatus: NonNullable<ReturnType<typeof useCliInstaller>['cliStatus']>,
   visibleProviders: readonly CliProviderStatus[],
   additionalConnectedCount: number,
+  configuredLocalCount: number,
   codexSnapshotPending: boolean,
   t: ReturnType<typeof useAppTranslation>['t']
 ): string | null {
@@ -582,10 +583,15 @@ function formatRuntimeAuthSummary(
       visibleProviders.filter(
         (provider) => !isPending(provider) && isProviderCountedAsConnected(provider)
       ).length + additionalConnectedCount;
-
-    return connected > 0
-      ? t('cliStatus.provider.connectedCount', { connected })
-      : t('cliStatus.provider.connectToGetStarted');
+    if (connected <= 0 && configuredLocalCount <= 0) {
+      return t('cliStatus.provider.connectToGetStarted');
+    }
+    return [
+      ...(connected > 0 ? [t('cliStatus.provider.connectedCount', { connected })] : []),
+      ...(configuredLocalCount > 0
+        ? [t('cliStatus.provider.configuredLocalCount', { count: configuredLocalCount })]
+        : []),
+    ].join(' · ');
   }
 
   if (cliStatus.authStatusChecking) {
@@ -713,22 +719,7 @@ function getOpenCodeDashboardChips(
   }
 
   const catalogModels = provider.modelCatalog?.models ?? [];
-  const configuredLocalCount = new Set(
-    catalogModels
-      .filter((model) => {
-        const route = model.metadata?.opencode;
-        return (
-          getOpenCodeModelRoutePresentationStatus({
-            modelId: model.launchModel,
-            catalogId: model.id,
-            providerId: route?.providerId,
-            routeKind: route?.routeKind,
-            accessKind: route?.accessKind,
-          }) === 'local'
-        );
-      })
-      .map((model) => model.launchModel)
-  ).size;
+  const configuredLocalCount = countConfiguredLocalOpenCodeCatalogModels(catalogModels);
   const verifiedCount = new Set(
     catalogModels
       .filter((model) => model.metadata?.opencode?.proofState === 'verified')
@@ -914,6 +905,10 @@ const InstalledBanner = ({
   );
   const detailedProviders = visibleProviders;
   const canOpenExtensions = cliStatus.installed;
+  const configuredLocalCount = countConfiguredLocalOpenCodeCatalogModels(
+    visibleProviders.find((provider) => provider.providerId === 'opencode')?.modelCatalog?.models ??
+      []
+  );
   const hasConnectedMultimodelProvider =
     isMultimodelRuntimeStatus(cliStatus) &&
     (visibleProviders.some(
@@ -921,7 +916,8 @@ const InstalledBanner = ({
         !isCodexSnapshotPending(provider, codexSnapshotPending) &&
         isProviderCountedAsConnected(provider)
     ) ||
-      openCodeConnectedPlanCount > 0);
+      openCodeConnectedPlanCount > 0 ||
+      configuredLocalCount > 0);
   const runtimeLabel = hasConnectedMultimodelProvider
     ? t('cliStatus.provider.readyToRunAgents')
     : formatRuntimeLabel(cliStatus);
@@ -929,6 +925,7 @@ const InstalledBanner = ({
     cliStatus,
     visibleProviders,
     openCodeConnectedPlanCount,
+    configuredLocalCount,
     codexSnapshotPending,
     t
   );

--- a/src/renderer/components/team/dialogs/TeamModelSelector.tsx
+++ b/src/renderer/components/team/dialogs/TeamModelSelector.tsx
@@ -89,6 +89,11 @@ import {
 
 import { CodexModelCatalogFallbackNotice } from './CodexModelCatalogFallbackNotice';
 import {
+  isAppManagedOpenCodeLocalModel,
+  OPENCODE_COMPANION_SOURCE_IDS,
+  shouldRetainOpenCodeLocalCatalogModel,
+} from './openCodeLocalCatalogVisibility';
+import {
   buildOpenCodeLocalModelOverlay,
   resolveOpenCodeLocalModelPresentation,
 } from './openCodeLocalModelOverlay';
@@ -255,7 +260,6 @@ const CURATED_OPENCODE_PROVIDER_TABS = [
   { sourceId: 'zai-coding-plan', label: 'Z.AI' },
   { sourceId: 'minimax-coding-plan', label: 'MiniMax' },
 ] as const;
-const OPENCODE_COMPANION_SOURCE_IDS = new Set(['cursor-acp', 'kiro']);
 
 const OPEN_CODE_ROUTE_FILTER_TAG_ORDER: readonly OpenCodeRouteFilterTag[] = [
   'local',
@@ -292,30 +296,6 @@ function getCuratedOpenCodeProviderTab(
     return { sourceId: normalizedSourceId, label: 'Xiaomi MiMo' };
   }
   return null;
-}
-
-function isAppManagedOpenCodeLocalModel(
-  modelId: string,
-  catalogModel: ProviderModelCatalogItem | null | undefined
-): boolean {
-  const route = catalogModel?.metadata?.opencode;
-  const sourceId =
-    route?.providerId?.trim().toLowerCase() ||
-    parseOpenCodeQualifiedModelRef(modelId)?.sourceId ||
-    null;
-  // OpenCode currently reports Cursor ACP and Kiro as configured_authless.
-  // They are companion runtimes, not local OpenAI-compatible servers managed by this app.
-  if (sourceId && OPENCODE_COMPANION_SOURCE_IDS.has(sourceId)) {
-    return false;
-  }
-  if (!route) {
-    return isOpenCodeLocalProviderId(sourceId);
-  }
-  if (route.routeKind !== 'configured_local') {
-    return false;
-  }
-
-  return route.accessKind !== 'credentialed' || modelId.startsWith('local/');
 }
 
 function getOpenCodeRouteGroup(
@@ -1776,7 +1756,11 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
             (option) =>
               !option.value.trim() ||
               !isAppManagedOpenCodeLocalModel(option.value, catalogModelById.get(option.value)) ||
-              openCodeLocalModelOverlay.modelIds.has(option.value)
+              shouldRetainOpenCodeLocalCatalogModel(
+                option.value,
+                catalogModelById.get(option.value),
+                openCodeLocalModelOverlay.modelIds
+              )
           )
         : unscopedRuntimeOptions;
     const presentedRuntimeOptions = addCodexAstraUpdatePreview(
@@ -1845,8 +1829,11 @@ export const TeamModelSelector: React.FC<TeamModelSelectorProps> = ({
           effectiveProviderId === 'opencode' &&
           openCodeLocalProviderLookupAuthoritative &&
           isAppManagedOpenCodeLocalModel(launchModel || catalogModelId, model) &&
-          !openCodeLocalModelOverlay.modelIds.has(launchModel) &&
-          !openCodeLocalModelOverlay.modelIds.has(catalogModelId)
+          !shouldRetainOpenCodeLocalCatalogModel(
+            launchModel || catalogModelId,
+            model,
+            openCodeLocalModelOverlay.modelIds
+          )
         ) {
           continue;
         }

--- a/src/renderer/components/team/dialogs/openCodeLocalCatalogVisibility.test.ts
+++ b/src/renderer/components/team/dialogs/openCodeLocalCatalogVisibility.test.ts
@@ -1,0 +1,117 @@
+import {
+  countConfiguredLocalOpenCodeCatalogModels,
+  isKnownConfiguredLocalOpenCodeCatalogModel,
+} from '@shared/utils/opencodeModelRoute';
+import { describe, expect, it } from 'vitest';
+
+import {
+  isAppManagedOpenCodeLocalModel,
+  shouldRetainOpenCodeLocalCatalogModel,
+} from './openCodeLocalCatalogVisibility';
+
+const ollamaCatalogModel = {
+  id: 'ollama/qwen',
+  launchModel: 'ollama/qwen',
+  metadata: {
+    opencode: {
+      providerId: 'ollama',
+      routeKind: 'configured_local' as const,
+      accessKind: 'configured_authless',
+    },
+  },
+};
+
+describe('openCodeLocalCatalogVisibility', () => {
+  it('treats known local configured routes as app-managed', () => {
+    expect(isAppManagedOpenCodeLocalModel('ollama/qwen', ollamaCatalogModel)).toBe(true);
+    expect(
+      isAppManagedOpenCodeLocalModel('kiro/auto', {
+        id: 'kiro/auto',
+        metadata: {
+          opencode: {
+            providerId: 'kiro',
+            routeKind: 'configured_local',
+            accessKind: 'configured_authless',
+          },
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('retains catalog Ollama when the live overlay is empty', () => {
+    expect(
+      shouldRetainOpenCodeLocalCatalogModel('ollama/qwen', ollamaCatalogModel, new Set())
+    ).toBe(true);
+    expect(
+      shouldRetainOpenCodeLocalCatalogModel(
+        'corp-local/model',
+        {
+          id: 'corp-local/model',
+          metadata: {
+            opencode: {
+              providerId: 'corp-local',
+              routeKind: 'configured_local',
+              accessKind: 'configured_authless',
+            },
+          },
+        },
+        new Set()
+      )
+    ).toBe(false);
+  });
+
+  it('retains overlay-discovered models even when they are not catalog local routes', () => {
+    expect(
+      shouldRetainOpenCodeLocalCatalogModel('corp-local/model', null, new Set(['corp-local/model']))
+    ).toBe(true);
+  });
+});
+
+describe('v2.14.1 vs current OpenCode local-provider status', () => {
+  function formatV2141RuntimeAuthSummary(input: {
+    connectedCount: number;
+    configuredLocalCount: number;
+  }): string {
+    return input.connectedCount > 0
+      ? `Providers: ${input.connectedCount} connected`
+      : 'Connect a provider to get started';
+  }
+
+  function formatCurrentRuntimeAuthSummary(input: {
+    connectedCount: number;
+    configuredLocalCount: number;
+  }): string {
+    if (input.connectedCount <= 0 && input.configuredLocalCount <= 0) {
+      return 'Connect a provider to get started';
+    }
+    return [
+      ...(input.connectedCount > 0 ? [`Providers: ${input.connectedCount} connected`] : []),
+      ...(input.configuredLocalCount > 0 ? [`${input.configuredLocalCount} configured local`] : []),
+    ].join(' · ');
+  }
+
+  it('already dropped Ollama from the connected header in v2.14.1', () => {
+    const configuredLocalCount = countConfiguredLocalOpenCodeCatalogModels([ollamaCatalogModel]);
+    expect(configuredLocalCount).toBe(1);
+    expect(formatV2141RuntimeAuthSummary({ connectedCount: 0, configuredLocalCount })).toBe(
+      'Connect a provider to get started'
+    );
+    expect(formatCurrentRuntimeAuthSummary({ connectedCount: 0, configuredLocalCount })).toBe(
+      '1 configured local'
+    );
+  });
+
+  it('already hid catalog Ollama after an empty overlay scan in v2.14.1', () => {
+    const emptyOverlay = new Set<string>();
+    const v2141KeptCatalogLocal =
+      emptyOverlay.has('ollama/qwen') ||
+      !isAppManagedOpenCodeLocalModel('ollama/qwen', ollamaCatalogModel);
+    expect(v2141KeptCatalogLocal).toBe(false);
+    expect(isKnownConfiguredLocalOpenCodeCatalogModel('ollama/qwen', ollamaCatalogModel)).toBe(
+      true
+    );
+    expect(
+      shouldRetainOpenCodeLocalCatalogModel('ollama/qwen', ollamaCatalogModel, emptyOverlay)
+    ).toBe(true);
+  });
+});

--- a/src/renderer/components/team/dialogs/openCodeLocalCatalogVisibility.ts
+++ b/src/renderer/components/team/dialogs/openCodeLocalCatalogVisibility.ts
@@ -1,0 +1,58 @@
+import { parseOpenCodeQualifiedModelRef } from '@shared/utils/opencodeModelRef';
+import {
+  isKnownConfiguredLocalOpenCodeCatalogModel,
+  isOpenCodeLocalProviderId,
+} from '@shared/utils/opencodeModelRoute';
+
+type CatalogModel = {
+  id?: string | null;
+  launchModel?: string | null;
+  metadata?: {
+    opencode?: {
+      providerId?: string | null;
+      routeKind?: string | null;
+      accessKind?: string | null;
+    } | null;
+  } | null;
+};
+
+export const OPENCODE_COMPANION_SOURCE_IDS = new Set(['cursor-acp', 'kiro']);
+
+export function isAppManagedOpenCodeLocalModel(
+  modelId: string,
+  catalogModel: CatalogModel | null | undefined
+): boolean {
+  const route = catalogModel?.metadata?.opencode;
+  const sourceId =
+    route?.providerId?.trim().toLowerCase() ||
+    parseOpenCodeQualifiedModelRef(modelId)?.sourceId ||
+    null;
+  // OpenCode currently reports Cursor ACP and Kiro as configured_authless.
+  // They are companion runtimes, not local OpenAI-compatible servers managed by this app.
+  if (sourceId && OPENCODE_COMPANION_SOURCE_IDS.has(sourceId)) {
+    return false;
+  }
+  if (!route) {
+    return isOpenCodeLocalProviderId(sourceId);
+  }
+  if (route.routeKind !== 'configured_local') {
+    return false;
+  }
+
+  return route.accessKind !== 'credentialed' || modelId.startsWith('local/');
+}
+
+export function shouldRetainOpenCodeLocalCatalogModel(
+  modelId: string,
+  catalogModel: CatalogModel | null | undefined,
+  overlayModelIds: ReadonlySet<string>
+): boolean {
+  if (
+    overlayModelIds.has(modelId) ||
+    (catalogModel?.launchModel && overlayModelIds.has(catalogModel.launchModel)) ||
+    (catalogModel?.id && overlayModelIds.has(catalogModel.id))
+  ) {
+    return true;
+  }
+  return isKnownConfiguredLocalOpenCodeCatalogModel(modelId, catalogModel);
+}

--- a/src/shared/utils/__tests__/opencodeModelRoute.test.ts
+++ b/src/shared/utils/__tests__/opencodeModelRoute.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  countConfiguredLocalOpenCodeCatalogModels,
   getOpenCodeModelRoutePresentationStatus,
   hasExplicitFreeOpenCodeModelId,
+  isKnownConfiguredLocalOpenCodeCatalogModel,
   isOpenCodeLocalProviderId,
   isOpenCodeModelExplicitlyFree,
 } from '../opencodeModelRoute';
@@ -96,5 +98,42 @@ describe('opencodeModelRoute', () => {
         routeKind: 'connected_provider',
       })
     ).toBe(true);
+  });
+
+  it('counts only known configured-local routes, not companion config', () => {
+    expect(
+      countConfiguredLocalOpenCodeCatalogModels([
+        {
+          id: 'ollama/qwen',
+          launchModel: 'ollama/qwen',
+          metadata: { opencode: { providerId: 'ollama', routeKind: 'configured_local' } },
+        },
+        {
+          id: 'lmstudio/phi',
+          launchModel: 'lmstudio/phi',
+          metadata: { opencode: { providerId: 'lmstudio', routeKind: 'configured_local' } },
+        },
+        {
+          id: 'kiro/auto',
+          launchModel: 'kiro/auto',
+          metadata: { opencode: { providerId: 'kiro', routeKind: 'configured_local' } },
+        },
+      ])
+    ).toBe(2);
+  });
+
+  it('keeps known local catalog models when the live overlay misses them', () => {
+    expect(
+      isKnownConfiguredLocalOpenCodeCatalogModel('ollama/qwen', {
+        id: 'ollama/qwen',
+        metadata: { opencode: { providerId: 'ollama', routeKind: 'configured_local' } },
+      })
+    ).toBe(true);
+    expect(
+      isKnownConfiguredLocalOpenCodeCatalogModel('corp-local/model', {
+        id: 'corp-local/model',
+        metadata: { opencode: { providerId: 'corp-local', routeKind: 'configured_local' } },
+      })
+    ).toBe(false);
   });
 });

--- a/src/shared/utils/opencodeModelRoute.ts
+++ b/src/shared/utils/opencodeModelRoute.ts
@@ -47,6 +47,58 @@ export function isOpenCodeLocalProviderId(providerId: string | null | undefined)
   return normalized ? OPEN_CODE_LOCAL_PROVIDER_IDS.has(normalized) : false;
 }
 
+export function isKnownConfiguredLocalOpenCodeCatalogModel(
+  modelId: string | null | undefined,
+  catalogModel?: {
+    id?: string | null;
+    launchModel?: string | null;
+    metadata?: {
+      opencode?: {
+        providerId?: string | null;
+        routeKind?: string | null;
+        accessKind?: string | null;
+      } | null;
+    } | null;
+  } | null
+): boolean {
+  const route = catalogModel?.metadata?.opencode;
+  return (
+    getOpenCodeModelRoutePresentationStatus({
+      modelId: modelId ?? catalogModel?.launchModel,
+      catalogId: catalogModel?.id,
+      providerId: route?.providerId,
+      routeKind: route?.routeKind,
+      accessKind: route?.accessKind,
+    }) === 'local'
+  );
+}
+
+export function countConfiguredLocalOpenCodeCatalogModels(
+  models: readonly {
+    id?: string | null;
+    launchModel?: string | null;
+    metadata?: {
+      opencode?: {
+        providerId?: string | null;
+        routeKind?: string | null;
+        accessKind?: string | null;
+      } | null;
+    } | null;
+  }[]
+): number {
+  const ids = new Set<string>();
+  for (const model of models) {
+    if (!isKnownConfiguredLocalOpenCodeCatalogModel(model.launchModel, model)) {
+      continue;
+    }
+    const id = model.launchModel?.trim() || model.id?.trim();
+    if (id) {
+      ids.add(id);
+    }
+  }
+  return ids.size;
+}
+
 export function getOpenCodeModelRoutePresentationStatus(
   input: OpenCodeModelRouteFacts
 ): OpenCodeModelRoutePresentationStatus {

--- a/test/renderer/components/cli/CliStatusVisibility.test.ts
+++ b/test/renderer/components/cli/CliStatusVisibility.test.ts
@@ -1681,6 +1681,98 @@ describe('CLI status visibility during completed install state', () => {
     });
   });
 
+  it('keeps configured local OpenCode models in the usable provider summary', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    storeState.cliInstallerState = 'idle';
+    storeState.cliStatus = createInstalledCliStatus({
+      flavor: 'agent_teams_orchestrator',
+      displayName: 'Multimodel runtime',
+      supportsSelfUpdate: false,
+      showVersionDetails: false,
+      showBinaryPath: false,
+      authLoggedIn: true,
+      providers: [
+        {
+          providerId: 'opencode',
+          displayName: 'OpenCode (200+ models)',
+          supported: true,
+          authenticated: false,
+          authMethod: 'opencode_configured_local',
+          verificationState: 'verified',
+          statusMessage: null,
+          models: ['ollama/qwen'],
+          canLoginFromUi: false,
+          capabilities: {
+            teamLaunch: true,
+            oneShot: false,
+          },
+          backend: { kind: 'opencode-cli', label: 'OpenCode CLI' },
+          modelCatalog: {
+            schemaVersion: 1,
+            providerId: 'opencode',
+            source: 'app-server',
+            status: 'ready',
+            fetchedAt: '2026-05-12T00:00:00.000Z',
+            staleAt: '2026-05-12T00:10:00.000Z',
+            defaultModelId: 'ollama/qwen',
+            defaultLaunchModel: 'ollama/qwen',
+            models: [
+              {
+                id: 'ollama/qwen',
+                launchModel: 'ollama/qwen',
+                displayName: 'qwen',
+                hidden: false,
+                supportedReasoningEfforts: [],
+                defaultReasoningEffort: null,
+                inputModalities: ['text'],
+                supportsPersonality: true,
+                isDefault: true,
+                upgrade: false,
+                source: 'app-server',
+                badgeLabel: null,
+                metadata: {
+                  opencode: {
+                    providerId: 'ollama',
+                    modelId: 'qwen',
+                    sourceLabel: 'Ollama',
+                    accessKind: 'configured_authless',
+                    routeKind: 'configured_local',
+                    proofState: 'needs_probe',
+                    requiresExecutionProof: true,
+                    reason: null,
+                  },
+                },
+              },
+            ],
+            diagnostics: {
+              configReadState: 'ready',
+              appServerState: 'healthy',
+            },
+          },
+        },
+      ],
+    });
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(React.createElement(CliStatusBanner));
+      await Promise.resolve();
+    });
+
+    expect(host.textContent).toContain('Ready to run agents');
+    expect(host.textContent).toContain('1 configured local');
+    expect(host.textContent).not.toContain('Connect a provider to get started');
+    expect(host.textContent).not.toContain('Providers: 1 connected');
+
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+  });
+
   it('shows a bounded catalog failure status and retains complete diagnostic details', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     storeState.cliInstallerState = 'idle';

--- a/test/renderer/components/team/TeamModelSelectorDisabledState.test.ts
+++ b/test/renderer/components/team/TeamModelSelectorDisabledState.test.ts
@@ -1495,6 +1495,102 @@ describe('TeamModelSelector disabled Codex models', () => {
     });
   });
 
+  it('keeps catalog Ollama visible after an empty authoritative local overlay lookup', async () => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    const loadModels = vi.fn(async () => providerModelsResponse('ollama'));
+    installLoadModelsApi(loadModels);
+    const localModelId = 'ollama/qwen';
+    const provider = {
+      providerId: 'opencode',
+      authenticated: true,
+      supported: true,
+      verificationState: 'verified',
+      statusCheckOutcome: 'authoritative',
+      detailMessage: null,
+      statusMessage: null,
+      capabilities: { teamLaunch: true },
+      models: [localModelId],
+      modelCatalogRefreshState: 'ready',
+      modelCatalog: {
+        schemaVersion: 1,
+        providerId: 'opencode',
+        source: 'app-server',
+        status: 'ready',
+        fetchedAt: '2026-07-20T12:00:00.000Z',
+        staleAt: '2099-07-20T12:10:00.000Z',
+        defaultModelId: localModelId,
+        defaultLaunchModel: localModelId,
+        models: [
+          {
+            id: localModelId,
+            launchModel: localModelId,
+            displayName: 'qwen',
+            hidden: false,
+            supportedReasoningEfforts: [],
+            defaultReasoningEffort: null,
+            inputModalities: ['text'],
+            supportsPersonality: false,
+            isDefault: true,
+            upgrade: false,
+            source: 'app-server',
+            metadata: {
+              opencode: {
+                providerId: 'ollama',
+                modelId: 'qwen',
+                sourceLabel: 'Ollama',
+                accessKind: 'configured_authless',
+                routeKind: 'configured_local',
+                proofState: 'needs_probe',
+                requiresExecutionProof: true,
+                reason: null,
+              },
+            },
+          },
+        ],
+        diagnostics: { configReadState: 'ready', appServerState: 'healthy' },
+      },
+      modelVerificationState: 'idle',
+      modelAvailability: [],
+    };
+    storeState.cliStatus = {
+      flavor: 'agent_teams_orchestrator',
+      providers: [provider],
+    };
+
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const root = createRoot(host);
+
+    await act(async () => {
+      root.render(
+        React.createElement(TeamModelSelector, {
+          providerId: 'opencode',
+          onProviderChange: () => undefined,
+          value: '',
+          onValueChange: () => undefined,
+        })
+      );
+      await Promise.resolve();
+    });
+    await flushFailClosedAuthorityClocks();
+
+    await vi.waitFor(() => {
+      expect(host.textContent).toContain('qwen');
+    });
+    expect(
+      host.querySelector('[data-testid="team-model-selector-provider-nav-ollama"]')
+    ).toBeNull();
+    expect(
+      host.querySelector('[data-testid="team-model-selector-opencode-route-tag-local"]')
+    ).not.toBeNull();
+    expect(loadModels).not.toHaveBeenCalled();
+
+    await act(async () => {
+      root.unmount();
+      await Promise.resolve();
+    });
+  });
+
   it('never dispatches a remote catalog load for a custom local provider route', async () => {
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
     const localLookup = createDeferred<RuntimeLocalProviderListResponse>();


### PR DESCRIPTION
## Summary
- Keep configured local OpenCode models such as Ollama visible after a catalog refresh instead of dropping them when the live overlay is empty.
- Show those providers as ready / configured local on the dashboard, without calling them Connected.
- Draft v2.14.3 hotfix notes. Runtime stays on v0.0.95.

## Test plan
- [x] Overlay-miss selector test: catalog `ollama/qwen` stays visible with empty `listLocalProviders`
- [x] CliStatusBanner: unauthenticated OpenCode + Ollama catalog shows Ready + configured local
- [x] `connectedCatalogSourceIds` includes available ollama/lmstudio
- [x] Live Ollama probe/configure (gated `LIVE_OLLAMA=1`)
- [x] `pnpm typecheck` and `pnpm guard:source-file-size`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Local OpenCode models, including Ollama and LM Studio models, remain visible and selectable after refreshing the model catalog.
  - Dashboard status now recognizes configured local models and displays an accurate readiness summary.
  - Local model routes are retained even when the latest catalog overlay does not include them.

- **Documentation**
  - Added draft release notes for v2.14.3, including runtime requirements and platform download links.

- **Tests**
  - Added coverage for local model visibility, status messaging, catalog refresh behavior, and live Ollama integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->