### PR TITLE
fix(tasks): enforce blockedBy on execution transitions

### DIFF
--- a/agent-teams-controller/src/internal/review.js
+++ b/agent-teams-controller/src/internal/review.js
@@ -533,6 +533,15 @@ function approveReview(context, taskId, flags = {}) {
     };
   });
 
+  try {
+    const approvedTask = tasks.getTask(context, taskId);
+    const history = Array.isArray(approvedTask.historyEvents) ? approvedTask.historyEvents : [];
+    const approval = [...history].reverse().find((event) => event && event.type === 'review_approved');
+    tasks.notifyUnblockedOwners(context, approvedTask, { reviewCycleId: approval && approval.id });
+  } catch (error) {
+    warnNonCritical('[review] dependency approval notification failed', error);
+  }
+
   if (result.alreadyApproved) {
     return result.payload;
   }

--- a/agent-teams-controller/src/internal/taskReadErrors.js
+++ b/agent-teams-controller/src/internal/taskReadErrors.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+function unreadableTaskAnomaly(filePath, error) {
+  return {
+    code: 'unreadable_task',
+    taskId: path.basename(filePath, '.json'),
+    filePath,
+    detail: error instanceof Error ? error.message : 'Unreadable task row',
+  };
+}
+
+function taskNotFound(taskRef) {
+  return Object.assign(new Error(`Task not found: ${taskRef}`), { code: 'TASK_NOT_FOUND' });
+}
+
+function assertReadableTaskRef(scan, taskRef) {
+  const anomaly = scan.anomalies.find((row) => row.code === 'unreadable_task' && row.taskId === taskRef);
+  if (anomaly) {
+    throw Object.assign(new Error(`Cannot read task ${taskRef}: ${anomaly.detail}`), {
+      code: 'TASK_UNREADABLE',
+    });
+  }
+}
+
+module.exports = { unreadableTaskAnomaly, taskNotFound, assertReadableTaskRef };

--- a/agent-teams-controller/src/internal/taskStore.js
+++ b/agent-teams-controller/src/internal/taskStore.js
@@ -1,3 +1,4 @@
+const { unreadableTaskAnomaly, taskNotFound, assertReadableTaskRef } = require('./taskReadErrors.js');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
@@ -161,16 +162,11 @@ function buildTaskScanSnapshot(paths) {
     try {
       rawTask = JSON.parse(fs.readFileSync(filePath, 'utf8'));
     } catch (error) {
-      anomalies.push({
-        code: 'unreadable_task',
-        taskId: path.basename(fileName, '.json'),
-        filePath,
-        detail: error instanceof Error ? error.message : 'Unreadable task row',
-      });
+      anomalies.push(unreadableTaskAnomaly(filePath, error));
       continue;
     }
-    if (!rawTask) continue;
-    if (rawTask.metadata && rawTask.metadata._internal === true) continue;
+
+    if (rawTask && rawTask.metadata && rawTask.metadata._internal === true) continue;
     const canonicalTaskId = path.basename(fileName, '.json');
     const persistedTaskId = getPersistedTaskId(rawTask);
     if (persistedTaskId) {
@@ -193,13 +189,7 @@ function buildTaskScanSnapshot(paths) {
         task,
       });
     } catch (error) {
-      const taskId = getPersistedTaskId(rawTask) || path.basename(fileName, '.json');
-      anomalies.push({
-        code: 'unreadable_task',
-        taskId,
-        filePath,
-        detail: error instanceof Error ? error.message : 'Unreadable task row',
-      });
+      anomalies.push(unreadableTaskAnomaly(filePath, error));
     }
   }
 
