### PR TITLE
fix(notifications): stop replaying recovered comment forwards as toasts

### DIFF
--- a/scripts/e2e/comment-notification-desktop.mjs
+++ b/scripts/e2e/comment-notification-desktop.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Real desktop/store/IPC/filesystem test. Never launches a team or provider.
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { createWriteStream } from 'node:fs';
 import { chmod, mkdir, mkdtemp, readFile, rename, writeFile } from 'node:fs/promises';
@@ -22,6 +22,8 @@ const project = path.join(artifacts, 'TEST-project');
 const nativeLog = path.join(artifacts, 'native-notifications.ndjson');
 const evidence = {
   kind: 'comment-notification-desktop-v1',
+  revision: execFileSync('git', ['rev-parse', 'HEAD'], { cwd: repo, encoding: 'utf8' }).trim(),
+  startedAt: new Date().toISOString(),
   artifacts,
   team,
   checks: [],
@@ -442,12 +444,14 @@ try {
   await forwarded('TEST_historical-removed');
   await snapshot('historical-startup', 2, 0);
   // Establish inbox baseline using a real watched file event, then prove it with a control.
-  const inboxEventCount = () => cdp.evaluate(
-    'window.__commentInboxEvents.filter((event) => event.type === "inbox").length'
-  );
+  const inboxEventCount = () =>
+    cdp.evaluate('window.__commentInboxEvents.filter((event) => event.type === "inbox").length');
   const baselineEvents = await inboxEventCount();
   await json(inboxFile, JSON.parse(await readFile(inboxFile, 'utf8')));
-  await until(async () => (await inboxEventCount()) > baselineEvents, 'engaged inbox watcher event');
+  await until(
+    async () => (await inboxEventCount()) > baselineEvents,
+    'engaged inbox watcher event'
+  );
   await delay(1500);
   await control('TEST_CONTROL_BASELINE');
   await until(
@@ -535,18 +539,23 @@ try {
     throw error;
   });
   evidence.blockedRuntimeCalls = evidence.runtimeDenied.trim()
-    ? evidence.runtimeDenied.trim().split('\n').map((line) => JSON.parse(line))
+    ? evidence.runtimeDenied
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
     : [];
   // The app probes provider status/bridge availability at startup. The fixture
   // rejects these with exit 77; no real runtime is reachable through this path.
   assert(
     evidence.blockedRuntimeCalls.every(
-      (args) => args[0] === 'runtime' &&
+      (args) =>
+        args[0] === 'runtime' &&
         (args[1] === 'opencode-command' || (args[1] === 'status' && args.includes('--summary')))
     ),
     'Only blocked startup availability probes expected; no lifecycle commands'
   );
   evidence.passed = true;
+  evidence.completedAt = new Date().toISOString();
 } catch (error) {
   evidence.error = error.stack || String(error);
   if (cdp) await cdp.screenshot(path.join(artifacts, 'failure.png')).catch(() => {});

--- a/scripts/e2e/comment-notification-desktop.mjs
+++ b/scripts/e2e/comment-notification-desktop.mjs
@@ -1,0 +1,564 @@
+#!/usr/bin/env node
+// Real desktop/store/IPC/filesystem test. Never launches a team or provider.
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { chmod, mkdir, mkdtemp, readFile, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { CdpClient } from './comment-notification/cdp.mjs';
+
+const repo = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const artifacts = await mkdtemp(path.join(os.tmpdir(), 'comment-notification-TEST-'));
+const home = path.join(artifacts, 'home');
+const claude = path.join(home, '.claude');
+const team = `comment-e2e-${randomUUID()}`;
+const teamDir = path.join(claude, 'teams', team);
+const taskDir = path.join(claude, 'tasks', team);
+const project = path.join(artifacts, 'TEST-project');
+const nativeLog = path.join(artifacts, 'native-notifications.ndjson');
+const evidence = {
+  kind: 'comment-notification-desktop-v1',
+  artifacts,
+  team,
+  checks: [],
+  snapshots: [],
+  passed: false,
+};
+const children = new Set();
+let cdp;
+let app;
+const desktopLog = createWriteStream(path.join(artifacts, 'desktop.log'));
+let interceptError;
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const json = async (file, value) => {
+  await mkdir(path.dirname(file), { recursive: true });
+  const temporary = `${file}.tmp`;
+  await writeFile(temporary, JSON.stringify(value, null, 2) + '\n');
+  await rename(temporary, file);
+};
+async function until(predicate, label, timeout = 30000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (interceptError) throw interceptError;
+    if (await predicate()) return;
+    await delay(100);
+  }
+  throw new Error(`Timed out: ${label}`);
+}
+function child(command, args, env, detached = false) {
+  const process = spawn(command, args, {
+    cwd: repo,
+    env,
+    detached,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  children.add(process);
+  process.output = '';
+  process.spawnFailure = null;
+  process.on('error', (error) => {
+    process.spawnFailure = error;
+  });
+  for (const stream of [process.stdout, process.stderr]) {
+    stream.on('data', (chunk) => {
+      process.output += chunk.toString();
+      if (process === app) desktopLog.write(chunk);
+    });
+  }
+  return process;
+}
+async function stop(process, group = false) {
+  if (!process) return;
+  const signal = (name) => {
+    try {
+      if (group) globalThis.process.kill(-process.pid, name);
+      else process.kill(name);
+    } catch (error) {
+      if (error.code !== 'ESRCH') throw error;
+    }
+  };
+  signal('SIGTERM');
+  await delay(1500);
+  // Only this harness's detached app process group, never shared hosts.
+  signal('SIGKILL');
+  children.delete(process);
+}
+const old = new Date(Date.now() - 86400000).toISOString();
+const comment = (id, author, createdAt = old) => ({
+  id,
+  author,
+  createdAt,
+  text: `TEST_${id}`,
+  type: 'regular',
+});
+const task = {
+  id: 'abcd1234',
+  subject: 'TEST comment notifications',
+  description: 'Disposable fixture only',
+  status: 'pending',
+  owner: 'active-teammate',
+  blocks: [],
+  blockedBy: [],
+  comments: [
+    comment('historical-active', 'active-teammate'),
+    comment('historical-removed', 'removed-teammate'),
+  ],
+};
+const taskFile = path.join(taskDir, `${task.id}.json`);
+const inboxFile = path.join(teamDir, 'inboxes', 'team-lead.json');
+let env;
+async function seed() {
+  const roots = {
+    HOME: home,
+    TMPDIR: path.join(artifacts, 'tmp'),
+    AGENT_TEAMS_ELECTRON_CLAUDE_ROOT: claude,
+    CLAUDE_CONFIG_DIR: path.join(artifacts, 'claude-config'),
+    AGENT_TEAMS_ELECTRON_USER_DATA_DIR: path.join(artifacts, 'user-data'),
+  };
+  for (const key of ['CONFIG', 'CACHE', 'DATA', 'STATE', 'RUNTIME'])
+    roots[`XDG_${key}_${key === 'RUNTIME' ? 'DIR' : 'HOME'}`] = path.join(
+      artifacts,
+      `xdg-${key.toLowerCase()}`
+    );
+  roots.CLAUDE_MULTIMODEL_DATA_HOME = path.join(artifacts, 'multimodel-data');
+  roots.CLAUDE_MULTIMODEL_CACHE_HOME = path.join(artifacts, 'multimodel-cache');
+  for (const directory of [...Object.values(roots), project, taskDir])
+    await mkdir(directory, { recursive: true });
+  await chmod(roots.XDG_RUNTIME_DIR, 0o700);
+  env = {
+    ...process.env,
+    ...roots,
+    SHELL: '/bin/sh',
+    GOMAXPROCS: '2',
+    COREPACK_HOME: process.env.COREPACK_HOME || '/root/.cache/node/corepack',
+    pnpm_config_verify_deps_before_run: 'false',
+    AGENT_TEAMS_DISABLE_SOURCEMAPS: '1',
+  };
+  // Do not pass credentials or provider-home overrides to the disposable desktop.
+  for (const key of Object.keys(env)) {
+    if (
+      /API_KEY|ACCESS_TOKEN|AUTH_TOKEN|SECRET|^(CODEX_HOME|OPENAI_BASE_URL|ANTHROPIC_BASE_URL|NODE_OPTIONS|ELECTRON_RUN_AS_NODE)$/.test(
+        key
+      )
+    )
+      delete env[key];
+  }
+  for (const key of [
+    'CLAUDE_DEV_RUNTIME_ROOT',
+    'CLAUDE_DEV_RUNTIME_CACHE_ROOT',
+    'CLAUDE_TERMINAL_PLATFORM_ROOT',
+    'TERMINAL_PLATFORM_ROOT',
+    'CLAUDE_TERMINAL_DAEMON_BINARY',
+    'AGENT_TEAMS_ORG_DEMO',
+  ])
+    delete env[key];
+  env.CLAUDE_DEV_RUNTIME_DISABLE_GH = '1';
+  delete env.ELECTRON_CLI_ARGS;
+  // electron-vite translates this into --no-sandbox for root-owned Linux CI.
+  if (process.getuid?.() === 0) env.NO_SANDBOX = '1';
+  const version = JSON.parse(await readFile(path.join(repo, 'runtime.lock.json'), 'utf8')).version;
+  const deny = path.join(artifacts, 'deny-runtime.cjs');
+  await writeFile(
+    deny,
+    `#!${process.execPath}\nconst fs = require('node:fs');\nif (process.argv.slice(2).join(' ') === '--version') { console.log(${JSON.stringify(version)}); } else { fs.appendFileSync(${JSON.stringify(path.join(artifacts, 'runtime-denied.ndjson'))}, JSON.stringify(process.argv.slice(2))+'\\n'); process.exitCode = 77; }\n`
+  );
+  await chmod(deny, 0o755);
+  env.CLAUDE_AGENT_TEAMS_ORCHESTRATOR_CLI_PATH = deny;
+  const members = ['team-lead', 'active-teammate'].map((name) => ({
+    name,
+    agentId: `${name}@${team}`,
+    agentType: name === 'team-lead' ? 'team-lead' : 'general-purpose',
+    cwd: project,
+    joinedAt: Date.now() - 86400000,
+    color: 'blue',
+    subscriptions: [],
+  }));
+  await json(path.join(teamDir, 'config.json'), {
+    name: team,
+    description: 'TEST only',
+    createdAt: Date.now() - 86400000,
+    leadAgentId: members[0].agentId,
+    members,
+    projectPath: project,
+  });
+  await json(path.join(teamDir, 'members.meta.json'), { version: 1, members });
+  await json(path.join(teamDir, 'team.meta.json'), {
+    version: 1,
+    cwd: project,
+    createdAt: Date.now() - 86400000,
+  });
+  await json(path.join(claude, 'agent-teams-config.json'), {
+    general: { appLocale: 'en', theme: 'dark', defaultTab: 'teams' },
+    notifications: {
+      enabled: true,
+      soundEnabled: false,
+      notifyOnTaskComments: true,
+      notifyOnLeadInbox: true,
+      notifyOnUserInbox: true,
+    },
+  });
+  await mkdir(path.join(claude, 'projects'), { recursive: true });
+  await json(taskFile, task);
+  await json(inboxFile, []);
+  await json(path.join(teamDir, 'comment-notification-journal.json'), []);
+  const history = [true, false].map((isRead, index) => ({
+    id: `preserved-${index}`,
+    isRead,
+    createdAt: Date.now() - 60000,
+    timestamp: Date.now() - 60000,
+    sessionId: `team:${team}`,
+    projectId: team,
+    filePath: '',
+    source: 'task_comment',
+    category: 'team',
+    teamEventType: 'task_comment',
+    message: `TEST preserved history ${index}`,
+    dedupeKey: `preserved-${index}`,
+    context: { projectName: team },
+  }));
+  evidence.preservedHistory = history;
+  await json(path.join(claude, 'agent-teams-notifications.json'), history);
+  await writeFile(nativeLog, '');
+  await json(path.join(artifacts, 'fixture.json'), { roots, team, project });
+}
+async function startBus() {
+  const bus = child('dbus-daemon', ['--session', '--nofork', '--print-address=1'], env);
+  await until(() => {
+    if (bus.spawnFailure) throw bus.spawnFailure;
+    if (bus.exitCode !== null) throw new Error(`Private D-Bus failed: ${bus.output}`);
+    return bus.output.includes('\n');
+  }, 'private D-Bus address');
+  env.DBUS_SESSION_BUS_ADDRESS = bus.output.split('\n')[0].trim();
+  const recorder = child(
+    '/usr/bin/python3',
+    [path.join(repo, 'scripts/e2e/comment-notification/notifications.py'), nativeLog],
+    env
+  );
+  await until(() => {
+    if (recorder.spawnFailure) throw recorder.spawnFailure;
+    if (recorder.exitCode !== null)
+      throw new Error(`OS notification observation unavailable: ${recorder.output}`);
+    return recorder.output.includes('READY');
+  }, 'native notification recorder');
+  evidence.notificationBoundary =
+    'Private org.freedesktop.Notifications.Notify service; real Electron notifications';
+}
+async function startApp() {
+  app = child('pnpm', ['dev:mcp'], env, true);
+  let port;
+  await until(
+    () => {
+      if (app.spawnFailure) throw app.spawnFailure;
+      if (app.exitCode !== null) throw new Error(`Desktop exited: ${app.output.slice(-4000)}`);
+      port = app.output.match(/DevTools listening on ws:\/\/127\.0\.0\.1:(\d+)\//)?.[1];
+      return port;
+    },
+    'owned dev:mcp CDP port',
+    180000
+  );
+  let target;
+  await until(
+    async () => {
+      try {
+        const targets = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json();
+        target = targets.find(
+          (item) => item.type === 'page' && item.url.startsWith('http://localhost:')
+        );
+        return target;
+      } catch {
+        return false;
+      }
+    },
+    'owned Electron renderer',
+    60000
+  );
+  cdp = await CdpClient.connect(target.webSocketDebuggerUrl);
+  await cdp.send('Runtime.enable');
+  await cdp.send('Page.enable');
+  await cdp.waitFor(
+    'window.electronAPI && window.__agentTeamsDevStore',
+    'real Electron API and dev store',
+    60000
+  );
+  // Opening the fixture through real IPC brings its idle inbox into watch scope.
+  await cdp.evaluate(`(async () => {
+    window.__commentInboxEvents = [];
+    window.electronAPI.teams.onTeamChange((_event, data) => {
+      if (data.teamName === ${JSON.stringify(team)}) window.__commentInboxEvents.push(data);
+    });
+    await window.electronAPI.teams.getData(${JSON.stringify(team)});
+  })()`);
+  await refresh();
+}
+const state = 'window.__agentTeamsDevStore';
+async function refresh() {
+  await cdp.evaluate(`${state}.getState().fetchAllTasks()`);
+  await cdp.waitFor(
+    `${state}.getState().globalTasksInitialized && !${state}.getState().globalTasksLoading`,
+    'task snapshot'
+  );
+  const tasks = await cdp.evaluate(`${state}.getState().globalTasks`);
+  assert(
+    tasks.some((item) => item.id === task.id && item.teamName === team),
+    'Real IPC must load fixture task'
+  );
+}
+async function history() {
+  return cdp.evaluate('window.electronAPI.notifications.get({limit:200})');
+}
+async function native() {
+  const text = await readFile(nativeLog, 'utf8');
+  return text.trim()
+    ? text
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+    : [];
+}
+async function snapshot(label, expectedTotal, expectedNative) {
+  // Negative checks span watcher debounce + async notification persistence.
+  await delay(2500);
+  const stored = await history();
+  const shown = await native();
+  assert.equal(stored.total, expectedTotal, `${label}: history total`);
+  assert.equal(stored.unreadCount, expectedTotal - 1, `${label}: unread count`);
+  for (const original of evidence.preservedHistory)
+    assert.deepEqual(
+      stored.notifications.find((row) => row.id === original.id),
+      original,
+      `${label}: preexisting history unchanged`
+    );
+  assert.equal(shown.length, expectedNative, `${label}: OS notification count`);
+  assert(
+    !stored.notifications.some((row) => /TEST_historical|TEST_recovered/.test(row.message)),
+    `${label}: no old notification rows`
+  );
+  const screenshot = path.join(artifacts, `${evidence.snapshots.length}-${label}.png`);
+  await cdp.screenshot(screenshot);
+  evidence.snapshots.push({ label, stored, native: shown, screenshot });
+  evidence.checks.push(label);
+  await json(path.join(artifacts, 'evidence.json'), evidence);
+}
+async function appendComment(value) {
+  task.comments.push(value);
+  await json(taskFile, task);
+  await refresh();
+}
+async function forwarded(marker) {
+  let messages;
+  await until(async () => {
+    messages = JSON.parse(await readFile(inboxFile, 'utf8'));
+    return messages.some(
+      (item) => item.messageKind === 'task_comment_notification' && item.text.includes(marker)
+    );
+  }, `real main journal delivery for ${marker}`);
+  evidence.forwarded = messages;
+}
+async function control(marker) {
+  const messages = JSON.parse(await readFile(inboxFile, 'utf8'));
+  messages.push({
+    from: 'removed-teammate',
+    text: marker,
+    timestamp: new Date().toISOString(),
+    read: false,
+    messageId: randomUUID(),
+  });
+  await json(inboxFile, messages);
+}
+async function firstSnapshotRace() {
+  // Delay only the transport call; real detector, clock, data and notification IPC remain intact.
+  const needle = 'function getImpl() {\n  if (window.electronAPI) return window.electronAPI;';
+  const replacement = `function getImpl() {
+    if (window.electronAPI) {
+      if (!window.__commentSnapshotGate) {
+        let release;
+        const ready = new Promise(resolve => { release = resolve; });
+        const gate = window.__commentSnapshotGate = { waiting: 0, release, released: false };
+        gate.api = { ...window.electronAPI, teams: { ...window.electronAPI.teams,
+          getAllTasks: async (...args) => { gate.waiting++; await ready; return window.electronAPI.teams.getAllTasks(...args); }
+        }};
+      }
+      return window.__commentSnapshotGate.api;
+    }`;
+  let patches = 0;
+  cdp.on('Fetch.requestPaused', async (event) => {
+    try {
+      const pathname = new URL(event.request.url).pathname;
+      if (!pathname.endsWith('/api/index.ts')) {
+        await cdp.send('Fetch.continueRequest', { requestId: event.requestId });
+        return;
+      }
+      const response = await cdp.send('Fetch.getResponseBody', { requestId: event.requestId });
+      const body = response.base64Encoded
+        ? Buffer.from(response.body, 'base64').toString()
+        : response.body;
+      assert(body.includes(needle), 'Transport gate must match real Vite API module');
+      patches++;
+      await cdp.send('Fetch.fulfillRequest', {
+        requestId: event.requestId,
+        responseCode: 200,
+        responseHeaders: [{ name: 'Content-Type', value: 'text/javascript' }],
+        body: Buffer.from(body.replace(needle, replacement)).toString('base64'),
+      });
+    } catch (error) {
+      interceptError = error;
+    }
+  });
+  await cdp.send('Network.setCacheDisabled', { cacheDisabled: true });
+  await cdp.send('Fetch.enable', {
+    patterns: [{ urlPattern: '*api/index.ts*', requestStage: 'Response' }],
+  });
+  await cdp.send('Page.reload', { ignoreCache: true });
+  await cdp.waitFor(
+    'window.__commentSnapshotGate?.waiting > 0 && window.__agentTeamsDevStore',
+    'initial task IPC held',
+    60000
+  );
+  assert.equal(
+    await cdp.evaluate(`${state}.getState().globalTasksInitialized`),
+    false,
+    'Must precede first snapshot baseline'
+  );
+  task.comments.push(comment('first-snapshot-fresh', 'active-teammate', new Date().toISOString()));
+  await json(taskFile, task);
+  await forwarded('TEST_first-snapshot-fresh');
+  await cdp.evaluate(`${state}.getState().fetchConfig()`);
+  await cdp.evaluate('window.__commentSnapshotGate.release()');
+  await refresh();
+  assert(patches > 0);
+  evidence.firstSnapshotTransportPatches = patches;
+  await cdp.send('Fetch.disable');
+}
+try {
+  assert.equal(process.platform, 'linux', 'Native boundary recorder requires Linux');
+  assert(process.env.DISPLAY, 'Run with xvfb-run -a');
+  console.log(JSON.stringify({ artifacts }));
+  await seed();
+  await startBus();
+  await startApp();
+  await forwarded('TEST_historical-removed');
+  await snapshot('historical-startup', 2, 0);
+  // Establish inbox baseline using a real watched file event, then prove it with a control.
+  const inboxEventCount = () => cdp.evaluate(
+    'window.__commentInboxEvents.filter((event) => event.type === "inbox").length'
+  );
+  const baselineEvents = await inboxEventCount();
+  await json(inboxFile, JSON.parse(await readFile(inboxFile, 'utf8')));
+  await until(async () => (await inboxEventCount()) > baselineEvents, 'engaged inbox watcher event');
+  await delay(1500);
+  await control('TEST_CONTROL_BASELINE');
+  await until(
+    async () => (await history()).total === 3,
+    'ordinary inbox control proves active watcher/baseline'
+  );
+  await snapshot('ordinary-inbox-control', 3, 1);
+  const recoveryStarted = Date.now();
+  await appendComment(comment('recovered-after-baseline', 'removed-teammate'));
+  await forwarded('TEST_recovered-after-baseline');
+  const recovered = evidence.forwarded.find((row) =>
+    row.text.includes('TEST_recovered-after-baseline')
+  );
+  assert(
+    Date.parse(recovered.timestamp) >= recoveryStarted,
+    'Historical recovery must produce a new envelope timestamp'
+  );
+  await snapshot('historical-recovery-after-baseline', 3, 1);
+  await appendComment(comment('fresh-once', 'active-teammate', new Date().toISOString()));
+  await forwarded('TEST_fresh-once');
+  await until(async () => (await history()).total === 4, 'new comment stored');
+  await snapshot('fresh-comment-once', 4, 2);
+  let current = await history();
+  assert.equal(
+    current.notifications.filter(
+      (row) => row.teamEventType === 'task_comment' && row.message.includes('TEST_fresh-once')
+    ).length,
+    1
+  );
+  assert(
+    (await native()).some((row) => row.body.includes('TEST_fresh-once')),
+    'Fresh comment reached actual OS boundary'
+  );
+  task.comments.reverse();
+  await json(taskFile, task);
+  await refresh();
+  await refresh();
+  await snapshot('refresh-and-reorder', 4, 2);
+  await firstSnapshotRace();
+  await forwarded('TEST_first-snapshot-fresh');
+  await until(async () => (await history()).total === 5, 'fresh first-snapshot comment stored');
+  await snapshot('fresh-in-first-snapshot', 5, 3);
+  assert((await native()).some((row) => row.body.includes('TEST_first-snapshot-fresh')));
+  await cdp.evaluate(
+    `(async () => { const config = await window.electronAPI.config.update('notifications', {notifyOnTaskComments:false}); ${state}.setState({appConfig:config}); })()`
+  );
+  await appendComment(comment('toggle-off', 'active-teammate', new Date().toISOString()));
+  await forwarded('TEST_toggle-off');
+  await until(async () => (await history()).total === 6, 'muted comment still stored');
+  await snapshot('comment-toggle-no-lead-duplicate', 6, 3);
+  current = await history();
+  assert.equal(
+    current.notifications.filter(
+      (row) => row.message.includes('TEST_toggle-off') && row.teamEventType === 'task_comment'
+    ).length,
+    1
+  );
+  await control('TEST_CONTROL_AFTER_TOGGLE');
+  await until(
+    async () => (await history()).total === 7,
+    'ordinary inbox works with comment toggle disabled'
+  );
+  await snapshot('ordinary-inbox-after-toggle', 7, 4);
+  // Restore toggle before both restart checks so replay cannot hide behind muted settings.
+  await cdp.evaluate(
+    `(async () => { const config = await window.electronAPI.config.update('notifications', {notifyOnTaskComments:true}); ${state}.setState({appConfig:config}); })()`
+  );
+  const previousTimeOrigin = await cdp.evaluate('performance.timeOrigin');
+  await cdp.send('Page.reload', { ignoreCache: true });
+  await cdp.waitFor(`performance.timeOrigin !== ${previousTimeOrigin}`, 'new renderer document');
+  await cdp.waitFor('window.__agentTeamsDevStore', 'renderer restarted');
+  await refresh();
+  await snapshot('renderer-restart-no-replay', 7, 4);
+  await cdp.close();
+  cdp = null;
+  await stop(app, true);
+  app = null;
+  await startApp();
+  await snapshot('app-restart-no-replay', 7, 4);
+  evidence.runtimeDenied = await readFile(
+    path.join(artifacts, 'runtime-denied.ndjson'),
+    'utf8'
+  ).catch((error) => {
+    if (error.code === 'ENOENT') return '';
+    throw error;
+  });
+  evidence.blockedRuntimeCalls = evidence.runtimeDenied.trim()
+    ? evidence.runtimeDenied.trim().split('\n').map((line) => JSON.parse(line))
+    : [];
+  // The app probes provider status/bridge availability at startup. The fixture
+  // rejects these with exit 77; no real runtime is reachable through this path.
+  assert(
+    evidence.blockedRuntimeCalls.every(
+      (args) => args[0] === 'runtime' &&
+        (args[1] === 'opencode-command' || (args[1] === 'status' && args.includes('--summary')))
+    ),
+    'Only blocked startup availability probes expected; no lifecycle commands'
+  );
+  evidence.passed = true;
+} catch (error) {
+  evidence.error = error.stack || String(error);
+  if (cdp) await cdp.screenshot(path.join(artifacts, 'failure.png')).catch(() => {});
+  process.exitCode = 1;
+} finally {
+  await cdp?.close().catch(() => {});
+  await stop(app, true);
+  for (const process of children) await stop(process);
+  await new Promise((resolve, reject) => {
+    desktopLog.once('error', reject);
+    desktopLog.end(resolve);
+  });
+  await json(path.join(artifacts, 'evidence.json'), evidence);
+  console.log(JSON.stringify({ passed: evidence.passed, artifacts, error: evidence.error }));
+}

--- a/scripts/e2e/comment-notification-desktop.mjs
+++ b/scripts/e2e/comment-notification-desktop.mjs
@@ -537,7 +537,8 @@ try {
     evidence.blockedRuntimeCalls.every(
       (args) =>
         (args[0] === 'runtime' &&
-          (args[1] === 'opencode-command' || (args[1] === 'status' && args.includes('--summary')))) ||
+          (args[1] === 'opencode-command' ||
+            (args[1] === 'status' && args.includes('--summary')))) ||
         (args.length === 5 &&
           args[2] === '--json' &&
           args[3] === '--provider' &&

--- a/scripts/e2e/comment-notification-desktop.mjs
+++ b/scripts/e2e/comment-notification-desktop.mjs
@@ -131,7 +131,13 @@ async function seed() {
     await mkdir(directory, { recursive: true });
   await chmod(roots.XDG_RUNTIME_DIR, 0o700);
   env = {
-    ...process.env,
+    // Keep only host settings needed to launch the desktop. Provider credentials
+    // and runtime/home overrides must never enter the disposable app.
+    ...Object.fromEntries(
+      ['PATH', 'DISPLAY', 'XAUTHORITY', 'LANG', 'LC_ALL', 'TZ'].flatMap((key) =>
+        process.env[key] === undefined ? [] : [[key, process.env[key]]]
+      )
+    ),
     ...roots,
     SHELL: '/bin/sh',
     GOMAXPROCS: '2',
@@ -139,26 +145,7 @@ async function seed() {
     pnpm_config_verify_deps_before_run: 'false',
     AGENT_TEAMS_DISABLE_SOURCEMAPS: '1',
   };
-  // Do not pass credentials or provider-home overrides to the disposable desktop.
-  for (const key of Object.keys(env)) {
-    if (
-      /API_KEY|ACCESS_TOKEN|AUTH_TOKEN|SECRET|^(CODEX_HOME|OPENAI_BASE_URL|ANTHROPIC_BASE_URL|NODE_OPTIONS|ELECTRON_RUN_AS_NODE)$/.test(
-        key
-      )
-    )
-      delete env[key];
-  }
-  for (const key of [
-    'CLAUDE_DEV_RUNTIME_ROOT',
-    'CLAUDE_DEV_RUNTIME_CACHE_ROOT',
-    'CLAUDE_TERMINAL_PLATFORM_ROOT',
-    'TERMINAL_PLATFORM_ROOT',
-    'CLAUDE_TERMINAL_DAEMON_BINARY',
-    'AGENT_TEAMS_ORG_DEMO',
-  ])
-    delete env[key];
   env.CLAUDE_DEV_RUNTIME_DISABLE_GH = '1';
-  delete env.ELECTRON_CLI_ARGS;
   // electron-vite translates this into --no-sandbox for root-owned Linux CI.
   if (process.getuid?.() === 0) env.NO_SANDBOX = '1';
   const version = JSON.parse(await readFile(path.join(repo, 'runtime.lock.json'), 'utf8')).version;
@@ -549,8 +536,14 @@ try {
   assert(
     evidence.blockedRuntimeCalls.every(
       (args) =>
-        args[0] === 'runtime' &&
-        (args[1] === 'opencode-command' || (args[1] === 'status' && args.includes('--summary')))
+        (args[0] === 'runtime' &&
+          (args[1] === 'opencode-command' || (args[1] === 'status' && args.includes('--summary')))) ||
+        (args.length === 5 &&
+          args[2] === '--json' &&
+          args[3] === '--provider' &&
+          ['anthropic', 'codex', 'opencode'].includes(args[4]) &&
+          ((args[0] === 'auth' && args[1] === 'status') ||
+            (args[0] === 'model' && args[1] === 'list')))
     ),
     'Only blocked startup availability probes expected; no lifecycle commands'
   );

--- a/scripts/e2e/comment-notification/README.md
+++ b/scripts/e2e/comment-notification/README.md
@@ -1,0 +1,52 @@
+# Comment notification desktop regression
+
+Run from the repository root on Linux with installed frozen dependencies and
+rebuilt Electron native modules:
+
+```sh
+xvfb-run -a -s '-screen 0 1280x900x24' node scripts/e2e/comment-notification-desktop.mjs
+```
+
+Requires Node/pnpm versions pinned by the project, `xvfb-run`, `dbus-daemon`, `libnotify4`, and
+`/usr/bin/python3` with `dbus` and `gi`. The harness owns `pnpm dev:mcp`; keep its
+default CDP port 9222 free. Root-owned Linux CI uses Electron's `NO_SANDBOX=1`.
+
+Each run creates a new `comment-notification-TEST-*` directory in the system
+temporary directory. HOME, Claude data, Electron userData, TMPDIR and XDG roots
+are isolated. The fixture contains a new empty TEST project and no provider
+credentials. Its runtime wrapper answers version checks and rejects all other
+calls with exit 77. Blocked startup availability probes are retained as evidence;
+lifecycle commands are rejected and fail the test. No team, agent or terminal is
+launched.
+
+The test exercises real Electron main/preload/renderer, task and inbox readers,
+filesystem watching, comment forwarding journal, notification persistence and
+the `org.freedesktop.Notifications.Notify` boundary on a private D-Bus session.
+Missing native notification support fails the run. Ordinary inbox and fresh
+comment controls must reach the native boundary, so silence alone cannot pass.
+
+Assertions cover:
+
+- Historical comments from current and removed members on startup.
+- An old comment recovered after inbox baseline with a new envelope timestamp.
+- New comments exactly once, including one created during the first task fetch.
+- Repeated and reordered snapshots, renderer reload and full app restart.
+- Comment toast toggle, independent ordinary inbox delivery, and unchanged
+  preexisting read/unread history.
+
+The initial-fetch race holds only the API module's `getAllTasks` transport using
+CDP response interception, then delegates to real preload IPC. It does not mock
+task data, clocks, notification logic or the native notification API.
+
+The final stdout line names the artifact directory. `evidence.json` includes
+per-step counts and history, `native-notifications.ndjson` records native calls,
+and screenshots show the actual renderer. `desktop.log` streams while the test
+runs. Artifacts remain available after success or failure; only owned processes
+are stopped. Exit 0 means all assertions passed. This proves Linux Electron
+notification dispatch; it does not exercise macOS or Windows notification UI.
+
+The production fix keeps internal `task_comment_notification` forwarding
+envelopes out of user notifications in both inbox and sent-message paths. The
+task detector owns comment notifications and applies the context-start cutoff,
+including the first snapshot. Forwarding/journal recovery and existing unread
+records remain intact. Related prior fix: https://github.com/777genius/agent-teams-ai/pull/629.

--- a/scripts/e2e/comment-notification/cdp.mjs
+++ b/scripts/e2e/comment-notification/cdp.mjs
@@ -83,7 +83,7 @@ export class CdpClient {
         lastTransientError = null;
       } catch (error) {
         if (
-          !/execution context was destroyed|cannot find (?:default )?execution context/i.test(
+          !/execution context was destroyed|cannot find (?:default )?execution context|cannot find context with specified id/i.test(
             String(error)
           )
         ) {

--- a/scripts/e2e/comment-notification/cdp.mjs
+++ b/scripts/e2e/comment-notification/cdp.mjs
@@ -1,0 +1,113 @@
+import { writeFile } from 'node:fs/promises';
+import WebSocket from 'ws';
+
+export class CdpClient {
+  constructor(socket) {
+    this.socket = socket;
+    this.nextId = 0;
+    this.pending = new Map();
+    this.listeners = new Map();
+    socket.on('message', (raw) => {
+      const message = JSON.parse(raw.toString());
+      if (message.id) {
+        const pending = this.pending.get(message.id);
+        if (!pending) return;
+        this.pending.delete(message.id);
+        clearTimeout(pending.timer);
+        if (message.error) pending.reject(new Error(message.error.message));
+        else pending.resolve(message.result);
+        return;
+      }
+      for (const listener of this.listeners.get(message.method) ?? []) {
+        Promise.resolve(listener(message.params)).catch((error) => {
+          process.stderr.write(`CDP listener ${message.method} failed: ${String(error)}\n`);
+        });
+      }
+    });
+    socket.on('close', () => {
+      for (const pending of this.pending.values()) {
+        clearTimeout(pending.timer);
+        pending.reject(new Error('CDP connection closed'));
+      }
+      this.pending.clear();
+    });
+  }
+
+  static async connect(url) {
+    const socket = new WebSocket(url);
+    await new Promise((resolve, reject) => {
+      socket.once('open', resolve);
+      socket.once('error', reject);
+    });
+    return new CdpClient(socket);
+  }
+
+  on(method, listener) {
+    const listeners = this.listeners.get(method) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(method, listeners);
+  }
+
+  send(method, params = {}) {
+    const id = ++this.nextId;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`CDP command timed out: ${method}`));
+      }, 30_000);
+      this.pending.set(id, { resolve, reject, timer });
+      this.socket.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  async evaluate(expression) {
+    const response = await this.send('Runtime.evaluate', {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    });
+    if (response.exceptionDetails) {
+      throw new Error(
+        response.exceptionDetails.exception?.description ?? 'Renderer evaluation failed'
+      );
+    }
+    return response.result.value;
+  }
+
+  async waitFor(expression, label, timeoutMs = 30_000) {
+    const deadline = Date.now() + timeoutMs;
+    let lastTransientError = null;
+    while (Date.now() < deadline) {
+      try {
+        if (await this.evaluate(`Boolean(${expression})`)) return;
+        lastTransientError = null;
+      } catch (error) {
+        if (
+          !/execution context was destroyed|cannot find (?:default )?execution context/i.test(
+            String(error)
+          )
+        ) {
+          throw error;
+        }
+        lastTransientError = error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(
+      `Timed out waiting for ${label}${lastTransientError ? `: ${String(lastTransientError)}` : ''}`
+    );
+  }
+
+  async screenshot(file) {
+    const result = await this.send('Page.captureScreenshot', { format: 'png', fromSurface: true });
+    await writeFile(file, Buffer.from(result.data, 'base64'));
+  }
+
+  close() {
+    return new Promise((resolve) => {
+      if (this.socket.readyState === WebSocket.CLOSED) return resolve();
+      this.socket.once('close', resolve);
+      this.socket.close();
+    });
+  }
+}

--- a/scripts/e2e/comment-notification/notifications.py
+++ b/scripts/e2e/comment-notification/notifications.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+"""Private test bus only: record the actual freedesktop Notification boundary."""
+import json
+import sys
+import time
+
+import dbus
+import dbus.service
+from dbus.mainloop.glib import DBusGMainLoop
+from gi.repository import GLib
+
+DBusGMainLoop(set_as_default=True)
+bus = dbus.SessionBus()
+name = dbus.service.BusName('org.freedesktop.Notifications', bus)
+
+
+class Notifications(dbus.service.Object):
+    def __init__(self):
+        super().__init__(bus, '/org/freedesktop/Notifications')
+        self.sequence = 0
+
+    @dbus.service.method('org.freedesktop.Notifications', in_signature='', out_signature='as')
+    def GetCapabilities(self):
+        return ['body', 'actions', 'persistence']
+
+    @dbus.service.method('org.freedesktop.Notifications', in_signature='', out_signature='ssss')
+    def GetServerInformation(self):
+        return ('Comment notification TEST recorder', 'TEST', '1.0', '1.2')
+
+    @dbus.service.method('org.freedesktop.Notifications', in_signature='susssasa{sv}i', out_signature='u')
+    def Notify(self, app, replaces, icon, summary, body, actions, hints, timeout):
+        self.sequence += 1
+        with open(sys.argv[1], 'a', encoding='utf-8') as stream:
+            stream.write(json.dumps({'id': self.sequence, 'at': time.time(), 'app': str(app),
+                                     'summary': str(summary), 'body': str(body)}) + '\n')
+        return self.sequence
+
+    @dbus.service.method('org.freedesktop.Notifications', in_signature='u', out_signature='')
+    def CloseNotification(self, notification_id):
+        pass
+
+
+service = Notifications()
+print('READY', flush=True)
+GLib.MainLoop().run()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -875,13 +875,13 @@ async function notifyNewInboxMessages(teamName: string, detail: string): Promise
 
     for (let i = 0; i < newMessages.length; i++) {
       const msg = newMessages[i];
-      // Skip messages sent from our own UI
+      // Comment forwards are lead runtime inputs; the task detector owns user notifications.
+      if (msg.messageKind === 'task_comment_notification') continue;
       if (msg.source && suppressedSources.has(msg.source)) continue;
       // Skip app-owned private bootstrap/control prompts. They are durable runtime proof inputs,
       // not user-visible conversation messages.
       if (isTeamInternalControlMessageEnvelope(msg)) continue;
-      // Skip internal review-pickup escalations. They are control-plane signals to the lead runtime,
-      // not user-facing inbox messages.
+      // Skip internal review-pickup escalations to the lead runtime.
       if (isReviewPickupEscalationMessage(msg)) continue;
       // Skip internal coordination noise (idle_notification, shutdown_*, etc.)
       if (shouldSuppressDesktopNotificationForInboxText(msg.text)) continue;
@@ -955,7 +955,8 @@ async function notifyNewSentMessages(teamName: string): Promise<void> {
     for (let i = 0; i < newMessages.length; i++) {
       const msg = newMessages[i];
       if ((msg.to ?? '').trim() !== 'user') continue;
-      // Skip messages sent from our own UI
+      // Comment forwards are lead runtime inputs; the task detector owns user notifications.
+      if (msg.messageKind === 'task_comment_notification') continue;
       if (msg.source && suppressedSources.has(msg.source)) continue;
       // Skip internal coordination noise
       if (shouldSuppressDesktopNotificationForInboxText(msg.text)) continue;

--- a/src/renderer/store/team/teamGlobalTaskNotifications.ts
+++ b/src/renderer/store/team/teamGlobalTaskNotifications.ts
@@ -80,6 +80,13 @@ export function processGlobalTaskNotifications(params: ProcessGlobalTaskNotifica
   const { oldTasks, newTasks, appConfig, teamByName, isInitialFetch } = params;
 
   if (isInitialFetch) {
+    // The first response can already contain comments created while IPC loaded.
+    // Apply the context cutoff before seeding so those events are delivered once.
+    detectTaskCommentNotifications(
+      buildTaskNotificationIndexes(oldTasks),
+      newTasks,
+      appConfig?.notifications?.notifyOnTaskComments ?? true
+    );
     seedGlobalTaskNotificationState(newTasks);
     return;
   }

--- a/test/main/index.comment-notifications.test.ts
+++ b/test/main/index.comment-notifications.test.ts
@@ -1,25 +1,31 @@
 import { readFileSync } from 'node:fs';
+
 import { transformWithEsbuild } from 'vite';
 import { describe, expect, it, vi } from 'vitest';
 
 // Execute the actual main entrypoint callback, with its I/O boundaries injected.
 // Importing index itself would boot Electron and unrelated provider services.
-async function inboxHarness() {
+async function inboxHarness(kind: 'inbox' | 'sent' = 'inbox') {
   const source = readFileSync('src/main/index.ts', 'utf8');
-  const start = source.indexOf('async function notifyNewInboxMessages(');
-  const end = source.indexOf('\n/**', start);
+  const functionName = kind === 'inbox' ? 'notifyNewInboxMessages' : 'notifyNewSentMessages';
+  const start = source.indexOf(`async function ${functionName}(`);
+  const end = source.indexOf(kind === 'inbox' ? '\n/**' : '\nprocess.on(', start);
   const { code } = await transformWithEsbuild(source.slice(start, end), 'inbox.ts');
   let messages: Record<string, unknown>[] = [];
   const addTeamNotification = vi.fn(async () => undefined);
   const dependencies = {
     logger: { debug() {}, warn() {} },
-    configManager: { getConfig: () => ({ notifications: { enabled: true, notifyOnLeadInbox: true } }) },
+    configManager: {
+      getConfig: () => ({ notifications: { enabled: true, notifyOnLeadInbox: true } }),
+    },
     existsSync: () => true,
     join: (...parts: string[]) => parts.join('/'),
     getTeamsBasePath: () => 'fixture',
     teamDataService: { getLeadMemberName: async () => 'team-lead' },
     teamInboxReader: { getMessagesFor: async () => messages },
     inboxMessageCounts: new Map(),
+    sentMessageCounts: new Map(),
+    sentMessagesStore: { readMessages: async () => messages },
     resolveTeamDisplayName: async () => 'Fixture',
     suppressedSources: new Set(['user_sent']),
     isTeamInternalControlMessageEnvelope: () => false,
@@ -28,14 +34,14 @@ async function inboxHarness() {
     extractNotificationContent: (text: string) => ({ summary: text, body: text }),
     notificationManager: { addTeamNotification },
   };
-  const notify = new Function(...Object.keys(dependencies), `${code}; return notifyNewInboxMessages;`)(
+  const notify = new Function(...Object.keys(dependencies), `${code}; return ${functionName};`)(
     ...Object.values(dependencies)
   ) as (team: string, detail: string) => Promise<void>;
   await notify('fixture', 'inboxes/team-lead.json');
   return {
     addTeamNotification,
     async append(message: Record<string, unknown>) {
-      messages = [message, ...messages];
+      messages = kind === 'inbox' ? [message, ...messages] : [...messages, message];
       await notify('fixture', 'inboxes/team-lead.json');
     },
   };
@@ -46,8 +52,12 @@ describe('main inbox task comment forwarding', () => {
     const harness = await inboxHarness();
     for (const author of ['removed-teammate', 'active-teammate']) {
       await harness.append({
-        from: author, source: 'system_notification', messageKind: 'task_comment_notification',
-        summary: 'Comment on #abcd1234', text: 'Forwarded task comment', timestamp: new Date().toISOString(),
+        from: author,
+        source: 'system_notification',
+        messageKind: 'task_comment_notification',
+        summary: 'Comment on #abcd1234',
+        text: 'Forwarded task comment',
+        timestamp: new Date().toISOString(),
       });
     }
     expect(harness.addTeamNotification).not.toHaveBeenCalled();
@@ -55,9 +65,45 @@ describe('main inbox task comment forwarding', () => {
 
   it('preserves ordinary inbox messages even from an author no longer on the team', async () => {
     const harness = await inboxHarness();
-    await harness.append({ from: 'removed-teammate', text: 'A genuine new message', timestamp: 'now' });
-    expect(harness.addTeamNotification).toHaveBeenCalledWith(expect.objectContaining({
-      teamEventType: 'lead_inbox', from: 'removed-teammate', body: 'A genuine new message',
-    }));
+    await harness.append({
+      from: 'removed-teammate',
+      text: 'A genuine new message',
+      timestamp: 'now',
+    });
+    expect(harness.addTeamNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamEventType: 'lead_inbox',
+        from: 'removed-teammate',
+        body: 'A genuine new message',
+      })
+    );
+  });
+});
+
+describe('main sent-message task comment forwarding', () => {
+  it('filters semantic comment forwards but retains ordinary sent messages to the user', async () => {
+    const harness = await inboxHarness('sent');
+    await harness.append({
+      from: 'removed-teammate',
+      to: 'user',
+      source: 'system_notification',
+      messageKind: 'task_comment_notification',
+      text: 'Recovered comment',
+      timestamp: 'now',
+    });
+    expect(harness.addTeamNotification).not.toHaveBeenCalled();
+    await harness.append({
+      from: 'removed-teammate',
+      to: 'user',
+      text: 'Ordinary sent control',
+      timestamp: 'later',
+    });
+    expect(harness.addTeamNotification).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        teamEventType: 'user_inbox',
+        from: 'removed-teammate',
+        body: 'Ordinary sent control',
+      })
+    );
   });
 });

--- a/test/main/index.comment-notifications.test.ts
+++ b/test/main/index.comment-notifications.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs';
+import { transformWithEsbuild } from 'vite';
+import { describe, expect, it, vi } from 'vitest';
+
+// Execute the actual main entrypoint callback, with its I/O boundaries injected.
+// Importing index itself would boot Electron and unrelated provider services.
+async function inboxHarness() {
+  const source = readFileSync('src/main/index.ts', 'utf8');
+  const start = source.indexOf('async function notifyNewInboxMessages(');
+  const end = source.indexOf('\n/**', start);
+  const { code } = await transformWithEsbuild(source.slice(start, end), 'inbox.ts');
+  let messages: Record<string, unknown>[] = [];
+  const addTeamNotification = vi.fn(async () => undefined);
+  const dependencies = {
+    logger: { debug() {}, warn() {} },
+    configManager: { getConfig: () => ({ notifications: { enabled: true, notifyOnLeadInbox: true } }) },
+    existsSync: () => true,
+    join: (...parts: string[]) => parts.join('/'),
+    getTeamsBasePath: () => 'fixture',
+    teamDataService: { getLeadMemberName: async () => 'team-lead' },
+    teamInboxReader: { getMessagesFor: async () => messages },
+    inboxMessageCounts: new Map(),
+    resolveTeamDisplayName: async () => 'Fixture',
+    suppressedSources: new Set(['user_sent']),
+    isTeamInternalControlMessageEnvelope: () => false,
+    isReviewPickupEscalationMessage: () => false,
+    shouldSuppressDesktopNotificationForInboxText: () => false,
+    extractNotificationContent: (text: string) => ({ summary: text, body: text }),
+    notificationManager: { addTeamNotification },
+  };
+  const notify = new Function(...Object.keys(dependencies), `${code}; return notifyNewInboxMessages;`)(
+    ...Object.values(dependencies)
+  ) as (team: string, detail: string) => Promise<void>;
+  await notify('fixture', 'inboxes/team-lead.json');
+  return {
+    addTeamNotification,
+    async append(message: Record<string, unknown>) {
+      messages = [message, ...messages];
+      await notify('fixture', 'inboxes/team-lead.json');
+    },
+  };
+}
+
+describe('main inbox task comment forwarding', () => {
+  it('does not turn historical or fresh lead forwarding envelopes into user notifications', async () => {
+    const harness = await inboxHarness();
+    for (const author of ['removed-teammate', 'active-teammate']) {
+      await harness.append({
+        from: author, source: 'system_notification', messageKind: 'task_comment_notification',
+        summary: 'Comment on #abcd1234', text: 'Forwarded task comment', timestamp: new Date().toISOString(),
+      });
+    }
+    expect(harness.addTeamNotification).not.toHaveBeenCalled();
+  });
+
+  it('preserves ordinary inbox messages even from an author no longer on the team', async () => {
+    const harness = await inboxHarness();
+    await harness.append({ from: 'removed-teammate', text: 'A genuine new message', timestamp: 'now' });
+    expect(harness.addTeamNotification).toHaveBeenCalledWith(expect.objectContaining({
+      teamEventType: 'lead_inbox', from: 'removed-teammate', body: 'A genuine new message',
+    }));
+  });
+});

--- a/test/main/index.comment-notifications.test.ts
+++ b/test/main/index.comment-notifications.test.ts
@@ -12,21 +12,21 @@ async function inboxHarness(kind: 'inbox' | 'sent' = 'inbox') {
   const end = source.indexOf(kind === 'inbox' ? '\n/**' : '\nprocess.on(', start);
   const { code } = await transformWithEsbuild(source.slice(start, end), 'inbox.ts');
   let messages: Record<string, unknown>[] = [];
-  const addTeamNotification = vi.fn(async () => undefined);
+  const addTeamNotification = vi.fn(() => Promise.resolve(undefined));
   const dependencies = {
-    logger: { debug() {}, warn() {} },
+    logger: { debug: vi.fn(), warn: vi.fn() },
     configManager: {
       getConfig: () => ({ notifications: { enabled: true, notifyOnLeadInbox: true } }),
     },
     existsSync: () => true,
     join: (...parts: string[]) => parts.join('/'),
     getTeamsBasePath: () => 'fixture',
-    teamDataService: { getLeadMemberName: async () => 'team-lead' },
-    teamInboxReader: { getMessagesFor: async () => messages },
+    teamDataService: { getLeadMemberName: () => Promise.resolve('team-lead') },
+    teamInboxReader: { getMessagesFor: () => Promise.resolve(messages) },
     inboxMessageCounts: new Map(),
     sentMessageCounts: new Map(),
-    sentMessagesStore: { readMessages: async () => messages },
-    resolveTeamDisplayName: async () => 'Fixture',
+    sentMessagesStore: { readMessages: () => Promise.resolve(messages) },
+    resolveTeamDisplayName: () => Promise.resolve('Fixture'),
     suppressedSources: new Set(['user_sent']),
     isTeamInternalControlMessageEnvelope: () => false,
     isReviewPickupEscalationMessage: () => false,
@@ -34,6 +34,8 @@ async function inboxHarness(kind: 'inbox' | 'sent' = 'inbox') {
     extractNotificationContent: (text: string) => ({ summary: text, body: text }),
     notificationManager: { addTeamNotification },
   };
+  // Compile only the fixed, trusted repository entrypoint; no external input is evaluated.
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, sonarjs/code-eval
   const notify = new Function(...Object.keys(dependencies), `${code}; return ${functionName};`)(
     ...Object.values(dependencies)
   ) as (team: string, detail: string) => Promise<void>;

--- a/test/renderer/store/teamGlobalTaskNotifications.startup.test.ts
+++ b/test/renderer/store/teamGlobalTaskNotifications.startup.test.ts
@@ -148,6 +148,15 @@ describe('task comment startup history', () => {
     expect(commentToasts()).toEqual([]);
   });
 
+  it('delivers comments created during the first request in its initial response', () => {
+    vi.setSystemTime('2026-09-09T10:01:00.000Z');
+    const snapshot = task([comment('old'), comment('during-load', new Date().toISOString())]);
+    refresh([], [snapshot], consumeFirstGlobalTasksFetchFlag());
+    refresh([snapshot], [snapshot]);
+    expect(commentToasts()).toMatchObject([{ target: { commentId: 'during-load' } }]);
+    expect(commentToasts()).toHaveLength(1);
+  });
+
   it('keeps comments created while the first context snapshot is still loading', () => {
     refresh([], [], consumeFirstGlobalTasksFetchFlag());
     vi.setSystemTime('2026-09-09T10:30:00.000Z');

--- a/test/renderer/store/teamGlobalTaskNotifications.test.ts
+++ b/test/renderer/store/teamGlobalTaskNotifications.test.ts
@@ -114,7 +114,9 @@ describe('teamGlobalTaskNotifications', () => {
         createTask({
           needsClarification: 'user',
           blockedBy: ['task-2'],
-          comments: [createComment({ text: 'Needs review' })],
+          comments: [
+            createComment({ text: 'Needs review', createdAt: '2026-05-22T08:00:00.000Z' }),
+          ],
           status: 'completed',
         }),
       ],


### PR DESCRIPTION
Recovering the comment forwarding journal assigns a fresh timestamp to old comments, including comments by removed teammates. Those internal envelopes were entering the ordinary inbox notification path and bypassing the renderer's historical-comment cutoff from #629.

Skip typed `task_comment_notification` envelopes before notification storage/toasts in both inbox and sent-message paths. Let the task detector deliver comments created while the first task snapshot loads. Preserve journal recovery, lead delivery and existing read/unread history.

Validation:

- Rejecting regressions fail before the fix and pass afterwards.
- 68 focused tests passed; project typecheck, focused lint and source-size guard passed.
- Independent hosted reviews of the production change and desktop harness/evidence found no actionable P1/P2 issues.
- Real Linux Electron desktop E2E passed all 10 scenarios: historical recovery and removed authors stay silent; fresh comments, including the first-fetch race, notify exactly once; toggles, retained read/unread history and renderer/app restarts behave correctly. Actual `org.freedesktop.Notifications.Notify` calls were captured on a private D-Bus service with ordinary inbox controls. Final history: 7 entries, 6 unread; native calls: 4. No agents or real projects were used.
- E2E ran at db67bd1ef789860ce312758af988a0340446b046. Later changes are one assertion line wrap, a CDP stale-context retry and stricter test stubs/lint documentation; focused tests, strict typed test lint and the CDP retry/error-propagation check passed again. Production bytes are unchanged from the reviewed commit. Full CI passed on final head 6160c23d6e7465db4dcd62482a0e1cfefced4d43, including both test shards, validation/build/typecheck, all lint shards and Windows smoke: https://github.com/777genius/agent-teams-ai/actions/runs/34706417471. macOS/Windows popup UI was not exercised.
- ReviewRouter's separate automated reviewer is unavailable with HTTP 503 from its control plane, including a bounded retry. It is not counted as completed review evidence.

Related: https://github.com/777genius/agent-teams-ai/pull/629

Refs #629