@@ -409,11 +399,12 @@ function resolveTaskRow(paths, taskRef, options = {}) {
 
   const includeDeleted = options.includeDeleted === true;
   const scan = scanTaskRows(paths);
+  assertReadableTaskRef(scan, normalizedRef);
   const exact = scan.rowsByCanonicalId.get(normalizedRef);
 
   if (exact) {
     if (!includeDeleted && exact.task.status === 'deleted') {
-      throw new Error(`Task not found: ${normalizedRef}`);
+      throw taskNotFound(normalizedRef);
     }
     assertTaskRowHasUnambiguousIdentity(scan, exact, normalizedRef);
     return exact;
@@ -449,7 +440,7 @@ function resolveTaskRow(paths, taskRef, options = {}) {
     return byDisplay[0];
   }
 
-  throw new Error(`Task not found: ${normalizedRef}`);
+  throw taskNotFound(normalizedRef);
 }
 
 function resolveTaskRef(paths, taskRef, options = {}) {

--- a/agent-teams-controller/src/internal/tasks.js
+++ b/agent-teams-controller/src/internal/tasks.js
@@ -150,11 +150,11 @@ function getOpenBlockers(context, task) {
     for (const id of blockerIds) {
         try {
             const blocker = taskStore.readTask(context.paths, id, { includeDeleted: true });
-            if (blocker.status !== 'completed' && blocker.status !== 'deleted') {
+            if (isTaskOpen(blocker)) {
                 blockers.push(blocker);
             }
-        } catch {
-            // missing task = not blocking
+        } catch (error) {
+            if (error.code !== 'TASK_NOT_FOUND') throw error;
         }
     }
     return blockers;
@@ -470,6 +470,7 @@ function startTask(context, taskId, actor) {
  * and `options.resolution` decides which of the two the owner is told about.
  */
 function notifyUnblockedOwners(context, resolvedTask, options = {}) {
+    if (isTaskOpen(resolvedTask)) return;
     const blockedIds = Array.isArray(resolvedTask.blocks) ? resolvedTask.blocks : [];
     if (blockedIds.length === 0) return;
 
@@ -483,16 +484,7 @@ function notifyUnblockedOwners(context, resolvedTask, options = {}) {
             if (!normalizeActorName(blockedTask.owner)) continue;
 
             const allBlockerIds = Array.isArray(blockedTask.blockedBy) ? blockedTask.blockedBy : [];
-            const pendingBlockerTasks = [];
-            for (const id of allBlockerIds) {
-                if (id === resolvedTask.id) continue;
-                try {
-                    const t = taskStore.readTask(context.paths, id, { includeDeleted: true });
-                    if (t.status !== 'completed' && t.status !== 'deleted') {
-                        pendingBlockerTasks.push(t);
-                    }
-                } catch { /* missing task = not blocking */ }
-            }
+            const pendingBlockerTasks = getOpenBlockers(context, blockedTask);
 
             const allResolved = pendingBlockerTasks.length === 0;
             const blockedLabel = `#${blockedTask.displayId || blockedTask.id}`;
@@ -525,7 +517,7 @@ function notifyUnblockedOwners(context, resolvedTask, options = {}) {
                 context,
                 blockedTask.id,
                 {
-                    id: `dep-resolved-${resolvedTask.id}-${blockedTask.id}`,
+                    id: `dep-resolved-${resolvedTask.id}-${blockedTask.id}${options.reviewCycleId ? `-${options.reviewCycleId}` : ''}`,
                     text: lines.join('\n'),
                     from: 'system',
                 },
@@ -1139,6 +1131,7 @@ module.exports = {
     MEMBER_DELEGATE_DESCRIPTION,
     buildProcessProtocolText,
     memberBriefing,
+    notifyUnblockedOwners,
     taskBriefing,
     unlinkTask,
     updateTask: (context, taskRef, updater) =>

--- a/agent-teams-controller/src/internal/tasks.js
+++ b/agent-teams-controller/src/internal/tasks.js
@@ -144,19 +144,35 @@ function mergeTaskRefs(primaryTaskRef, extraTaskRefs) {
     return merged.length > 0 ? merged : undefined;
 }
 
-function hasOpenBlockers(context, task) {
+function getOpenBlockers(context, task) {
+    const blockers = [];
     const blockerIds = Array.isArray(task.blockedBy) ? task.blockedBy : [];
     for (const id of blockerIds) {
         try {
             const blocker = taskStore.readTask(context.paths, id, { includeDeleted: true });
             if (blocker.status !== 'completed' && blocker.status !== 'deleted') {
-                return true;
+                blockers.push(blocker);
             }
         } catch {
             // missing task = not blocking
         }
     }
-    return false;
+    return blockers;
+}
+
+function hasOpenBlockers(context, task) {
+    return getOpenBlockers(context, task).length > 0;
+}
+
+function assertDependenciesResolved(context, task, status) {
+    const blockers = getOpenBlockers(context, task);
+    if (blockers.length > 0) {
+        const labels = blockers.map((blocker) => `#${blocker.displayId || blocker.id} (${blocker.status})`);
+        throw new Error(
+            `Cannot set task #${task.displayId || task.id} to ${status}: unresolved dependencies ${labels.join(', ')}. ` +
+            `Wait or work on another task, then retry once dependencies are resolved. Ask the lead if a dependency is incorrect.`
+        );
+    }
 }
 
 function maybeNotifyAssignedOwner(context, task, options = {}) {
@@ -362,6 +378,9 @@ function setTaskStatus(context, taskId, status, actor, options = {}) {
                       allowLeadOverride:
                           normalizedStatus !== 'in_progress' && normalizedStatus !== 'completed',
                   });
+        if (normalizedStatus === 'in_progress' || normalizedStatus === 'completed') {
+            assertDependenciesResolved(context, before, normalizedStatus);
+        }
         let task = taskStore.setTaskStatus(context.paths, taskId, status, actorForWrite);
         if (normalizedStatus === 'deleted' || normalizedStatus === 'in_progress' || normalizedStatus === 'pending') {
             const state = kanbanStore.readKanbanState(context.paths, context.teamName);
@@ -372,6 +391,9 @@ function setTaskStatus(context, taskId, status, actor, options = {}) {
         }
         return { task, becameDeleted: before.status !== 'deleted' && task.status === 'deleted' };
     });
+    if (task.status === 'completed') {
+        runCompletedTaskFollowUps(context, task);
+    }
     if (becameDeleted) {
         runDeletedTaskFollowUps(context, task);
     }
@@ -431,6 +453,7 @@ function startTask(context, taskId, actor) {
         const before = taskStore.readTask(context.paths, taskId, { includeDeleted: true });
         assertTaskNotDeleted(before, 'starting work');
         const actorForWrite = assertTaskOwnerMutation(context, before, actor, 'start it');
+        assertDependenciesResolved(context, before, 'in_progress');
         let task = taskStore.setTaskStatus(context.paths, taskId, 'in_progress', actorForWrite);
         const state = kanbanStore.readKanbanState(context.paths, context.teamName);
         if (hasKanbanReference(state, task.id)) {
@@ -576,8 +599,7 @@ function notifyLeadWhenBoardCompleted(context, completedTask) {
     }
 }
 
-function completeTask(context, taskId, actor) {
-    const task = setTaskStatus(context, taskId, 'completed', actor);
+function runCompletedTaskFollowUps(context, task) {
     try {
         notifyUnblockedOwners(context, task);
     } catch (error) {
@@ -588,7 +610,10 @@ function completeTask(context, taskId, actor) {
     } catch (error) {
         warnNonCritical(`[tasks] board-completion follow-up failed for task ${task.id}`, error);
     }
-    return task;
+}
+
+function completeTask(context, taskId, actor) {
+    return setTaskStatus(context, taskId, 'completed', actor);
 }
 
 function softDeleteTask(context, taskId, actor) {

--- a/agent-teams-controller/test/controller.test.js
+++ b/agent-teams-controller/test/controller.test.js
@@ -147,8 +147,8 @@ controller.messages.sendMessage({
     const claudeDir = makeClaudeDir();
     const controller = createController({ teamName: 'my-team', claudeDir });
 
-    const base = controller.tasks.createTask({ subject: 'Base task' });
-    const dependency = controller.tasks.createTask({ subject: 'Dependency task' });
+    const base = controller.tasks.createTask({ subject: 'Base task', owner: 'bob' });
+    const dependency = controller.tasks.createTask({ subject: 'Dependency task', owner: 'bob' });
     const created = controller.tasks.createTask({
       subject: 'Blocked task',
       owner: 'bob',
@@ -166,6 +166,8 @@ controller.messages.sendMessage({
     expect(controller.tasks.getTask(created.displayId).blockedBy).toEqual([base.id, dependency.id]);
 
     controller.kanban.addReviewer('alice');
+    controller.tasks.completeTask(base.id, 'bob');
+    controller.tasks.completeTask(dependency.id, 'bob');
     controller.tasks.completeTask(created.id, 'bob');
     controller.review.requestReview(created.id, { from: 'alice' });
     controller.review.approveReview(created.id, { 'notify-owner': true, from: 'alice' });
@@ -668,7 +670,10 @@ controller.messages.sendMessage({
       owner: 'carol',
       blockedBy: [lateBlocker.id],
     });
-    controller.taskBoard.completeTask(finished.id, 'carol');
+    // Model a legacy inconsistent row; execution APIs now reject open blockers.
+    const finishedPath = path.join(claudeDir, 'tasks', 'my-team', `${finished.id}.json`);
+    const finishedRow = JSON.parse(fs.readFileSync(finishedPath, 'utf8'));
+    fs.writeFileSync(finishedPath, JSON.stringify({ ...finishedRow, status: 'completed' }));
     controller.taskBoard.softDeleteTask(lateBlocker.id, 'alice');
     expect(readCarolInbox()).toHaveLength(2);
   });

--- a/agent-teams-controller/test/taskDependencyTransitions.test.js
+++ b/agent-teams-controller/test/taskDependencyTransitions.test.js
@@ -1,0 +1,123 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { createController } = require('../src/index.js');
+
+const transitions = [
+  ['start', 'in_progress', (tasks, id) => tasks.startTask(id, 'bob')],
+  ['complete', 'completed', (tasks, id) => tasks.completeTask(id, 'bob')],
+  ['set in_progress', 'in_progress', (tasks, id) => tasks.setTaskStatus(id, 'in_progress', 'bob')],
+  ['set completed', 'completed', (tasks, id) => tasks.setTaskStatus(id, 'completed', 'bob')],
+];
+
+describe('issue-618 dependency transitions', () => {
+  let dir;
+  let tasks;
+  let sequence = 0;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'issue618-controller-'));
+    fs.mkdirSync(path.join(dir, 'teams', 'fixture'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'teams', 'fixture', 'config.json'), JSON.stringify({
+      name: 'fixture', members: [{ name: 'alice', role: 'team-lead' }, { name: 'bob', role: 'developer' }],
+    }));
+    tasks = createController({ teamName: 'fixture', claudeDir: dir }).taskBoard;
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const snapshot = () => Object.fromEntries(fs.readdirSync(dir, { recursive: true })
+    .filter((file) => fs.statSync(path.join(dir, file)).isFile())
+    .map((file) => [file, fs.readFileSync(path.join(dir, file), 'utf8')]));
+  const create = (blockedBy = []) => tasks.createTask({ subject: `Fixture task ${++sequence}`, owner: 'bob', blockedBy });
+  const inbox = (owner) => {
+    const file = path.join(dir, 'teams', 'fixture', 'inboxes', `${owner}.json`);
+    return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : [];
+  };
+  const rewrite = (task, patch) => {
+    const file = path.join(dir, 'tasks', 'fixture', `${task.id}.json`);
+    fs.writeFileSync(file, JSON.stringify({ ...JSON.parse(fs.readFileSync(file, 'utf8')), ...patch }));
+  };
+
+  describe.each(transitions)('%s', (_name, status, transition) => {
+    it.each(['pending', 'in_progress'])('refuses %s blockers without changing any fixture file', (blockerStatus) => {
+      const blocker = create();
+      tasks.setTaskStatus(blocker.id, blockerStatus, 'bob');
+      const dependent = create([blocker.id]);
+      // Include kanban and already-inconsistent protected states in the snapshot.
+      rewrite(dependent, { status });
+      fs.writeFileSync(path.join(dir, 'teams', 'fixture', 'kanban-state.json'), JSON.stringify({
+        tasks: { [dependent.id]: { column: 'review' } }, columnOrder: { review: [dependent.id] },
+      }));
+      const before = snapshot();
+      expect(() => transition(tasks, dependent.id)).toThrow(`to ${status}: unresolved dependencies #${blocker.displayId} (${blockerStatus})`);
+      expect(snapshot()).toEqual(before);
+    });
+
+    it.each(['completed', 'deleted', 'missing', 'empty'])('allows %s dependencies', (resolution) => {
+      const blocker = create();
+      const dependent = create(resolution === 'empty' ? [] : [blocker.id]);
+      if (resolution === 'completed' || resolution === 'deleted') tasks.setTaskStatus(blocker.id, resolution, 'bob');
+      if (resolution === 'missing') fs.unlinkSync(path.join(dir, 'tasks', 'fixture', `${blocker.id}.json`));
+      expect(transition(tasks, dependent.id).status).toBe(status);
+    });
+
+    it('lists only remaining open blockers', () => {
+      const first = create();
+      const second = create();
+      const dependent = create([first.id, second.id]);
+      tasks.completeTask(first.id, 'bob');
+      const before = snapshot();
+      let error;
+      try { transition(tasks, dependent.id); } catch (caught) { error = caught; }
+      expect(error.message).toContain(`#${second.displayId} (pending)`);
+      expect(error.message).not.toContain(`#${first.displayId}`);
+      expect(snapshot()).toEqual(before);
+    });
+  });
+
+  it('preserves administrative transitions, restore and owner checks', () => {
+    const blocker = create();
+    const dependent = create([blocker.id]);
+    tasks = createController({ teamName: 'fixture', claudeDir: dir, allowUserMessageSender: false }).taskBoard;
+    expect(() => tasks.startTask(dependent.id, 'alice')).toThrow(/owned/i);
+    expect(() => tasks.completeTask(dependent.id, 'alice')).toThrow(/owned/i);
+    expect(() => tasks.setTaskStatus(dependent.id, 'completed', 'alice')).toThrow(/owned/i);
+    expect(tasks.setTaskStatus(dependent.id, 'pending', 'alice').status).toBe('pending');
+    expect(tasks.setTaskStatus(dependent.id, 'deleted', 'alice').status).toBe('deleted');
+    expect(() => tasks.startTask(dependent.id, 'bob')).toThrow(/deleted/);
+    expect(tasks.restoreTask(dependent.id, 'alice').status).toBe('pending');
+    expect(() => tasks.startTask(dependent.id, 'bob')).toThrow(/unresolved dependencies/);
+  });
+
+  it.each(['complete', 'set completed'])('%s preserves partial/final notices and retry deduplication', (method) => {
+    const finish = method === 'complete' ? transitions[1][2] : transitions[3][2];
+    const first = create();
+    const second = create();
+    const dependent = create([first.id, second.id]);
+    tasks.startTask(first.id, 'bob');
+    finish(tasks, first.id);
+    const partial = tasks.getTask(dependent.id).comments;
+    expect(partial).toHaveLength(1);
+    expect(partial[0].text).toContain('Still waiting on:');
+    expect(partial[0].text).not.toContain('task_start');
+    tasks.startTask(second.id, 'bob');
+    finish(tasks, second.id);
+    const completed = tasks.getTask(second.id);
+    finish(tasks, second.id);
+    tasks.completeTask(second.id, 'bob');
+    tasks.setTaskStatus(second.id, 'completed', 'bob');
+    expect(tasks.getTask(second.id).historyEvents).toEqual(completed.historyEvents);
+    expect(tasks.getTask(second.id).workIntervals).toEqual(completed.workIntervals);
+    const comments = tasks.getTask(dependent.id).comments;
+    expect(comments).toHaveLength(2);
+    expect(comments[1].text).toContain('task_get');
+    expect(comments[1].text).toContain('task_start');
+    expect(inbox('bob').filter((row) => row.text.includes('Dependency resolved'))).toHaveLength(2);
+    expect(inbox('alice').filter((row) => row.text.includes('Dependency resolved'))).toHaveLength(0);
+    tasks.startTask(dependent.id, 'bob');
+    finish(tasks, dependent.id);
+    tasks.completeTask(dependent.id, 'bob');
+    tasks.setTaskStatus(dependent.id, 'completed', 'bob');
+    expect(inbox('alice').filter((row) => String(row.messageId).startsWith('board-complete:'))).toHaveLength(1);
+    tasks.setTaskStatus(second.id, 'deleted', 'bob');
+    expect(tasks.getTask(dependent.id).comments).toEqual(comments);
+  });
+});

--- a/agent-teams-controller/test/taskDependencyTransitions.test.js
+++ b/agent-teams-controller/test/taskDependencyTransitions.test.js
@@ -51,6 +51,24 @@ describe('issue-618 dependency transitions', () => {
       expect(snapshot()).toEqual(before);
     });
 
+    it.each(['review', 'needsFix'])('keeps completed blockers in %s open', (reviewState) => {
+      const blocker = create();
+      const dependent = create([blocker.id]);
+      rewrite(blocker, { status: 'completed', reviewState });
+      const before = snapshot();
+      expect(() => transition(tasks, dependent.id)).toThrow(/unresolved dependencies/);
+      expect(snapshot()).toEqual(before);
+    });
+
+    it.each(['{', 'null', 'false', '0', '{}'])('rejects unreadable blocker %s without writes', (payload) => {
+      const blocker = create();
+      const dependent = create([blocker.id]);
+      fs.writeFileSync(path.join(dir, 'tasks', 'fixture', `${blocker.id}.json`), payload);
+      const before = snapshot();
+      expect(() => transition(tasks, dependent.id)).toThrow(/Cannot read task/);
+      expect(snapshot()).toEqual(before);
+    });
+
     it.each(['completed', 'deleted', 'missing', 'empty'])('allows %s dependencies', (resolution) => {
       const blocker = create();
       const dependent = create(resolution === 'empty' ? [] : [blocker.id]);
@@ -71,6 +89,37 @@ describe('issue-618 dependency transitions', () => {
       expect(error.message).not.toContain(`#${first.displayId}`);
       expect(snapshot()).toEqual(before);
     });
+  });
+
+  it('wakes dependents again after approval and deduplicates approval retries', () => {
+    const blocker = create();
+    const dependent = create([blocker.id]);
+    tasks.completeTask(blocker.id, 'bob');
+    expect(tasks.getTask(dependent.id).comments).toHaveLength(1);
+    tasks.requestReview(blocker.id, { from: 'bob', reviewer: 'alice' });
+    expect(() => tasks.startTask(dependent.id, 'bob')).toThrow(/unresolved dependencies/);
+    tasks.completeTask(blocker.id, 'bob');
+    expect(tasks.getTask(dependent.id).comments).toHaveLength(1);
+    const assignedDuringReview = create([blocker.id]);
+    const beforeInbox = inbox('bob').length;
+    tasks.approveReview(blocker.id, { from: 'alice' });
+    expect(tasks.getTask(dependent.id).comments).toHaveLength(2);
+    expect(tasks.getTask(assignedDuringReview.id).comments).toHaveLength(1);
+    expect(inbox('bob').length).toBeGreaterThan(beforeInbox);
+    const afterInbox = inbox('bob').length;
+    tasks.approveReview(blocker.id, { from: 'alice' });
+    expect(tasks.getTask(dependent.id).comments).toHaveLength(2);
+    expect(inbox('bob')).toHaveLength(afterInbox);
+    expect(tasks.startTask(dependent.id, 'bob').status).toBe('in_progress');
+  });
+
+  it('does not resolve a malformed canonical file through another task display ID', () => {
+    const blocker = create();
+    const dependent = create([blocker.id]);
+    const other = create();
+    rewrite(other, { displayId: blocker.id, status: 'completed' });
+    fs.writeFileSync(path.join(dir, 'tasks', 'fixture', `${blocker.id}.json`), 'null');
+    expect(() => tasks.startTask(dependent.id, 'bob')).toThrow(/Cannot read task/);
   });
 
   it('preserves administrative transitions, restore and owner checks', () => {

--- a/mcp-server/src/tools/taskTools.ts
+++ b/mcp-server/src/tools/taskTools.ts
@@ -430,7 +430,7 @@ export function registerTaskTools(server: Pick<FastMCP, 'addTool'>) {
   server.addTool({
     name: 'task_set_status',
     description:
-      'Set task work status. Execution transitions require the current owner; lead override is limited to administrative transitions.',
+      'Set task work status. Open dependencies prevent in_progress/completed. Execution transitions require the current owner; lead override is limited to administrative transitions.',
     parameters: z.object({
       ...toolContextSchema,
       taskId: z.string().min(1),
@@ -479,7 +479,7 @@ export function registerTaskTools(server: Pick<FastMCP, 'addTool'>) {
 
   server.addTool({
     name: 'task_start',
-    description: 'Mark task as in progress. Only the current owner may start it.',
+    description: 'Mark task as in progress. Only the current owner may start it. Open dependencies prevent starting.',
     parameters: z.object({
       ...toolContextSchema,
       taskId: z.string().min(1),
@@ -502,7 +502,7 @@ export function registerTaskTools(server: Pick<FastMCP, 'addTool'>) {
 
   server.addTool({
     name: 'task_complete',
-    description: 'Mark task as completed. Only the current owner may complete it.',
+    description: 'Mark task as completed. Only the current owner may complete it. Open dependencies prevent completion.',
     parameters: z.object({
       ...toolContextSchema,
       taskId: z.string().min(1),

--- a/mcp-server/test/stdio.e2e.test.ts
+++ b/mcp-server/test/stdio.e2e.test.ts
@@ -253,6 +253,92 @@ describe('agent-teams-mcp stdio e2e', () => {
     await rm(claudeDir, { recursive: true, force: true });
   });
 
+  it.each(['task_complete', 'task_set_status'])(
+    'issue-618 enforces dependencies and delivers one unblock notice via %s over stdio',
+    async (completionTool) => {
+      const teamName = 'issue-618-e2e';
+      await writeTeamConfig(claudeDir, teamName);
+      const client = new McpStdIoClient(serverPath, workspaceRoot);
+      let requestId = 3;
+      const call = async (name: string, args: Record<string, unknown>) => {
+        const response = await client.callTool(name, { claudeDir, teamName, ...args }, requestId++);
+        return (response as { result: unknown }).result;
+      };
+      try {
+        await client.initialize();
+        const blocker = parseJsonToolResult(
+          await call('task_create', { subject: 'Prepare input', owner: 'alice' })
+        );
+        const dependent = parseJsonToolResult(
+          await call('task_create', {
+            subject: 'Consume input',
+            owner: 'bob',
+            blockedBy: [blocker.id],
+          })
+        );
+        const dependentPath = path.join(claudeDir, 'tasks', teamName, `${dependent.id}.json`);
+        const before = await readFile(dependentPath, 'utf8');
+        for (const [name, extra] of [
+          ['task_start', {}],
+          ['task_complete', {}],
+          ['task_set_status', { status: 'in_progress' }],
+          ['task_set_status', { status: 'completed' }],
+        ] as const) {
+          const rejected = await call(name, { taskId: dependent.id, actor: 'bob', ...extra });
+          expect(rejected).toMatchObject({ isError: true });
+          expect(JSON.stringify(rejected)).toContain(`#${blocker.displayId}`);
+          expect(await readFile(dependentPath, 'utf8')).toBe(before);
+        }
+        for (const name of [
+          completionTool,
+          completionTool,
+          completionTool === 'task_complete' ? 'task_set_status' : 'task_complete',
+        ]) {
+          expect(
+            parseJsonToolResult(
+              await call(name, {
+                taskId: blocker.id,
+                actor: 'alice',
+                ...(name === 'task_set_status' ? { status: 'completed' } : {}),
+              })
+            ).status
+          ).toBe('completed');
+        }
+        const stored = JSON.parse(await readFile(dependentPath, 'utf8'));
+        const commentId = `dep-resolved-${blocker.id}-${dependent.id}`;
+        expect(
+          stored.comments.filter((entry: { id: string }) => entry.id === commentId)
+        ).toHaveLength(1);
+        const inbox = JSON.parse(
+          await readFile(path.join(claudeDir, 'teams', teamName, 'inboxes', 'bob.json'), 'utf8')
+        ) as Array<{ text: string }>;
+        const notices = inbox.filter((entry) => entry.text.includes('Dependency resolved'));
+        expect(notices).toHaveLength(1);
+        expect(notices[0].text).toContain('task_get');
+        expect(notices[0].text).toContain('task_start');
+        expect(notices[0].text).toContain(dependent.id);
+        expect(
+          parseJsonToolResult(
+            await call('task_start', {
+              taskId: dependent.id,
+              actor: 'bob',
+            })
+          ).status
+        ).toBe('in_progress');
+        expect(
+          parseJsonToolResult(
+            await call('task_complete', {
+              taskId: dependent.id,
+              actor: 'bob',
+            })
+          ).status
+        ).toBe('completed');
+      } finally {
+        await client.close();
+      }
+    }
+  );
+
   it('boots over stdio, lists task tools, and executes task lifecycle calls', async () => {
     await writeTeamConfig(claudeDir, 'e2e-team');
     const client = new McpStdIoClient(serverPath, workspaceRoot);

--- a/mcp-server/test/tools.test.ts
+++ b/mcp-server/test/tools.test.ts
@@ -119,6 +119,70 @@ describe('agent-teams-mcp tools', () => {
     };
   }
 
+  it.each(['task_complete', 'task_set_status'])('issue-618 resolves dependencies through %s with owner notices and deduplicated retries', async (completionTool) => {
+    const claudeDir = makeClaudeDir();
+    const teamName = 'issue618';
+    writeTeamConfig(claudeDir, teamName, {
+      projectPath: claudeDir,
+      members: [{ name: 'lead', role: 'team-lead' }, { name: 'alice', role: 'developer' }],
+    });
+    const call = async (name: string, args: Record<string, unknown>) =>
+      parseJsonToolResult(await getTool(name).execute({ claudeDir, teamName, ...args }));
+    let sequence = 0;
+    const create = async (blockedBy: string[] = []) =>
+      await call('task_create', { subject: `Disposable dependency test ${++sequence}`, owner: 'alice', blockedBy });
+    const inbox = (owner: string): Array<{ text: string; messageId?: string }> => {
+      const file = path.join(claudeDir, 'teams', teamName, 'inboxes', `${owner}.json`);
+      return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : [];
+    };
+    const first = await create();
+    const second = await create();
+    const dependent = await create([first.id, second.id]);
+    const protectedCalls: Array<[string, Record<string, unknown>]> = [
+      ['task_start', {}], ['task_complete', {}],
+      ['task_set_status', { status: 'in_progress' }], ['task_set_status', { status: 'completed' }],
+    ];
+    for (const blockerStatus of ['pending', 'in_progress']) {
+      await call('task_set_status', { taskId: first.id, actor: 'alice', status: blockerStatus });
+      const before = fs.readFileSync(path.join(claudeDir, 'tasks', teamName, `${dependent.id}.json`), 'utf8');
+      const notices = inbox('alice');
+      for (const [name, args] of protectedCalls) {
+        await expect(call(name, { taskId: dependent.id, actor: 'alice', ...args })).rejects.toThrow('unresolved dependencies');
+      }
+      expect(fs.readFileSync(path.join(claudeDir, 'tasks', teamName, `${dependent.id}.json`), 'utf8')).toBe(before);
+      expect(inbox('alice')).toEqual(notices);
+    }
+    const finish = async (taskId: string) => await call(completionTool, { taskId, actor: 'alice', status: 'completed' });
+    await finish(first.id);
+    const partial = inbox('alice').filter((row) => row.text.includes('Dependency resolved'));
+    expect(partial).toHaveLength(1);
+    expect(partial[0].text).toContain('Still waiting on:');
+    expect(partial[0].text).not.toContain('task_start');
+    for (const [name, args] of protectedCalls) {
+      await expect(call(name, { taskId: dependent.id, actor: 'alice', ...args })).rejects.toThrow(`#${second.displayId} (pending)`);
+    }
+    await finish(second.id);
+    await finish(second.id);
+    await call('task_complete', { taskId: second.id, actor: 'alice' });
+    await call('task_set_status', { taskId: second.id, actor: 'alice', status: 'completed' });
+    const notices = inbox('alice').filter((row) => row.text.includes('Dependency resolved'));
+    expect(notices).toHaveLength(2);
+    expect(notices[1].text).toContain(`task_get { teamName: "${teamName}", taskId: "${dependent.id}" }`);
+    expect(notices[1].text).toContain(`task_start { teamName: "${teamName}", taskId: "${dependent.id}", actor: "alice" }`);
+    expect(inbox('lead').filter((row) => row.text.includes('Dependency resolved'))).toHaveLength(0);
+    const stored = JSON.parse(fs.readFileSync(path.join(claudeDir, 'tasks', teamName, `${dependent.id}.json`), 'utf8'));
+    expect(stored.comments.map((comment: { id: string }) => comment.id)).toEqual([
+      `dep-resolved-${first.id}-${dependent.id}`, `dep-resolved-${second.id}-${dependent.id}`,
+    ]);
+    for (const [name, args] of protectedCalls) {
+      expect((await call(name, { taskId: dependent.id, actor: 'alice', ...args })).status).toBe(
+        name === 'task_start' || args.status === 'in_progress' ? 'in_progress' : 'completed'
+      );
+    }
+    await finish(dependent.id);
+    expect(inbox('lead').filter((row) => row.messageId?.startsWith('board-complete:'))).toHaveLength(1);
+  });
+
   it('registers the full expected MCP tool surface', () => {
     expect([...tools.keys()].sort()).toEqual([...AGENT_TEAMS_REGISTERED_TOOL_NAMES].sort());
   });


### PR DESCRIPTION
Tasks with unresolved dependencies can currently be started or completed through explicit MCP status calls. This change rejects those transitions under the existing board lock and makes task_set_status(completed) use the same dependency and board-completion notifications as task_complete.

Completed blockers awaiting review or fixes remain open. Approval wakes dependent owners with per-review deduplication. Unreadable task files and identity errors fail closed; genuinely missing and deleted dependencies retain their existing behavior.

Validation:
- Isolated server: 387 controller tests, 66 MCP tests, MCP build, and both stdio E2E dependency cases passed. Final follow-up hardening passed all 61 dependency regression cases.
- Separate Astra review verified both bot findings and reviewed the fixes; no outstanding actionable findings.
- Final commit bc334a1f448503baeee2169ec9210b4be20c6589 passed full GitHub CI, CodeQL, Windows smoke and CodeRabbit review.
- Optional ReviewRouter could not start its review due to external HTTP 503; independent source review was completed separately.
- Tests use temporary sandbox data, without live member agents or real user projects.

Refs #618
https://github.com/777genius/agent-teams-ai/issues/618
